### PR TITLE
fix(docker): copy root tsconfigs into app prod build stage

### DIFF
--- a/Dockerfile.app.optimized
+++ b/Dockerfile.app.optimized
@@ -108,6 +108,12 @@ RUN --mount=type=cache,id=pnpm-build-${APP_NAME},target=/home/viteuser/.pnpm-sto
 # Pruned source — only the lib.* directories the app actually depends on.
 COPY --from=pruner --chown=viteuser:nodejs /app/out/full/ ./
 
+# turbo prune --docker doesn't copy root-level config files into out/full/.
+# Workspace tsconfigs extend ../tsconfig.base.json (ESM build) and lib.types
+# additionally extends ../tsconfig.cjs.base.json for its dual ESM+CJS build.
+# Mirrors Dockerfile.service.
+COPY --chown=viteuser:nodejs tsconfig.base.json tsconfig.cjs.base.json ./
+
 # Build libraries first, then the specific app using Turbo
 # Use cache mount for Turbo cache
 # The '...' prefix builds all dependencies first, then the target app


### PR DESCRIPTION
## Summary

The **Docker** workflow (prod image builds) has been red on every `main` push. The `client`/`admin`/`rescue` **app** image builds fail in the `build` stage with:

```
@adopt-dont-shop/lib.types:build: error TS5083: Cannot read file '/app/tsconfig.base.json'.
```

### Root cause

`turbo prune --docker` does **not** copy root-level config files (like `tsconfig.base.json`) into `out/full/`. `packages/lib.types/tsconfig.json` extends `../../tsconfig.base.json` (and `tsconfig.cjs.json` extends `../../tsconfig.cjs.base.json`), which from `/app/packages/lib.types` resolves to `/app/tsconfig.base.json` — a file that never made it into the build context. So `tsc` fails as soon as Turbo builds `lib.types`, taking the whole app build down.

This surfaced after the npm→pnpm migration (#1022), whose own description noted Docker image builds were the unverified gate at merge.

`Dockerfile.service` already documents and handles this exact problem (it copies both root tsconfigs into its build stage), which is why the **service** images build fine. This change brings `Dockerfile.app.optimized` in line with it.

### Change

One line in the `build` stage of `Dockerfile.app.optimized`, mirroring `Dockerfile.service`:

```dockerfile
COPY --chown=viteuser:nodejs tsconfig.base.json tsconfig.cjs.base.json ./
```

### Verification

No Docker daemon is available in this environment, so the image build could not be run locally. The fix is a faithful mirror of the proven-working `Dockerfile.service` (lines 64–67) and directly supplies the missing file named in the `TS5083` error. CI's Docker workflow on this branch is the real gate.

> [!NOTE]
> This fixes the **app** build failures only. The 11 **service** image jobs fail at a separate step — the Trivy scan (`--severity CRITICAL,HIGH --exit-code 1`) finds HIGH/CRITICAL CVEs in the base images and exits non-zero. That is a pre-existing, separate issue (a security-policy decision) and is intentionally out of scope here.

https://claude.ai/code/session_01RDxEbpnf5cSpVjr8AKP3wr

---
_Generated by [Claude Code](https://claude.ai/code/session_01RDxEbpnf5cSpVjr8AKP3wr)_