### PR TITLE
feat: signed principal tokens, deploy bypass gating + audit trail, E2E build caching (ADS-800, ADS-826, ADS-792)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -150,6 +150,15 @@ BCRYPT_ROUNDS=12
 # Required in production (min 32 chars). Generate with: npm run secrets:generate
 UPLOAD_SIGNING_SECRET=CHANGE_THIS_TO_A_STRONG_RANDOM_UPLOAD_SIGNING_SECRET
 
+# Internal gRPC Principal Signing Key (ADS-800)
+# Shared HMAC key for the signed x-principal-token the gateway stamps on
+# every downstream gRPC call. When set, services REQUIRE a valid token and
+# take the principal from it — forged x-user-* metadata headers lose. When
+# unset, the legacy header-trust behaviour applies (phased rollout). Must be
+# the SAME value for the gateway and every gRPC service.
+# Generate with: openssl rand -hex 32
+#PRINCIPAL_SIGNING_KEY=
+
 # -----------------------------------------------------------------------------
 # Frontend API Configuration (Shared across all apps)
 # -----------------------------------------------------------------------------

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -389,14 +389,34 @@ jobs:
 
       - uses: ./.github/actions/setup-workspace
 
-      # NOTE: deliberately NO docker/setup-buildx-action here. The
-      # docker-container builder it creates stores every image twice — once
-      # in the BuildKit cache, once exported as a tarball and re-imported
-      # into the daemon ("sending tarball" / "importing to docker") — which
-      # doubles peak disk for a 14-image build. The daemon's integrated
-      # BuildKit (DOCKER_BUILDKIT=1 is set job-wide) builds straight into
-      # the image store and still supports the dockerfile:1.4 syntax and
-      # RUN --mount=type=cache used by Dockerfile.service.
+      # ADS-792: expose ACTIONS_RUNTIME_TOKEN + cache-service URLs to plain
+      # `run:` steps so the raw `docker buildx bake` call below can use
+      # cache-from/cache-to type=gha. JS actions (docker/build-push-action)
+      # receive these implicitly; shell steps do not.
+      - uses: crazy-max/ghaction-github-runtime@04d248b84655b509d8c44dc1d6f990c879747487  # v4.0.0
+
+      # ADS-792: type=gha cache import/export requires a docker-container
+      # builder — the daemon's integrated BuildKit does not support it.
+      # Known tradeoff (this previously kept buildx out of this job): the
+      # container builder stores layers twice at peak — BuildKit cache plus
+      # the tarball re-import into the daemon ("sending tarball"). Two
+      # things keep that inside the runner's disk budget now:
+      #   - warm GHA cache hits skip re-executing (and re-storing
+      #     intermediates for) the expensive npm-ci/turbo layers;
+      #   - the build step prunes the BuildKit cache immediately after
+      #     --load, before the stack boots.
+      # ENOSPC under a fully cold cache is the residual risk — see the
+      # build step below. max-parallelism=4 replaces the old
+      # COMPOSE_PARALLEL_LIMIT=4: 12 concurrent `npm ci` runs against the
+      # registry was the ECONNRESET source ADS-792 describes.
+      - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5  # v4.1.0
+        with:
+          driver-opts: |
+            image=moby/buildkit:v0.23.0
+            network=host
+          buildkitd-config-inline: |
+            [worker.oci]
+              max-parallelism = 4
 
       - name: Resolve Playwright version
         id: pw
@@ -430,6 +450,10 @@ jobs:
             echo "SESSION_SECRET=$(openssl rand -base64 32)"
             echo "CSRF_SECRET=$(openssl rand -base64 32)"
             echo "ENCRYPTION_KEY=$(openssl rand -hex 32)"
+            # HMAC key for the service-to-service principal tokens minted
+            # and verified by packages/service-bootstrap (read via
+            # config-secrets as PRINCIPAL_SIGNING_KEY).
+            echo "PRINCIPAL_SIGNING_KEY=$(openssl rand -hex 32)"
             # ADS-600 made REDIS_PASSWORD a required secret in
             # docker-compose.yml; the CI stack-up step refuses to
             # start without it. Generate it here so every E2E run
@@ -473,18 +497,75 @@ jobs:
           timeout 90 bash -c 'until docker compose -f docker-compose.yml exec -T database pg_isready -U postgres; do sleep 2; done'
 
       - name: Build images
-        # ADS-792: build with the daemon's integrated BuildKit
-        # (DOCKER_BUILDKIT=1 is set job-wide) — NOT a buildx container
-        # builder, which stores every image twice (BuildKit cache +
-        # tarball re-import) and doubles peak disk for a 14-image build.
-        # type=gha layer caching needs that container driver plus the
-        # Actions runtime token, so proper caching is deferred to the
-        # build-push-action→GHCR design on the ticket. The npm-registry
-        # congestion (ECONNRESET) that motivated caching is mitigated by
-        # capping build concurrency instead of all images running npm ci
-        # simultaneously.
+        # ADS-792: `buildx bake` against docker-compose.yml with BuildKit GHA
+        # layer caching. Design notes:
+        #
+        # PER-TARGET scopes (scope=e2e-<service>): GHA cache writes are
+        # last-write-wins per scope, so a single shared scope with 12 targets
+        # exporting concurrently thrashes — each save evicts the previous
+        # target's layers and the hit rate collapses.
+        #
+        # mode=min, not mode=max, against the repo's 10GB Actions cache
+        # budget (shared with the npm/turbo/lib-dist/Playwright caches and
+        # docker.yml's type=gha caches):
+        #   - the `development` targets inherit FROM the build stage, so the
+        #     expensive npm-ci + turbo-build layers ARE final-image layers
+        #     and mode=min still caches them;
+        #   - mode=max would additionally export intermediates like the
+        #     `pruner` stage, whose COPY-the-whole-repo layer changes every
+        #     commit — pure churn, several GB per scope, guaranteed eviction
+        #     pressure across 12 scopes;
+        #   - estimated mode=min footprint: ~0.3-0.6GB x 12 scopes. Layers
+        #     shared between images are still stored once per scope — the
+        #     price of not thrashing;
+        #   - ignore-error=true: a cache-backend outage degrades to an
+        #     uncached build instead of failing CI.
+        #
+        # Targets are discovered from the compose file via `bake --print`
+        # (buildx parses compose profiles as "all", so every buildable
+        # service is included) — compose-stack changes need no edits here.
+        # Bake assigns NO tags when compose services have no `image:` field,
+        # so each target's tag is set explicitly to the <project>-<service>
+        # name that `docker compose up --no-build` later resolves (project =
+        # lowercased checkout directory name, the same default compose uses).
+        # If bake ever fails to resolve targets (e.g. a compose-file feature
+        # it can't parse), fall back to the previous uncached compose build
+        # rather than breaking the job.
         run: |
-          COMPOSE_PARALLEL_LIMIT=4 docker compose -f docker-compose.yml --profile full build
+          set -euo pipefail
+          # bake interpolates the compose file itself, so the ${VAR:?} guards
+          # (REDIS_PASSWORD, JWT_SECRET, ...) need the generated .env values
+          # in the process env.
+          set -a; source ./.env; set +a
+
+          project="$(basename "$PWD" | tr '[:upper:]' '[:lower:]')"
+          mapfile -t targets < <(docker buildx bake -f docker-compose.yml --print 2>/dev/null | jq -r '.group.default.targets[]' || true)
+
+          if [ "${#targets[@]}" -eq 0 ]; then
+            echo "::warning title=bake fallback::buildx bake resolved no targets from docker-compose.yml — falling back to uncached docker compose build"
+            COMPOSE_PARALLEL_LIMIT=4 docker compose -f docker-compose.yml --profile full build
+            exit 0
+          fi
+
+          echo "Building ${#targets[@]} targets: ${targets[*]}"
+          set_args=()
+          for t in "${targets[@]}"; do
+            set_args+=(
+              --set "${t}.tags=${project}-${t}"
+              --set "${t}.cache-from=type=gha,scope=e2e-${t}"
+              --set "${t}.cache-to=type=gha,mode=min,scope=e2e-${t},ignore-error=true"
+            )
+          done
+
+          # --load = output=type=docker: images land in the daemon store
+          # under the tags set above, where `up --no-build` expects them.
+          docker buildx bake -f docker-compose.yml --load "${set_args[@]}"
+
+          # The BuildKit cache is dead weight once the images are in the
+          # daemon store — reclaim the disk before the stack boots.
+          docker buildx prune -af > /dev/null
+          docker image ls --format '{{.Repository}}:{{.Tag}}  {{.Size}}' | grep "^${project}-" || true
+          df -h /
 
       - name: Start the full stack (images already built)
         # Phase 11 follow-up: bring the apps + gateway + services + nginx up

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,6 +23,15 @@ on:
         required: false
         type: boolean
         default: false
+      # ADS-826: free-text justification for setting either skip_* flag.
+      # The preflight job fails the run when a skip flag is set and this is
+      # empty. The value is recorded in the run summary and in a
+      # `deploy-bypass-audit` issue. Ignored for normal deploys.
+      bypass_reason:
+        description: 'Justification for skip_ci_check / skip_cosign_verify (required when either is set; recorded in the audit trail)'
+        required: false
+        type: string
+        default: ''
       # ADS-824: per-service tag overrides. Newline- or comma-separated
       # KEY=VALUE pairs where KEY must match ^(SERVICE|APP)_[A-Z_]+_TAG$.
       # Example: SERVICE_AUTH_TAG=abc1234,SERVICE_PETS_TAG=def5678
@@ -46,7 +55,140 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  # ADS-826: preflight gate + audit trail for deploy safety bypasses.
+  # Runs before anything is built so an unjustified bypass fails fast:
+  #   1. requires `bypass_reason` whenever skip_ci_check / skip_cosign_verify
+  #      is set;
+  #   2. resolves which protected environment the deploy job must clear —
+  #      ALL production deploys pause for approval; bypass runs targeting
+  #      production route to the dedicated `production-bypass` environment so
+  #      reviewers can see at a glance that safety checks are being skipped.
+  #      Staging stays automatic (bypasses there are audited but not gated);
+  #   3. records every bypass in the run summary AND as a
+  #      `deploy-bypass-audit` issue, so the trail survives log retention and
+  #      is visible to the approver before they sign off.
+  # Admin one-time setup (required reviewers on the two environments) is
+  # documented in docs/operations/deploy.md — "Production approval gate".
+  preflight:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      # Needed to create the deploy-bypass-audit issue below; the other jobs
+      # keep the workflow-level contents:read only.
+      issues: write
+    outputs:
+      deploy_environment: ${{ steps.resolve-env.outputs.deploy_environment }}
+    env:
+      TARGET_ENV: ${{ github.event.inputs.environment }}
+      SKIP_CI_CHECK: ${{ github.event.inputs.skip_ci_check }}
+      SKIP_COSIGN_VERIFY: ${{ github.event.inputs.skip_cosign_verify }}
+      BYPASS_REASON: ${{ github.event.inputs.bypass_reason }}
+    steps:
+      - name: Require bypass_reason when a skip flag is set
+        run: |
+          set -euo pipefail
+          if [ "$SKIP_CI_CHECK" != "true" ] && [ "$SKIP_COSIGN_VERIFY" != "true" ]; then
+            echo "No safety bypass requested — bypass_reason not required."
+            exit 0
+          fi
+          if [ -z "$(printf '%s' "$BYPASS_REASON" | tr -d '[:space:]')" ]; then
+            echo "ERROR: skip_ci_check/skip_cosign_verify is set but bypass_reason is empty."
+            echo "Re-run the dispatch with a justification — every bypass is audited."
+            exit 1
+          fi
+          echo "Safety bypass requested. Reason: $BYPASS_REASON"
+
+      - name: Resolve approval environment
+        id: resolve-env
+        run: |
+          set -euo pipefail
+          DEPLOY_ENVIRONMENT="$TARGET_ENV"
+          if [ "$TARGET_ENV" = "production" ] && \
+             { [ "$SKIP_CI_CHECK" = "true" ] || [ "$SKIP_COSIGN_VERIFY" = "true" ]; }; then
+            DEPLOY_ENVIRONMENT="production-bypass"
+          fi
+          echo "deploy_environment=$DEPLOY_ENVIRONMENT" >> "$GITHUB_OUTPUT"
+          echo "Deploy job will run in the '$DEPLOY_ENVIRONMENT' environment."
+
+      - name: Record bypass in run summary
+        if: github.event.inputs.skip_ci_check == 'true' || github.event.inputs.skip_cosign_verify == 'true'
+        env:
+          ACTOR: ${{ github.actor }}
+          DEPLOY_SHA: ${{ github.sha }}
+          DEPLOY_ENVIRONMENT: ${{ steps.resolve-env.outputs.deploy_environment }}
+        run: |
+          {
+            echo "## Deploy safety bypass"
+            echo ""
+            echo "| Field | Value |"
+            echo "| --- | --- |"
+            echo "| Actor | @${ACTOR} |"
+            echo "| Target environment | ${TARGET_ENV} (approval environment: ${DEPLOY_ENVIRONMENT}) |"
+            echo "| DEPLOY_SHA | ${DEPLOY_SHA} |"
+            echo "| skip_ci_check | ${SKIP_CI_CHECK} |"
+            echo "| skip_cosign_verify | ${SKIP_COSIGN_VERIFY} |"
+            echo "| Reason | ${BYPASS_REASON} |"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Open deploy-bypass-audit issue
+        if: github.event.inputs.skip_ci_check == 'true' || github.event.inputs.skip_cosign_verify == 'true'
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
+        env:
+          DEPLOY_ENVIRONMENT: ${{ steps.resolve-env.outputs.deploy_environment }}
+        with:
+          script: |
+            const {
+              TARGET_ENV,
+              DEPLOY_ENVIRONMENT,
+              SKIP_CI_CHECK,
+              SKIP_COSIGN_VERIFY,
+              BYPASS_REASON,
+            } = process.env;
+            const label = 'deploy-bypass-audit';
+
+            // Ensure the audit label exists — the first bypass on a repo
+            // without it must not lose its audit record to a 422.
+            try {
+              await github.rest.issues.getLabel({ ...context.repo, name: label });
+            } catch (error) {
+              if (error.status !== 404) throw error;
+              await github.rest.issues.createLabel({
+                ...context.repo,
+                name: label,
+                color: 'B60205',
+                description: 'Audit record of a deploy run that bypassed a safety check',
+              });
+            }
+
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const shortSha = context.sha.slice(0, 7);
+            const body = [
+              'A deploy was dispatched with one or more safety checks bypassed.',
+              '',
+              `| Field | Value |`,
+              `| --- | --- |`,
+              `| Actor | @${context.actor} |`,
+              `| Target environment | ${TARGET_ENV} |`,
+              `| Approval environment | ${DEPLOY_ENVIRONMENT} |`,
+              `| DEPLOY_SHA | ${context.sha} |`,
+              `| skip_ci_check | ${SKIP_CI_CHECK} |`,
+              `| skip_cosign_verify | ${SKIP_COSIGN_VERIFY} |`,
+              `| Reason | ${BYPASS_REASON} |`,
+              `| Workflow run | ${runUrl} |`,
+              '',
+              'See docs/operations/deploy.md ("Production approval gate") for the policy.',
+            ].join('\n');
+
+            await github.rest.issues.create({
+              ...context.repo,
+              title: `Deploy bypass: ${TARGET_ENV} @ ${shortSha} by ${context.actor}`,
+              labels: [label],
+              body,
+            });
+
   build-and-push:
+    needs: preflight
     runs-on: ubuntu-latest
     timeout-minutes: 60
     permissions:
@@ -311,10 +453,13 @@ jobs:
           done
 
   deploy:
-    needs: verify-images
+    needs: [preflight, verify-images]
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    environment: ${{ github.event.inputs.environment }}
+    # ADS-826: resolved by the preflight job — `staging` (automatic),
+    # `production` (required-reviewer approval), or `production-bypass`
+    # (separately-reviewed approval for runs that skip a safety check).
+    environment: ${{ needs.preflight.outputs.deploy_environment }}
     steps:
       # ADS-824: validate tag_overrides before touching the host.
       # Keys must match ^(SERVICE|APP)_[A-Z_]+_TAG$; values must be
@@ -361,13 +506,14 @@ jobs:
           SECRET_UPLOAD_SIGNING_SECRET: ${{ secrets.UPLOAD_SIGNING_SECRET }}
           SECRET_DB_PASSWORD: ${{ secrets.DB_PASSWORD }}
           SECRET_REDIS_PASSWORD: ${{ secrets.REDIS_PASSWORD }}
+          SECRET_PRINCIPAL_SIGNING_KEY: ${{ secrets.PRINCIPAL_SIGNING_KEY }}
         uses: appleboy/ssh-action@0ff4204d59e8e51228ff73bce53f80d53301dee2  # v1.2.5
         with:
           host: ${{ secrets.HETZNER_HOST }}
           username: deploy
           key: ${{ secrets.HETZNER_SSH_KEY }}
           fingerprint: ${{ secrets.HETZNER_HOST_FINGERPRINT }}
-          envs: GHCR_TOKEN,SECRET_JWT_SECRET,SECRET_JWT_REFRESH_SECRET,SECRET_SESSION_SECRET,SECRET_CSRF_SECRET,SECRET_ENCRYPTION_KEY,SECRET_UPLOAD_SIGNING_SECRET,SECRET_DB_PASSWORD,SECRET_REDIS_PASSWORD
+          envs: GHCR_TOKEN,SECRET_JWT_SECRET,SECRET_JWT_REFRESH_SECRET,SECRET_SESSION_SECRET,SECRET_CSRF_SECRET,SECRET_ENCRYPTION_KEY,SECRET_UPLOAD_SIGNING_SECRET,SECRET_DB_PASSWORD,SECRET_REDIS_PASSWORD,SECRET_PRINCIPAL_SIGNING_KEY
           script: |
             set -euo pipefail
             ENV="${{ github.event.inputs.environment }}"
@@ -442,6 +588,7 @@ jobs:
               printf '%s' "$SECRET_UPLOAD_SIGNING_SECRET" > secrets/upload_signing_secret
               printf '%s' "$SECRET_DB_PASSWORD"          > secrets/db_password
               printf '%s' "$SECRET_REDIS_PASSWORD"       > secrets/redis_password
+              printf '%s' "$SECRET_PRINCIPAL_SIGNING_KEY" > secrets/principal_signing_key
               chmod 600 secrets/*
             fi
 

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -58,6 +58,7 @@ x-service-common: &service-common
   secrets:
     - database_url
     - redis_url
+    - principal_signing_key
   deploy:
     resources:
       limits:
@@ -74,6 +75,10 @@ x-service-env: &service-env
   DATABASE_URL_FILE: /run/secrets/database_url
   NATS_URL: "nats://nats:4222"
   REDIS_URL_FILE: /run/secrets/redis_url
+  # ADS-800: shared HMAC key for signed principal tokens. Present → each
+  # service REQUIRES a valid x-principal-token (forged x-user-* headers
+  # lose); the gateway signs with the same key.
+  PRINCIPAL_SIGNING_KEY_FILE: /run/secrets/principal_signing_key
 
 services:
   # Database - Production configuration
@@ -202,6 +207,9 @@ services:
       # the gateway's own file streaming in production.
       SERVE_LOCAL_UPLOADS: "false"
       UPLOAD_SIGNING_SECRET_FILE: /run/secrets/upload_signing_secret
+      # ADS-800: the gateway signs the x-principal-token it forwards on
+      # every downstream gRPC call.
+      PRINCIPAL_SIGNING_KEY_FILE: /run/secrets/principal_signing_key
       # ADS-813: forward CUTOVER_* flags so the gateway registers /api/v1/*
       # routes. Without these the gateway boots healthy but 404s every API
       # route (compose does not pass host env implicitly). Default true — all
@@ -216,9 +224,11 @@ services:
       CUTOVER_AUDIT: '${CUTOVER_AUDIT:-true}'
       CUTOVER_CHAT: '${CUTOVER_CHAT:-true}'
       CUTOVER_CMS: '${CUTOVER_CMS:-true}'
-    # Gateway has no DB; it only needs the upload-signing secret.
+    # Gateway has no DB; it needs the upload-signing secret plus the
+    # principal-signing key (ADS-800 — it is the token signer).
     secrets:
       - upload_signing_secret
+      - principal_signing_key
     volumes:
       - uploads:/app/uploads
     expose:
@@ -248,6 +258,7 @@ services:
       - redis_url
       - jwt_secret
       - jwt_refresh_secret
+      - principal_signing_key
     expose:
       - "5002"
     healthcheck:
@@ -579,3 +590,5 @@ secrets:
     file: ./secrets/jwt_refresh_secret
   upload_signing_secret:
     file: ./secrets/upload_signing_secret
+  principal_signing_key:
+    file: ./secrets/principal_signing_key

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -43,6 +43,7 @@ x-service-common: &service-common
   secrets:
     - database_url
     - redis_url
+    - principal_signing_key
   # staging mirrors prod limits so performance regressions surface pre-prod (ADS-836)
   deploy:
     resources:
@@ -62,6 +63,10 @@ x-service-env: &service-env
   DATABASE_URL_FILE: /run/secrets/database_url
   NATS_URL: "nats://nats:4222"
   REDIS_URL_FILE: /run/secrets/redis_url
+  # ADS-800: shared HMAC key for signed principal tokens. Present → each
+  # service REQUIRES a valid x-principal-token (forged x-user-* headers
+  # lose); the gateway signs with the same key.
+  PRINCIPAL_SIGNING_KEY_FILE: /run/secrets/principal_signing_key
 
 services:
   database:
@@ -182,6 +187,9 @@ services:
       # Staging has no per-stack nginx; the gateway serves /uploads itself.
       SERVE_LOCAL_UPLOADS: "true"
       UPLOAD_SIGNING_SECRET_FILE: /run/secrets/upload_signing_secret
+      # ADS-800: the gateway signs the x-principal-token it forwards on
+      # every downstream gRPC call.
+      PRINCIPAL_SIGNING_KEY_FILE: /run/secrets/principal_signing_key
       # ADS-813: forward CUTOVER_* flags so the gateway registers /api/v1/*
       # routes. Without these the gateway boots healthy but 404s every API
       # route (compose does not pass host env implicitly). Default true — all
@@ -196,9 +204,11 @@ services:
       CUTOVER_AUDIT: '${CUTOVER_AUDIT:-true}'
       CUTOVER_CHAT: '${CUTOVER_CHAT:-true}'
       CUTOVER_CMS: '${CUTOVER_CMS:-true}'
-    # Gateway has no DB; it only needs the upload-signing secret.
+    # Gateway has no DB; it needs the upload-signing secret plus the
+    # principal-signing key (ADS-800 — it is the token signer).
     secrets:
       - upload_signing_secret
+      - principal_signing_key
     volumes:
       - uploads:/app/uploads
     expose:
@@ -228,6 +238,7 @@ services:
       - redis_url
       - jwt_secret
       - jwt_refresh_secret
+      - principal_signing_key
     expose:
       - "5002"
     healthcheck:
@@ -488,3 +499,5 @@ secrets:
     file: ./secrets/jwt_refresh_secret
   upload_signing_secret:
     file: ./secrets/upload_signing_secret
+  principal_signing_key:
+    file: ./secrets/principal_signing_key

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,11 @@ x-service-env: &ms-env
   DATABASE_URL: postgresql://${POSTGRES_USER:-adopt_user}:${POSTGRES_PASSWORD}@database:5432/${POSTGRES_DB:-adopt_dont_shop_dev}
   NATS_URL: nats://nats:4222
   REDIS_URL: redis://:${REDIS_PASSWORD}@redis:6379
+  # ADS-800: shared HMAC key for signed principal tokens. When set, the
+  # gateway stamps x-principal-token on every downstream gRPC call and the
+  # services REQUIRE it (forged x-user-* headers lose). Optional — unset
+  # keeps the legacy header-trust behaviour for phased rollout.
+  PRINCIPAL_SIGNING_KEY: ${PRINCIPAL_SIGNING_KEY:-}
 
 x-service-deps: &ms-deps
   database:
@@ -342,6 +347,9 @@ services:
       CUTOVER_AUDIT: ${CUTOVER_AUDIT:-true}
       CUTOVER_CHAT: ${CUTOVER_CHAT:-true}
       CUTOVER_CMS: ${CUTOVER_CMS:-true}
+      # ADS-800: same shared key as the *ms-env services — the gateway is
+      # the signer, the services are the verifiers.
+      PRINCIPAL_SIGNING_KEY: ${PRINCIPAL_SIGNING_KEY:-}
     ports:
       - '127.0.0.1:4000:4000'
     depends_on:

--- a/docs/operations/deploy.md
+++ b/docs/operations/deploy.md
@@ -109,6 +109,50 @@ host. See [`docs/security/image-signing.md`](../security/image-signing.md)
 for the trust model, the manual verification command, and the documented
 emergency-bypass procedure.
 
+## Production approval gate
+
+All `production` runs of `.github/workflows/deploy.yml` pause for reviewer
+approval before the `deploy` job touches the host (the build/verify jobs run
+first, so reviewers approve a fully built and signature-verified release).
+Staging deploys stay automatic. [ADS-826]
+
+The deploy job's `environment:` is resolved by the workflow's `preflight` job:
+
+| Dispatch | Approval environment |
+|---|---|
+| `environment=staging` (with or without skip flags) | `staging` — no approval |
+| `environment=production`, no skip flags | `production` |
+| `environment=production` + `skip_ci_check` and/or `skip_cosign_verify` | `production-bypass` |
+
+Bypass runs route to the dedicated `production-bypass` environment so the
+reviewer list sees at a glance that safety checks are being skipped. Any run
+with a skip flag set must also provide the `bypass_reason` dispatch input —
+the preflight job fails the run if it is empty — and every bypass (staging
+included) is recorded in the run summary and as a GitHub issue labelled
+`deploy-bypass-audit`.
+
+### One-time admin setup
+
+Configure required reviewers once per repository (repo admin):
+
+1. Go to **Settings → Environments**.
+2. Click **New environment** (or open it if it already exists from a past
+   run), name it exactly `production`, and click **Configure environment**.
+3. Tick **Required reviewers** and add the people/teams allowed to approve
+   production deploys (up to six entries).
+4. Tick **Prevent self-review** so the person who dispatched the deploy
+   cannot approve their own run.
+5. Click **Save protection rules**.
+6. Repeat steps 2-5 for a second environment named exactly
+   `production-bypass`. Keep its reviewer list to the small set of people
+   allowed to sign off on safety-check bypasses.
+
+Note: environments that have not been configured do not block anything —
+GitHub auto-creates an unprotected environment the first time a workflow
+references it, and an unprotected environment deploys without approval. The
+workflow change therefore merges safely before this setup is done; the gate
+only takes effect once required reviewers are saved.
+
 ## Release deploy
 
 The `service-backend-migrate` init container runs `npm run db:migrate`

--- a/docs/security/image-signing.md
+++ b/docs/security/image-signing.md
@@ -100,6 +100,13 @@ Every use of `skip_cosign_verify=true` emits a `::warning::` annotation
 in the workflow run and prints a `WARNING: cosign verification SKIPPED`
 line in the job log, so the bypass is searchable in deploy history.
 
+Since ADS-826 the flag also requires the `bypass_reason` dispatch input
+(the run fails fast without it), records the bypass in the run summary
+and in a `deploy-bypass-audit` issue, and — for production targets —
+routes the deploy job to the `production-bypass` environment for
+reviewer approval. See
+[`docs/operations/deploy.md`](../operations/deploy.md#production-approval-gate).
+
 ## Known gaps
 
 - `.github/workflows/rollback.yml` pulls and runs previously-built images

--- a/docs/security/internal-grpc-trust.md
+++ b/docs/security/internal-grpc-trust.md
@@ -1,8 +1,10 @@
 # Internal gRPC trust model
 
 > Tracked in [ADS-829](https://linear.app/ideasquared/issue/ADS-829). Created
-> 2026-06 as part of the production-readiness security review. mTLS hardening
-> is tracked separately as [ADS-800](https://linear.app/ideasquared/issue/ADS-800).
+> 2026-06 as part of the production-readiness security review.
+> [ADS-800](https://linear.app/ideasquared/issue/ADS-800) added signed
+> principal tokens (below); mTLS for encryption-in-transit remains future
+> work.
 
 This document records the current trust assumptions for inter-service gRPC
 traffic, the mitigations in place, the accepted risk, and the roadmap to
@@ -33,22 +35,52 @@ two-step discipline on every inbound HTTP request:
    header is present, the gateway calls `service.auth ValidateToken` and, on
    success, sets the validated `x-user-*` headers from the returned `Principal`.
 
-Downstream services trust these headers as ground truth. The extraction
-logic lives in
-[`packages/service-bootstrap/src/principal.ts`](../../packages/service-bootstrap/src/principal.ts):
-`extractPrincipal(metadata)` reads `x-user-id`, `x-user-roles`, and
-`x-user-permissions` directly from the gRPC `Metadata` object without any
-cryptographic verification. The `principalToMetadata` function performs the
-inverse — serialising a `Principal` back to outbound metadata — used by
-services that forward a caller's identity to a second downstream service
-(e.g. `applications → pets`).
+The extraction logic lives in
+[`packages/service-bootstrap/src/principal.ts`](../../packages/service-bootstrap/src/principal.ts).
+Without a signing key configured (legacy mode), `extractPrincipal(metadata)`
+reads `x-user-id`, `x-user-roles`, and `x-user-permissions` directly from the
+gRPC `Metadata` object without any cryptographic verification. The
+`principalToMetadata` function performs the inverse — serialising a
+`Principal` back to outbound metadata — used by services that forward a
+caller's identity to a second downstream service (e.g. `applications → pets`).
 
 Service-to-service calls that originate inside the cluster (not forwarded
 user traffic) stamp a **system principal** directly into the metadata. For
 example, the notifications service stamps `x-user-id: svc-notifications`,
 `x-user-roles: admin`, `x-user-permissions: admin.users.broadcast` when
 calling `service.auth ListUserIdsByCohort`
-([`services/notifications/src/grpc/auth-client.ts:65-68`](../../services/notifications/src/grpc/auth-client.ts)).
+([`services/notifications/src/grpc/auth-client.ts`](../../services/notifications/src/grpc/auth-client.ts)).
+
+## Signed principal tokens (ADS-800)
+
+When the shared `PRINCIPAL_SIGNING_KEY` secret is deployed (read via
+`@adopt-dont-shop/config-secrets`, so both the plaintext env var and the
+`PRINCIPAL_SIGNING_KEY_FILE` Docker-secret form work), principal propagation
+is cryptographically verified:
+
+- **Signing.** The gateway's `authenticate` middleware signs the validated
+  principal and stamps it as an `x-principal-token` header alongside the
+  `x-user-*` headers; `buildMetadata` forwards it on every gateway → service
+  gRPC call. `principalToMetadata` (service → service identity forwarding,
+  e.g. `applications → pets`) and the notifications auth-client (system
+  principal) sign with the same helper.
+- **Token format.** `base64url(JSON payload incl. iat/exp)` + `.` +
+  `base64url(HMAC-SHA256(payload, key))`, implemented with `node:crypto`
+  only in
+  [`packages/service-bootstrap/src/principal-token.ts`](../../packages/service-bootstrap/src/principal-token.ts).
+  Default TTL is 120 s; MAC comparison uses `crypto.timingSafeEqual`.
+- **Verification.** When a service has the key configured,
+  `extractPrincipal` REQUIRES a valid token and takes the principal **from
+  the token payload** — the `x-user-*` headers become informational, so a
+  forged header can no longer win. A missing, malformed, tampered, or
+  expired token maps to gRPC `UNAUTHENTICATED`.
+- **Rollout.** The key is optional on both sides. Key unset on a service →
+  legacy header trust (unchanged). Key set on a service but not on the
+  gateway → that service rejects all authenticated traffic with
+  `UNAUTHENTICATED`, so deploy the key to the **signers (gateway,
+  notifications) first**, then to the verifiers. The dev compose passes
+  `PRINCIPAL_SIGNING_KEY` from `.env`; production/staging mount
+  `/run/secrets/principal_signing_key`.
 
 ## Threat model
 
@@ -59,13 +91,21 @@ calling `service.auth ListUserIdsByCohort`
 - Unauthenticated access to protected RPCs on publicly-reachable paths — the
   gateway validates the bearer token and returns 401 before forwarding.
 
+- With `PRINCIPAL_SIGNING_KEY` deployed: a process on the internal network
+  forging `x-user-*` gRPC metadata. Services take the principal from the
+  HMAC-verified `x-principal-token`; without the key an attacker cannot mint
+  one, and tampering or replay beyond the 120 s TTL fails verification.
+
 **What the current model does NOT prevent:**
 
-- Any process that can reach the internal Docker bridge network can open a
-  gRPC connection to any service and supply arbitrary `x-user-*` metadata.
-  There is no certificate check, channel binding, or token validation at the
-  gRPC layer. An attacker with network access to the internal network can
-  impersonate any user or service principal.
+- Without `PRINCIPAL_SIGNING_KEY` deployed (legacy mode), any process that
+  can reach the internal Docker bridge network can open a gRPC connection to
+  any service and supply arbitrary `x-user-*` metadata and impersonate any
+  user or service principal.
+- Traffic is still HTTP/2 cleartext — an attacker who can sniff the internal
+  network can read payloads and capture a valid token for replay within its
+  TTL. There is no certificate check or channel binding at the gRPC layer;
+  encryption-in-transit needs mTLS (future work).
 
 **Scope of "network access":**
 
@@ -82,7 +122,8 @@ accessible from outside the Docker network without going through nginx.
 
 **Accepted risk:**
 
-The current posture is accepted on the basis that:
+The remaining posture (cleartext channel; header trust where the key is not
+yet deployed) is accepted on the basis that:
 
 - The Docker internal network is not publicly routable.
 - No gRPC port is exposed on a host interface in any environment (dev or
@@ -95,25 +136,29 @@ current deployment scale and is tracked for remediation.
 
 ## Roadmap
 
-[ADS-800](https://linear.app/ideasquared/issue/ADS-800) tracks adding mutual
-TLS (mTLS) to all inter-service gRPC channels. Once that lands:
-
-- Each service will present a client certificate issued by an internal CA.
-- The server will verify the client certificate before processing any RPC.
-- `ServerCredentials.createInsecure()` and `credentials.createInsecure()`
-  will be replaced with TLS credentials in
-  `packages/service-bootstrap/src/grpc-server.ts` and each client file.
-- The principal-propagation model (`x-user-*` headers) remains, but the
-  channel itself will no longer be spoofable from an unauthenticated network
-  position.
+- **Done (ADS-800):** signed principal tokens — header forgery on the
+  internal network is mitigated wherever `PRINCIPAL_SIGNING_KEY` is
+  deployed (see above).
+- **Future work:** mutual TLS (mTLS) on all inter-service gRPC channels for
+  encryption-in-transit and channel-level peer authentication. Once that
+  lands:
+  - Each service will present a client certificate issued by an internal CA.
+  - The server will verify the client certificate before processing any RPC.
+  - `ServerCredentials.createInsecure()` and `credentials.createInsecure()`
+    will be replaced with TLS credentials in
+    `packages/service-bootstrap/src/grpc-server.ts` and each client file.
+  - The principal-propagation model (signed `x-principal-token` +
+    informational `x-user-*` headers) remains; the channel itself stops
+    being sniffable/spoofable from an unauthenticated network position.
 
 ## Known gaps not covered by ADS-800
 
 - The gateway's `authenticate` middleware does not 401 unauthenticated
   requests to non-public paths today (Phase 2.6 item noted in
-  `services/gateway/src/middleware/authenticate.ts:85-91`). Until that
+  `services/gateway/src/middleware/authenticate.ts`). Until that
   lands, a request with no token can still reach downstream handlers that
   apply their own auth gate.
 - Outbound service-to-service system principals (e.g. `svc-notifications`)
-  are hardcoded strings with no runtime attestation beyond the channel trust
-  described above.
+  are hardcoded strings. With the key deployed they are at least signed by a
+  key-holding process, but any key holder can mint any principal — there is
+  no per-service identity attestation (that needs mTLS client certs).

--- a/package-lock.json
+++ b/package-lock.json
@@ -28967,13 +28967,15 @@
       "version": "0.1.0",
       "dependencies": {
         "@adopt-dont-shop/authz": "*",
+        "@adopt-dont-shop/config-secrets": "*",
         "@adopt-dont-shop/lib.types": "*",
         "@adopt-dont-shop/observability": "*",
         "@grpc/grpc-js": "^1.14.4",
         "fastify": "^5.8.5",
         "nats": "^2.29.3",
         "pg": "^8.21.0",
-        "winston": "^3.19.0"
+        "winston": "^3.19.0",
+        "zod": "^4.4.3"
       },
       "devDependencies": {
         "@types/pg": "^8.15.5"
@@ -29214,6 +29216,7 @@
         "@adopt-dont-shop/events": "*",
         "@adopt-dont-shop/observability": "*",
         "@adopt-dont-shop/proto": "*",
+        "@adopt-dont-shop/service-bootstrap": "*",
         "@adopt-dont-shop/storage": "*",
         "@fastify/multipart": "^9.0.3",
         "@fastify/rate-limit": "^10.3.0",

--- a/packages/service-bootstrap/package.json
+++ b/packages/service-bootstrap/package.json
@@ -31,13 +31,15 @@
   },
   "dependencies": {
     "@adopt-dont-shop/authz": "*",
+    "@adopt-dont-shop/config-secrets": "*",
     "@adopt-dont-shop/lib.types": "*",
     "@adopt-dont-shop/observability": "*",
     "@grpc/grpc-js": "^1.14.4",
     "fastify": "^5.8.5",
     "nats": "^2.29.3",
     "pg": "^8.21.0",
-    "winston": "^3.19.0"
+    "winston": "^3.19.0",
+    "zod": "^4.4.3"
   },
   "peerDependencies": {
     "nats": "^2.29.3",

--- a/packages/service-bootstrap/src/adapter.test.ts
+++ b/packages/service-bootstrap/src/adapter.test.ts
@@ -1,9 +1,14 @@
 import { Metadata, status, type ServerUnaryCall, type sendUnaryData } from '@grpc/grpc-js';
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import type { Logger } from 'winston';
 
 import { adapt, adaptUnauth, HandlerError, type HandlerDeps } from './adapter.js';
+import {
+  PRINCIPAL_TOKEN_HEADER,
+  resetDefaultPrincipalSigningKeyForTests,
+  signPrincipalToken,
+} from './principal-token.js';
 
 function makeLogger() {
   const calls: Array<{ level: string; msg: string; meta?: unknown }> = [];
@@ -126,6 +131,132 @@ describe('adapt — error code mapping (canonical CODE_TO_GRPC table)', () => {
     expect(err).toMatchObject({ code: status.INTERNAL, details: 'internal error' });
     expect((err as Error).message).toBe('internal error');
     expect(calls.find(c => c.level === 'error')?.msg).toContain('unhandled');
+  });
+});
+
+describe('adapt — signed principal verification (ADS-800)', () => {
+  const SIGNING_KEY = 'adapter-test-key';
+  const TOKEN_PRINCIPAL = {
+    userId: 'usr-signed',
+    roles: ['admin'],
+    permissions: ['pets.read'],
+  };
+
+  afterEach(() => {
+    delete process.env.PRINCIPAL_SIGNING_KEY;
+    resetDefaultPrincipalSigningKeyForTests();
+  });
+
+  it('takes the principal from a valid token, ignoring forged headers', async () => {
+    const handler = vi.fn(async (_d, principal) => ({ userId: principal.userId }));
+    const { logger } = makeLogger();
+    const wrapped = adapt('service.test', handler, {
+      deps,
+      logger,
+      principalVerification: { signingKey: SIGNING_KEY },
+    });
+
+    const callback = vi.fn() as unknown as sendUnaryData<unknown>;
+    const metadata = buildMetadata({
+      ...VALID_HEADERS, // forged / informational headers say usr-1
+      [PRINCIPAL_TOKEN_HEADER]: signPrincipalToken(TOKEN_PRINCIPAL, SIGNING_KEY),
+    });
+    wrapped(makeCall({}, metadata), callback);
+    await new Promise(r => setImmediate(r));
+
+    const [err, res] = vi.mocked(callback).mock.calls[0];
+    expect(err).toBeNull();
+    expect(res).toEqual({ userId: 'usr-signed' });
+  });
+
+  it('UNAUTHENTICATED when verification is configured and the token is missing', async () => {
+    const handler = vi.fn();
+    const { logger } = makeLogger();
+    const wrapped = adapt('service.test', handler, {
+      deps,
+      logger,
+      principalVerification: { signingKey: SIGNING_KEY },
+    });
+
+    const callback = vi.fn() as unknown as sendUnaryData<unknown>;
+    wrapped(makeCall({}, buildMetadata(VALID_HEADERS)), callback);
+    await new Promise(r => setImmediate(r));
+
+    expect(handler).not.toHaveBeenCalled();
+    const [err] = vi.mocked(callback).mock.calls[0];
+    expect(err).toMatchObject({ code: status.UNAUTHENTICATED });
+  });
+
+  it('UNAUTHENTICATED when the token is signed with the wrong key', async () => {
+    const handler = vi.fn();
+    const { logger } = makeLogger();
+    const wrapped = adapt('service.test', handler, {
+      deps,
+      logger,
+      principalVerification: { signingKey: SIGNING_KEY },
+    });
+
+    const callback = vi.fn() as unknown as sendUnaryData<unknown>;
+    const metadata = buildMetadata({
+      [PRINCIPAL_TOKEN_HEADER]: signPrincipalToken(TOKEN_PRINCIPAL, 'wrong-key'),
+    });
+    wrapped(makeCall({}, metadata), callback);
+    await new Promise(r => setImmediate(r));
+
+    expect(handler).not.toHaveBeenCalled();
+    const [err] = vi.mocked(callback).mock.calls[0];
+    expect(err).toMatchObject({ code: status.UNAUTHENTICATED });
+  });
+
+  it('picks up PRINCIPAL_SIGNING_KEY from the environment when no explicit config is passed', async () => {
+    process.env.PRINCIPAL_SIGNING_KEY = SIGNING_KEY;
+    resetDefaultPrincipalSigningKeyForTests();
+
+    const handler = vi.fn(async (_d, principal) => ({ userId: principal.userId }));
+    const { logger } = makeLogger();
+    const wrapped = adapt('service.test', handler, { deps, logger });
+
+    // Headers alone are no longer enough…
+    const rejected = vi.fn() as unknown as sendUnaryData<unknown>;
+    wrapped(makeCall({}, buildMetadata(VALID_HEADERS)), rejected);
+    await new Promise(r => setImmediate(r));
+    expect(vi.mocked(rejected).mock.calls[0][0]).toMatchObject({
+      code: status.UNAUTHENTICATED,
+    });
+
+    // …but a signed token is.
+    const accepted = vi.fn() as unknown as sendUnaryData<unknown>;
+    wrapped(
+      makeCall(
+        {},
+        buildMetadata({
+          [PRINCIPAL_TOKEN_HEADER]: signPrincipalToken(TOKEN_PRINCIPAL, SIGNING_KEY),
+        })
+      ),
+      accepted
+    );
+    await new Promise(r => setImmediate(r));
+    const [err, res] = vi.mocked(accepted).mock.calls[0];
+    expect(err).toBeNull();
+    expect(res).toEqual({ userId: 'usr-signed' });
+  });
+
+  it('adaptUnauth with verification: forged headers without a token → null principal', async () => {
+    const handler = vi.fn(async (_d, principal) => ({ principal }));
+    const { logger } = makeLogger();
+    const wrapped = adaptUnauth('service.test', handler, {
+      deps,
+      logger,
+      principalVerification: { signingKey: SIGNING_KEY },
+    });
+
+    const callback = vi.fn() as unknown as sendUnaryData<unknown>;
+    wrapped(makeCall({}, buildMetadata(VALID_HEADERS)), callback);
+    await new Promise(r => setImmediate(r));
+
+    const [err, res] = vi.mocked(callback).mock.calls[0];
+    expect(err).toBeNull();
+    expect((res as { principal: null }).principal).toBeNull();
   });
 });
 

--- a/packages/service-bootstrap/src/adapter.ts
+++ b/packages/service-bootstrap/src/adapter.ts
@@ -34,7 +34,13 @@ import {
 } from '@adopt-dont-shop/observability';
 import type { Logger } from 'winston';
 
-import { extractPrincipal, extractPrincipalOptional, MissingPrincipalError } from './principal.js';
+import { getDefaultPrincipalSigningKey, PrincipalTokenError } from './principal-token.js';
+import {
+  extractPrincipal,
+  extractPrincipalOptional,
+  MissingPrincipalError,
+  type PrincipalVerification,
+} from './principal.js';
 
 // Canonical error code set. Services declare HandlerErrorCode as a
 // subset of this union; the shared CODE_TO_GRPC table covers all codes.
@@ -89,21 +95,36 @@ export type UnaryHandlerUnauth<Deps, Req, Res> = (
 export type AdaptOptions<Deps> = {
   deps: Deps;
   logger: Logger;
+  // Signed-principal verification (ADS-800). When set — or when the
+  // service has PRINCIPAL_SIGNING_KEY configured (resolved via
+  // config-secrets, so the _FILE variant works) — extractPrincipal
+  // requires a valid x-principal-token and takes the principal from the
+  // token payload instead of the x-user-* headers. Unset and no env key
+  // → legacy header-trust behaviour, unchanged.
+  principalVerification?: PrincipalVerification;
 };
+
+// Resolve the default verification config from PRINCIPAL_SIGNING_KEY.
+// Returns undefined when no key is configured (legacy header trust).
+function defaultPrincipalVerification(): PrincipalVerification | undefined {
+  const signingKey = getDefaultPrincipalSigningKey();
+  return signingKey ? { signingKey } : undefined;
+}
 
 export function adapt<Deps, Req, Res>(
   serviceName: string,
   handler: UnaryHandler<Deps, Req, Res>,
-  { deps, logger }: AdaptOptions<Deps>
+  { deps, logger, principalVerification }: AdaptOptions<Deps>
 ): (call: ServerUnaryCall<Req, Res>, callback: sendUnaryData<Res>) => void {
   return (call, callback) => {
+    const verification = principalVerification ?? defaultPrincipalVerification();
     const method = handler.name || 'unknown';
     const stop = startGrpcTimer(serviceName, method);
     const requestId = extractRequestIdFromMetadata(call.metadata);
     echoRequestId(call, requestId);
     void runWithRequestId(requestId, async () => {
       try {
-        const principal = extractPrincipal(call.metadata);
+        const principal = extractPrincipal(call.metadata, verification);
         const response = await handler(deps, principal, call.request);
         stop(status.OK);
         callback(null, response);
@@ -122,16 +143,17 @@ export function adapt<Deps, Req, Res>(
 export function adaptUnauth<Deps, Req, Res>(
   serviceName: string,
   handler: UnaryHandlerUnauth<Deps, Req, Res>,
-  { deps, logger }: AdaptOptions<Deps>
+  { deps, logger, principalVerification }: AdaptOptions<Deps>
 ): (call: ServerUnaryCall<Req, Res>, callback: sendUnaryData<Res>) => void {
   return (call, callback) => {
+    const verification = principalVerification ?? defaultPrincipalVerification();
     const method = handler.name || 'unknown';
     const stop = startGrpcTimer(serviceName, method);
     const requestId = extractRequestIdFromMetadata(call.metadata);
     echoRequestId(call, requestId);
     void runWithRequestId(requestId, async () => {
       try {
-        const principal = extractPrincipalOptional(call.metadata);
+        const principal = extractPrincipalOptional(call.metadata, verification);
         const response = await handler(deps, principal, call.request);
         stop(status.OK);
         callback(null, response);
@@ -162,6 +184,11 @@ function toServiceError(err: unknown, metadata: Metadata, logger: Logger): Servi
   if (isMissingPrincipalError(err)) {
     return makeServiceError(status.UNAUTHENTICATED, (err as Error).message, metadata);
   }
+  // PrincipalTokenError (ADS-800) — invalid / expired / malformed signed
+  // principal token. Same UNAUTHENTICATED path as a missing principal.
+  if (isPrincipalTokenError(err)) {
+    return makeServiceError(status.UNAUTHENTICATED, (err as Error).message, metadata);
+  }
   // HandlerError — duck-type on name + code rather than instanceof so that
   // service-local HandlerError subclasses (defined before handlers.ts was
   // migrated) are still detected correctly across module boundaries.
@@ -178,6 +205,13 @@ function isMissingPrincipalError(err: unknown): boolean {
   return (
     err instanceof MissingPrincipalError ||
     (err instanceof Error && err.name === 'MissingPrincipalError')
+  );
+}
+
+function isPrincipalTokenError(err: unknown): boolean {
+  return (
+    err instanceof PrincipalTokenError ||
+    (err instanceof Error && err.name === 'PrincipalTokenError')
   );
 }
 

--- a/packages/service-bootstrap/src/index.ts
+++ b/packages/service-bootstrap/src/index.ts
@@ -15,9 +15,18 @@
 //                               NOT_FOUND, ALREADY_EXISTS,
 //                               FAILED_PRECONDITION, INTERNAL).
 //   HandlerDeps               — base dependency type (pool + nats).
-//   extractPrincipal          — parse x-user-* gRPC metadata headers.
+//   extractPrincipal          — parse x-user-* gRPC metadata headers; when a
+//                               PRINCIPAL_SIGNING_KEY is configured, requires
+//                               and verifies a signed x-principal-token
+//                               instead (ADS-800).
 //   extractPrincipalOptional  — same but returns null on missing headers.
 //   MissingPrincipalError     — thrown by extractPrincipal on absent headers.
+//   principalToMetadata       — inverse of extractPrincipal; also stamps a
+//                               signed x-principal-token when a key is set.
+//   signPrincipalToken /
+//   verifyPrincipalToken      — HMAC-SHA256 signed principal tokens (ADS-800).
+//   PrincipalTokenError       — typed verification error (malformed /
+//                               bad_signature / expired).
 //   runServiceShutdown        — SIGTERM/SIGINT teardown sequencer.
 
 export { createMicroserviceServer } from './server.js';
@@ -41,6 +50,23 @@ export {
   principalToMetadata,
   MissingPrincipalError,
 } from './principal.js';
+export type { PrincipalVerification, PrincipalSigning } from './principal.js';
+
+export {
+  signPrincipalToken,
+  verifyPrincipalToken,
+  PrincipalTokenError,
+  PRINCIPAL_TOKEN_HEADER,
+  DEFAULT_PRINCIPAL_TOKEN_TTL_MS,
+  getDefaultPrincipalSigningKey,
+  resetDefaultPrincipalSigningKeyForTests,
+} from './principal-token.js';
+export type {
+  PrincipalTokenInput,
+  PrincipalTokenPayload,
+  PrincipalTokenErrorReason,
+  SignPrincipalTokenOptions,
+} from './principal-token.js';
 
 export { runServiceShutdown } from './shutdown.js';
 export type { ShutdownDeps } from './shutdown.js';

--- a/packages/service-bootstrap/src/principal-token.test.ts
+++ b/packages/service-bootstrap/src/principal-token.test.ts
@@ -1,0 +1,167 @@
+import * as crypto from 'node:crypto';
+
+import { describe, expect, it, vi } from 'vitest';
+
+// Spy-wrap timingSafeEqual so the suite can assert the MAC comparison is
+// constant-time rather than a `===` on strings (which leaks length/prefix
+// timing). Everything else passes through to the real node:crypto.
+vi.mock('node:crypto', async importOriginal => {
+  const actual = await importOriginal<typeof import('node:crypto')>();
+  return {
+    ...actual,
+    timingSafeEqual: vi.fn(actual.timingSafeEqual),
+  };
+});
+
+import {
+  DEFAULT_PRINCIPAL_TOKEN_TTL_MS,
+  PrincipalTokenError,
+  signPrincipalToken,
+  verifyPrincipalToken,
+} from './principal-token.js';
+
+const KEY = 'test-signing-key';
+
+const PRINCIPAL = {
+  userId: 'usr-1',
+  roles: ['rescue_staff', 'admin'],
+  permissions: ['pets.read', 'pets.update'],
+  rescueId: 'rsc-42',
+};
+
+describe('signPrincipalToken / verifyPrincipalToken — round trip', () => {
+  it('round-trips a full principal (incl. rescueId)', () => {
+    const token = signPrincipalToken(PRINCIPAL, KEY);
+    const verified = verifyPrincipalToken(token, KEY);
+    expect(verified).toEqual(PRINCIPAL);
+  });
+
+  it('round-trips a principal without rescueId', () => {
+    const { rescueId: _ignored, ...noRescue } = PRINCIPAL;
+    const token = signPrincipalToken(noRescue, KEY);
+    const verified = verifyPrincipalToken(token, KEY);
+    expect(verified.rescueId).toBeUndefined();
+    expect(verified.userId).toBe('usr-1');
+  });
+
+  it('produces a compact two-part dot-separated token', () => {
+    const token = signPrincipalToken(PRINCIPAL, KEY);
+    expect(token.split('.')).toHaveLength(2);
+    // base64url only — no '+', '/', '=' that would break header transport.
+    expect(token).toMatch(/^[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+$/);
+  });
+
+  it('defaults to a 120s TTL', () => {
+    const now = Date.now();
+    const token = signPrincipalToken(PRINCIPAL, KEY, { now });
+    // Just before expiry: still valid.
+    expect(() =>
+      verifyPrincipalToken(token, KEY, now + DEFAULT_PRINCIPAL_TOKEN_TTL_MS - 1)
+    ).not.toThrow();
+    // Just after expiry: rejected.
+    expect(() =>
+      verifyPrincipalToken(token, KEY, now + DEFAULT_PRINCIPAL_TOKEN_TTL_MS + 1)
+    ).toThrow(PrincipalTokenError);
+  });
+
+  it('honours a custom ttlMs', () => {
+    const now = Date.now();
+    const token = signPrincipalToken(PRINCIPAL, KEY, { now, ttlMs: 5_000 });
+    expect(() => verifyPrincipalToken(token, KEY, now + 4_999)).not.toThrow();
+    expect(() => verifyPrincipalToken(token, KEY, now + 5_001)).toThrow(PrincipalTokenError);
+  });
+});
+
+describe('verifyPrincipalToken — rejection paths', () => {
+  it('rejects a tampered payload (bad_signature)', () => {
+    const token = signPrincipalToken(PRINCIPAL, KEY);
+    const [payload, sig] = token.split('.');
+    const forged = JSON.parse(Buffer.from(payload, 'base64url').toString('utf8')) as Record<
+      string,
+      unknown
+    >;
+    forged.userId = 'attacker';
+    const tampered = `${Buffer.from(JSON.stringify(forged)).toString('base64url')}.${sig}`;
+
+    expect(() => verifyPrincipalToken(tampered, KEY)).toThrowError(PrincipalTokenError);
+    try {
+      verifyPrincipalToken(tampered, KEY);
+      expect.unreachable('should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(PrincipalTokenError);
+      expect((err as PrincipalTokenError).reason).toBe('bad_signature');
+    }
+  });
+
+  it('rejects a token signed with a different key (bad_signature)', () => {
+    const token = signPrincipalToken(PRINCIPAL, 'some-other-key');
+    try {
+      verifyPrincipalToken(token, KEY);
+      expect.unreachable('should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(PrincipalTokenError);
+      expect((err as PrincipalTokenError).reason).toBe('bad_signature');
+    }
+  });
+
+  it('rejects an expired token (expired)', () => {
+    const token = signPrincipalToken(PRINCIPAL, KEY, { ttlMs: -1 });
+    try {
+      verifyPrincipalToken(token, KEY);
+      expect.unreachable('should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(PrincipalTokenError);
+      expect((err as PrincipalTokenError).reason).toBe('expired');
+    }
+  });
+
+  it.each([
+    ['no separator', 'not-a-token'],
+    ['too many parts', 'a.b.c'],
+    ['empty payload', '.c2ln'],
+    ['empty signature', 'cGF5bG9hZA.'],
+    ['empty string', ''],
+  ])('rejects a malformed token: %s', (_label, bad) => {
+    try {
+      verifyPrincipalToken(bad, KEY);
+      expect.unreachable('should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(PrincipalTokenError);
+      expect((err as PrincipalTokenError).reason).toBe('malformed');
+    }
+  });
+
+  it('rejects a signed-but-not-JSON payload as malformed', () => {
+    // Build a token whose signature is valid for a non-JSON payload —
+    // signature passes, JSON parse fails.
+    const payload = Buffer.from('this is not json').toString('base64url');
+    const sig = crypto.createHmac('sha256', KEY).update(payload).digest('base64url');
+    try {
+      verifyPrincipalToken(`${payload}.${sig}`, KEY);
+      expect.unreachable('should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(PrincipalTokenError);
+      expect((err as PrincipalTokenError).reason).toBe('malformed');
+    }
+  });
+
+  it('rejects a signed payload that fails schema validation as malformed', () => {
+    const payload = Buffer.from(JSON.stringify({ userId: 'u' })).toString('base64url');
+    const sig = crypto.createHmac('sha256', KEY).update(payload).digest('base64url');
+    try {
+      verifyPrincipalToken(`${payload}.${sig}`, KEY);
+      expect.unreachable('should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(PrincipalTokenError);
+      expect((err as PrincipalTokenError).reason).toBe('malformed');
+    }
+  });
+
+  it('compares signatures with crypto.timingSafeEqual', () => {
+    const spy = vi.mocked(crypto.timingSafeEqual);
+    spy.mockClear();
+    const token = signPrincipalToken(PRINCIPAL, KEY);
+    verifyPrincipalToken(token, KEY);
+    expect(spy).toHaveBeenCalled();
+  });
+});

--- a/packages/service-bootstrap/src/principal-token.ts
+++ b/packages/service-bootstrap/src/principal-token.ts
@@ -1,0 +1,166 @@
+// Signed principal tokens for internal gRPC (ADS-800).
+//
+// The gateway (and any service stamping a system principal on a direct
+// service-to-service call) signs the principal it puts into the x-user-*
+// metadata headers and attaches the result as `x-principal-token`. A
+// receiving service configured with PRINCIPAL_SIGNING_KEY verifies the
+// token and takes the principal FROM THE TOKEN PAYLOAD — the headers
+// become informational, so a forged header can no longer win.
+//
+// Token format (compact, header-safe):
+//   base64url(JSON payload incl. iat/exp) + "." + base64url(HMAC-SHA256
+//   over the encoded payload, keyed with the shared signing key)
+//
+// node:crypto only — no new runtime dependency, no JWT library. The TTL
+// is short (default 120s): gRPC calls happen within the lifetime of the
+// originating request, and 120s is generous for clock skew between
+// containers on the same host.
+
+import { createHmac, timingSafeEqual } from 'node:crypto';
+
+import { z } from 'zod';
+
+import { readSecret } from '@adopt-dont-shop/config-secrets';
+
+import type { Principal } from '@adopt-dont-shop/authz';
+import type { Permission, RescueId, UserId, UserRole } from '@adopt-dont-shop/lib.types';
+
+export const DEFAULT_PRINCIPAL_TOKEN_TTL_MS = 120_000;
+
+export const PRINCIPAL_TOKEN_HEADER = 'x-principal-token';
+
+// Schema-first: the wire payload is the principal plus iat/exp epoch-ms
+// timestamps. Roles/permissions travel as plain strings — the verifier
+// narrows them back to the lib.types unions the same way extractPrincipal
+// always has for the header path.
+const PrincipalTokenInputSchema = z.object({
+  userId: z.string().min(1),
+  roles: z.array(z.string()),
+  permissions: z.array(z.string()),
+  rescueId: z.string().min(1).optional(),
+});
+
+const PrincipalTokenPayloadSchema = PrincipalTokenInputSchema.extend({
+  iat: z.number().int(),
+  exp: z.number().int(),
+});
+
+export type PrincipalTokenInput = z.infer<typeof PrincipalTokenInputSchema>;
+export type PrincipalTokenPayload = z.infer<typeof PrincipalTokenPayloadSchema>;
+
+export type PrincipalTokenErrorReason = 'malformed' | 'bad_signature' | 'expired';
+
+export class PrincipalTokenError extends Error {
+  constructor(
+    public readonly reason: PrincipalTokenErrorReason,
+    message: string
+  ) {
+    super(message);
+    this.name = 'PrincipalTokenError';
+  }
+}
+
+export type SignPrincipalTokenOptions = {
+  // Token lifetime in milliseconds. Defaults to 120s.
+  ttlMs?: number;
+  // Epoch-ms "now" — injectable for tests; defaults to Date.now().
+  now?: number;
+};
+
+export function signPrincipalToken(
+  principal: PrincipalTokenInput,
+  key: string,
+  opts: SignPrincipalTokenOptions = {}
+): string {
+  const iat = opts.now ?? Date.now();
+  const exp = iat + (opts.ttlMs ?? DEFAULT_PRINCIPAL_TOKEN_TTL_MS);
+  const payload: PrincipalTokenPayload = {
+    userId: principal.userId,
+    roles: [...principal.roles],
+    permissions: [...principal.permissions],
+    ...(principal.rescueId !== undefined ? { rescueId: principal.rescueId } : {}),
+    iat,
+    exp,
+  };
+  const encoded = Buffer.from(JSON.stringify(payload), 'utf8').toString('base64url');
+  return `${encoded}.${mac(encoded, key)}`;
+}
+
+export function verifyPrincipalToken(token: string, key: string, now?: number): Principal {
+  const parts = token.split('.');
+  if (parts.length !== 2 || parts[0].length === 0 || parts[1].length === 0) {
+    throw new PrincipalTokenError('malformed', 'principal token is not a two-part compact token');
+  }
+  const [encoded, signature] = parts;
+
+  // Verify the MAC before touching the payload. timingSafeEqual demands
+  // equal-length buffers — a length mismatch is itself a bad signature.
+  const expected = Buffer.from(mac(encoded, key), 'base64url');
+  const provided = Buffer.from(signature, 'base64url');
+  if (provided.length !== expected.length || !timingSafeEqual(provided, expected)) {
+    throw new PrincipalTokenError('bad_signature', 'principal token signature mismatch');
+  }
+
+  const payload = parsePayload(encoded);
+
+  if ((now ?? Date.now()) > payload.exp) {
+    throw new PrincipalTokenError('expired', 'principal token has expired');
+  }
+
+  // Same narrowing extractPrincipal performs on the header path: the
+  // wire carries plain strings; lib.types brands/unions are compile-time
+  // constructs over string.
+  return {
+    userId: payload.userId as UserId,
+    roles: payload.roles as UserRole[],
+    permissions: payload.permissions as Permission[],
+    rescueId: payload.rescueId !== undefined ? (payload.rescueId as RescueId) : undefined,
+  };
+}
+
+function parsePayload(encoded: string): PrincipalTokenPayload {
+  let raw: unknown;
+  try {
+    raw = JSON.parse(Buffer.from(encoded, 'base64url').toString('utf8'));
+  } catch {
+    throw new PrincipalTokenError('malformed', 'principal token payload is not valid JSON');
+  }
+  const parsed = PrincipalTokenPayloadSchema.safeParse(raw);
+  if (!parsed.success) {
+    throw new PrincipalTokenError(
+      'malformed',
+      'principal token payload does not match the expected schema'
+    );
+  }
+  return parsed.data;
+}
+
+function mac(encodedPayload: string, key: string): string {
+  return createHmac('sha256', key).update(encodedPayload).digest('base64url');
+}
+
+// --- Default signing-key resolution ----------------------------------
+//
+// PRINCIPAL_SIGNING_KEY is read through config-secrets (so the
+// PRINCIPAL_SIGNING_KEY_FILE Docker-secret variant works) and memoised:
+// principalToMetadata signs per-request, and re-reading a file-mounted
+// secret on every outbound call would be a sync read on the hot path.
+// Secrets are boot-time configuration — they don't rotate mid-process.
+
+let cachedDefaultKey: string | undefined;
+let defaultKeyResolved = false;
+
+export function getDefaultPrincipalSigningKey(): string | undefined {
+  if (!defaultKeyResolved) {
+    cachedDefaultKey = readSecret('PRINCIPAL_SIGNING_KEY')?.trim() || undefined;
+    defaultKeyResolved = true;
+  }
+  return cachedDefaultKey;
+}
+
+// Test seam — process.env changes after first resolution are invisible
+// without this.
+export function resetDefaultPrincipalSigningKeyForTests(): void {
+  cachedDefaultKey = undefined;
+  defaultKeyResolved = false;
+}

--- a/packages/service-bootstrap/src/principal.test.ts
+++ b/packages/service-bootstrap/src/principal.test.ts
@@ -1,7 +1,18 @@
 import { Metadata } from '@grpc/grpc-js';
 import { describe, expect, it } from 'vitest';
 
-import { extractPrincipal, extractPrincipalOptional, MissingPrincipalError } from './principal.js';
+import {
+  PRINCIPAL_TOKEN_HEADER,
+  PrincipalTokenError,
+  signPrincipalToken,
+  verifyPrincipalToken,
+} from './principal-token.js';
+import {
+  extractPrincipal,
+  extractPrincipalOptional,
+  MissingPrincipalError,
+  principalToMetadata,
+} from './principal.js';
 
 function build(headers: Record<string, string>): Metadata {
   const m = new Metadata();
@@ -52,6 +63,117 @@ describe('extractPrincipal', () => {
       })
     );
     expect(p.permissions).toEqual([]);
+  });
+});
+
+const SIGNING_KEY = 'principal-test-key';
+
+const TOKEN_PRINCIPAL = {
+  userId: 'usr-token',
+  roles: ['rescue_staff'],
+  permissions: ['pets.read'],
+  rescueId: 'rsc-token',
+};
+
+describe('extractPrincipal — with verification (signing key set)', () => {
+  it('accepts a valid token and takes the principal from the token payload', () => {
+    const token = signPrincipalToken(TOKEN_PRINCIPAL, SIGNING_KEY);
+    const p = extractPrincipal(build({ [PRINCIPAL_TOKEN_HEADER]: token }), {
+      signingKey: SIGNING_KEY,
+    });
+    expect(p).toEqual(TOKEN_PRINCIPAL);
+  });
+
+  it('rejects a request with no token even when x-user-* headers are present', () => {
+    const m = build({
+      'x-user-id': 'attacker',
+      'x-user-roles': 'super_admin',
+      'x-user-permissions': 'admin.security.manage',
+    });
+    expect(() => extractPrincipal(m, { signingKey: SIGNING_KEY })).toThrowError(
+      MissingPrincipalError
+    );
+  });
+
+  it('forged headers alongside a valid token: the token payload wins', () => {
+    const token = signPrincipalToken(TOKEN_PRINCIPAL, SIGNING_KEY);
+    const m = build({
+      [PRINCIPAL_TOKEN_HEADER]: token,
+      'x-user-id': 'attacker',
+      'x-user-roles': 'super_admin',
+      'x-user-permissions': 'admin.security.manage',
+      'x-rescue-id': 'rsc-attacker',
+    });
+    const p = extractPrincipal(m, { signingKey: SIGNING_KEY });
+    expect(p.userId).toBe('usr-token');
+    expect(p.roles).toEqual(['rescue_staff']);
+    expect(p.permissions).toEqual(['pets.read']);
+    expect(p.rescueId).toBe('rsc-token');
+  });
+
+  it('rejects a token signed with the wrong key', () => {
+    const token = signPrincipalToken(TOKEN_PRINCIPAL, 'wrong-key');
+    expect(() =>
+      extractPrincipal(build({ [PRINCIPAL_TOKEN_HEADER]: token }), { signingKey: SIGNING_KEY })
+    ).toThrowError(PrincipalTokenError);
+  });
+
+  it('rejects an expired token', () => {
+    const token = signPrincipalToken(TOKEN_PRINCIPAL, SIGNING_KEY, { ttlMs: -1 });
+    expect(() =>
+      extractPrincipal(build({ [PRINCIPAL_TOKEN_HEADER]: token }), { signingKey: SIGNING_KEY })
+    ).toThrowError(PrincipalTokenError);
+  });
+});
+
+describe('extractPrincipalOptional — with verification (signing key set)', () => {
+  it('returns null when no token is present (even with forged headers)', () => {
+    const m = build({ 'x-user-id': 'attacker', 'x-user-roles': 'super_admin' });
+    expect(extractPrincipalOptional(m, { signingKey: SIGNING_KEY })).toBeNull();
+  });
+
+  it('returns null for an invalid token rather than trusting headers', () => {
+    const m = build({
+      [PRINCIPAL_TOKEN_HEADER]: signPrincipalToken(TOKEN_PRINCIPAL, 'wrong-key'),
+      'x-user-id': 'attacker',
+      'x-user-roles': 'super_admin',
+    });
+    expect(extractPrincipalOptional(m, { signingKey: SIGNING_KEY })).toBeNull();
+  });
+
+  it('returns the token principal for a valid token', () => {
+    const m = build({
+      [PRINCIPAL_TOKEN_HEADER]: signPrincipalToken(TOKEN_PRINCIPAL, SIGNING_KEY),
+    });
+    expect(extractPrincipalOptional(m, { signingKey: SIGNING_KEY })?.userId).toBe('usr-token');
+  });
+});
+
+describe('principalToMetadata — signing', () => {
+  const principal = extractPrincipal(
+    build({
+      'x-user-id': 'usr-fwd',
+      'x-user-roles': 'rescue_staff',
+      'x-user-permissions': 'pets.read',
+      'x-rescue-id': 'rsc-9',
+    })
+  );
+
+  it('stamps x-principal-token when a signing key is supplied', () => {
+    const m = principalToMetadata(principal, { signingKey: SIGNING_KEY });
+    const token = m.get(PRINCIPAL_TOKEN_HEADER)[0];
+    expect(typeof token).toBe('string');
+    expect(verifyPrincipalToken(String(token), SIGNING_KEY)).toEqual(principal);
+  });
+
+  it('round-trips through extractPrincipal with verification enabled', () => {
+    const m = principalToMetadata(principal, { signingKey: SIGNING_KEY });
+    expect(extractPrincipal(m, { signingKey: SIGNING_KEY })).toEqual(principal);
+  });
+
+  it('does not stamp a token when no signing key is configured', () => {
+    const m = principalToMetadata(principal);
+    expect(m.get(PRINCIPAL_TOKEN_HEADER)).toHaveLength(0);
   });
 });
 

--- a/packages/service-bootstrap/src/principal.ts
+++ b/packages/service-bootstrap/src/principal.ts
@@ -1,5 +1,12 @@
 import { Metadata } from '@grpc/grpc-js';
 
+import {
+  getDefaultPrincipalSigningKey,
+  PRINCIPAL_TOKEN_HEADER,
+  signPrincipalToken,
+  verifyPrincipalToken,
+} from './principal-token.js';
+
 import type { Principal } from '@adopt-dont-shop/authz';
 import type { Permission, RescueId, UserId, UserRole } from '@adopt-dont-shop/lib.types';
 
@@ -10,7 +17,29 @@ export class MissingPrincipalError extends Error {
   }
 }
 
-export function extractPrincipal(metadata: Metadata): Principal {
+// Verification config (ADS-800). When a signing key is present the
+// service REQUIRES a valid x-principal-token and takes the principal
+// from the token payload — the x-user-* headers become informational,
+// so a forged header can't win. When absent, the legacy header-trust
+// behaviour is unchanged (phased rollout / dev without the key).
+export type PrincipalVerification = {
+  signingKey: string;
+};
+
+export function extractPrincipal(
+  metadata: Metadata,
+  verification?: PrincipalVerification
+): Principal {
+  if (verification) {
+    const token = headerOne(metadata, PRINCIPAL_TOKEN_HEADER);
+    if (!token) {
+      throw new MissingPrincipalError(`missing ${PRINCIPAL_TOKEN_HEADER} metadata`);
+    }
+    // Throws PrincipalTokenError (→ UNAUTHENTICATED) on bad signature /
+    // expiry / malformed payload.
+    return verifyPrincipalToken(token, verification.signingKey);
+  }
+
   const userId = headerOne(metadata, 'x-user-id');
   if (!userId) {
     throw new MissingPrincipalError('missing x-user-id metadata');
@@ -45,26 +74,48 @@ export function extractPrincipal(metadata: Metadata): Principal {
 
 // extractPrincipalOptional — returns null if metadata is absent or incomplete.
 // Used by public-read handlers (adaptUnauth) so they can pass null through
-// to the handler rather than throwing.
-export function extractPrincipalOptional(metadata: Metadata): Principal | null {
+// to the handler rather than throwing. With verification enabled this is
+// fail-closed: a missing OR invalid token yields null (unauthenticated),
+// never a header-derived principal.
+export function extractPrincipalOptional(
+  metadata: Metadata,
+  verification?: PrincipalVerification
+): Principal | null {
   try {
-    return extractPrincipal(metadata);
+    return extractPrincipal(metadata, verification);
   } catch {
     return null;
   }
 }
 
+export type PrincipalSigning = {
+  signingKey: string;
+  ttlMs?: number;
+};
+
 // principalToMetadata — inverse of extractPrincipal. Serialises a Principal
 // back into x-user-* metadata headers for outbound service-to-service calls.
 // Used by services that forward the caller's identity to another service
 // (e.g. applications → pets, matching → pets).
-export function principalToMetadata(principal: Principal): Metadata {
+//
+// When a signing key is available — passed explicitly, or resolved from
+// PRINCIPAL_SIGNING_KEY via config-secrets — the same principal is also
+// stamped as a signed x-principal-token so a downstream service running
+// with verification enabled accepts the forwarded call.
+export function principalToMetadata(principal: Principal, signing?: PrincipalSigning): Metadata {
   const metadata = new Metadata();
   metadata.set('x-user-id', principal.userId);
   metadata.set('x-user-roles', principal.roles.join(','));
   metadata.set('x-user-permissions', principal.permissions.join(','));
   if (principal.rescueId !== undefined) {
     metadata.set('x-rescue-id', principal.rescueId);
+  }
+  const signingKey = signing?.signingKey ?? getDefaultPrincipalSigningKey();
+  if (signingKey) {
+    metadata.set(
+      PRINCIPAL_TOKEN_HEADER,
+      signPrincipalToken(principal, signingKey, { ttlMs: signing?.ttlMs })
+    );
   }
   return metadata;
 }

--- a/secrets/README.md
+++ b/secrets/README.md
@@ -19,6 +19,7 @@ before `docker compose up -d`; the deploy workflow
 | `jwt_secret`                  | `service-auth`                  | access-token signing secret                                    |
 | `jwt_refresh_secret`          | `service-auth`                  | refresh-token signing secret                                   |
 | `upload_signing_secret`       | `service-gateway`               | HMAC secret for `/uploads-signed` URLs                         |
+| `principal_signing_key`       | `service-gateway` + every domain service | HMAC key for the signed `x-principal-token` gRPC metadata (ADS-800) |
 | `db_password` (staging only)  | `database` container            | Postgres superuser password (read via `POSTGRES_PASSWORD_FILE`) |
 
 Each file must contain only the secret value (trailing whitespace is

--- a/services/gateway/package.json
+++ b/services/gateway/package.json
@@ -36,6 +36,7 @@
     "@adopt-dont-shop/events": "*",
     "@adopt-dont-shop/observability": "*",
     "@adopt-dont-shop/proto": "*",
+    "@adopt-dont-shop/service-bootstrap": "*",
     "@adopt-dont-shop/storage": "*",
     "@fastify/multipart": "^9.0.3",
     "@fastify/rate-limit": "^10.3.0",

--- a/services/gateway/src/config.test.ts
+++ b/services/gateway/src/config.test.ts
@@ -104,3 +104,20 @@ describe('loadConfig', () => {
     expect(config.rateLimit.max).toBe(100);
   });
 });
+
+describe('loadConfig — principal signing key (ADS-800)', () => {
+  it('is undefined when PRINCIPAL_SIGNING_KEY is unset', () => {
+    const config = loadConfig({});
+    expect(config.principalSigningKey).toBeUndefined();
+  });
+
+  it('reads PRINCIPAL_SIGNING_KEY from the environment', () => {
+    const config = loadConfig({ PRINCIPAL_SIGNING_KEY: 'dev-signing-key' });
+    expect(config.principalSigningKey).toBe('dev-signing-key');
+  });
+
+  it('treats a blank PRINCIPAL_SIGNING_KEY as unset', () => {
+    const config = loadConfig({ PRINCIPAL_SIGNING_KEY: '   ' });
+    expect(config.principalSigningKey).toBeUndefined();
+  });
+});

--- a/services/gateway/src/config.ts
+++ b/services/gateway/src/config.ts
@@ -101,6 +101,13 @@ export type GatewayConfig = {
   config: {
     publicEnabled: boolean;
   };
+  // HMAC key for signed principal tokens (ADS-800). When set, the
+  // authenticate middleware stamps a signed x-principal-token alongside
+  // the x-user-* headers so downstream gRPC services running with the
+  // same key can verify the principal instead of trusting bare headers.
+  // Optional: unset → legacy header-only propagation (phased rollout).
+  // Read via config-secrets so PRINCIPAL_SIGNING_KEY_FILE works.
+  principalSigningKey: string | undefined;
   // Rate limiting — applied at the gateway edge for every route.
   // Backed by a shared Redis store in production/staging so per-replica
   // limits don't multiply by N replicas. Falls back to an in-memory
@@ -174,6 +181,7 @@ export const loadConfig = (env: NodeJS.ProcessEnv = process.env): GatewayConfig 
     config: {
       publicEnabled: env.GATEWAY_CONFIG_ENABLED?.trim().toLowerCase() !== 'false',
     },
+    principalSigningKey: readSecret('PRINCIPAL_SIGNING_KEY', env)?.trim() || undefined,
     rateLimit: buildRateLimitConfig(env),
   };
 };

--- a/services/gateway/src/middleware/authenticate.test.ts
+++ b/services/gateway/src/middleware/authenticate.test.ts
@@ -2,6 +2,7 @@ import Fastify, { type FastifyInstance } from 'fastify';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { AuthV1, type ValidateTokenResponse } from '@adopt-dont-shop/proto';
+import { verifyPrincipalToken } from '@adopt-dont-shop/service-bootstrap';
 
 import type { AuthClient } from '../grpc-clients/auth-client.js';
 
@@ -22,7 +23,7 @@ type ValidatedHeaders = {
   'x-rescue-id'?: string;
 };
 
-function makeApp(authClient: AuthClient): Promise<FastifyInstance> {
+function makeApp(authClient: AuthClient, principalSigningKey?: string): Promise<FastifyInstance> {
   const app = Fastify({ logger: false });
   // Echo endpoint that returns the headers the middleware left on
   // the request. Anything spoofable that survives is a failure.
@@ -33,11 +34,14 @@ function makeApp(authClient: AuthClient): Promise<FastifyInstance> {
       roles: h['x-user-roles'] ?? null,
       permissions: h['x-user-permissions'] ?? null,
       rescueId: h['x-rescue-id'] ?? null,
+      principalToken: h['x-principal-token'] ?? null,
     };
   });
   app.get('/health/simple', async () => ({ ok: true }));
   app.post('/api/auth/login', async () => ({ logged: 'in' }));
-  return registerAuthenticate(app, { authClient, logger: quietLogger }).then(() => app);
+  return registerAuthenticate(app, { authClient, logger: quietLogger, principalSigningKey }).then(
+    () => app
+  );
 }
 
 function makeAuthClient(): { client: AuthClient; validateMock: ReturnType<typeof vi.fn> } {
@@ -217,6 +221,84 @@ describe('registerAuthenticate — no token on protected route', () => {
       // spoof, and the middleware didn't add any.
       const body = res.json() as ValidatedHeaders;
       expect(body['x-user-id']).toBeUndefined();
+    } finally {
+      await app.close();
+    }
+  });
+});
+
+describe('registerAuthenticate — signed principal token (ADS-800)', () => {
+  const SIGNING_KEY = 'gateway-test-signing-key';
+
+  it('strips a client-supplied x-principal-token even when no signing key is configured', async () => {
+    const { client } = makeAuthClient();
+    const app = await makeApp(client);
+    try {
+      const res = await app.inject({
+        method: 'GET',
+        url: '/api/echo',
+        headers: { 'x-principal-token': 'forged.token' },
+      });
+      expect(res.statusCode).toBe(200);
+      expect((res.json() as { principalToken: string | null }).principalToken).toBeNull();
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('stamps a verifiable x-principal-token over the validated principal when a key is configured', async () => {
+    const { client, validateMock } = makeAuthClient();
+    validateMock.mockResolvedValueOnce(VALIDATED_RES);
+    const app = await makeApp(client, SIGNING_KEY);
+    try {
+      const res = await app.inject({
+        method: 'GET',
+        url: '/api/echo',
+        headers: {
+          authorization: 'Bearer good.token',
+          // Forged token alongside a valid bearer: must be replaced.
+          'x-principal-token': 'forged.token',
+        },
+      });
+      expect(res.statusCode).toBe(200);
+      const { principalToken } = res.json() as { principalToken: string | null };
+      expect(principalToken).not.toBeNull();
+      expect(principalToken).not.toBe('forged.token');
+      const principal = verifyPrincipalToken(String(principalToken), SIGNING_KEY);
+      expect(principal.userId).toBe('usr-1');
+      expect(principal.roles).toEqual(['rescue_staff', 'admin']);
+      expect(principal.permissions).toEqual(['pets.read', 'pets.update']);
+      expect(principal.rescueId).toBe('rsc-1');
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('does not stamp x-principal-token when no signing key is configured', async () => {
+    const { client, validateMock } = makeAuthClient();
+    validateMock.mockResolvedValueOnce(VALIDATED_RES);
+    const app = await makeApp(client);
+    try {
+      const res = await app.inject({
+        method: 'GET',
+        url: '/api/echo',
+        headers: { authorization: 'Bearer good.token' },
+      });
+      expect(res.statusCode).toBe(200);
+      expect((res.json() as { principalToken: string | null }).principalToken).toBeNull();
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('does not stamp x-principal-token for an unauthenticated request even with a key', async () => {
+    const { client, validateMock } = makeAuthClient();
+    const app = await makeApp(client, SIGNING_KEY);
+    try {
+      const res = await app.inject({ method: 'GET', url: '/api/echo' });
+      expect(res.statusCode).toBe(200);
+      expect((res.json() as { principalToken: string | null }).principalToken).toBeNull();
+      expect(validateMock).not.toHaveBeenCalled();
     } finally {
       await app.close();
     }

--- a/services/gateway/src/middleware/authenticate.ts
+++ b/services/gateway/src/middleware/authenticate.ts
@@ -32,20 +32,31 @@ import { status as grpcStatus, Metadata } from '@grpc/grpc-js';
 import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
 import type { Logger } from 'winston';
 
+import { signPrincipalToken } from '@adopt-dont-shop/service-bootstrap';
+
 import type { AuthClient } from '../grpc-clients/auth-client.js';
 
 export type AuthMiddlewareOptions = {
   authClient: AuthClient;
   logger: Logger;
+  // ADS-800: when set, a signed x-principal-token is stamped alongside
+  // the x-user-* headers after ValidateToken succeeds, signed over the
+  // same principal. buildMetadata forwards it so downstream services
+  // running with the same PRINCIPAL_SIGNING_KEY verify the principal
+  // cryptographically instead of trusting the bare headers.
+  principalSigningKey?: string;
 };
 
 // Headers we strip on every request — anything else the client sends
-// is forwarded as-is.
+// is forwarded as-is. x-principal-token is in the list because the
+// gateway mints it itself (ADS-800); a client-supplied one must never
+// survive.
 const SPOOFABLE_HEADERS = [
   'x-user-id',
   'x-user-roles',
   'x-user-permissions',
   'x-rescue-id',
+  'x-principal-token',
 ] as const;
 
 // Paths the gateway lets through WITHOUT requiring (or rejecting on
@@ -69,7 +80,7 @@ export const registerAuthenticate = async (
   app: FastifyInstance,
   opts: AuthMiddlewareOptions
 ): Promise<void> => {
-  const { authClient, logger } = opts;
+  const { authClient, logger, principalSigningKey } = opts;
 
   app.addHook('onRequest', async (req, reply) => {
     // Step 1: strip spoofable headers. ALWAYS.
@@ -114,11 +125,26 @@ export const registerAuthenticate = async (
       // forwarding) picks it up via the same paths that previously
       // trusted client-supplied versions.
       const headers = req.headers as Record<string, string>;
+      const roles = principal.roles.map(stringifyRole);
       headers['x-user-id'] = principal.userId;
-      headers['x-user-roles'] = principal.roles.map(stringifyRole).join(',');
+      headers['x-user-roles'] = roles.join(',');
       headers['x-user-permissions'] = principal.permissions.join(',');
       if (principal.rescueId) {
         headers['x-rescue-id'] = principal.rescueId;
+      }
+      // ADS-800: sign the same principal so downstream services can
+      // verify it instead of trusting the headers. Minted per request —
+      // well inside the token TTL for any gRPC call this request makes.
+      if (principalSigningKey) {
+        headers['x-principal-token'] = signPrincipalToken(
+          {
+            userId: principal.userId,
+            roles,
+            permissions: [...principal.permissions],
+            ...(principal.rescueId ? { rescueId: principal.rescueId } : {}),
+          },
+          principalSigningKey
+        );
       }
     } catch (err) {
       // Invalid / expired / revoked token. On public paths, drop the

--- a/services/gateway/src/middleware/metadata.test.ts
+++ b/services/gateway/src/middleware/metadata.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+
+import type { FastifyRequest } from 'fastify';
+
+import { buildMetadata } from './metadata.js';
+
+// buildMetadata only reads req.headers — a plain object is enough.
+function makeRequest(headers: Record<string, string | string[] | undefined>): FastifyRequest {
+  return { headers } as unknown as FastifyRequest;
+}
+
+describe('buildMetadata', () => {
+  it('forwards the identity, request-id and principal-token headers', () => {
+    const m = buildMetadata(
+      makeRequest({
+        'x-user-id': 'usr-1',
+        'x-user-roles': 'rescue_staff,admin',
+        'x-user-permissions': 'pets.read',
+        'x-rescue-id': 'rsc-1',
+        'x-request-id': 'req-1',
+        'x-principal-token': 'payload.signature',
+      })
+    );
+
+    expect(m.get('x-user-id')).toEqual(['usr-1']);
+    expect(m.get('x-user-roles')).toEqual(['rescue_staff,admin']);
+    expect(m.get('x-user-permissions')).toEqual(['pets.read']);
+    expect(m.get('x-rescue-id')).toEqual(['rsc-1']);
+    expect(m.get('x-request-id')).toEqual(['req-1']);
+    expect(m.get('x-principal-token')).toEqual(['payload.signature']);
+  });
+
+  it('omits absent and empty headers', () => {
+    const m = buildMetadata(makeRequest({ 'x-user-id': '', 'x-request-id': undefined }));
+    expect(m.get('x-user-id')).toHaveLength(0);
+    expect(m.get('x-request-id')).toHaveLength(0);
+    expect(m.get('x-principal-token')).toHaveLength(0);
+  });
+
+  it('does not forward arbitrary headers', () => {
+    const m = buildMetadata(makeRequest({ authorization: 'Bearer secret', cookie: 'a=b' }));
+    expect(m.get('authorization')).toHaveLength(0);
+    expect(m.get('cookie')).toHaveLength(0);
+  });
+});

--- a/services/gateway/src/middleware/metadata.ts
+++ b/services/gateway/src/middleware/metadata.ts
@@ -5,6 +5,9 @@
 // Forwards:
 //   - x-user-id / x-user-roles / x-user-permissions / x-rescue-id
 //     (stamped by the authenticate middleware after ValidateToken)
+//   - x-principal-token (ADS-800 — signed principal, stamped by the
+//     authenticate middleware when PRINCIPAL_SIGNING_KEY is configured;
+//     the middleware strips any client-supplied value first)
 //   - x-request-id (stamped by the request-id middleware; either
 //     mirrored from the inbound header or minted as a UUID)
 //
@@ -20,6 +23,7 @@ const FORWARDED_HEADERS = [
   'x-user-roles',
   'x-user-permissions',
   'x-rescue-id',
+  'x-principal-token',
   'x-request-id',
 ] as const;
 

--- a/services/gateway/src/server.ts
+++ b/services/gateway/src/server.ts
@@ -330,7 +330,11 @@ export const createServer = async (opts: CreateServerOptions): Promise<FastifyIn
   // request that ends up at the catch-all proxy can't carry forged
   // x-user-* headers to the monolith.
   if (opts.authClient) {
-    await registerAuthenticate(server, { authClient: opts.authClient, logger });
+    await registerAuthenticate(server, {
+      authClient: opts.authClient,
+      logger,
+      principalSigningKey: config.principalSigningKey,
+    });
   }
 
   // Service-specific routes register at /api/v1/<domain> BEFORE the

--- a/services/notifications/src/grpc/auth-client.test.ts
+++ b/services/notifications/src/grpc/auth-client.test.ts
@@ -28,6 +28,11 @@ import {
   type ListUserIdsByCohortRequest,
   type ListUserIdsByCohortResponse,
 } from '@adopt-dont-shop/proto';
+import {
+  PRINCIPAL_TOKEN_HEADER,
+  resetDefaultPrincipalSigningKeyForTests,
+  verifyPrincipalToken,
+} from '@adopt-dont-shop/service-bootstrap';
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
@@ -173,6 +178,85 @@ describe('createAuthCohortClient (notifications) — deadline + retry behaviour'
     } catch (err: unknown) {
       expect((err as { code?: number }).code).toBe(status.INVALID_ARGUMENT);
       expect(callCount).toBe(1);
+    } finally {
+      client.close();
+    }
+  });
+});
+
+describe('createAuthCohortClient — signed system principal (ADS-800)', () => {
+  const SIGNING_KEY = 'notifications-test-signing-key';
+  let server: Server;
+
+  beforeEach(() => {
+    server = new Server();
+  });
+
+  afterEach(async () => {
+    delete process.env.PRINCIPAL_SIGNING_KEY;
+    resetDefaultPrincipalSigningKeyForTests();
+    await new Promise<void>(resolve => server.tryShutdown(() => resolve()));
+  });
+
+  const emptyResponse: ListUserIdsByCohortResponse = {
+    userIds: [],
+    total: 0,
+    page: 1,
+    totalPages: 0,
+  };
+
+  const startCapturingServer = async (): Promise<{ port: number; captured: Metadata[] }> => {
+    const captured: Metadata[] = [];
+    server.addService(AuthV1.AuthServiceService, {
+      listUserIdsByCohort: (
+        call: ServerUnaryCall<ListUserIdsByCohortRequest, ListUserIdsByCohortResponse>,
+        cb: sendUnaryData<ListUserIdsByCohortResponse>
+      ) => {
+        captured.push(call.metadata);
+        cb(null, emptyResponse);
+      },
+    });
+    const port = await new Promise<number>((resolve, reject) => {
+      server.bindAsync('127.0.0.1:0', ServerCredentials.createInsecure(), (err, boundPort) =>
+        err ? reject(err) : resolve(boundPort)
+      );
+    });
+    return { port, captured };
+  };
+
+  it('stamps a verifiable x-principal-token over the system principal when PRINCIPAL_SIGNING_KEY is set', async () => {
+    process.env.PRINCIPAL_SIGNING_KEY = SIGNING_KEY;
+    resetDefaultPrincipalSigningKeyForTests();
+
+    const { port, captured } = await startCapturingServer();
+    const client = createAuthCohortClient({ address: `127.0.0.1:${port}` });
+    try {
+      await client.listUserIdsByCohort(emptyListRequest);
+      expect(captured).toHaveLength(1);
+      const meta = captured[0];
+      // Legacy headers still present for services running without the key.
+      expect(meta.get('x-user-id')).toEqual(['svc-notifications']);
+      expect(meta.get('x-user-roles')).toEqual(['admin']);
+      expect(meta.get('x-user-permissions')).toEqual(['admin.users.broadcast']);
+      // And the signed token carries the same principal.
+      const token = String(meta.get(PRINCIPAL_TOKEN_HEADER)[0]);
+      const principal = verifyPrincipalToken(token, SIGNING_KEY);
+      expect(principal.userId).toBe('svc-notifications');
+      expect(principal.roles).toEqual(['admin']);
+      expect(principal.permissions).toEqual(['admin.users.broadcast']);
+    } finally {
+      client.close();
+    }
+  });
+
+  it('does not stamp x-principal-token when no signing key is configured', async () => {
+    const { port, captured } = await startCapturingServer();
+    const client = createAuthCohortClient({ address: `127.0.0.1:${port}` });
+    try {
+      await client.listUserIdsByCohort(emptyListRequest);
+      expect(captured).toHaveLength(1);
+      expect(captured[0].get(PRINCIPAL_TOKEN_HEADER)).toHaveLength(0);
+      expect(captured[0].get('x-user-id')).toEqual(['svc-notifications']);
     } finally {
       client.close();
     }

--- a/services/notifications/src/grpc/auth-client.ts
+++ b/services/notifications/src/grpc/auth-client.ts
@@ -10,6 +10,11 @@ import {
   type ListUserIdsByCohortRequest,
   type ListUserIdsByCohortResponse,
 } from '@adopt-dont-shop/proto';
+import {
+  getDefaultPrincipalSigningKey,
+  PRINCIPAL_TOKEN_HEADER,
+  signPrincipalToken,
+} from '@adopt-dont-shop/service-bootstrap';
 
 import type { AuthCohortClient } from './handlers.js';
 
@@ -49,6 +54,12 @@ const isRetryableError = (err: unknown): boolean => {
 
 const sleep = (ms: number): Promise<void> => new Promise(resolve => setTimeout(resolve, ms));
 
+const splitList = (raw: string): string[] =>
+  raw
+    .split(',')
+    .map(s => s.trim())
+    .filter(Boolean);
+
 const jitteredBackoff = (attempt: number, baseMs: number): number => {
   // Exponential backoff with ±25% jitter: 100ms, 200ms (base defaults).
   const base = baseMs * Math.pow(2, attempt - 1);
@@ -62,10 +73,29 @@ export function createAuthCohortClient(opts: CreateAuthCohortClientOptions): Aut
   const deadlineMs = opts.deadlineMs ?? DEFAULT_DEADLINE_MS;
   const maxRetries = opts.maxRetries ?? DEFAULT_MAX_RETRIES;
 
-  const systemMeta = new Metadata();
-  systemMeta.set('x-user-id', opts.systemUserId ?? 'svc-notifications');
-  systemMeta.set('x-user-roles', opts.systemRoles ?? 'admin');
-  systemMeta.set('x-user-permissions', opts.systemPermissions ?? 'admin.users.broadcast');
+  const systemPrincipal = {
+    userId: opts.systemUserId ?? 'svc-notifications',
+    roles: splitList(opts.systemRoles ?? 'admin'),
+    permissions: splitList(opts.systemPermissions ?? 'admin.users.broadcast'),
+  };
+
+  // Built per attempt, not once at client creation: the signed
+  // x-principal-token (ADS-800) carries a short TTL, so a metadata
+  // object minted at boot would expire. When PRINCIPAL_SIGNING_KEY is
+  // configured (read via config-secrets, _FILE variant supported) the
+  // system principal is signed with the shared helper; the x-user-*
+  // headers stay for services still running without the key.
+  const buildSystemMetadata = (): Metadata => {
+    const meta = new Metadata();
+    meta.set('x-user-id', systemPrincipal.userId);
+    meta.set('x-user-roles', systemPrincipal.roles.join(','));
+    meta.set('x-user-permissions', systemPrincipal.permissions.join(','));
+    const signingKey = getDefaultPrincipalSigningKey();
+    if (signingKey) {
+      meta.set(PRINCIPAL_TOKEN_HEADER, signPrincipalToken(systemPrincipal, signingKey));
+    }
+    return meta;
+  };
 
   const callWithRetry = <Req, Res>(
     fn: (
@@ -81,7 +111,7 @@ export function createAuthCohortClient(opts: CreateAuthCohortClientOptions): Aut
         const options: Partial<CallOptions> = {
           deadline: new Date(Date.now() + deadlineMs),
         };
-        fn.call(stub, req, systemMeta, options, (err: unknown, res: Res) => {
+        fn.call(stub, req, buildSystemMetadata(), options, (err: unknown, res: Res) => {
           if (err) {
             if (remaining > 0 && isRetryableError(err)) {
               const retryIndex = maxRetries - remaining + 1;


### PR DESCRIPTION
Batch 5 from the June 2026 architecture audit — the decision-gated tickets. One conventional commit per ticket group.

## ADS-800 — signed principal tokens for internal gRPC (Security)
Scope pivot (agreed, recorded on the ticket): app-layer signed principals instead of mTLS — addresses identity forgery on the single-host compose deployment without cert provisioning; mTLS remains future work for encryption-in-transit.

- New token helper in `service-bootstrap` (node:crypto HMAC-SHA256, base64url compact, 120s TTL, timing-safe verify, zod payload schema, typed errors)
- Gateway strips `x-principal-token` from inbound requests and stamps a signed token alongside `x-user-*` on every gRPC call; notifications' direct S2S path signs its system principal per attempt
- Services with `PRINCIPAL_SIGNING_KEY` configured require a valid token and take the principal **from the token** (forged headers lose, UNAUTHENTICATED on failure); key unset = legacy behaviour, so rollout is phased — deploy signers first, then enable verification per service
- Wired through dev compose, prod/staging `_FILE` secrets, deploy.yml materialisation, and E2E secret generation; `internal-grpc-trust.md` rewritten

## ADS-826 — deploy bypass approval + audit trail (Security)
- New `preflight` job: production → `production` environment; production + `skip_ci_check`/`skip_cosign_verify` → `production-bypass` (reviewers see they're approving a bypass); any bypass requires non-empty `bypass_reason` or the run fails before anything builds
- Every bypass recorded in the run summary and a `deploy-bypass-audit` issue (actor, env, DEPLOY_SHA, flags, reason)
- Environments don't block until an admin adds required reviewers — safe to merge first; setup clicks in `docs/operations/deploy.md`

## ADS-792 residual — E2E image builds use BuildKit GHA cache
- `buildx bake` with per-target `type=gha` scopes, `mode=min` (reasoned against the 10GB budget in step comments), `ignore-error` degradation, dynamic target discovery with fallback to the previous uncached build
- Tags set explicitly to what `compose up --no-build` resolves (verified against `compose config --images` — bake assigns none from this compose file)
- Known residual risk: cold-cache peak disk with the container driver; mitigated by the disk-free step + post-load `buildx prune`. Watch the first run's `df -h`.

## Post-merge manual steps (admin)
1. **GitHub secret**: add `PRINCIPAL_SIGNING_KEY` (`openssl rand -hex 32`) to both deploy environments — the next prod/staging deploy materialises `secrets/principal_signing_key` from it.
2. **Environments**: Settings → Environments → `production` and `production-bypass` → Required reviewers (+ prevent self-review). Until then the gates don't block.

## Verification
- service-bootstrap 73, gateway 577, notifications 207, auth 196 tests green; turbo lint+type-check 17/17 on touched packages; regression run over applications/matching/pets
- All three compose files validate (`docker compose config -q`); workflow YAML parsed + `bash -n` on every run block + `node --check` on the github-script body; bake config dry-run produced correct tags/scopes for all 12 targets

https://claude.ai/code/session_01TkXXzRRpj4roTevghDLV6n

---
_Generated by [Claude Code](https://claude.ai/code/session_01TkXXzRRpj4roTevghDLV6n)_