### PR TITLE
chore(services): deep code-quality review and fixes

### DIFF
--- a/docs/services-code-quality-review.md
+++ b/docs/services-code-quality-review.md
@@ -1,0 +1,183 @@
+# Services Code-Quality Review
+
+Deep audit of all 11 backend microservices in `services/*`, covering four
+dimensions — **security & authz**, **correctness & data**, **testing**, and
+**maintainability** — against the repo conventions (`service-bootstrap`,
+`events` publish-after-commit, `authz`, `config-secrets`, audit discipline)
+and `.claude/CLAUDE.md`.
+
+Each service was audited in isolation; genuine findings were fixed in place
+with tests, and larger structural items were deferred to the backlog below.
+Because the service test suites mock `pg`, every database-facing fix was
+independently verified against the actual migration schema and the `HEAD`
+source (not just by a green test run).
+
+## Executive summary
+
+| Service | Headline fixes | Result |
+|---|---|---|
+| auth | Login user-enumeration timing oracle; JWT algorithm pinning (HS256) | ✅ green |
+| applications | GDPR erasure hit non-existent columns/table → would throw at runtime | ✅ green |
+| notifications | GDPR `email_queue` not erased (PII); invitee email logged; unsafe casts | ✅ green |
+| pets | Orphan-pet authz hole (any permission-holder could mutate) | ✅ green |
+| rescue | Rescue rejection persisted with no failure reason | ✅ green |
+| moderation | Duplicate auto-reports on event redelivery (no idempotency arbiter) | ✅ green |
+| gateway | Internal 5xx error details leaked to clients | ✅ green |
+| chat | GDPR erasure left soft-deleted message PII; participants delete would throw | ✅ green |
+| matching | endSession guard simplified; GDPR erasure had no tests | ✅ green |
+| cms | Event idempotency keys collided → publish/unpublish silently dropped | ✅ green |
+| audit | No changes — service audited and found sound | ✅ green |
+
+**Verification:** `pnpm exec turbo lint type-check test --filter='./services/*'`
+→ 42/42 tasks pass (lint + type-check + test for all 11 services).
+
+**No shared-package bugs were found** — `service-bootstrap`, `events`,
+`authz`, `db`, `config-secrets`, `proto`, and `observability` all behaved as
+their consumers rely on.
+
+## Cross-cutting themes
+
+1. **GDPR erasure was the highest-risk area.** Three services had erasure
+   defects that mocked tests could not catch: `applications` and `chat`
+   referenced columns/tables that don't exist (runtime throw → erasure
+   fails), and `notifications` + `chat` left PII behind (queued emails,
+   already-soft-deleted messages). All fixed.
+2. **Event idempotency-key discipline.** `moderation` lacked an `ON CONFLICT`
+   arbiter (duplicate auto-reports on JetStream redelivery) and `cms` reused
+   one dedup key across publish/unpublish/archive (broker dropped
+   transitions). Both fixed; a few non-deterministic *update* event ids are
+   deferred (low impact).
+3. **Authz scope edges.** `pets` orphan records bypassed rescue scope;
+   `gateway` leaked internal error detail. Fixed. A couple of
+   defense-in-depth / super_admin-consistency items are deferred for product
+   sign-off.
+
+## Per-service detail
+
+### auth
+- **Fixed (Medium, security):** unknown-email login now runs a dummy bcrypt
+  compare so response latency no longer reveals registered emails.
+- **Fixed (Medium, security):** JWT signing pinned to HS256 on sign *and*
+  verify (rejects algorithm-substitution); tests added.
+- **Deferred:** unify `refresh_tokens` revocation columns (`revoked_at` vs
+  `is_revoked`) so logout/rotation reflect in ListSessions and RevokeSession
+  blocks refresh (ADS-801 — cross-handler contract); login lockout policy
+  (`locked_until`) — intentionally a later auth-policy module.
+
+### applications
+- **Fixed (High, GDPR/correctness):** erasure UPDATE referenced non-existent
+  `answers`/`references` columns and a non-existent `applications.documents`
+  table — a real erase would throw. Now scrubs the JSONB `documents` blob the
+  projector writes (`{answers, references}`) and deletes from
+  `application_documents`. Guarded `removeDocument` against empty id.
+
+### notifications
+- **Fixed (High, GDPR):** erasure now hard-deletes the user's `email_queue`
+  rows (recipient address + rendered body are PII).
+- **Fixed (Medium, security):** stopped logging the invitee email on
+  `rescue.staffInvited`.
+- **Fixed (Medium, maintainability):** removed unsafe `Promise` type
+  assertions in the email worker and scheduler.
+
+### pets
+- **Fixed (High, authz):** `deletePet`/`updatePet` gated orphan pets (no
+  `rescue_id`) via `requirePermission(..., undefined)`, which skips the scope
+  check and admits any permission-holder — contradicting the documented
+  "super_admin only" intent. Introduced `isPermittedRescueMutation` to gate
+  the orphan case on the `super_admin` role; test added.
+- **Deferred:** `pets.updated` event id embeds `Date.now()` (non-deterministic
+  idempotency key) — switch to a version key if its consumer needs dedupe.
+
+### rescue
+- **Fixed (Medium, correctness):** `verifyRescue` accepted a `→ rejected`
+  transition with no `failureReason`, persisting NULL and losing the audit
+  record; now rejected with `INVALID_ARGUMENT` before any write.
+- **Fixed (Low, testing):** added cross-rescue `endFosterPlacement` denial test.
+- **Deferred:** deterministic event ids for `rescue.updated`/`statusChanged`
+  (needs `version` surfaced); invitation dedupe policy; `is_verified`
+  consistency between the self vs explicit-`rescueId` list paths.
+
+### moderation
+- **Fixed (High, correctness):** `fileReport` had no `ON CONFLICT`, so
+  JetStream redelivery minted duplicate auto-reports. Added migration 009
+  (partial unique index scoped to the SYSTEM reporter) and an `ON CONFLICT`
+  targeting it; human reports unaffected. Removed two redundant casts.
+- **Deferred:** content-scanner uses substring match, not `\b` word
+  boundaries (documented seed scanner to be replaced); `ADMIN_DASHBOARD`
+  placeholder permission pending a `MODERATION_*` namespace in lib.types.
+
+### gateway
+- **Fixed (High, security):** `handleGrpcError` forwarded upstream gRPC
+  `details`/`message` on 5xx, leaking stack/DB/connection-string fragments to
+  clients. Now returns a generic message for 5xx while preserving 4xx
+  validation text; leakage-path tests added.
+- **Deferred:** body-supplied `userId`/`adopterId` forwarding to downstream
+  (defense-in-depth — the BFF delegates authz to downstream services via the
+  signed principal token; gateway-side equality enforcement would be a
+  cross-service contract change). Recommend confirming downstream enforces
+  principal-subject equality.
+
+### chat
+- **Fixed (High, GDPR):** message scrub was guarded by `deleted_at IS NULL`,
+  so a user's own previously soft-deleted messages kept their content (PII).
+  Now scrubs every authored message idempotently (`content <> '[erased]'`,
+  `COALESCE(deleted_at, now())`).
+- **Fixed (High, GDPR):** `chat_participants` were deleted by a non-existent
+  `user_id` column (actual column `participant_id`) — would throw. Corrected.
+- **Added:** 11 tests (participant gating, permission-denied, message length,
+  reaction idempotency, GDPR).
+- **Deferred:** `openChat` inserts a null-UUID `rescue_id` placeholder
+  (TODO) — rescue-scoped search can't match gRPC-created chats until the
+  gateway translator resolves the real `rescue_id` (cross-service).
+
+### matching
+- **Fixed (Low, maintainability):** simplified a convoluted `endSession`
+  ownership guard (dead `!hasPermission(...) === false` term) to the flat,
+  fail-closed shape `recordSwipe` uses; behaviour-preserving
+  (`ensureSwipePermission` runs first).
+- **Fixed (Medium, testing):** added GDPR erasure tests (previously none).
+- **Deferred:** re-swipe idempotency — `swipe_actions` has no unique
+  constraint / `ON CONFLICT`, so re-swiping double-counts; needs a migration
+  plus a product decision (append-only log vs dedupe). Schema-prefix
+  consistency in `gdpr/erase.ts` / `profile-stats-handlers.ts` if
+  `MATCHING_SCHEMA` is overridden.
+
+### audit
+- **No changes.** The append-only store was verified genuinely immutable
+  (row-level `BEFORE UPDATE OR DELETE` trigger), inserts idempotent
+  (`ON CONFLICT (event_id) DO NOTHING`), keyset cursor stable, GDPR sweep
+  reconciliation sound. Candidates were intentional design or speculative
+  hardening; per CLAUDE.md (no gold-plating) nothing was changed.
+- **Deferred:** route `reports-handlers` authz through `requirePermission`
+  for super_admin-bypass consistency; decide whether
+  `getGdprErasureRequest` should return `NOT_FOUND` (vs `PERMISSION_DENIED`)
+  to a non-admin non-owner to avoid an existence-leak. Both need product
+  sign-off (they change access semantics / test contracts).
+
+### cms
+- **Fixed (High, correctness):** every `publish()` used the bare aggregate id
+  as the JetStream dedup key, so publish/unpublish/archive of the same
+  content shared one key and the broker dropped all but the first within the
+  dedup window. Keys now namespaced by event type (with a timestamp suffix
+  for repeatable update/restore, matching pets/rescue).
+- **Fixed (Medium, maintainability):** removed 6 unsafe row-cast assertions by
+  typing the query generic.
+- **Added:** 9 tests (anonymous published-only reads, admin permission
+  gating, slug collision/validation). 40 → 49.
+- **Deferred:** CMS publish/unpublish/archive has no transition validation or
+  transition log (contrast `pets`); needs product input on legal transitions.
+
+## Deferred backlog (needs product/architecture decision)
+
+| Service | Item | Why deferred |
+|---|---|---|
+| auth | Unify `refresh_tokens` revocation model (ADS-801) | Cross-handler contract change |
+| auth | Login lockout (`locked_until`) | Later auth-policy module |
+| pets / rescue / cms | Deterministic ids for `*.updated`/`statusChanged` events | Needs version surfaced; low impact |
+| rescue | Invitation dedupe; `is_verified` list consistency | Product policy |
+| gateway | Gateway-side principal==subject enforcement | BFF delegates authz downstream |
+| chat | Real `rescue_id` on `openChat` | Needs proto field / gateway translator |
+| matching | Re-swipe idempotency | Migration + append-vs-dedupe decision |
+| moderation | `MODERATION_*` permission namespace; regex content scanner | Cross-package; scanner to be replaced |
+| audit | reports-handlers super_admin consistency; GDPR existence-leak | Changes access semantics |
+| cms | Publish/archive transition state machine | Product intent for legal transitions |

--- a/services/applications/src/gdpr/erase.test.ts
+++ b/services/applications/src/gdpr/erase.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import type { GdprErasureRequestedPayload } from '@adopt-dont-shop/events';
+import type { PoolClient } from 'pg';
+
+import { eraseApplications } from './erase.js';
+
+const payload: GdprErasureRequestedPayload = {
+  userId: 'usr-erase-1',
+  correlationId: 'corr-1',
+  requestedAt: '2026-06-15T12:00:00.000Z',
+} as unknown as GdprErasureRequestedPayload;
+
+function makeClient(): { client: PoolClient; query: ReturnType<typeof vi.fn> } {
+  const query = vi.fn().mockResolvedValue({ rowCount: 0 });
+  return { client: { query } as unknown as PoolClient, query };
+}
+
+describe('eraseApplications', () => {
+  it('scrubs the read-model PII columns that actually exist', async () => {
+    const { client, query } = makeClient();
+    query.mockResolvedValueOnce({ rowCount: 2 }); // applications update
+    query.mockResolvedValueOnce({ rowCount: 1 }); // documents delete
+
+    await eraseApplications(client, payload);
+
+    const updateSql = query.mock.calls[0][0] as string;
+    // The read model has NO `answers` / `references` columns — answers and
+    // references live inside the JSONB `documents` column. Referencing the
+    // non-existent columns would make the UPDATE throw at runtime.
+    expect(updateSql).not.toMatch(/\banswers\s*=/);
+    expect(updateSql).not.toMatch(/"references"\s*=/);
+    // It MUST scrub the documents JSONB blob that holds answers/references.
+    expect(updateSql).toMatch(/documents\s*=/);
+    expect(query.mock.calls[0][1]).toEqual([payload.userId]);
+  });
+
+  it('hard-deletes document metadata from the application_documents table', async () => {
+    const { client, query } = makeClient();
+    query.mockResolvedValueOnce({ rowCount: 0 });
+    query.mockResolvedValueOnce({ rowCount: 3 });
+
+    await eraseApplications(client, payload);
+
+    const deleteSql = query.mock.calls[1][0] as string;
+    // The metadata table is `application_documents`, not `documents`.
+    expect(deleteSql).toMatch(/application_documents/);
+  });
+
+  it('returns the total rows touched across both statements', async () => {
+    const { client, query } = makeClient();
+    query.mockResolvedValueOnce({ rowCount: 2 });
+    query.mockResolvedValueOnce({ rowCount: 3 });
+
+    const total = await eraseApplications(client, payload);
+
+    expect(total).toBe(5);
+  });
+});

--- a/services/applications/src/gdpr/erase.ts
+++ b/services/applications/src/gdpr/erase.ts
@@ -14,12 +14,13 @@ export async function eraseApplications(
 ): Promise<number> {
   let total = 0;
 
-  // The applications table stores the user's answers + references as
-  // JSONB. Scrub these alongside the personal columns.
+  // The applications read model stores the user's answers + references
+  // inside the JSONB `documents` column (the projector writes
+  // { answers, references } there — there are no separate answers /
+  // references columns). Scrub that blob alongside the free-text notes.
   const appsRes = await client.query(
     `UPDATE applications.applications
-        SET answers = '{}'::jsonb,
-            "references" = '[]'::jsonb,
+        SET documents = '{"answers":{},"references":[]}'::jsonb,
             notes = NULL,
             interview_notes = NULL,
             home_visit_notes = NULL,
@@ -33,9 +34,9 @@ export async function eraseApplications(
   // sitting in storage are erased by a separate retention sweep — see
   // gateway uploads route).
   const docsRes = await client.query(
-    `DELETE FROM applications.documents
+    `DELETE FROM applications.application_documents
        USING applications.applications a
-       WHERE applications.documents.application_id = a.application_id
+       WHERE applications.application_documents.application_id = a.application_id
          AND a.user_id = $1`,
     [payload.userId]
   );

--- a/services/applications/src/grpc/document-handlers.test.ts
+++ b/services/applications/src/grpc/document-handlers.test.ts
@@ -178,6 +178,14 @@ describe('removeDocument', () => {
     ).rejects.toBeInstanceOf(HandlerError);
   });
 
+  it('throws INVALID_ARGUMENT when application_id is empty', async () => {
+    const { deps, query } = makeDeps();
+    await expect(
+      removeDocument(deps, makePrincipal(), { applicationId: '', documentId: 'doc-1' })
+    ).rejects.toMatchObject({ code: 'INVALID_ARGUMENT' });
+    expect(query).not.toHaveBeenCalled();
+  });
+
   it('soft-deletes the document and returns an empty response', async () => {
     const { deps, query } = makeDeps();
     query.mockResolvedValueOnce({ rowCount: 1 });

--- a/services/applications/src/grpc/document-handlers.ts
+++ b/services/applications/src/grpc/document-handlers.ts
@@ -159,6 +159,9 @@ export async function removeDocument(
   if (!requirePermission(principal, APPLICATIONS_UPDATE)) {
     throw new HandlerError('PERMISSION_DENIED', `'${APPLICATIONS_UPDATE}' required`);
   }
+  if (req.applicationId === '') {
+    throw new HandlerError('INVALID_ARGUMENT', 'application_id is required');
+  }
   if (req.documentId === '') {
     throw new HandlerError('INVALID_ARGUMENT', 'document_id is required');
   }

--- a/services/applications/src/grpc/read-handlers.test.ts
+++ b/services/applications/src/grpc/read-handlers.test.ts
@@ -184,6 +184,41 @@ describe('listApplications', () => {
     expect(indexParams).toContain('approved');
   });
 
+  it('decodes a supplied cursor into a correctly-parameterised keyset predicate', async () => {
+    const { deps, query } = makeDeps();
+    query.mockResolvedValueOnce({ rows: [] });
+
+    const cursor = Buffer.from(
+      JSON.stringify({ createdAt: '2026-06-02T12:00:00.000Z', applicationId: 'app-1' }),
+      'utf8'
+    ).toString('base64url');
+
+    await listApplications(deps, makePrincipal({ userId: 'usr-1' }), {
+      limit: 20,
+      statusFilter: S.APPLICATION_STATUS_UNSPECIFIED,
+      cursor,
+    });
+
+    const sql = query.mock.calls[0][0] as string;
+    const params = query.mock.calls[0][1] as unknown[];
+    // user_id = $1, then the keyset predicate references $2 (created_at)
+    // twice and $3 (application_id) once, LIMIT is the final placeholder.
+    expect(sql).toContain('(created_at < $2 OR (created_at = $2 AND application_id < $3))');
+    // $1 user id, $2 cursor created_at, $3 cursor application_id, $4 limit+1.
+    expect(params).toEqual(['usr-1', '2026-06-02T12:00:00.000Z', 'app-1', 21]);
+  });
+
+  it('rejects a malformed cursor with INVALID_ARGUMENT', async () => {
+    const { deps } = makeDeps();
+    await expect(
+      listApplications(deps, makePrincipal(), {
+        limit: 20,
+        statusFilter: S.APPLICATION_STATUS_UNSPECIFIED,
+        cursor: 'not-a-valid-cursor!!!',
+      })
+    ).rejects.toMatchObject({ code: 'INVALID_ARGUMENT' });
+  });
+
   it('emits a next_cursor when more rows exist', async () => {
     const { deps, query } = makeDeps();
     // limit 1 → fetch 2; two index rows means hasMore.

--- a/services/auth/src/grpc/admin-handlers.test.ts
+++ b/services/auth/src/grpc/admin-handlers.test.ts
@@ -1,5 +1,5 @@
 import type { NatsConnection } from 'nats';
-import type { Pool, PoolClient } from 'pg';
+import type { Pool } from 'pg';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { Principal } from '@adopt-dont-shop/authz';

--- a/services/auth/src/grpc/handlers.test.ts
+++ b/services/auth/src/grpc/handlers.test.ts
@@ -160,6 +160,23 @@ describe('login', () => {
     });
   });
 
+  it('performs a password comparison even when the email is unknown (no enumeration timing leak)', async () => {
+    mocks.poolMock.query.mockResolvedValueOnce({ rows: [] });
+    mocks.hasherMock.compare.mockResolvedValueOnce(false);
+
+    await expect(login(mocks.deps, null, BASE_LOGIN_REQ)).rejects.toMatchObject({
+      code: 'UNAUTHENTICATED',
+    });
+
+    // The hasher must be exercised so a missing account costs the same
+    // wall-clock time as a wrong password against a real account.
+    expect(mocks.hasherMock.compare).toHaveBeenCalledTimes(1);
+    expect(mocks.hasherMock.compare).toHaveBeenCalledWith(
+      BASE_LOGIN_REQ.password,
+      expect.any(String)
+    );
+  });
+
   it('returns PERMISSION_DENIED when account is locked', async () => {
     mocks.poolMock.query.mockResolvedValueOnce({
       rows: [userRowFixture({ locked_until: new Date(Date.now() + 60_000) })],

--- a/services/auth/src/grpc/handlers.ts
+++ b/services/auth/src/grpc/handlers.ts
@@ -243,6 +243,11 @@ function rolesToProto(roles: UserRole[]): AuthV1.UserRole[] {
 
 // --- Login -----------------------------------------------------------
 
+// A fixed valid bcrypt hash (of an arbitrary throwaway password) used only
+// to spend an equivalent amount of CPU when the email is unknown, so login
+// latency doesn't reveal whether an account exists.
+const DUMMY_PASSWORD_HASH = '$2a$12$0000000000000000000000000000000000000000000000000000u';
+
 export async function login(
   deps: HandlerDeps,
   _principal: Principal | null,
@@ -264,6 +269,10 @@ export async function login(
     [req.email]
   );
   if (userRes.rows.length === 0) {
+    // Run a dummy comparison against a fixed hash so an unknown email
+    // costs the same wall-clock time as a wrong password — otherwise the
+    // early return is a user-enumeration timing oracle.
+    await deps.passwordHasher.compare(req.password, DUMMY_PASSWORD_HASH);
     throw new HandlerError('UNAUTHENTICATED', 'invalid credentials');
   }
   const user = userRes.rows[0];

--- a/services/auth/src/grpc/token-issuer.test.ts
+++ b/services/auth/src/grpc/token-issuer.test.ts
@@ -1,3 +1,4 @@
+import jwt from 'jsonwebtoken';
 import { describe, expect, it } from 'vitest';
 
 import { createJwtTokenIssuer } from './token-issuer.js';
@@ -52,5 +53,30 @@ describe('createJwtTokenIssuer', () => {
     const minted = await issuer.mint('usr-1');
     const tampered = minted.pair.accessToken.slice(0, -3) + 'AAA';
     await expect(issuer.verifyAccess(tampered)).rejects.toThrowError();
+  });
+
+  it('verifyAccess REJECTS a token signed with a non-HS256 algorithm (algorithm pinning)', async () => {
+    const issuer = createJwtTokenIssuer(cfg);
+    const now = Math.floor(Date.now() / 1000);
+    // A valid HMAC token over the SAME secret but with HS512 instead of the
+    // pinned HS256 — must be rejected so an attacker can't substitute the
+    // signing algorithm.
+    const hs512 = jwt.sign(
+      { sub: 'usr-1', jti: 'j1', iat: now, exp: now + 600 },
+      cfg.accessSecret,
+      { algorithm: 'HS512' }
+    );
+    await expect(issuer.verifyAccess(hs512)).rejects.toThrowError();
+  });
+
+  it('verifyRefresh REJECTS a token signed with a non-HS256 algorithm (algorithm pinning)', async () => {
+    const issuer = createJwtTokenIssuer(cfg);
+    const now = Math.floor(Date.now() / 1000);
+    const hs512 = jwt.sign(
+      { sub: 'usr-1', jti: 'j1', iat: now, exp: now + 600 },
+      cfg.refreshSecret,
+      { algorithm: 'HS512' }
+    );
+    await expect(issuer.verifyRefresh(hs512)).rejects.toThrowError();
   });
 });

--- a/services/auth/src/grpc/token-issuer.ts
+++ b/services/auth/src/grpc/token-issuer.ts
@@ -26,6 +26,11 @@ import type {
 const ACCESS_TTL_SECONDS = 15 * 60;
 const REFRESH_TTL_SECONDS = 30 * 24 * 60 * 60;
 
+// Pin the signing algorithm on BOTH sign and verify. Without pinning,
+// jwt.verify trusts the `alg` header on the inbound token, which opens
+// the door to algorithm-substitution attacks. We only ever issue HS256.
+const SIGNING_ALGORITHM = 'HS256' as const;
+
 export type TokenIssuerConfig = {
   accessSecret: string;
   refreshSecret: string;
@@ -43,11 +48,13 @@ export function createJwtTokenIssuer(cfg: TokenIssuerConfig): TokenIssuer {
 
       const accessToken = jwt.sign(
         { sub: userId, jti: accessJti, iat: now, exp: accessExp },
-        cfg.accessSecret
+        cfg.accessSecret,
+        { algorithm: SIGNING_ALGORITHM }
       );
       const refreshToken = jwt.sign(
         { sub: userId, jti: refreshJti, iat: now, exp: refreshExp },
-        cfg.refreshSecret
+        cfg.refreshSecret,
+        { algorithm: SIGNING_ALGORITHM }
       );
 
       const minted: MintedTokens = {
@@ -66,12 +73,16 @@ export function createJwtTokenIssuer(cfg: TokenIssuerConfig): TokenIssuer {
     },
 
     verifyAccess: async token => {
-      const decoded = jwt.verify(token, cfg.accessSecret) as Record<string, unknown>;
+      const decoded = jwt.verify(token, cfg.accessSecret, {
+        algorithms: [SIGNING_ALGORITHM],
+      }) as Record<string, unknown>;
       return toAccessClaims(decoded);
     },
 
     verifyRefresh: async token => {
-      const decoded = jwt.verify(token, cfg.refreshSecret) as Record<string, unknown>;
+      const decoded = jwt.verify(token, cfg.refreshSecret, {
+        algorithms: [SIGNING_ALGORITHM],
+      }) as Record<string, unknown>;
       return toRefreshClaims(decoded);
     },
   };

--- a/services/chat/src/gdpr/erase.test.ts
+++ b/services/chat/src/gdpr/erase.test.ts
@@ -1,0 +1,86 @@
+import type { PoolClient } from 'pg';
+import { describe, expect, it, vi } from 'vitest';
+
+import type { GdprErasureRequestedPayload } from '@adopt-dont-shop/events';
+
+import { eraseChat } from './erase.js';
+
+const PAYLOAD: GdprErasureRequestedPayload = {
+  userId: 'usr-erase',
+  correlationId: 'corr-1',
+  requestedAt: '2026-06-15T00:00:00Z',
+};
+
+function makeClient(rowCounts: number[]): {
+  client: PoolClient;
+  calls: Array<{ text: string; values: unknown[] }>;
+} {
+  const calls: Array<{ text: string; values: unknown[] }> = [];
+  let i = 0;
+  const query = vi.fn(async (text: string, values: unknown[]) => {
+    calls.push({ text, values });
+    const rowCount = rowCounts[i] ?? 0;
+    i += 1;
+    return { rowCount, rows: [] };
+  });
+  return { client: { query } as unknown as PoolClient, calls };
+}
+
+describe('eraseChat', () => {
+  it('keys the chat_participants delete on participant_id (the real column, not user_id)', async () => {
+    const { client, calls } = makeClient([1, 1, 1, 1]);
+    await eraseChat(client, PAYLOAD);
+    const participantsCall = calls.find(c => c.text.includes('chat_participants'));
+    expect(participantsCall).toBeDefined();
+    // chat_participants has no `user_id` column — the membership FK is
+    // `participant_id`. Guard against the regression where erase keyed
+    // on a non-existent column (would throw at runtime, aborting the saga).
+    expect(participantsCall?.text).toMatch(/participant_id\s*=\s*\$1/);
+    expect(participantsCall?.text).not.toMatch(/\buser_id\b/);
+  });
+
+  it('anonymises the user-authored messages and drops their reactions + reads', async () => {
+    const { client, calls } = makeClient([2, 3, 1, 1]);
+    const total = await eraseChat(client, PAYLOAD);
+
+    expect(calls).toHaveLength(4);
+    expect(calls.every(c => c.values[0] === 'usr-erase')).toBe(true);
+
+    const msgCall = calls.find(c => c.text.includes('messages'));
+    expect(msgCall?.text).toMatch(/SET content = '\[erased\]'/);
+    expect(msgCall?.text).toMatch(/sender_id = \$1/);
+
+    expect(calls.some(c => c.text.includes('message_reactions'))).toBe(true);
+    expect(calls.some(c => c.text.includes('message_reads'))).toBe(true);
+
+    // Sum of the row counts is reported back to the saga.
+    expect(total).toBe(7);
+  });
+
+  it('returns 0 when the user has no data in this schema (idempotent re-run)', async () => {
+    const { client } = makeClient([0, 0, 0, 0]);
+    const total = await eraseChat(client, PAYLOAD);
+    expect(total).toBe(0);
+  });
+
+  it("scrubs content from the user's own already-soft-deleted messages (no deleted_at guard)", async () => {
+    const { calls } = makeClient([0, 0, 0, 0]);
+    const client = {
+      query: vi.fn(async (text: string, values: unknown[]) => {
+        calls.push({ text, values });
+        return { rowCount: 0, rows: [] };
+      }),
+    } as unknown as PoolClient;
+
+    await eraseChat(client, PAYLOAD);
+
+    const msgCall = calls.find(c => c.text.includes('messages'));
+    // GDPR erasure must remove PII even from messages the user had already
+    // soft-deleted themselves — those rows still carry content in the DB.
+    // The scrub must NOT be gated on `deleted_at IS NULL`.
+    expect(msgCall?.text).not.toMatch(/deleted_at\s+IS\s+NULL/i);
+    // And it must only touch rows that aren't already scrubbed, so re-runs
+    // stay idempotent.
+    expect(msgCall?.text).toMatch(/content\s*<>\s*'\[erased\]'/i);
+  });
+});

--- a/services/chat/src/gdpr/erase.ts
+++ b/services/chat/src/gdpr/erase.ts
@@ -14,10 +14,15 @@ export async function eraseChat(
 ): Promise<number> {
   let total = 0;
 
+  // Scrub content from EVERY message the user authored — including ones
+  // they had already soft-deleted themselves, whose `content` still sits
+  // in the DB and is PII. `deleted_at` is set if not already (preserving
+  // the original deletion time via COALESCE). The `content <> '[erased]'`
+  // guard keeps re-runs idempotent (already-scrubbed rows aren't touched).
   const msgRes = await client.query(
     `UPDATE chat.messages
-        SET content = '[erased]', deleted_at = now(), updated_at = now()
-      WHERE sender_id = $1 AND deleted_at IS NULL`,
+        SET content = '[erased]', deleted_at = COALESCE(deleted_at, now()), updated_at = now()
+      WHERE sender_id = $1 AND content <> '[erased]'`,
     [payload.userId]
   );
   total += msgRes.rowCount ?? 0;
@@ -25,7 +30,7 @@ export async function eraseChat(
   for (const sql of [
     `DELETE FROM chat.message_reactions WHERE user_id = $1`,
     `DELETE FROM chat.message_reads WHERE user_id = $1`,
-    `DELETE FROM chat.chat_participants WHERE user_id = $1`,
+    `DELETE FROM chat.chat_participants WHERE participant_id = $1`,
   ]) {
     const res = await client.query(sql, [payload.userId]);
     total += res.rowCount ?? 0;

--- a/services/chat/src/grpc/handlers.test.ts
+++ b/services/chat/src/grpc/handlers.test.ts
@@ -225,6 +225,12 @@ describe('sendMessage', () => {
     });
   });
 
+  it('rejects a body over the length limit', async () => {
+    await expect(
+      sendMessage(mocks.deps, ADOPTER_PRINCIPAL, { ...BASE_SEND, body: 'a'.repeat(10_001) })
+    ).rejects.toMatchObject({ code: 'INVALID_ARGUMENT' });
+  });
+
   it('inserts the message and publishes chat.messageCreated after commit', async () => {
     // isParticipantOrAdmin → one row
     mocks.poolScript.push({ rows: [{ chat_participant_id: 'p-1' }] });
@@ -256,6 +262,14 @@ describe('listMessages', () => {
     await expect(listMessages(mocks.deps, UNPRIVILEGED_PRINCIPAL, BASE_LIST)).rejects.toMatchObject(
       { code: 'PERMISSION_DENIED' }
     );
+  });
+
+  it('rejects a participant-scope miss (has chat.read but is not a member)', async () => {
+    // isParticipantOrAdmin SELECT → no rows
+    mocks.poolScript.push({ rows: [] });
+    await expect(listMessages(mocks.deps, ADOPTER_PRINCIPAL, BASE_LIST)).rejects.toMatchObject({
+      code: 'PERMISSION_DENIED',
+    });
   });
 
   it('returns ordered rows with reactions aggregated', async () => {
@@ -343,6 +357,20 @@ describe('markRead', () => {
     mocks = makeMocks();
   });
 
+  it('rejects principals without chat.read', async () => {
+    await expect(markRead(mocks.deps, UNPRIVILEGED_PRINCIPAL, BASE_MARK)).rejects.toMatchObject({
+      code: 'PERMISSION_DENIED',
+    });
+  });
+
+  it('rejects a non-participant (participant-scope miss)', async () => {
+    // isParticipantOrAdmin → no rows
+    mocks.poolScript.push({ rows: [] });
+    await expect(markRead(mocks.deps, ADOPTER_PRINCIPAL, BASE_MARK)).rejects.toMatchObject({
+      code: 'PERMISSION_DENIED',
+    });
+  });
+
   it('rejects when message does not exist in chat', async () => {
     // isParticipantOrAdmin → ok
     mocks.poolScript.push({ rows: [{ chat_participant_id: 'p-1' }] });
@@ -384,12 +412,47 @@ describe('react', () => {
     mocks = makeMocks();
   });
 
+  it('rejects principals without chat.send', async () => {
+    await expect(react(mocks.deps, UNPRIVILEGED_PRINCIPAL, BASE_REACT)).rejects.toMatchObject({
+      code: 'PERMISSION_DENIED',
+    });
+  });
+
+  it('rejects reacting in a chat the caller is not a member of', async () => {
+    // message lookup → ok (resolves the chat)
+    mocks.poolScript.push({ rows: [{ chat_id: 'chat-1' }] });
+    // isParticipantOrAdmin → no rows
+    mocks.poolScript.push({ rows: [] });
+    await expect(react(mocks.deps, ADOPTER_PRINCIPAL, BASE_REACT)).rejects.toMatchObject({
+      code: 'PERMISSION_DENIED',
+    });
+  });
+
   it('returns NOT_FOUND when the target message is missing', async () => {
     // message lookup → empty
     mocks.poolScript.push({ rows: [] });
     await expect(react(mocks.deps, ADOPTER_PRINCIPAL, BASE_REACT)).rejects.toMatchObject({
       code: 'NOT_FOUND',
     });
+  });
+
+  it('uses ON CONFLICT DO NOTHING so re-reacting is idempotent', async () => {
+    mocks.poolScript.push({ rows: [{ chat_id: 'chat-1' }] });
+    mocks.poolScript.push({ rows: [{ chat_participant_id: 'p-1' }] });
+    mocks.clientScript.push({
+      rows: [{ participant_id: 'usr-adopter' }, { participant_id: 'usr-rescue' }],
+    });
+    mocks.clientScript.push({ rows: [] });
+    mocks.poolScript.push({ rows: [messageRowFixture()] });
+    mocks.poolScript.push({ rows: [] });
+
+    await react(mocks.deps, ADOPTER_PRINCIPAL, BASE_REACT);
+
+    const insertCall = mocks.clientMock.query.mock.calls.find(
+      ([sql]) => typeof sql === 'string' && sql.includes('INSERT INTO message_reactions')
+    );
+    expect(insertCall).toBeDefined();
+    expect(insertCall?.[0]).toMatch(/ON CONFLICT \(message_id, user_id, emoji\) DO NOTHING/);
   });
 
   it('adds a reaction and publishes chat.reactionAdded', async () => {
@@ -675,6 +738,24 @@ describe('deleteMessage', () => {
     await expect(
       deleteMessage(mocks.deps, ADOPTER_PRINCIPAL, { messageId: 'msg-1' })
     ).rejects.toMatchObject({ code: 'PERMISSION_DENIED' });
+  });
+
+  it('lets the sender soft-delete their own message and publishes chat.messageDeleted', async () => {
+    // existing row → sender owns it, not yet deleted
+    mocks.poolMock.query.mockResolvedValueOnce({
+      rows: [messageRowFixture({ sender_id: 'usr-adopter' })],
+    });
+    // Inside withTransaction: UPDATE returning, SELECT participants
+    mocks.clientScript.push({ rows: [messageRowFixture({ deleted_at: new Date() })] });
+    mocks.clientScript.push({
+      rows: [{ participant_id: 'usr-adopter' }, { participant_id: 'usr-rescue' }],
+    });
+    // After commit: reactions lookup
+    mocks.poolMock.query.mockResolvedValueOnce({ rows: [] });
+
+    const res = await deleteMessage(mocks.deps, ADOPTER_PRINCIPAL, { messageId: 'msg-1' });
+    expect(res.message?.deletedAt).toBeDefined();
+    expect(mocks.natsMock.publish.mock.calls[0][0]).toBe('chat.messageDeleted');
   });
 
   it('is idempotent on an already-deleted row (no write, no publish)', async () => {

--- a/services/cms/src/grpc/handlers.test.ts
+++ b/services/cms/src/grpc/handlers.test.ts
@@ -228,6 +228,75 @@ describe('admin reads', () => {
   });
 });
 
+describe('anonymous reads never leak unpublished content', () => {
+  let mocks: ReturnType<typeof makeMocks>;
+  beforeEach(() => {
+    mocks = makeMocks();
+  });
+
+  it('getPublicContentBySlug constrains the query to published + non-deleted rows', async () => {
+    mocks.poolScript.push({ rows: [contentRow({ status: 'published' })] });
+    await getPublicContentBySlug(mocks.deps, null, { slug: 'hello' });
+    const [sql] = mocks.poolMock.query.mock.calls[0] as [string];
+    expect(sql).toContain("status = 'published'");
+    expect(sql).toContain('deleted_at IS NULL');
+  });
+
+  it('listPublicContent never filters by an admin-only status (cannot request drafts)', async () => {
+    mocks.poolScript.push({ rows: [{ count: '0' }] });
+    mocks.poolScript.push({ rows: [] });
+    // A public caller has no `status` field on its request; the handler must
+    // hard-code published and ignore any attempt to widen the filter.
+    await listPublicContent(mocks.deps, null, { contentType: 0, page: 1, limit: 10 });
+    const [countSql] = mocks.poolMock.query.mock.calls[0] as [string];
+    expect(countSql).toContain("status = 'published'");
+    expect(countSql).not.toContain('status = $');
+  });
+});
+
+describe('admin write handlers gate on permission', () => {
+  let mocks: ReturnType<typeof makeMocks>;
+  beforeEach(() => {
+    mocks = makeMocks();
+  });
+
+  it('createContent refuses callers without cms.content.create', async () => {
+    await expect(
+      createContent(mocks.deps, NO_PERMS, {
+        title: 'x',
+        slug: 'hello',
+        contentType: CmsV1.ContentType.CONTENT_TYPE_PAGE,
+        content: '',
+        metaKeywords: [],
+      })
+    ).rejects.toMatchObject({ code: 'PERMISSION_DENIED' });
+  });
+
+  it('publishContent refuses callers without cms.content.publish', async () => {
+    await expect(publishContent(mocks.deps, NO_PERMS, { contentId: 'c-1' })).rejects.toMatchObject({
+      code: 'PERMISSION_DENIED',
+    });
+  });
+
+  it('archiveContent refuses callers without cms.content.publish', async () => {
+    await expect(archiveContent(mocks.deps, NO_PERMS, { contentId: 'c-1' })).rejects.toMatchObject({
+      code: 'PERMISSION_DENIED',
+    });
+  });
+
+  it('createMenu refuses callers without cms.menu.create', async () => {
+    await expect(
+      createMenu(mocks.deps, NO_PERMS, { name: 'X', location: 'header', itemsJson: '[]' })
+    ).rejects.toMatchObject({ code: 'PERMISSION_DENIED' });
+  });
+
+  it('deleteMenu refuses callers without cms.menu.delete', async () => {
+    await expect(deleteMenu(mocks.deps, NO_PERMS, { menuId: 'm-1' })).rejects.toMatchObject({
+      code: 'PERMISSION_DENIED',
+    });
+  });
+});
+
 describe('createContent', () => {
   let mocks: ReturnType<typeof makeMocks>;
   beforeEach(() => {
@@ -324,6 +393,40 @@ describe('updateContent', () => {
       })
     ).rejects.toMatchObject({ code: 'NOT_FOUND' });
   });
+
+  it('translates a slug collision on update into ALREADY_EXISTS', async () => {
+    mocks.clientScript.push({ rows: [contentRow()] }); // SELECT FOR UPDATE
+    mocks.clientMock.query = vi.fn(async (sql: string) => {
+      const op = sql.trim().split(/\s+/)[0].toUpperCase();
+      if (op === 'BEGIN' || op === 'COMMIT' || op === 'ROLLBACK') {
+        return { rows: [], rowCount: 0 };
+      }
+      if (op === 'SELECT') {
+        return { rows: [contentRow()], rowCount: 1 };
+      }
+      const err = new Error('duplicate key') as Error & { code: string };
+      err.code = '23505';
+      throw err;
+    });
+    await expect(
+      updateContent(mocks.deps, ADMIN, {
+        contentId: 'c-1',
+        slug: 'taken',
+        setMetaKeywords: false,
+      })
+    ).rejects.toMatchObject({ code: 'ALREADY_EXISTS' });
+  });
+
+  it('rejects an invalid slug shape on update', async () => {
+    mocks.clientScript.push({ rows: [contentRow()] });
+    await expect(
+      updateContent(mocks.deps, ADMIN, {
+        contentId: 'c-1',
+        slug: 'Not Valid',
+        setMetaKeywords: false,
+      })
+    ).rejects.toMatchObject({ code: 'INVALID_ARGUMENT' });
+  });
 });
 
 describe('deleteContent', () => {
@@ -369,6 +472,63 @@ describe('workflow actions', () => {
     mocks.clientScript.push({ rows: [contentRow({ status: 'archived' })] });
     const res = await archiveContent(mocks.deps, ADMIN, { contentId: 'c-1' });
     expect(res.content?.status).toBe(CmsV1.ContentStatus.CONTENT_STATUS_ARCHIVED);
+  });
+});
+
+describe('event idempotency keys (Nats-Msg-Id)', () => {
+  let mocks: ReturnType<typeof makeMocks>;
+  beforeEach(() => {
+    mocks = makeMocks();
+  });
+
+  // The JetStream dedup window de-dups by Nats-Msg-Id stream-wide. Using the
+  // bare aggregate id for every event type means a create+publish of the same
+  // content within the window collides and the broker silently drops one. Each
+  // distinct business action must carry a distinct msgID — namespaced by event
+  // type, like the pets/rescue services.
+  const msgIdFor = (type: string): string | undefined => {
+    const call = mocks.natsMock.jetstream().publish.mock.calls.find(c => c[0] === type) as
+      | [string, unknown, { msgID?: string }]
+      | undefined;
+    return call?.[2]?.msgID;
+  };
+
+  it('namespaces the create event id by event type', async () => {
+    mocks.clientScript.push({ rows: [contentRow()] });
+    await createContent(mocks.deps, ADMIN, {
+      title: 'Hello',
+      slug: 'hello',
+      contentType: CmsV1.ContentType.CONTENT_TYPE_PAGE,
+      content: 'body',
+      metaKeywords: [],
+    });
+    expect(msgIdFor('cms.contentCreated')).toBe('cms.contentCreated.c-1');
+  });
+
+  it('publish and unpublish of the same content do not share a msgID', async () => {
+    mocks.clientScript.push({ rows: [contentRow({ status: 'published' })] });
+    await publishContent(mocks.deps, ADMIN, { contentId: 'c-1' });
+    const publishId = msgIdFor('cms.contentPublished');
+
+    mocks.natsMock.jetstream().publish.mockClear();
+    mocks.clientScript.push({ rows: [contentRow({ status: 'draft' })] });
+    await unpublishContent(mocks.deps, ADMIN, { contentId: 'c-1' });
+    const unpublishId = msgIdFor('cms.contentUnpublished');
+
+    expect(publishId).toBeTruthy();
+    expect(unpublishId).toBeTruthy();
+    expect(publishId).not.toBe(unpublishId);
+  });
+
+  it('namespaces menu create + delete event ids by event type', async () => {
+    mocks.clientScript.push({ rows: [menuRow()] });
+    await createMenu(mocks.deps, ADMIN, {
+      name: 'Main',
+      location: 'header',
+      itemsJson: '[]',
+      isActive: true,
+    });
+    expect(msgIdFor('cms.menuCreated')).toBe('cms.menuCreated.m-1');
   });
 });
 

--- a/services/cms/src/grpc/handlers.ts
+++ b/services/cms/src/grpc/handlers.ts
@@ -454,7 +454,7 @@ export async function createContent(
       createdAt: new Date().toISOString(),
     };
     try {
-      const result = await client.query(
+      const result = await client.query<ContentRow>(
         `INSERT INTO cms_content (
            title, slug, content_type, status, content, excerpt, meta_title,
            meta_description, meta_keywords, featured_image_url, scheduled_publish_at,
@@ -477,12 +477,12 @@ export async function createContent(
           principal.userId,
         ]
       );
-      const inserted = (result.rows as ContentRow[])[0];
+      const inserted = result.rows[0];
       if (!inserted) {
         throw new HandlerError('INTERNAL', 'insert returned no row');
       }
       publish({
-        id: inserted.content_id,
+        id: `cms.contentCreated.${inserted.content_id}`,
         type: 'cms.contentCreated',
         payload: { contentId: inserted.content_id, slug, contentType, actorId: principal.userId },
       });
@@ -512,11 +512,11 @@ export async function updateContent(
   }
 
   const row = await withTransaction(deps, async ({ client, publish }) => {
-    const currentResult = await client.query(
+    const currentResult = await client.query<ContentRow>(
       `SELECT ${CONTENT_COLUMNS} FROM cms_content WHERE content_id = $1 AND deleted_at IS NULL FOR UPDATE`,
       [id]
     );
-    const current = (currentResult.rows as ContentRow[])[0];
+    const current = currentResult.rows[0];
     if (!current) {
       throw new HandlerError('NOT_FOUND', `content ${id} not found`);
     }
@@ -587,7 +587,7 @@ export async function updateContent(
     params.push(id);
     let result;
     try {
-      result = await client.query(
+      result = await client.query<ContentRow>(
         `UPDATE cms_content SET ${setSql.join(', ')} WHERE content_id = $${params.length}
          RETURNING ${CONTENT_COLUMNS}`,
         params
@@ -598,12 +598,12 @@ export async function updateContent(
       }
       throw err;
     }
-    const updated = (result.rows as ContentRow[])[0];
+    const updated = result.rows[0];
     if (!updated) {
       throw new HandlerError('INTERNAL', 'update returned no row');
     }
     publish({
-      id: updated.content_id,
+      id: `cms.contentUpdated.${updated.content_id}.${Date.now()}`,
       type: 'cms.contentUpdated',
       payload: { contentId: updated.content_id, actorId: principal.userId },
     });
@@ -634,7 +634,7 @@ export async function deleteContent(
     const wasDeleted = result.rowCount !== null && result.rowCount > 0;
     if (wasDeleted) {
       publish({
-        id,
+        id: `cms.contentDeleted.${id}`,
         type: 'cms.contentDeleted',
         payload: { contentId: id, actorId: principal.userId },
       });
@@ -656,18 +656,22 @@ async function setStatus(
 ): Promise<ContentRow> {
   return withTransaction(deps, async ({ client, publish }) => {
     const setExtra = setPublishedAt ? ', published_at = now()' : '';
-    const result = await client.query(
+    const result = await client.query<ContentRow>(
       `UPDATE cms_content
          SET status = $1, last_modified_by = $2, updated_at = now() ${setExtra}
        WHERE content_id = $3 AND deleted_at IS NULL
        RETURNING ${CONTENT_COLUMNS}`,
       [status, principal.userId, contentId]
     );
-    const row = (result.rows as ContentRow[])[0];
+    const row = result.rows[0];
     if (!row) {
       throw new HandlerError('NOT_FOUND', `content ${contentId} not found`);
     }
-    publish({ id: contentId, type: topic, payload: { contentId, actorId: principal.userId } });
+    publish({
+      id: `${topic}.${contentId}`,
+      type: topic,
+      payload: { contentId, actorId: principal.userId },
+    });
     return row;
   });
 }
@@ -770,11 +774,11 @@ export async function restoreVersion(
   }
 
   const row = await withTransaction(deps, async ({ client, publish }) => {
-    const currentResult = await client.query(
+    const currentResult = await client.query<ContentRow>(
       `SELECT ${CONTENT_COLUMNS} FROM cms_content WHERE content_id = $1 AND deleted_at IS NULL FOR UPDATE`,
       [id]
     );
-    const current = (currentResult.rows as ContentRow[])[0];
+    const current = currentResult.rows[0];
     if (!current) {
       throw new HandlerError('NOT_FOUND', `content ${id} not found`);
     }
@@ -797,7 +801,7 @@ export async function restoreVersion(
       },
     ];
 
-    const result = await client.query(
+    const result = await client.query<ContentRow>(
       `UPDATE cms_content
          SET title = $1, content = $2, excerpt = $3, versions = $4, current_version = $5,
              last_modified_by = $6, updated_at = now()
@@ -813,12 +817,12 @@ export async function restoreVersion(
         id,
       ]
     );
-    const restored = (result.rows as ContentRow[])[0];
+    const restored = result.rows[0];
     if (!restored) {
       throw new HandlerError('INTERNAL', 'update returned no row');
     }
     publish({
-      id,
+      id: `cms.contentRestored.${id}.${Date.now()}`,
       type: 'cms.contentRestored',
       payload: { contentId: id, fromVersion: req.version, actorId: principal.userId },
     });
@@ -897,18 +901,18 @@ export async function createMenu(
   const items = parseItems(req.itemsJson);
 
   const row = await withTransaction(deps, async ({ client, publish }) => {
-    const result = await client.query(
+    const result = await client.query<MenuRow>(
       `INSERT INTO cms_navigation_menus (name, location, items, is_active)
          VALUES ($1, $2, $3, $4)
        RETURNING ${MENU_COLUMNS}`,
       [name, location, JSON.stringify(items), req.isActive ?? true]
     );
-    const inserted = (result.rows as MenuRow[])[0];
+    const inserted = result.rows[0];
     if (!inserted) {
       throw new HandlerError('INTERNAL', 'insert returned no row');
     }
     publish({
-      id: inserted.menu_id,
+      id: `cms.menuCreated.${inserted.menu_id}`,
       type: 'cms.menuCreated',
       payload: { menuId: inserted.menu_id, location, actorId: principal.userId },
     });
@@ -957,18 +961,18 @@ export async function updateMenu(
   params.push(id);
 
   const row = await withTransaction(deps, async ({ client, publish }) => {
-    const result = await client.query(
+    const result = await client.query<MenuRow>(
       `UPDATE cms_navigation_menus SET ${setSql.join(', ')}
          WHERE menu_id = $${params.length} AND deleted_at IS NULL
          RETURNING ${MENU_COLUMNS}`,
       params
     );
-    const updated = (result.rows as MenuRow[])[0];
+    const updated = result.rows[0];
     if (!updated) {
       throw new HandlerError('NOT_FOUND', `menu ${id} not found`);
     }
     publish({
-      id: updated.menu_id,
+      id: `cms.menuUpdated.${updated.menu_id}.${Date.now()}`,
       type: 'cms.menuUpdated',
       payload: { menuId: updated.menu_id, actorId: principal.userId },
     });
@@ -999,7 +1003,7 @@ export async function deleteMenu(
     const wasDeleted = result.rowCount !== null && result.rowCount > 0;
     if (wasDeleted) {
       publish({
-        id,
+        id: `cms.menuDeleted.${id}`,
         type: 'cms.menuDeleted',
         payload: { menuId: id, actorId: principal.userId },
       });

--- a/services/gateway/src/middleware/grpc-error.test.ts
+++ b/services/gateway/src/middleware/grpc-error.test.ts
@@ -132,14 +132,44 @@ describe('handleGrpcError', () => {
     expect(reply.send).toHaveBeenCalledWith({ error: 'pet not found' });
   });
 
-  it('sends { error: message } when details is absent but message is set', () => {
-    handleGrpcError({ code: status.INTERNAL, message: 'crash' }, reply);
-    expect(reply.send).toHaveBeenCalledWith({ error: 'crash' });
-  });
-
   it('sends { error: "internal_error" } when neither details nor message is set', () => {
     handleGrpcError({ code: status.INTERNAL }, reply);
     expect(reply.send).toHaveBeenCalledWith({ error: 'internal_error' });
+  });
+
+  // ── 5xx codes never leak upstream message/details to the client ──────────────
+  // The upstream message/details on a server-side error can carry internal
+  // stack fragments, DB errors, file paths, etc. We forward upstream text only
+  // for client-facing (4xx) codes — those come from validation / business logic.
+
+  it('does NOT leak upstream message on INTERNAL (500)', () => {
+    handleGrpcError({ code: status.INTERNAL, message: 'connection to db pool failed' }, reply);
+    expect(reply.send).toHaveBeenCalledWith({ error: 'internal_error' });
+  });
+
+  it('does NOT leak upstream details on INTERNAL (500)', () => {
+    handleGrpcError({ code: status.INTERNAL, details: 'ECONNREFUSED 10.0.3.5:5432' }, reply);
+    expect(reply.send).toHaveBeenCalledWith({ error: 'internal_error' });
+  });
+
+  it('does NOT leak upstream text on UNAVAILABLE (503)', () => {
+    handleGrpcError({ code: status.UNAVAILABLE, details: 'no connection established' }, reply);
+    expect(reply.send).toHaveBeenCalledWith({ error: 'service_unavailable' });
+  });
+
+  it('does NOT leak upstream text on DEADLINE_EXCEEDED (504)', () => {
+    handleGrpcError({ code: status.DEADLINE_EXCEEDED, details: 'retry budget exhausted' }, reply);
+    expect(reply.send).toHaveBeenCalledWith({ error: 'gateway_timeout' });
+  });
+
+  it('does NOT leak a non-gRPC Error message to the client', () => {
+    handleGrpcError(new Error('TypeError: cannot read property foo of undefined'), reply);
+    expect(reply.send).toHaveBeenCalledWith({ error: 'internal_error' });
+  });
+
+  it('still forwards upstream details for client-facing codes (400)', () => {
+    handleGrpcError({ code: status.INVALID_ARGUMENT, details: 'email is required' }, reply);
+    expect(reply.send).toHaveBeenCalledWith({ error: 'email is required' });
   });
 
   it('prefers details over message when both are present', () => {

--- a/services/gateway/src/middleware/grpc-error.ts
+++ b/services/gateway/src/middleware/grpc-error.ts
@@ -34,9 +34,28 @@ export const GRPC_TO_HTTP: Record<number, number> = {
 
 type GrpcError = { code?: number; details?: string; message?: string };
 
+// Generic client-safe messages for server-side (5xx) statuses. The
+// upstream message/details on a 5xx can carry internal stack fragments,
+// raw DB errors, connection strings or file paths — none of which a
+// client should see. We forward the upstream text ONLY for client-facing
+// (4xx) codes, where it comes from validation / business logic and is
+// meant for the caller.
+const GENERIC_5XX_MESSAGE: Record<number, string> = {
+  500: 'internal_error',
+  501: 'not_implemented',
+  502: 'bad_gateway',
+  503: 'service_unavailable',
+  504: 'gateway_timeout',
+};
+
 export const handleGrpcError = (err: unknown, reply: FastifyReply): FastifyReply => {
   const grpcErr = err as GrpcError;
   const httpStatus = (grpcErr?.code !== undefined && GRPC_TO_HTTP[grpcErr.code]) || 500;
+  if (httpStatus >= 500) {
+    return reply
+      .code(httpStatus)
+      .send({ error: GENERIC_5XX_MESSAGE[httpStatus] ?? 'internal_error' });
+  }
   return reply.code(httpStatus).send({
     error: grpcErr?.details ?? grpcErr?.message ?? 'internal_error',
   });

--- a/services/gateway/src/routes/audit.test.ts
+++ b/services/gateway/src/routes/audit.test.ts
@@ -150,7 +150,11 @@ describe('GET /api/v1/audit', () => {
     });
 
     expect(httpRes.statusCode).toBe(httpCode);
-    expect(httpRes.json()).toMatchObject({ error: 'test' });
+    // 4xx codes echo the upstream detail; 5xx are sanitised so internal
+    // text never reaches the client.
+    expect(httpRes.json()).toMatchObject({
+      error: httpCode >= 500 ? 'internal_error' : 'test',
+    });
   });
 });
 

--- a/services/gateway/src/routes/matching.test.ts
+++ b/services/gateway/src/routes/matching.test.ts
@@ -194,7 +194,11 @@ describe('POST /api/v1/matching/sessions', () => {
     });
 
     expect(httpRes.statusCode).toBe(httpCode);
-    expect(httpRes.json()).toMatchObject({ error: 'oops' });
+    // 4xx codes echo the upstream detail; 5xx are sanitised so internal
+    // text never reaches the client.
+    expect(httpRes.json()).toMatchObject({
+      error: httpCode >= 500 ? 'internal_error' : 'oops',
+    });
   });
 });
 

--- a/services/matching/src/gdpr/erase.test.ts
+++ b/services/matching/src/gdpr/erase.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import type { GdprErasureRequestedPayload } from '@adopt-dont-shop/events';
+import type { PoolClient } from 'pg';
+
+import { eraseMatching } from './erase.js';
+
+const payload: GdprErasureRequestedPayload = {
+  userId: 'usr-erase-1',
+  correlationId: 'corr-1',
+  requestedAt: '2026-06-15T12:00:00.000Z',
+} as unknown as GdprErasureRequestedPayload;
+
+function makeClient(): { client: PoolClient; query: ReturnType<typeof vi.fn> } {
+  const query = vi.fn().mockResolvedValue({ rowCount: 0 });
+  return { client: { query } as unknown as PoolClient, query };
+}
+
+describe('eraseMatching', () => {
+  it('deletes swipe actions before sessions so the FK does not block the delete', async () => {
+    const { client, query } = makeClient();
+
+    await eraseMatching(client, payload);
+
+    const actionsSql = query.mock.calls[0][0] as string;
+    const sessionsSql = query.mock.calls[1][0] as string;
+    expect(actionsSql).toMatch(/DELETE FROM .*swipe_actions/s);
+    expect(sessionsSql).toMatch(/DELETE FROM .*swipe_sessions/s);
+  });
+
+  it('removes the swipe history, sessions, and match profile for the user', async () => {
+    const { client, query } = makeClient();
+
+    await eraseMatching(client, payload);
+
+    const tables = query.mock.calls.map(call => call[0] as string).join('\n');
+    expect(tables).toMatch(/swipe_actions/);
+    expect(tables).toMatch(/swipe_sessions/);
+    expect(tables).toMatch(/adopter_match_profiles/);
+    // Every statement is scoped to the erased user's id only.
+    for (const call of query.mock.calls) {
+      expect(call[1]).toEqual([payload.userId]);
+    }
+  });
+
+  it('returns the total rows erased across all statements', async () => {
+    const { client, query } = makeClient();
+    query.mockResolvedValueOnce({ rowCount: 4 }); // swipe_actions
+    query.mockResolvedValueOnce({ rowCount: 2 }); // swipe_sessions
+    query.mockResolvedValueOnce({ rowCount: 1 }); // adopter_match_profiles
+
+    const total = await eraseMatching(client, payload);
+
+    expect(total).toBe(7);
+  });
+});

--- a/services/matching/src/grpc/handlers.test.ts
+++ b/services/matching/src/grpc/handlers.test.ts
@@ -180,6 +180,34 @@ describe('endSession', () => {
     expect(publish.mock.calls.length).toBe(0);
   });
 
+  it('throws PERMISSION_DENIED when a non-owner without super_admin ends the session', async () => {
+    const { deps } = makeDeps([{ rows: [sessionRow({ user_id: 'someone-else' })] }]);
+    await expect(endSession(deps, makePrincipal(), { sessionId: 'sess-1' })).rejects.toMatchObject({
+      code: 'PERMISSION_DENIED',
+    });
+  });
+
+  it('allows a super_admin to end another user session', async () => {
+    const { deps } = makeDeps([
+      { rows: [sessionRow({ user_id: 'someone-else' })] }, // SELECT FOR UPDATE
+      {
+        rows: [
+          sessionRow({
+            user_id: 'someone-else',
+            end_time: new Date('2026-06-01T13:00:00.000Z'),
+            is_active: false,
+          }),
+        ],
+      }, // UPDATE RETURNING
+    ]);
+    const res = await endSession(
+      deps,
+      makePrincipal({ userId: 'admin-1', roles: ['super_admin'] }),
+      { sessionId: 'sess-1' }
+    );
+    expect(res.session.isActive).toBe(false);
+  });
+
   it('closes an active session and publishes matching.sessionEnded', async () => {
     const { deps } = makeDeps([
       { rows: [sessionRow()] }, // SELECT FOR UPDATE

--- a/services/matching/src/grpc/handlers.ts
+++ b/services/matching/src/grpc/handlers.ts
@@ -162,20 +162,14 @@ export async function endSession(
 
     const row = existing.rows[0];
 
-    // Authz scope: a swipe session belongs to its user; only the
-    // owner can close it. Admins bypass via super_admin (handled by
-    // requirePermission).
+    // Ownership: only the session owner can close it. super_admin
+    // bypasses (CAD pattern) — same guard shape as recordSwipe.
     if (
       row.user_id !== null &&
       row.user_id !== principal.userId &&
-      !hasPermission(principal, PETS_VIEW) === false
+      !principal.roles.includes('super_admin')
     ) {
-      // hasPermission gate above already covered — just guard the
-      // ownership here. Admins skip via super_admin in
-      // requirePermission.
-      if (!principal.roles.includes('super_admin')) {
-        throw new HandlerError('PERMISSION_DENIED', 'not the session owner');
-      }
+      throw new HandlerError('PERMISSION_DENIED', 'not the session owner');
     }
 
     // Idempotency: closing an already-closed session is a no-op.

--- a/services/moderation/src/grpc/handlers.test.ts
+++ b/services/moderation/src/grpc/handlers.test.ts
@@ -141,6 +141,18 @@ describe('fileReport', () => {
       fileReport(deps, makePrincipal(), { ...VALID_FILE_REQ, metadataJson: 'not-json' })
     ).rejects.toMatchObject({ code: 'INVALID_ARGUMENT' });
   });
+
+  it('uses ON CONFLICT so a re-delivered auto-report is idempotent (no duplicate row)', async () => {
+    // The NATS subscribers re-file the SAME (reporter, entity_type, entity_id)
+    // tuple when JetStream redelivers an event. The insert must collapse to a
+    // no-op that returns the existing row rather than minting a duplicate.
+    const { deps, query } = makeDeps([{ rows: [reportRow()] }]);
+    await fileReport(deps, makePrincipal(), VALID_FILE_REQ);
+    const sql = String(query.mock.calls[0][0]);
+    expect(sql).toMatch(/ON CONFLICT/i);
+    expect(sql).toMatch(/reported_entity_type/);
+    expect(sql).toMatch(/reported_entity_id/);
+  });
 });
 
 describe('getReport', () => {

--- a/services/moderation/src/grpc/handlers.ts
+++ b/services/moderation/src/grpc/handlers.ts
@@ -35,6 +35,8 @@ import type {
 } from '@adopt-dont-shop/proto';
 
 import { HandlerError, type HandlerDeps } from './adapter.js';
+import { SYSTEM_USER_ID } from '../nats/system-principal.js';
+
 import { decodeCursor, encodeCursor, InvalidCursorError } from './cursor.js';
 import { categoryToDb, entityTypeToDb, reportStatusToDb, severityToDb } from './enum-map.js';
 import {
@@ -103,6 +105,9 @@ export async function fileReport(
          metadata
        )
        VALUES ($1, $2, $3, $4, $5, $6, $7, 'pending', $8, $9, $10::jsonb)
+       ON CONFLICT (reported_entity_type, reported_entity_id)
+         WHERE reporter_id = '${SYSTEM_USER_ID}'
+         DO UPDATE SET updated_at = reports.updated_at
        RETURNING report_id, reporter_id, reported_entity_type, reported_entity_id,
                  reported_user_id, category, severity, status, title, description,
                  metadata, assigned_moderator, assigned_at, resolved_by, resolved_at,

--- a/services/moderation/src/migrations/009_add_system_autoreport_unique_index.ts
+++ b/services/moderation/src/migrations/009_add_system_autoreport_unique_index.ts
@@ -1,0 +1,33 @@
+import type { MigrationBuilder } from 'node-pg-migrate';
+
+// Idempotency guard for system-originated auto-reports.
+//
+// The NATS subscribers (src/nats/subscribers.ts) re-file the SAME
+// (reporter_id, reported_entity_type, reported_entity_id) tuple every
+// time JetStream redelivers a chat.messageCreated / pets.created /
+// applications.submitted event. Without a unique arbiter, FileReport's
+// INSERT mints a fresh report_id each time and floods the moderator
+// queue with duplicates.
+//
+// Scope the constraint to the SYSTEM reporter only — a real user filing
+// a second report about the same entity is legitimate and must still
+// insert. The partial index keys on (reported_entity_type,
+// reported_entity_id) WHERE reporter_id = SYSTEM_USER_ID, which is the
+// exact arbiter FileReport's `ON CONFLICT ... WHERE reporter_id = ...`
+// targets.
+
+const SYSTEM_USER_ID = '00000000-0000-0000-0000-000000000000';
+
+export const up = async (pgm: MigrationBuilder): Promise<void> => {
+  pgm.createIndex('reports', ['reported_entity_type', 'reported_entity_id'], {
+    name: 'reports_system_autoreport_uniq',
+    unique: true,
+    where: `reporter_id = '${SYSTEM_USER_ID}'`,
+  });
+};
+
+export const down = async (pgm: MigrationBuilder): Promise<void> => {
+  pgm.dropIndex('reports', ['reported_entity_type', 'reported_entity_id'], {
+    name: 'reports_system_autoreport_uniq',
+  });
+};

--- a/services/moderation/src/migrations/migrations.test.ts
+++ b/services/moderation/src/migrations/migrations.test.ts
@@ -47,6 +47,7 @@ describe('moderation migrations', () => {
     '006_create_user_sanctions.ts',
     '007_create_support_tickets.ts',
     '008_create_support_ticket_responses.ts',
+    '009_add_system_autoreport_unique_index.ts',
   ])('%s exports `up` and `down` functions', async filename => {
     const mod = (await import(`./${filename}`)) as {
       up: unknown;

--- a/services/moderation/src/nats/subscribers.ts
+++ b/services/moderation/src/nats/subscribers.ts
@@ -94,7 +94,7 @@ export const registerSubscribers = (opts: RegisterSubscribersOptions): Subscript
         await fileAutoReport(deps, {
           reportedEntityType: ModerationV1.ReportEntityType.REPORT_ENTITY_TYPE_MESSAGE,
           reportedEntityId: event.messageId,
-          reportedUserId: event.senderId as string,
+          reportedUserId: event.senderId,
           category: CATEGORY_TO_PROTO[hit.category],
           severity: severityFor(hit),
           title: `Auto-report: ${hit.reason}`,
@@ -143,7 +143,7 @@ export const registerSubscribers = (opts: RegisterSubscribersOptions): Subscript
         await fileAutoReport(deps, {
           reportedEntityType: ModerationV1.ReportEntityType.REPORT_ENTITY_TYPE_APPLICATION,
           reportedEntityId: event.applicationId,
-          reportedUserId: event.adopterId as string,
+          reportedUserId: event.adopterId,
           category: CATEGORY_TO_PROTO[hit.category],
           severity: severityFor(hit),
           title: `Auto-report: application — ${hit.reason}`,

--- a/services/notifications/src/email/worker.ts
+++ b/services/notifications/src/email/worker.ts
@@ -145,7 +145,7 @@ export const startEmailWorker = (opts: EmailWorkerOptions): RunningEmailWorker =
         })
         .finally(() => {
           schedule();
-        }) as Promise<number>;
+        });
     }, pollIntervalMs);
   };
 

--- a/services/notifications/src/gdpr/erase.test.ts
+++ b/services/notifications/src/gdpr/erase.test.ts
@@ -22,15 +22,25 @@ function fakeClient(counts: number[]): PoolClient {
 }
 
 describe('eraseNotifications', () => {
-  it('deletes from all four user-keyed tables in the notifications schema', async () => {
-    const client = fakeClient([4, 1, 1, 2]);
+  it('deletes from all user-keyed tables in the notifications schema, including the email queue', async () => {
+    const client = fakeClient([4, 1, 1, 2, 3]);
     const total = await eraseNotifications(client, PAYLOAD);
-    expect(total).toBe(8);
+    expect(total).toBe(11);
     const calls = (client.query as ReturnType<typeof vi.fn>).mock.calls;
-    expect(calls).toHaveLength(4);
+    expect(calls).toHaveLength(5);
     expect(String(calls[0][0])).toContain('DELETE FROM notifications.notifications');
     expect(String(calls[1][0])).toContain('DELETE FROM notifications.user_notification_prefs');
     expect(String(calls[2][0])).toContain('DELETE FROM notifications.email_preferences');
     expect(String(calls[3][0])).toContain('DELETE FROM notifications.device_tokens');
+    expect(String(calls[4][0])).toContain('DELETE FROM notifications.email_queue');
+  });
+
+  it('parameterizes the user id on every delete', async () => {
+    const client = fakeClient([0, 0, 0, 0, 0]);
+    await eraseNotifications(client, PAYLOAD);
+    const calls = (client.query as ReturnType<typeof vi.fn>).mock.calls;
+    for (const call of calls) {
+      expect(call[1]).toEqual([PAYLOAD.userId]);
+    }
   });
 });

--- a/services/notifications/src/gdpr/erase.ts
+++ b/services/notifications/src/gdpr/erase.ts
@@ -1,8 +1,10 @@
 // GDPR erasure for the notifications schema. Drops notification rows,
-// device tokens, and the per-user prefs entry. No anonymisation
-// strategy here — notifications are intrinsically about the user, so
-// scrubbing PII while leaving the row would still leak (e.g. message
-// body contains the user's name). Hard-delete is the right tool.
+// device tokens, the per-user prefs entry, and the user's email_queue
+// rows. No anonymisation strategy here — notifications are intrinsically
+// about the user, so scrubbing PII while leaving the row would still
+// leak (e.g. message body contains the user's name, an email_queue row
+// holds the recipient address and rendered body). Hard-delete is the
+// right tool.
 
 import type { PoolClient } from 'pg';
 
@@ -19,6 +21,7 @@ export async function eraseNotifications(
     'notifications.user_notification_prefs',
     'notifications.email_preferences',
     'notifications.device_tokens',
+    'notifications.email_queue',
   ];
   for (const table of tables) {
     const res = await client.query(`DELETE FROM ${table} WHERE user_id = $1`, [payload.userId]);

--- a/services/notifications/src/grpc/handlers.ts
+++ b/services/notifications/src/grpc/handlers.ts
@@ -398,10 +398,10 @@ export async function dismissNotification(
   }
 
   // Fetch outside the transaction first so we can return NOT_FOUND
-  // cleanly without holding a write lock. The DB scope check below
-  // covers the TOCTOU window: even if the row's user_id changed
-  // between SELECT and UPDATE (it can't — user_id is immutable), the
-  // UPDATE WHERE clause re-enforces.
+  // cleanly without holding a write lock. The ownership check below
+  // runs against this SELECTed row; there is no TOCTOU window because
+  // user_id is immutable, so the row the UPDATE targets by
+  // notification_id still belongs to the same user.
   const existing = await deps.pool.query<NotificationRow>(
     `SELECT * FROM notifications.notifications WHERE notification_id = $1 AND deleted_at IS NULL`,
     [req.notificationId]

--- a/services/notifications/src/nats/subscribers.ts
+++ b/services/notifications/src/nats/subscribers.ts
@@ -246,10 +246,12 @@ export const registerSubscribers = (opts: RegisterSubscribersOptions): Subscript
       nats,
       { subject: 'rescue.staffInvited', durable: durableFor('rescue.staffInvited'), onError },
       async payload => {
+        // The invitee email is PII — keep it out of operational logs
+        // (Layer 1 redaction only protects known fields). Identifiers
+        // are sufficient to trace the event.
         logger.info('rescue.staffInvited received', {
           invitationId: payload.invitationId,
           rescueId: payload.rescueId,
-          email: payload.email,
         });
       }
     )

--- a/services/notifications/src/scheduler/scheduler.ts
+++ b/services/notifications/src/scheduler/scheduler.ts
@@ -103,9 +103,10 @@ export const startScheduler = (jobs: ScheduledJob[], opts: SchedulerOptions): Ru
           opts.logger.error('scheduler.tick_error', { err });
           return [] as string[];
         })
+        .then(() => undefined)
         .finally(() => {
           schedule();
-        }) as unknown as Promise<void>;
+        });
     }, tickIntervalMs);
   };
 

--- a/services/pets/src/gdpr/erase.test.ts
+++ b/services/pets/src/gdpr/erase.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import type { GdprErasureRequestedPayload } from '@adopt-dont-shop/events';
+import type { PoolClient } from 'pg';
+
+import { erasePets } from './erase.js';
+
+const payload: GdprErasureRequestedPayload = {
+  userId: 'usr-erase-1',
+  correlationId: 'corr-1',
+  requestedAt: '2026-06-15T12:00:00.000Z',
+} as unknown as GdprErasureRequestedPayload;
+
+function makeClient(): { client: PoolClient; query: ReturnType<typeof vi.fn> } {
+  const query = vi.fn().mockResolvedValue({ rowCount: 0 });
+  return { client: { query } as unknown as PoolClient, query };
+}
+
+describe('erasePets', () => {
+  it('deletes the user’s favourites by user_id', async () => {
+    const { client, query } = makeClient();
+    await erasePets(client, payload);
+
+    const favSql = query.mock.calls.find(call => /user_favorites/.test(call[0] as string));
+    expect(favSql).toBeDefined();
+    const [sql, params] = favSql as [string, unknown[]];
+    expect(sql).toMatch(/user_id = \$1/);
+    expect(params).toEqual([payload.userId]);
+  });
+
+  it('deletes the user’s ratings via reviewer_id, not a non-existent user_id column', async () => {
+    const { client, query } = makeClient();
+    await erasePets(client, payload);
+
+    const ratingsCall = query.mock.calls.find(call => /ratings/.test(call[0] as string));
+    expect(ratingsCall).toBeDefined();
+    const [sql, params] = ratingsCall as [string, unknown[]];
+    // The ratings table keys the author as `reviewer_id`; there is no
+    // `user_id` column, so the old query threw at runtime and aborted
+    // the whole erasure.
+    expect(sql).toMatch(/reviewer_id = \$1/);
+    expect(sql).not.toMatch(/\buser_id\b/);
+    expect(params).toEqual([payload.userId]);
+  });
+
+  it('returns the total rows touched across both statements', async () => {
+    const { client, query } = makeClient();
+    query.mockResolvedValueOnce({ rowCount: 2 }); // favourites
+    query.mockResolvedValueOnce({ rowCount: 3 }); // ratings
+
+    const total = await erasePets(client, payload);
+
+    expect(total).toBe(5);
+  });
+});

--- a/services/pets/src/gdpr/erase.ts
+++ b/services/pets/src/gdpr/erase.ts
@@ -13,7 +13,9 @@ export async function erasePets(
   let total = 0;
   for (const sql of [
     `DELETE FROM pets.user_favorites WHERE user_id = $1`,
-    `DELETE FROM pets.ratings WHERE user_id = $1`,
+    // The ratings author column is `reviewer_id` (there is no `user_id`
+    // column on pets.ratings — keying on it would throw at runtime).
+    `DELETE FROM pets.ratings WHERE reviewer_id = $1`,
   ]) {
     const res = await client.query(sql, [payload.userId]);
     total += res.rowCount ?? 0;

--- a/services/pets/src/grpc/handlers.test.ts
+++ b/services/pets/src/grpc/handlers.test.ts
@@ -277,6 +277,22 @@ describe('updatePet', () => {
     ).rejects.toMatchObject({ code: 'PERMISSION_DENIED' });
   });
 
+  it('PERMISSION_DENIED for a no-rescue (orphan) pet unless super_admin', async () => {
+    mocks.poolMock.query.mockResolvedValueOnce({ rows: [petRow({ rescue_id: null })] });
+    // Staff with pets.update but the pet has no rescue scope — must NOT
+    // fall through to an unscoped permission pass.
+    await expect(
+      updatePet(mocks.deps, STAFF, { petId: 'pet-1', name: 'x' } as never)
+    ).rejects.toMatchObject({ code: 'PERMISSION_DENIED' });
+  });
+
+  it('lets super_admin update a no-rescue (orphan) pet', async () => {
+    mocks.poolMock.query.mockResolvedValueOnce({ rows: [petRow({ rescue_id: null })] });
+    mocks.clientMock.query.mockResolvedValue({ rows: [petRow({ rescue_id: null, name: 'x' })] });
+    const res = await updatePet(mocks.deps, SUPER_ADMIN, { petId: 'pet-1', name: 'x' } as never);
+    expect(res.pet.name).toBe('x');
+  });
+
   it('no-ops (returns current row, no write) when no fields supplied', async () => {
     mocks.poolMock.query.mockResolvedValueOnce({ rows: [petRow()] });
     const res = await updatePet(mocks.deps, STAFF, { petId: 'pet-1' } as never);
@@ -406,6 +422,20 @@ describe('deletePet', () => {
     await expect(deletePet(mocks.deps, OTHER_STAFF, { petId: 'pet-1' })).rejects.toMatchObject({
       code: 'PERMISSION_DENIED',
     });
+  });
+
+  it('PERMISSION_DENIED for a no-rescue (orphan) pet unless super_admin', async () => {
+    mocks.poolMock.query.mockResolvedValueOnce({ rows: [petRow({ rescue_id: null })] });
+    await expect(deletePet(mocks.deps, STAFF, { petId: 'pet-1' })).rejects.toMatchObject({
+      code: 'PERMISSION_DENIED',
+    });
+  });
+
+  it('lets super_admin soft-delete a no-rescue (orphan) pet', async () => {
+    mocks.poolMock.query.mockResolvedValueOnce({ rows: [petRow({ rescue_id: null })] });
+    mocks.clientMock.query.mockResolvedValue({ rows: [] });
+    const res = await deletePet(mocks.deps, SUPER_ADMIN, { petId: 'pet-1' });
+    expect(res.deleted).toBe(true);
   });
 });
 

--- a/services/pets/src/grpc/handlers.ts
+++ b/services/pets/src/grpc/handlers.ts
@@ -579,7 +579,7 @@ export async function deletePet(
   if (!existing) {
     throw new HandlerError('NOT_FOUND', `pet ${req.petId} not found`);
   }
-  if (!requirePermission(principal, PETS_DELETE, scopeFor(existing))) {
+  if (!isPermittedRescueMutation(principal, PETS_DELETE, existing)) {
     throw new HandlerError('PERMISSION_DENIED', `'${PETS_DELETE}' required for this rescue`);
   }
 
@@ -613,13 +613,23 @@ async function fetchPet(deps: HandlerDeps, petId: string): Promise<PetRow | unde
 // degrades to a plain permission check, which would wrongly let any
 // pets.update holder through, so we gate the no-rescue case explicitly.
 function assertRescueScopedUpdate(principal: Principal, row: PetRow): void {
-  if (!requirePermission(principal, PETS_UPDATE, scopeFor(row))) {
+  if (!isPermittedRescueMutation(principal, PETS_UPDATE, row)) {
     throw new HandlerError('PERMISSION_DENIED', `'${PETS_UPDATE}' required for this rescue`);
   }
 }
 
-function scopeFor(row: PetRow): { rescueId: RescueId } | undefined {
-  return row.rescue_id ? { rescueId: row.rescue_id as RescueId } : undefined;
+// Gate a mutation on a pet's rescue scope. Orphan pets (no rescue_id)
+// have no scope to check against, so requirePermission would let any
+// holder of the permission through — we restrict those to super_admin.
+function isPermittedRescueMutation(
+  principal: Principal,
+  permission: Permission,
+  row: PetRow
+): boolean {
+  if (!row.rescue_id) {
+    return principal.roles.includes('super_admin');
+  }
+  return requirePermission(principal, permission, { rescueId: row.rescue_id as RescueId });
 }
 
 function clampLimit(requested: number): number {

--- a/services/rescue/src/gdpr/erase.test.ts
+++ b/services/rescue/src/gdpr/erase.test.ts
@@ -1,0 +1,66 @@
+import type { PoolClient } from 'pg';
+import { describe, expect, it, vi } from 'vitest';
+
+import type { GdprErasureRequestedPayload } from '@adopt-dont-shop/events';
+
+import { eraseRescue } from './erase.js';
+
+const PAYLOAD: GdprErasureRequestedPayload = {
+  userId: 'usr-erase',
+  correlationId: 'corr-1',
+  requestedAt: '2026-06-15T00:00:00Z',
+};
+
+function makeClient(rowCounts: number[]): {
+  client: PoolClient;
+  calls: Array<{ text: string; values: unknown[] }>;
+} {
+  const calls: Array<{ text: string; values: unknown[] }> = [];
+  let i = 0;
+  const query = vi.fn(async (text: string, values: unknown[]) => {
+    calls.push({ text, values });
+    const rowCount = rowCounts[i] ?? 0;
+    i += 1;
+    return { rowCount, rows: [] };
+  });
+  return { client: { query } as unknown as PoolClient, calls };
+}
+
+describe('eraseRescue', () => {
+  it('targets only columns that exist on the rescue schema (no invited_user_id)', async () => {
+    const { client, calls } = makeClient([1, 1, 1]);
+    await eraseRescue(client, PAYLOAD);
+    // The invitations table has no `invited_user_id` column — guard against
+    // the regression where erase referenced a non-existent column.
+    for (const call of calls) {
+      expect(call.text).not.toContain('invited_user_id');
+    }
+  });
+
+  it('never NULLs the NOT NULL foster_user_id column', async () => {
+    const { client, calls } = makeClient([1, 1, 1]);
+    await eraseRescue(client, PAYLOAD);
+    const fosterCall = calls.find(c => c.text.includes('foster_placements'));
+    expect(fosterCall).toBeDefined();
+    expect(fosterCall?.text).not.toMatch(/foster_user_id\s*=\s*NULL/i);
+  });
+
+  it('erases staff memberships, foster placements and invitations for the user', async () => {
+    const { client, calls } = makeClient([2, 1, 3]);
+    const total = await eraseRescue(client, PAYLOAD);
+
+    expect(calls).toHaveLength(3);
+    expect(calls.every(c => c.values[0] === 'usr-erase')).toBe(true);
+    expect(calls.some(c => c.text.includes('staff_members'))).toBe(true);
+    expect(calls.some(c => c.text.includes('foster_placements'))).toBe(true);
+    expect(calls.some(c => c.text.includes('invitations'))).toBe(true);
+    // Sum of the row counts is reported back to the saga.
+    expect(total).toBe(6);
+  });
+
+  it('returns 0 when the user has no data in this schema (idempotent re-run)', async () => {
+    const { client } = makeClient([0, 0, 0]);
+    const total = await eraseRescue(client, PAYLOAD);
+    expect(total).toBe(0);
+  });
+});

--- a/services/rescue/src/gdpr/erase.ts
+++ b/services/rescue/src/gdpr/erase.ts
@@ -1,7 +1,10 @@
 // GDPR erasure for the rescue schema. Strategy: drop the user's staff
-// memberships (so they no longer have rescue-scoped permissions) and
-// detach them from any foster placements they were running. Rescue
-// rows themselves are organisation records, not user-personal data.
+// memberships (so they no longer have rescue-scoped permissions),
+// soft-delete any foster placements they were running (foster_user_id is
+// NOT NULL, so we can't detach in place — soft-delete preserves the
+// org's history without retaining the erased user as an active foster),
+// and drop invitations linked to the user. Rescue rows themselves are
+// organisation records, not user-personal data.
 
 import type { PoolClient } from 'pg';
 
@@ -14,8 +17,8 @@ export async function eraseRescue(
   let total = 0;
   for (const sql of [
     `DELETE FROM rescue.staff_members WHERE user_id = $1`,
-    `UPDATE rescue.foster_placements SET foster_user_id = NULL, updated_at = now() WHERE foster_user_id = $1`,
-    `DELETE FROM rescue.invitations WHERE invited_user_id = $1`,
+    `UPDATE rescue.foster_placements SET deleted_at = now(), updated_at = now() WHERE foster_user_id = $1 AND deleted_at IS NULL`,
+    `DELETE FROM rescue.invitations WHERE user_id = $1`,
   ]) {
     const res = await client.query(sql, [payload.userId]);
     total += res.rowCount ?? 0;

--- a/services/rescue/src/grpc/handlers.test.ts
+++ b/services/rescue/src/grpc/handlers.test.ts
@@ -350,6 +350,18 @@ describe('verifyRescue', () => {
     expect(publishedSubjects).toEqual(['rescue.verified']);
   });
 
+  it('INVALID_ARGUMENT when rejecting without a failure reason', async () => {
+    mocks.poolMock.query.mockResolvedValueOnce({ rows: [rescueRow({ status: 'pending' })] });
+    await expect(
+      verifyRescue(mocks.deps, ADMIN, {
+        rescueId: 'rsc-1',
+        toStatus: RescueV1.RescueStatus.RESCUE_STATUS_REJECTED,
+      } as never)
+    ).rejects.toMatchObject({ code: 'INVALID_ARGUMENT' });
+    // No write happened — the guard fires before the transaction.
+    expect(mocks.clientMock.query).not.toHaveBeenCalled();
+  });
+
   it('publishes rescue.rejected when transitioning pending → rejected with a reason', async () => {
     mocks.poolMock.query.mockResolvedValueOnce({ rows: [rescueRow({ status: 'pending' })] });
     const publishedSubjects: string[] = [];

--- a/services/rescue/src/grpc/handlers.ts
+++ b/services/rescue/src/grpc/handlers.ts
@@ -500,6 +500,11 @@ export async function verifyRescue(
       `illegal status transition ${existing.status} → ${toStatus}`
     );
   }
+  // A rejection must carry a reason — the SQL denormalises it onto the
+  // row and downstream consumers / the audit trail rely on it.
+  if (toStatus === 'rejected' && !req.failureReason) {
+    throw new HandlerError('INVALID_ARGUMENT', 'failure_reason is required when rejecting');
+  }
 
   let updated: RescueRow | undefined;
   await withTransaction(deps, async ({ client, publish }) => {

--- a/services/rescue/src/grpc/staff-foster-handlers.test.ts
+++ b/services/rescue/src/grpc/staff-foster-handlers.test.ts
@@ -279,6 +279,21 @@ describe('endFosterPlacement', () => {
     ).rejects.toMatchObject({ code: 'INVALID_ARGUMENT' });
   });
 
+  it('PERMISSION_DENIED when the placement belongs to another rescue', async () => {
+    // Existing placement is owned by a rescue the STAFF principal is not
+    // scoped to — the foster.update gate must reject the cross-rescue end.
+    mocks.poolMock.query.mockResolvedValueOnce({
+      rows: [fosterRow({ rescue_id: 'rsc-other' })],
+    });
+    await expect(
+      endFosterPlacement(mocks.deps, STAFF, {
+        placementId: 'fp-1',
+        outcome: RescueV1.FosterEndOutcome.FOSTER_END_OUTCOME_RETURN_TO_RESCUE,
+      })
+    ).rejects.toMatchObject({ code: 'PERMISSION_DENIED' });
+    expect(mocks.natsMock.publish).not.toHaveBeenCalled();
+  });
+
   it('is idempotent on already-ended placements (no publish)', async () => {
     mocks.poolMock.query.mockResolvedValueOnce({
       rows: [fosterRow({ status: 'completed', end_date: new Date() })],


### PR DESCRIPTION
## Deep code-quality review of `services/*`

A systematic deep audit of all **11 backend microservices** against the repo's conventions (`service-bootstrap`, `events` publish-after-commit, `authz`, `config-secrets`, audit discipline) and `.claude/CLAUDE.md`, across four dimensions: **security & authz**, **correctness & data**, **testing**, and **maintainability**. Genuine findings are fixed with tests; larger structural items are deferred to a backlog.

Full write-up: [`docs/services-code-quality-review.md`](docs/services-code-quality-review.md).

Because the service test suites mock `pg`, every database-facing fix was independently verified against the actual migration schema and `HEAD` source — not just by a green test run.

### Results

`pnpm exec turbo lint type-check test --filter='./services/*'` → **42/42 tasks pass** (lint + type-check + test for all 11 services). **No shared-package bugs found.**

| Service | Headline fix |
|---|---|
| auth | Login user-enumeration timing oracle; JWT algorithm pinning (HS256) |
| applications | GDPR erasure hit non-existent columns/table → **would throw at runtime** |
| notifications | GDPR `email_queue` not erased (PII); invitee email logged; unsafe casts |
| pets | Orphan-pet authz hole — any permission-holder could mutate |
| rescue | Rescue rejection persisted with no failure reason |
| moderation | Duplicate auto-reports on event redelivery (no idempotency arbiter) |
| gateway | Internal 5xx error details leaked to clients |
| chat | GDPR erasure left soft-deleted message PII; participant delete would throw |
| matching | endSession guard simplified; GDPR erasure had no tests |
| cms | Event idempotency keys collided → publish/unpublish silently dropped |
| audit | No changes — audited and found sound (immutable store verified) |

### Cross-cutting themes
1. **GDPR erasure** was the highest-risk area — `applications`/`chat` referenced columns/tables that don't exist (erase would throw), and `notifications`/`chat` left PII behind. All fixed.
2. **Event idempotency keys** — `moderation` lacked an `ON CONFLICT` arbiter; `cms` reused one dedup key across publish/unpublish/archive. Both fixed.
3. **Authz scope edges** — `pets` orphan records bypassed rescue scope; `gateway` leaked internal error detail. Fixed.

### Deferred (needs product/architecture sign-off)
Items requiring a migration or contract change are listed in the report's backlog — e.g. `auth` refresh-token revocation unification (ADS-801), `matching` re-swipe idempotency, `cms` publish/archive transition state machine, `gateway` gateway-side principal-subject enforcement, `audit` super_admin/reports consistency. None block this PR.

https://claude.ai/code/session_014EbfJyKja1PmRfjcZWokaH