### PR TITLE
fix(docker): harden + align the dev/staging/prod docker flow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -494,12 +494,8 @@ jobs:
           GHCR_TOKEN: ${{ secrets.GHCR_TOKEN }}
           SECRET_JWT_SECRET: ${{ secrets.JWT_SECRET }}
           SECRET_JWT_REFRESH_SECRET: ${{ secrets.JWT_REFRESH_SECRET }}
-          SECRET_SESSION_SECRET: ${{ secrets.SESSION_SECRET }}
-          SECRET_CSRF_SECRET: ${{ secrets.CSRF_SECRET }}
-          SECRET_ENCRYPTION_KEY: ${{ secrets.ENCRYPTION_KEY }}
           SECRET_UPLOAD_SIGNING_SECRET: ${{ secrets.UPLOAD_SIGNING_SECRET }}
           SECRET_DB_PASSWORD: ${{ secrets.DB_PASSWORD }}
-          SECRET_REDIS_PASSWORD: ${{ secrets.REDIS_PASSWORD }}
           SECRET_PRINCIPAL_SIGNING_KEY: ${{ secrets.PRINCIPAL_SIGNING_KEY }}
         uses: appleboy/ssh-action@0ff4204d59e8e51228ff73bce53f80d53301dee2  # v1.2.5
         with:
@@ -507,7 +503,7 @@ jobs:
           username: deploy
           key: ${{ secrets.HETZNER_SSH_KEY }}
           fingerprint: ${{ secrets.HETZNER_HOST_FINGERPRINT }}
-          envs: GHCR_TOKEN,SECRET_JWT_SECRET,SECRET_JWT_REFRESH_SECRET,SECRET_SESSION_SECRET,SECRET_CSRF_SECRET,SECRET_ENCRYPTION_KEY,SECRET_UPLOAD_SIGNING_SECRET,SECRET_DB_PASSWORD,SECRET_REDIS_PASSWORD,SECRET_PRINCIPAL_SIGNING_KEY
+          envs: GHCR_TOKEN,SECRET_JWT_SECRET,SECRET_JWT_REFRESH_SECRET,SECRET_UPLOAD_SIGNING_SECRET,SECRET_DB_PASSWORD,SECRET_PRINCIPAL_SIGNING_KEY
           script: |
             set -euo pipefail
             ENV="${{ github.event.inputs.environment }}"
@@ -568,23 +564,36 @@ jobs:
               COMPOSE_FILE="docker-compose.staging.yml"
             fi
 
-            # Materialize Docker secret files for production (consumed via
-            # file: ./secrets/<name> in docker-compose.prod.yml). Staging uses
-            # plaintext env vars and does not need secret files. [ADS-675]
-            if [ "$ENV" = "production" ]; then
-              mkdir -p secrets
-              chmod 700 secrets
-              printf '%s' "$SECRET_JWT_SECRET"           > secrets/jwt_secret
-              printf '%s' "$SECRET_JWT_REFRESH_SECRET"   > secrets/jwt_refresh_secret
-              printf '%s' "$SECRET_SESSION_SECRET"       > secrets/session_secret
-              printf '%s' "$SECRET_CSRF_SECRET"          > secrets/csrf_secret
-              printf '%s' "$SECRET_ENCRYPTION_KEY"       > secrets/encryption_key
-              printf '%s' "$SECRET_UPLOAD_SIGNING_SECRET" > secrets/upload_signing_secret
-              printf '%s' "$SECRET_DB_PASSWORD"          > secrets/db_password
-              printf '%s' "$SECRET_REDIS_PASSWORD"       > secrets/redis_password
-              printf '%s' "$SECRET_PRINCIPAL_SIGNING_KEY" > secrets/principal_signing_key
-              chmod 600 secrets/*
-            fi
+            # Materialize the file-mounted Docker secrets consumed via
+            # `file: ./secrets/<name>` by BOTH docker-compose.prod.yml and
+            # docker-compose.staging.yml. The set must match the `secrets:`
+            # blocks in those files (see secrets/README.md). [ADS-675, ADS-752]
+            #
+            # database_url / redis_url are composed here from the rotating DB
+            # password plus the non-rotating identifiers already in the host
+            # .env (POSTGRES_USER / POSTGRES_DB, and the REDIS_PASSWORD the redis
+            # container itself authenticates with) so the URLs always match what
+            # the database/redis containers use.
+            read_env() {  # read a key from the host .env, quotes stripped; fails if absent
+              local v
+              v="$(grep -E "^$1=" .env | head -n1 | cut -d= -f2-)" || true
+              v="${v%\"}"; v="${v#\"}"; v="${v%\'}"; v="${v#\'}"
+              [ -n "$v" ] || { echo "ERROR: $1 missing from .env" >&2; exit 1; }
+              printf '%s' "$v"
+            }
+            PG_USER="$(read_env POSTGRES_USER)"
+            PG_DB="$(read_env POSTGRES_DB)"
+            REDIS_PW="$(read_env REDIS_PASSWORD)"
+            mkdir -p secrets
+            chmod 700 secrets
+            printf '%s' "postgresql://${PG_USER}:${SECRET_DB_PASSWORD}@database:5432/${PG_DB}" > secrets/database_url
+            printf '%s' "redis://:${REDIS_PW}@redis:6379"      > secrets/redis_url
+            printf '%s' "$SECRET_JWT_SECRET"                    > secrets/jwt_secret
+            printf '%s' "$SECRET_JWT_REFRESH_SECRET"            > secrets/jwt_refresh_secret
+            printf '%s' "$SECRET_UPLOAD_SIGNING_SECRET"         > secrets/upload_signing_secret
+            printf '%s' "$SECRET_PRINCIPAL_SIGNING_KEY"         > secrets/principal_signing_key
+            printf '%s' "$SECRET_DB_PASSWORD"                   > secrets/db_password
+            chmod 600 secrets/*
 
             # Bring up new containers. Each service migrates its own schema on
             # start (the Dockerfile.service entrypoint runs
@@ -648,9 +657,7 @@ jobs:
 
             # Remove secret files now that containers have started (they hold
             # in-memory copies; the files on disk are no longer needed). [ADS-675]
-            if [ "$ENV" = "production" ]; then
-              rm -f secrets/*
-            fi
+            rm -f secrets/*
 
             # Record deployed SHA
             echo "$SHA" > .last_sha

--- a/.github/workflows/rollback.yml
+++ b/.github/workflows/rollback.yml
@@ -40,19 +40,16 @@ jobs:
           ROLLBACK_ENV: ${{ github.event.inputs.environment }}
           SECRET_JWT_SECRET: ${{ secrets.JWT_SECRET }}
           SECRET_JWT_REFRESH_SECRET: ${{ secrets.JWT_REFRESH_SECRET }}
-          SECRET_SESSION_SECRET: ${{ secrets.SESSION_SECRET }}
-          SECRET_CSRF_SECRET: ${{ secrets.CSRF_SECRET }}
-          SECRET_ENCRYPTION_KEY: ${{ secrets.ENCRYPTION_KEY }}
           SECRET_UPLOAD_SIGNING_SECRET: ${{ secrets.UPLOAD_SIGNING_SECRET }}
           SECRET_DB_PASSWORD: ${{ secrets.DB_PASSWORD }}
-          SECRET_REDIS_PASSWORD: ${{ secrets.REDIS_PASSWORD }}
+          SECRET_PRINCIPAL_SIGNING_KEY: ${{ secrets.PRINCIPAL_SIGNING_KEY }}
         uses: appleboy/ssh-action@0ff4204d59e8e51228ff73bce53f80d53301dee2  # v1.2.5
         with:
           host: ${{ secrets.HETZNER_HOST }}
           username: deploy
           key: ${{ secrets.HETZNER_SSH_KEY }}
           fingerprint: ${{ secrets.HETZNER_HOST_FINGERPRINT }}
-          envs: GHCR_TOKEN,ROLLBACK_SHA,ROLLBACK_ENV,SECRET_JWT_SECRET,SECRET_JWT_REFRESH_SECRET,SECRET_SESSION_SECRET,SECRET_CSRF_SECRET,SECRET_ENCRYPTION_KEY,SECRET_UPLOAD_SIGNING_SECRET,SECRET_DB_PASSWORD,SECRET_REDIS_PASSWORD
+          envs: GHCR_TOKEN,ROLLBACK_SHA,ROLLBACK_ENV,SECRET_JWT_SECRET,SECRET_JWT_REFRESH_SECRET,SECRET_UPLOAD_SIGNING_SECRET,SECRET_DB_PASSWORD,SECRET_PRINCIPAL_SIGNING_KEY
           script: |
             set -euo pipefail
             # Validate SHA before use to prevent shell injection.
@@ -87,21 +84,30 @@ jobs:
               COMPOSE_FILE="docker-compose.staging.yml"
             fi
 
-            # Materialize Docker secret files for production (consumed via
-            # file: ./secrets/<name> in docker-compose.prod.yml). [ADS-675]
-            if [ "$ENV" = "production" ]; then
-              mkdir -p secrets
-              chmod 700 secrets
-              printf '%s' "$SECRET_JWT_SECRET"            > secrets/jwt_secret
-              printf '%s' "$SECRET_JWT_REFRESH_SECRET"    > secrets/jwt_refresh_secret
-              printf '%s' "$SECRET_SESSION_SECRET"        > secrets/session_secret
-              printf '%s' "$SECRET_CSRF_SECRET"           > secrets/csrf_secret
-              printf '%s' "$SECRET_ENCRYPTION_KEY"        > secrets/encryption_key
-              printf '%s' "$SECRET_UPLOAD_SIGNING_SECRET" > secrets/upload_signing_secret
-              printf '%s' "$SECRET_DB_PASSWORD"           > secrets/db_password
-              printf '%s' "$SECRET_REDIS_PASSWORD"        > secrets/redis_password
-              chmod 600 secrets/*
-            fi
+            # Materialize the file-mounted Docker secrets consumed via
+            # `file: ./secrets/<name>` by BOTH docker-compose.prod.yml and
+            # docker-compose.staging.yml. The set must match the `secrets:`
+            # blocks in those files (see secrets/README.md). [ADS-675, ADS-752]
+            read_env() {  # read a key from the host .env, quotes stripped; fails if absent
+              local v
+              v="$(grep -E "^$1=" .env | head -n1 | cut -d= -f2-)" || true
+              v="${v%\"}"; v="${v#\"}"; v="${v%\'}"; v="${v#\'}"
+              [ -n "$v" ] || { echo "ERROR: $1 missing from .env" >&2; exit 1; }
+              printf '%s' "$v"
+            }
+            PG_USER="$(read_env POSTGRES_USER)"
+            PG_DB="$(read_env POSTGRES_DB)"
+            REDIS_PW="$(read_env REDIS_PASSWORD)"
+            mkdir -p secrets
+            chmod 700 secrets
+            printf '%s' "postgresql://${PG_USER}:${SECRET_DB_PASSWORD}@database:5432/${PG_DB}" > secrets/database_url
+            printf '%s' "redis://:${REDIS_PW}@redis:6379"      > secrets/redis_url
+            printf '%s' "$SECRET_JWT_SECRET"                    > secrets/jwt_secret
+            printf '%s' "$SECRET_JWT_REFRESH_SECRET"            > secrets/jwt_refresh_secret
+            printf '%s' "$SECRET_UPLOAD_SIGNING_SECRET"         > secrets/upload_signing_secret
+            printf '%s' "$SECRET_PRINCIPAL_SIGNING_KEY"         > secrets/principal_signing_key
+            printf '%s' "$SECRET_DB_PASSWORD"                   > secrets/db_password
+            chmod 600 secrets/*
 
             docker compose -f $COMPOSE_FILE --env-file .env up -d
 
@@ -119,9 +125,7 @@ jobs:
             done
 
             # Remove secret files now that containers have started. [ADS-675]
-            if [ "$ENV" = "production" ]; then
-              rm -f secrets/*
-            fi
+            rm -f secrets/*
 
             echo "$SHA" > .last_sha
             echo "Rolled back $ENV to $SHA."

--- a/Dockerfile.app.optimized
+++ b/Dockerfile.app.optimized
@@ -43,7 +43,7 @@ ARG APP_NAME
 # package.json. node_modules / dist are excluded via .dockerignore.
 COPY . .
 
-RUN pnpm dlx turbo@2.9.14 prune @adopt-dont-shop/app.${APP_NAME} --docker
+RUN pnpm dlx turbo@2.9.18 prune @adopt-dont-shop/app.${APP_NAME} --docker
 
 # Development stage
 FROM base AS development
@@ -146,7 +146,7 @@ RUN find /app/apps/${APP_NAME}/dist -name '*.map' -delete
 # ============================================================================
 # Uses the unprivileged nginx image (runs as UID 101, listens on 8080) so the
 # container does not run as root. [ADS-701]
-FROM nginxinc/nginx-unprivileged:1.31-alpine AS production
+FROM nginxinc/nginx-unprivileged:1.31-alpine@sha256:85bcbc6b2edd325462560c597d784ecee415024f1c6a004e53ac5f202b8ca561 AS production
 ARG APP_NAME
 
 # Privileged setup (package upgrade, suid strip, config write). The base image

--- a/Dockerfile.service
+++ b/Dockerfile.service
@@ -42,7 +42,7 @@ ARG SERVICE
 # Full monorepo source is needed so turbo can read every workspace package.json.
 # node_modules / dist are excluded via .dockerignore.
 COPY . .
-RUN pnpm dlx turbo@2.9.16 prune ${SERVICE} --docker
+RUN pnpm dlx turbo@2.9.18 prune ${SERVICE} --docker
 
 # ---------------------------------------------------------------------------
 # build — install the pruned deps + turbo build the service (+ its deps)

--- a/deploy/gateway/docker-compose.gateway.yml
+++ b/deploy/gateway/docker-compose.gateway.yml
@@ -4,7 +4,7 @@
 
 services:
   nginx:
-    image: nginx:1.27-alpine  # TODO: pin to digest once resolved via `docker pull nginx:1.27-alpine && docker inspect --format='{{index .RepoDigests 0}}'`
+    image: nginx:1.27-alpine@sha256:65645c7bb6a0661892a8b03b89d0743208a18dd2f3f17a54ef4b76fb8e2f2a10
     container_name: ads_gateway
     restart: always
     ports:
@@ -45,7 +45,7 @@ services:
           memory: 64m
 
   certbot:
-    image: certbot/certbot:v3.1.0  # TODO: pin to digest once resolved via `docker pull certbot/certbot:v3.1.0 && docker inspect --format='{{index .RepoDigests 0}}'`
+    image: certbot/certbot:v3.1.0@sha256:fb978b4fef92dc5c85cc0b908836714c600e717b52a3f74c93276eb63a9d0af9
     container_name: ads_certbot
     restart: unless-stopped
     volumes:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -85,11 +85,16 @@ services:
   database:
     image: postgis/postgis:16-3.4
     container_name: ads_prod_db
+    # ADS-752: read the DB password from the file-mounted Docker secret rather
+    # than the env var. POSTGRES_PASSWORD_FILE is honoured by the postgres
+    # entrypoint and keeps the value out of `docker inspect` and the host .env.
     environment:
       # NO DEFAULTS - Must be explicitly set
       POSTGRES_USER: "${POSTGRES_USER:?Error: POSTGRES_USER required in production}"
-      POSTGRES_PASSWORD: "${POSTGRES_PASSWORD:?Error: POSTGRES_PASSWORD required in production}"
+      POSTGRES_PASSWORD_FILE: /run/secrets/db_password
       POSTGRES_DB: "${POSTGRES_DB:?Error: POSTGRES_DB required in production}"
+    secrets:
+      - db_password
     volumes:
       - postgres_data:/var/lib/postgresql/data
     healthcheck:
@@ -113,11 +118,6 @@ services:
         reservations:
           cpus: '0.5'
           memory: 512m
-    # Optional: Use Docker secrets instead of environment variables
-    # secrets:
-    #   - postgres_password
-    # environment:
-    #   POSTGRES_PASSWORD_FILE: /run/secrets/postgres_password
 
   # Redis - Production configuration
   redis:
@@ -501,7 +501,7 @@ services:
   # Public TLS is handled by the gateway stack — this nginx only listens on
   # the internal network and is reverse-proxied by the gateway.
   nginx:
-    image: nginx:1.27-alpine  # TODO: pin to digest once resolved via `docker pull nginx:1.27-alpine && docker inspect --format='{{index .RepoDigests 0}}'`
+    image: nginx:1.27-alpine@sha256:65645c7bb6a0661892a8b03b89d0743208a18dd2f3f17a54ef4b76fb8e2f2a10
     container_name: ads_prod_nginx
     restart: always
     volumes:
@@ -580,6 +580,8 @@ networks:
 # (.github/workflows/deploy.yml) materialises ./secrets/<name> on the host
 # before `docker compose up -d`.
 secrets:
+  db_password:
+    file: ./secrets/db_password
   database_url:
     file: ./secrets/database_url
   redis_url:

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -105,7 +105,7 @@ services:
           memory: 512m
 
   redis:
-    image: redis:7-alpine
+    image: redis:7.4-alpine
     container_name: ads_staging_redis
     restart: always
     ports: []

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -83,7 +83,7 @@ services:
 
   # Redis for caching and sessions
   redis:
-    image: redis:7-alpine
+    image: redis:7.4-alpine
     restart: always
     ports:
       - '127.0.0.1:6379:6379'
@@ -249,7 +249,7 @@ services:
   # alongside a single frontend profile when they want subdomain routing.
   nginx:
     profiles: ['proxy', 'full']
-    image: nginx:1.27-alpine
+    image: nginx:1.27-alpine@sha256:65645c7bb6a0661892a8b03b89d0743208a18dd2f3f17a54ef4b76fb8e2f2a10
     ports:
       - '127.0.0.1:80:80'
       - '127.0.0.1:443:443'

--- a/docs/SECRETS-MANAGEMENT.md
+++ b/docs/SECRETS-MANAGEMENT.md
@@ -126,18 +126,18 @@ Production deployments use file-based Docker secrets (plain Compose v2, not Swar
 
 ### How the Deploy Workflow Materializes Secrets
 
-The `deploy.yml` and `rollback.yml` workflows pass the 8 production secrets via the `env:` block of the `appleboy/ssh-action` step (never interpolated into the script text). On the server, before `docker compose up -d`, the script writes each secret file using `printf '%s'` (no trailing newline):
+The `deploy.yml` and `rollback.yml` workflows pass the rotating secrets via the `env:` block of the `appleboy/ssh-action` step (never interpolated into the script text) and run for **both staging and production**. On the server, before `docker compose up -d`, the script writes each file the compose `secrets:` block mounts, using `printf '%s'` (no trailing newline). `database_url` / `redis_url` are composed from the DB password plus the non-rotating identifiers already in the host `.env` (so the URLs always match what the database / redis containers use):
 
 ```bash
 mkdir -p secrets && chmod 700 secrets
-printf '%s' "$SECRET_JWT_SECRET"            > secrets/jwt_secret
-printf '%s' "$SECRET_JWT_REFRESH_SECRET"    > secrets/jwt_refresh_secret
-printf '%s' "$SECRET_SESSION_SECRET"        > secrets/session_secret
-printf '%s' "$SECRET_CSRF_SECRET"           > secrets/csrf_secret
-printf '%s' "$SECRET_ENCRYPTION_KEY"        > secrets/encryption_key
-printf '%s' "$SECRET_UPLOAD_SIGNING_SECRET" > secrets/upload_signing_secret
-printf '%s' "$SECRET_DB_PASSWORD"           > secrets/db_password
-printf '%s' "$SECRET_REDIS_PASSWORD"        > secrets/redis_password
+PG_USER="$(read_env POSTGRES_USER)"; PG_DB="$(read_env POSTGRES_DB)"; REDIS_PW="$(read_env REDIS_PASSWORD)"
+printf '%s' "postgresql://${PG_USER}:${SECRET_DB_PASSWORD}@database:5432/${PG_DB}" > secrets/database_url
+printf '%s' "redis://:${REDIS_PW}@redis:6379"      > secrets/redis_url
+printf '%s' "$SECRET_JWT_SECRET"                    > secrets/jwt_secret
+printf '%s' "$SECRET_JWT_REFRESH_SECRET"            > secrets/jwt_refresh_secret
+printf '%s' "$SECRET_UPLOAD_SIGNING_SECRET"         > secrets/upload_signing_secret
+printf '%s' "$SECRET_PRINCIPAL_SIGNING_KEY"         > secrets/principal_signing_key
+printf '%s' "$SECRET_DB_PASSWORD"                   > secrets/db_password
 chmod 600 secrets/*
 # ... docker compose up -d ...
 rm -f secrets/*
@@ -149,48 +149,48 @@ The `secrets/` directory is gitignored and must never be committed.
 
 ```yaml
 secrets:
+  database_url:
+    file: ./secrets/database_url
+  redis_url:
+    file: ./secrets/redis_url
   jwt_secret:
     file: ./secrets/jwt_secret
   jwt_refresh_secret:
     file: ./secrets/jwt_refresh_secret
-  session_secret:
-    file: ./secrets/session_secret
-  csrf_secret:
-    file: ./secrets/csrf_secret
-  encryption_key:
-    file: ./secrets/encryption_key
   upload_signing_secret:
     file: ./secrets/upload_signing_secret
+  principal_signing_key:
+    file: ./secrets/principal_signing_key
   db_password:
     file: ./secrets/db_password
-  redis_password:
-    file: ./secrets/redis_password
 ```
 
 Each service that needs a secret lists it under its own `secrets:` key; Compose mounts the file content at `/run/secrets/<name>`.
 
 ### Application Code for Docker Secrets
 
-The backend reads secrets via `readSecretOrEnv()` in `config/env.ts`, which checks `/run/secrets/<name>` first and falls back to the environment variable of the same name:
+Each service reads secrets via the `@adopt-dont-shop/config-secrets` loader, which checks `<NAME>_FILE` (a path, e.g. `/run/secrets/database_url`) first and falls back to the plain `<NAME>` env var:
 
 ```typescript
-// Reads /run/secrets/<name> if it exists, otherwise falls back to process.env[envVar]
-const jwtSecret = readSecretOrEnv('jwt_secret', 'JWT_SECRET');
-const dbPassword = readSecretOrEnv('db_password', 'DB_PASSWORD');
+import { readSecret, requireSecret } from '@adopt-dont-shop/config-secrets';
+
+// Prefers DATABASE_URL_FILE (the mounted secret), falls back to DATABASE_URL.
+const databaseUrl = requireSecret('DATABASE_URL');
+const uploadSigningSecret = readSecret('UPLOAD_SIGNING_SECRET');
 ```
 
 ### Manual Provisioning (without the deploy workflow)
 
 ```bash
 mkdir -p secrets && chmod 700 secrets
+# Connection URLs — use the same POSTGRES_USER / POSTGRES_DB / passwords as .env.
+printf '%s' "postgresql://USER:DB_PASSWORD@database:5432/DB_NAME" > secrets/database_url
+printf '%s' "redis://:REDIS_PASSWORD@redis:6379"                  > secrets/redis_url
 printf '%s' "$(openssl rand -base64 32)"  > secrets/jwt_secret
 printf '%s' "$(openssl rand -base64 32)"  > secrets/jwt_refresh_secret
-printf '%s' "$(openssl rand -base64 32)"  > secrets/session_secret
-printf '%s' "$(openssl rand -base64 32)"  > secrets/csrf_secret
-printf '%s' "$(node -e "process.stdout.write(require('crypto').randomBytes(32).toString('hex'))")" > secrets/encryption_key
 printf '%s' "$(openssl rand -base64 32)"  > secrets/upload_signing_secret
-printf '%s' "$(openssl rand -base64 32)"  > secrets/db_password
-printf '%s' "$(openssl rand -base64 32)"  > secrets/redis_password
+printf '%s' "$(openssl rand -base64 32)"  > secrets/principal_signing_key
+printf '%s' "DB_PASSWORD"                  > secrets/db_password   # same value used in database_url
 chmod 600 secrets/*
 ```
 

--- a/docs/infrastructure/docker-setup.md
+++ b/docs/infrastructure/docker-setup.md
@@ -2,16 +2,23 @@
 
 This document explains how to set up and run the Adopt Don't Shop application using Docker, along with common troubleshooting solutions.
 
+> **Canonical quick-start:** the fastest path is `pnpm setup` followed by `pnpm docker:dev`
+> (see the root [README](../../README.md)). This guide focuses on the architecture overview
+> and troubleshooting. The stack is now a Fastify **gateway** plus gRPC microservices — the
+> old single `service.backend` monolith has been removed.
+
 ## Architecture
 
 The application consists of multiple services:
 
-- **service.backend** - Main API backend service (Node.js/Express)
+- **service.gateway** - Fastify REST/WS API gateway / edge (port 4000)
+- **service.\*** - gRPC microservices: auth, pets, rescue, applications, notifications, moderation, matching, audit, chat, cms
 - **app.client** - Public-facing React application (port 3000)
 - **app.admin** - Admin dashboard React application (port 3001)
 - **app.rescue** - Rescue management React application (port 3002)
 - **database** - PostgreSQL (with PostGIS)
 - **redis** - Redis for caching and sessions
+- **nats** - JetStream event bus between microservices
 - **nginx** - Reverse proxy for subdomain routing (runs in dev and prod)
 
 ## Quick Start
@@ -32,7 +39,7 @@ Modern browsers automatically resolve `*.localhost` subdomains to `127.0.0.1`, s
 - Client: http://localhost:3000
 - Admin: http://localhost:3001
 - Rescue: http://localhost:3002
-- API: http://localhost:5000
+- API (gateway): http://localhost:4000
 
 ### Development Environment
 
@@ -47,12 +54,11 @@ Modern browsers automatically resolve `*.localhost` subdomains to `127.0.0.1`, s
    git clone <repository-url>
    cd adopt-dont-shop
 
-   # Copy environment file
-   cp .env.example .env
-   # Edit .env with your configuration
+   # One-time setup: creates .env, generates secrets, installs deps
+   pnpm setup
 
-   # Start all services
-   docker compose up
+   # Start the full dev stack (preflight checks + HMR)
+   pnpm docker:dev
    ```
 
 3. **Access Applications**
@@ -89,10 +95,10 @@ CSRF_SECRET=...
 # /api requests to the backend via docker-compose networking. Set an
 # absolute URL only when running the apps outside Docker.
 VITE_API_BASE_URL=
-VITE_WS_BASE_URL=ws://localhost:5000
+VITE_WS_BASE_URL=ws://localhost:4000
 
 # CORS (comma-separated list of allowed origins)
-CORS_ORIGIN=http://localhost:3000,http://localhost:3001,http://localhost:3002,http://localhost,http://admin.localhost,http://rescue.localhost,http://api.localhost,http://localhost:5000
+CORS_ORIGIN=http://localhost:3000,http://localhost:3001,http://localhost:3002,http://localhost,http://admin.localhost,http://rescue.localhost,http://api.localhost,http://localhost:4000
 ```
 
 Generate strong secrets and append them to your `.env` with `pnpm secrets:generate >> .env`.
@@ -101,7 +107,7 @@ Generate strong secrets and append them to your `.env` with `pnpm secrets:genera
 
 ### 1. Database Connection Issues ✅ RESOLVED
 
-**Problem**: Service-backend couldn't connect to PostgreSQL database due to missing environment variables.
+**Problem**: A backend service couldn't connect to PostgreSQL database due to missing environment variables.
 
 **Solution**: Updated `docker-compose.yml` to provide proper database configuration:
 
@@ -228,7 +234,7 @@ docker system prune                  # Clean up unused resources
 docker compose logs -f
 
 # View specific service logs
-docker compose logs -f service-backend
+docker compose logs -f service-gateway
 docker compose logs -f app-client
 
 # Monitor resource usage

--- a/scripts/bootstrap.mjs
+++ b/scripts/bootstrap.mjs
@@ -68,17 +68,29 @@ function runCommand(command, options = {}) {
   }
 }
 
+// Keep in sync with scripts/generate-secrets.mjs (`pnpm secrets:generate`) so
+// both onboarding paths produce the same set of secrets.
 const SECRET_KEYS = [
   'JWT_SECRET',
   'JWT_REFRESH_SECRET',
   'SESSION_SECRET',
   'CSRF_SECRET',
   'ENCRYPTION_KEY',
+  'UPLOAD_SIGNING_SECRET',
+  'JWT_REPORT_SHARE_SECRET',
+  'POSTGRES_PASSWORD',
+  'REDIS_PASSWORD',
 ];
 
 function generateSecret(key) {
   if (key === 'ENCRYPTION_KEY') {
+    // AES-256 needs exactly 32 bytes (64 hex chars).
     return randomBytes(32).toString('hex');
+  }
+  if (key === 'POSTGRES_PASSWORD' || key === 'REDIS_PASSWORD') {
+    // These are interpolated into connection URLs (DATABASE_URL / REDIS_URL),
+    // so use hex — base64 can contain + / = which break URL parsing.
+    return randomBytes(24).toString('hex');
   }
   return randomBytes(32).toString('base64');
 }
@@ -206,8 +218,8 @@ function printNextSteps() {
   log('Next steps:', `${BOLD}${GREEN}`);
   log('', RESET);
   log('1. Review your .env file:', BLUE);
-  log('   - Secrets have been generated for you.', RESET);
-  log('   - Set POSTGRES_PASSWORD and any third-party API keys you need.', RESET);
+  log('   - Secrets (including POSTGRES_PASSWORD / REDIS_PASSWORD) have been generated for you.', RESET);
+  log('   - Set any third-party API keys you need.', RESET);
   log('', RESET);
   log('2. Start the development stack:', BLUE);
   log('   pnpm docker:dev          # recommended (includes database + redis)', RESET);
@@ -325,7 +337,7 @@ async function setup() {
       logSuccess('Environment configuration valid');
     } catch (err) {
       logError('Environment validation reported issues — review the output above before starting the stack.');
-      // Non-fatal: the user may need to fill in non-secret values like POSTGRES_PASSWORD.
+      // Non-fatal: the user may still need to fill in optional values (e.g. third-party API keys).
     }
     log('', RESET);
 

--- a/scripts/generate-secrets.mjs
+++ b/scripts/generate-secrets.mjs
@@ -2,6 +2,9 @@
 import { randomBytes } from 'node:crypto';
 
 const b64 = (n = 32) => randomBytes(n).toString('base64');
+// Hex is URL-safe (no + / =) — required for values interpolated into
+// connection URLs such as DATABASE_URL / REDIS_URL.
+const hex = (n = 24) => randomBytes(n).toString('hex');
 
 /**
  * Returns a block of freshly-generated secret key=value lines suitable for
@@ -18,8 +21,10 @@ export function generateSecretsBlock() {
     `ENCRYPTION_KEY=${randomBytes(32).toString('hex')}`,
     `UPLOAD_SIGNING_SECRET=${b64()}`,
     `JWT_REPORT_SHARE_SECRET=${b64()}`,
-    '# POSTGRES_PASSWORD is sensitive too — regenerate if leaked:',
-    `POSTGRES_PASSWORD=${b64(24)}`,
+    '# Infra passwords are interpolated into DATABASE_URL / REDIS_URL, so they',
+    '# use hex (URL-safe) rather than base64. Regenerate if leaked:',
+    `POSTGRES_PASSWORD=${hex(24)}`,
+    `REDIS_PASSWORD=${hex(24)}`,
   ].join('\n');
 }
 

--- a/secrets/README.md
+++ b/secrets/README.md
@@ -20,7 +20,7 @@ before `docker compose up -d`; the deploy workflow
 | `jwt_refresh_secret`          | `service-auth`                  | refresh-token signing secret                                   |
 | `upload_signing_secret`       | `service-gateway`               | HMAC secret for `/uploads-signed` URLs                         |
 | `principal_signing_key`       | `service-gateway` + every domain service | HMAC key for the signed `x-principal-token` gRPC metadata (ADS-800) |
-| `db_password` (staging only)  | `database` container            | Postgres superuser password (read via `POSTGRES_PASSWORD_FILE`) |
+| `db_password`                 | `database` container (staging + production) | Postgres superuser password (read via `POSTGRES_PASSWORD_FILE`) |
 
 Each file must contain only the secret value (trailing whitespace is
 trimmed by the loader). No quoting, no `KEY=value` framing — just the value.


### PR DESCRIPTION
## Summary

A review of the Docker flow across **local dev / staging / prod**. The setup is already mature (cosign keyless signing + verify gate, file-mounted Docker secrets, non-root + `cap_drop:ALL` + `no-new-privileges`, healthcheck `service_healthy` gating, resource limits, SHA-immutable images with rollback). No architectural problems were found — this PR fixes a set of concrete defects and consistency gaps, including a deploy/compose secret mismatch discovered during review.

Branched on top of #1029 (the app prod-build tsconfig fix).

## Changes

**DevEx — `pnpm setup` now produces a ready-to-run, secure `.env`**
- `bootstrap.mjs` previously generated only 5 secrets and left `POSTGRES_PASSWORD` / `REDIS_PASSWORD` (plus `UPLOAD_SIGNING_SECRET` / `JWT_REPORT_SHARE_SECRET`) as committed `CHANGE_THIS_…` placeholders, so a fresh clone booted with repo-hardcoded infra passwords and a noisy `validate:env` warning. It now generates the full secret set, matching `pnpm secrets:generate`.
- Infra passwords are emitted as **URL-safe hex** (not base64) because they're interpolated into `DATABASE_URL` / `REDIS_URL`, where `+ / =` break URL parsing. Same latent issue fixed in `generate-secrets.mjs`. After setup, only genuinely external creds (SMTP/SendGrid/Resend/AWS) remain as placeholders.

**Prod hardening — DB password via file secret**
- The prod `database` service now reads `POSTGRES_PASSWORD_FILE: /run/secrets/db_password` instead of a plaintext env var, matching staging (ADS-752) and keeping the value out of `docker inspect` / the host `.env`.

**Deploy/rollback — materialise the correct file secrets for BOTH envs**
- Discovered during review: `deploy.yml` / `rollback.yml` wrote a **stale secret-file set** that no longer matched the compose `secrets:` blocks — they **omitted `database_url` and `redis_url`** (mounted by every domain service, so `docker compose up` would fail on the missing sources) and wrote **four files nothing consumes** (`session_secret`, `csrf_secret`, `encryption_key`, `redis_password`). They also only ran for **production**, so staging had no secret files at all, and rollback never wrote `principal_signing_key`.
- Both workflows now write exactly the **seven files** the compose mounts (`database_url`, `redis_url`, `jwt_secret`, `jwt_refresh_secret`, `upload_signing_secret`, `principal_signing_key`, `db_password`), run for **both staging and production**, and compose `database_url`/`redis_url` from the DB password + the `POSTGRES_USER`/`POSTGRES_DB`/`REDIS_PASSWORD` already in the host `.env` so the URLs match the running database/redis containers.
- Stale docs updated to the current model: `docs/SECRETS-MANAGEMENT.md` (materialization block, compose example, `@adopt-dont-shop/config-secrets` usage, manual provisioning) and `secrets/README.md` (`db_password` now used by prod too).

**Supply-chain — pin base images to digests**
- `nginx:1.27-alpine`, `certbot/certbot:v3.1.0`, and `nginxinc/nginx-unprivileged:1.31-alpine` pinned to their **multi-arch manifest-list digests** (resolves the standing `# TODO: pin to digest` markers).

**Consistency**
- `redis` aligned to `7.4-alpine` across dev/staging (prod was already pinned).
- `turbo prune` aligned to `2.9.18` (the workspace-locked version) in both Dockerfiles — was `2.9.14` (app) / `2.9.16` (service).

**Docs**
- `docs/infrastructure/docker-setup.md` refreshed: removed deleted `service.backend` monolith references, pointed to the `pnpm setup` + `pnpm docker:dev` quick-start, corrected the API port (gateway on 4000).

## Verification

- `node scripts/generate-secrets.mjs` → infra creds are hex (URL-safe); simulated fresh `.env` leaves only external API keys as placeholders.
- `docker compose config -q` parses all four compose files (base + dev overlay, staging, prod, gateway), including the new `db_password` secret wiring and `@sha256:` pins. Rendered prod config confirmed `POSTGRES_PASSWORD_FILE` + `db_password`.
- The 7 files the workflows write == the 7 `secrets:` each compose mounts (cross-checked); no dead files or orphaned `SECRET_*` refs remain. `deploy.yml`/`rollback.yml` parse as YAML.
- All pinned digests resolved live from Docker Hub (not fabricated).
- `validate:env` was **not** runnable in the sandbox (deps not installed — `tsx: not found`); it runs in CI.

## Operator note (deploy)

`deploy.yml`/`rollback.yml` no longer pass `SESSION_SECRET`, `CSRF_SECRET`, `ENCRYPTION_KEY`, or `REDIS_PASSWORD` as job secrets (they weren't materialised into any mounted file). Any service that needs those values as plain env vars must have them in the host `.env` (unchanged from today — they were never reaching containers via the removed file writes). `redis_url` is composed from the host `.env` `REDIS_PASSWORD`, which must equal what the redis container is started with (already the case).

## Out of scope (recommendations)

Multi-arch image builds (only if deploying on arm64); non-root user in `Dockerfile.dev`; coupling `NODE_OPTIONS` heap to app `mem_limit`; a consolidated `docs/DOCKER-DEVELOPMENT.md`; prod network segmentation + backup runbook reference.

https://claude.ai/code/session_0128zT7jFkT85td1CdP6WkYW