### PR TITLE
ci(security): run Trivy image scanning on PRs, not just push to main

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -9,9 +9,10 @@ name: Docker
 #   smoke test for the dev images.
 # - Push to main/develop keeps the broader source path set so a regression
 #   that only manifests inside a container is caught before deploy.
-# - Production-stage builds + Trivy run only on push events. The PR loop
-#   doesn't deploy prod images, so re-running the multi-stage prod build
-#   on every PR was duplicating native `tsc + vite build` from ci.yml.
+# - Production-stage builds + Trivy run on both PR and push events (ADS-833).
+#   PRs are already narrowed to Dockerfile-changing changes, so the extra prod
+#   build cost is bounded. Scanning before merge prevents CRITICAL/HIGH CVEs
+#   from being tagged on main before they're detected.
 
 on:
   push:
@@ -102,7 +103,8 @@ jobs:
           cache-to: type=gha,mode=max,ignore-error=true
 
   # ============================================================================
-  # BUILD SERVICES — dev image on all triggers, prod image + Trivy scan on push
+  # BUILD SERVICES — dev image on all triggers, prod image + Trivy scan on
+  # all triggers (ADS-833: scan PRs so CVEs are caught before merge, not after)
   #
   # Replaces the CVE-scan coverage lost when the service.backend monolith
   # was deleted in #995 (the old `build-backend` job ran a single Trivy
@@ -146,7 +148,6 @@ jobs:
             network=host
 
       - name: Log in to GHCR (for Trivy DB pulls)
-        if: github.event_name != 'pull_request'
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee  # v4.2.0
         with:
           registry: ghcr.io
@@ -168,12 +169,10 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max,ignore-error=true
 
-      # Push-only: the prod stage re-runs the full multi-stage build,
-      # which is expensive across 11 images. ci.yml + E2E already cover
-      # source-level regressions on PRs; keep prod build + Trivy as a
-      # pre-deploy gate on main pushes.
+      # Build the prod image on all triggers so Trivy can scan it (ADS-833).
+      # On PRs this workflow is already narrowed to Dockerfile-changing changes,
+      # so the extra build cost is bounded to the cases where scanning matters.
       - name: Build production image
-        if: github.event_name != 'pull_request'
         uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf  # v7.2.0
         with:
           context: .
@@ -190,7 +189,6 @@ jobs:
           cache-to: type=gha,mode=max,ignore-error=true
 
       - name: Run Trivy vulnerability scanner
-        if: github.event_name != 'pull_request'
         run: |
           docker run --rm \
             -v /var/run/docker.sock:/var/run/docker.sock \
@@ -205,7 +203,7 @@ jobs:
               paragonjenko/adoptdontshop:service-${{ matrix.service }}-prod-${{ github.sha }}
 
       - name: Upload Trivy results to GitHub Security tab
-        if: github.event_name != 'pull_request' && always() && hashFiles(format('trivy-results-{0}.sarif', matrix.service)) != ''
+        if: always() && hashFiles(format('trivy-results-{0}.sarif', matrix.service)) != ''
         uses: github/codeql-action/upload-sarif@87557b9c84dde89fdd9b10e88954ac2f4248e463  # v4.36.1
         with:
           sarif_file: 'trivy-results-${{ matrix.service }}.sarif'


### PR DESCRIPTION
## Summary

- Removes the `github.event_name != 'pull_request'` guard from four steps in the `build-services` job: GHCR login, production image build, Trivy scan, and SARIF upload
- CRITICAL/HIGH CVEs in any service image now fail CI **before merge**, not after the image is tagged on `main`
- SARIF results are uploaded to the Security tab on both PRs and pushes for triage in both contexts
- The existing PR path filter (`**/Dockerfile*`, `docker-compose*.yml`, `.dockerignore`) already bounds the extra prod-build cost to PRs where scanning is actually relevant

Closes **ADS-833**

## Acceptance criteria

- [x] PRs that introduce CRITICAL/HIGH CVEs in any service image fail CI before merge
- [x] Scan results uploaded for triage (SARIF) on both PRs and pushes

## Test plan

- [ ] Open a test PR that changes a Dockerfile — confirm the `Build ${{ matrix.service }} Image` jobs now include the prod-image build and Trivy scan steps (previously skipped on PRs)
- [ ] Confirm SARIF results appear in the repo Security → Code scanning tab on the PR
- [ ] Confirm a push to main still produces the same scan output as before

---
_Generated by [Claude Code](https://claude.ai/code/session_01ASZ2XcCyMLifvJyJd2Ayn6)_