### PR TITLE
chore(services): deep code-quality review pass 2

### DIFF
--- a/docs/services-code-quality-review-pass-2.md
+++ b/docs/services-code-quality-review-pass-2.md
@@ -1,0 +1,81 @@
+# Services Code-Quality Review — Pass 2
+
+A second, deeper sweep of all 11 backend services (pass 1 is merged in #1038),
+plus several maintainer-approved decisions implemented. Pass 2 targeted what a
+first pass misses: concurrency/transaction safety, crash recovery, query
+performance & missing indexes, access-control edges, and GDPR-erasure
+correctness.
+
+As in pass 1, every database-facing fix was **independently verified against
+the real migration schema and `HEAD`**, not just by a green run — the service
+suites mock `pg`, so wrong column/table names and `NOT NULL` violations pass
+unit tests but throw in production. Several sub-agents also misattributed their
+own changes (claiming work was "pre-existing" or the "baseline was red"); every
+committed diff was reviewed directly rather than trusted from the agent's
+summary.
+
+## Verification
+`pnpm exec turbo lint type-check test --filter='./services/*'` → **42/42 tasks
+pass** (lint + type-check + test for all 11 services). **No shared-package code
+was modified** (findings there are handed off below).
+
+## Per-service fixes (one commit each)
+
+| Service | Pass-2 fixes |
+|---|---|
+| **auth** | ADS-801 resolved: split-brain token revocation (a revoked session kept minting tokens), broken rotation-family chain, privilege-persistence after deactivation; missing verify/reset token indexes (migrations 012/013). **Plus** progressive login soft-lock (decision). |
+| **gateway** | Broken access control — a `rescue_staff` user could read another rescue's dashboard via `?rescueId=`; circuit breaker tripped on benign client-fault codes (NOT_FOUND/UNAUTHENTICATED). |
+| **applications** | GDPR erasure left PII in the append-only **event stream** (Get/List fold it, so it resurfaced); event idempotency-key collisions (`${aggregateId}:${version}`). |
+| **notifications** | Emails orphaned in `sending` by a crashed worker were never reclaimed; reclaim with retry budget/dead-letter + partial index (migration 007); quiet-hours `HH:MM:SS` boundary. |
+| **pets** | Deterministic `pets.updated` event id; negative-limit → INVALID_ARGUMENT; composite keyset index (migration 007). |
+| **rescue** | Invitation dedupe — re-invite refreshes the pending row via a partial unique index (migration 007) instead of duplicating (decision); deterministic event ids. |
+| **matching** | `Recommend` never excluded already-swiped pets (deps unused) — now excludes dedupe-safely; stats `COUNT(*)` double-counted re-swipes (DISTINCT ON latest); GDPR missed anonymous-session swipes; composite index (migration 004). Append-only history preserved (decision). |
+| **moderation** | Content scanner upgraded to word-boundary matching + per-term severity (decision); GDPR erase set `reporter_id = NULL` on a NOT NULL column → threw; made nullable (migration 010). |
+| **chat** | Reaction emoji length bound → INVALID_ARGUMENT (was a Postgres 22001 surfaced as INTERNAL). |
+| **cms** | Status transition state machine with `FOR UPDATE` validation (decision); GDPR erase set `author_id = NULL` on a NOT NULL column → threw; made nullable (migration 003). |
+| **audit** | `completed_at` counted all completion keys, not just `EXPECTED_SERVICES`, risking premature GDPR completion; existence-leak → `NOT_FOUND` (decision); reports super_admin consistency via `requirePermission` (decision). |
+
+## Cross-cutting themes
+1. **GDPR erasure remained the highest-risk area.** Pass 2 found four more
+   runtime erasure bugs mocked tests can't catch: `NOT NULL` columns set to
+   `NULL` (moderation `reporter_id`, cms `author_id`) that throw and tear down
+   the saga; PII left in the applications event stream; and anonymous-session
+   swipes missed in matching.
+2. **Token/session security depth** — the ADS-801 revocation split-brain let a
+   revoked session keep minting tokens; resolved with dual-write reconciliation,
+   family inheritance, an atomic rotation gate (also reuse detection), and an
+   active-user re-check.
+3. **Access control & crash recovery** — gateway cross-rescue read; the
+   notifications email worker's stuck-`sending` gap.
+4. **Performance** — added the keyset/composite indexes the hot read paths
+   actually need (pets, rescue, matching).
+
+## Handoff — follow-up PRs (cross-package; each needs a decision)
+
+These were investigated and deliberately **not** forced into this PR: each
+crosses a shared-package/proto/RBAC boundary with cross-service blast radius and
+an open decision. Recommended as separate focused PRs.
+
+### A. GDPR erasure of email-keyed rows (`packages/events` + gateway)
+`GdprErasureRequestedPayload` carries only `userId`. Email-keyed rows with no
+`user_id` (e.g. rescue pending invitations) therefore can't be erased — a PII
+residue. **Decision:** the gateway publisher has `userId` but not the email, so
+closing this means the gateway looks up the email (auth gRPC) and adds an
+optional `email` to the payload — which broadcasts that PII on the NATS event.
+Recommend doing it (erasure completeness outweighs the scoped PII spread), but
+it's a contract + privacy call.
+
+### B. chat `rescueId` on `openChat` (`packages/proto` + gateway + chat)
+`openChat` inserts a null-UUID `rescue_id` placeholder, so rescue-scoped chat
+search never matches gRPC-created chats. **Approved direction:** add `rescueId`
+to `OpenChatRequest` and have the gateway populate it from the application
+context. Requires `buf generate` codegen (committed output + CI freshness gate)
++ gateway wiring + chat persistence.
+
+### C. `MODERATION_*` permission namespace (`lib.types` + authz seed + moderation)
+Every moderator-only handler gates on the `ADMIN_DASHBOARD` placeholder, which
+conflates "view admin dashboard" with "take moderation action" and makes a
+"reporters see only their own reports" path impossible. **Decision needed:** the
+exact permission set (e.g. `MODERATION_VIEW` / `MODERATION_ACT`) **and** a
+seed/migration granting them to the admin/moderator roles — without the seed,
+switching the gate would deny all moderators. Recommend a dedicated RBAC PR.

--- a/services/applications/src/gdpr/erase.test.ts
+++ b/services/applications/src/gdpr/erase.test.ts
@@ -16,15 +16,22 @@ function makeClient(): { client: PoolClient; query: ReturnType<typeof vi.fn> } {
   return { client: { query } as unknown as PoolClient, query };
 }
 
+// Find the first call whose SQL matches `pattern`, or fail loudly.
+function sqlMatching(query: ReturnType<typeof vi.fn>, pattern: RegExp): string {
+  const call = query.mock.calls.find(c => pattern.test(c[0] as string));
+  if (call === undefined) {
+    throw new Error(`no query matched ${pattern}`);
+  }
+  return call[0] as string;
+}
+
 describe('eraseApplications', () => {
   it('scrubs the read-model PII columns that actually exist', async () => {
     const { client, query } = makeClient();
-    query.mockResolvedValueOnce({ rowCount: 2 }); // applications update
-    query.mockResolvedValueOnce({ rowCount: 1 }); // documents delete
 
     await eraseApplications(client, payload);
 
-    const updateSql = query.mock.calls[0][0] as string;
+    const updateSql = sqlMatching(query, /UPDATE applications\.applications/);
     // The read model has NO `answers` / `references` columns — answers and
     // references live inside the JSONB `documents` column. Referencing the
     // non-existent columns would make the UPDATE throw at runtime.
@@ -32,28 +39,68 @@ describe('eraseApplications', () => {
     expect(updateSql).not.toMatch(/"references"\s*=/);
     // It MUST scrub the documents JSONB blob that holds answers/references.
     expect(updateSql).toMatch(/documents\s*=/);
-    expect(query.mock.calls[0][1]).toEqual([payload.userId]);
   });
 
   it('hard-deletes document metadata from the application_documents table', async () => {
     const { client, query } = makeClient();
-    query.mockResolvedValueOnce({ rowCount: 0 });
-    query.mockResolvedValueOnce({ rowCount: 3 });
 
     await eraseApplications(client, payload);
 
-    const deleteSql = query.mock.calls[1][0] as string;
+    const deleteSql = sqlMatching(query, /DELETE FROM applications\.application_documents/);
     // The metadata table is `application_documents`, not `documents`.
     expect(deleteSql).toMatch(/application_documents/);
   });
 
-  it('returns the total rows touched across both statements', async () => {
+  it('scrubs PII out of the immutable event store for the user', async () => {
     const { client, query } = makeClient();
-    query.mockResolvedValueOnce({ rowCount: 2 });
-    query.mockResolvedValueOnce({ rowCount: 3 });
+
+    await eraseApplications(client, payload);
+
+    // The read path (Get/List) folds the EVENT STREAM, not the read-model
+    // blob — so erasure that only touches `applications` leaves answers,
+    // references and free-text notes resurfacing on the next Get. The
+    // event_data JSONB must be scrubbed too.
+    const eventSql = sqlMatching(query, /UPDATE applications\.application_events/);
+    expect(eventSql).toMatch(/event_data/);
+    // Scoped to the user's aggregates via the read-model owner join.
+    expect(eventSql).toMatch(/user_id/);
+  });
+
+  it('opens the append-only escape hatch before mutating the event store', async () => {
+    const { client, query } = makeClient();
+
+    await eraseApplications(client, payload);
+
+    // application_events is append-only (immutable trigger). The only
+    // sanctioned mutation path is the per-transaction GUC the trigger
+    // checks — it must be SET LOCAL (transaction-scoped) before the UPDATE.
+    const hatchIdx = query.mock.calls.findIndex(c =>
+      /SET\s+LOCAL\s+applications\.allow_event_mutation\s*=\s*'on'/i.test(c[0] as string)
+    );
+    const eventUpdateIdx = query.mock.calls.findIndex(c =>
+      /UPDATE applications\.application_events/.test(c[0] as string)
+    );
+    expect(hatchIdx).toBeGreaterThanOrEqual(0);
+    expect(eventUpdateIdx).toBeGreaterThan(hatchIdx);
+  });
+
+  it('returns the total read-model + document rows touched', async () => {
+    const { client, query } = makeClient();
+    query.mockImplementation((sql: string) => {
+      if (/UPDATE applications\.applications\b/.test(sql)) {
+        return Promise.resolve({ rowCount: 2 });
+      }
+      if (/DELETE FROM applications\.application_documents/.test(sql)) {
+        return Promise.resolve({ rowCount: 3 });
+      }
+      return Promise.resolve({ rowCount: 7 });
+    });
 
     const total = await eraseApplications(client, payload);
 
+    // The count reflects the user-facing records erased (applications +
+    // documents); event-store scrubbing is an internal anonymisation and
+    // is not double-counted into the reported total.
     expect(total).toBe(5);
   });
 });

--- a/services/applications/src/gdpr/erase.ts
+++ b/services/applications/src/gdpr/erase.ts
@@ -30,6 +30,36 @@ export async function eraseApplications(
   );
   total += appsRes.rowCount ?? 0;
 
+  // The read path (Get/List/timeline) folds the EVENT STREAM, not the
+  // read-model blob above — so scrubbing only `applications` leaves the
+  // adopter's answers, references and free-text reason/notes in
+  // application_events.event_data, where the next Get re-folds and
+  // resurfaces them. We must anonymise the event payloads too.
+  //
+  // application_events is append-only (migration 001 installs a trigger
+  // that rejects UPDATE/DELETE). The trigger honours one sanctioned
+  // escape hatch: the `applications.allow_event_mutation` GUC. SET LOCAL
+  // scopes it to THIS transaction only, so it can't leak across the
+  // pooled connection. We strip the PII-bearing keys from each payload
+  // (answers, references, notes, note, reason) while preserving the
+  // forensic skeleton (type, ids, timestamps, status transitions, the
+  // rescue actor who acted) so the timeline still reconstructs.
+  await client.query(`SET LOCAL applications.allow_event_mutation = 'on'`);
+  await client.query(
+    `UPDATE applications.application_events e
+        SET event_data = e.event_data
+              - 'answers'
+              - 'answersPatch'
+              - 'references'
+              - 'notes'
+              - 'note'
+              - 'reason'
+       FROM applications.applications a
+      WHERE e.aggregate_id = a.application_id
+        AND a.user_id = $1`,
+    [payload.userId]
+  );
+
   // Documents the user uploaded: hard-delete the metadata rows (the bytes
   // sitting in storage are erased by a separate retention sweep — see
   // gateway uploads route).

--- a/services/applications/src/grpc/command-runner.ts
+++ b/services/applications/src/grpc/command-runner.ts
@@ -81,13 +81,31 @@ export async function runCommand(
 
     await projectReadModel(client, nextState);
 
-    const evt = publishFor(nextState);
-    if (evt !== null) {
-      publish(evt);
-    }
+    publishWithVersionedId(publish, publishFor, nextState);
 
     return nextState;
   });
+}
+
+// The envelope `id` becomes the JetStream Nats-Msg-Id used for
+// broker-side de-dup. Handlers pass the aggregate id as the base, but a
+// bare aggregate id collides across EVERY event of the same aggregate —
+// JetStream would drop the second and later events (submitted after
+// draftCreated, etc.) as duplicates inside the dedup window. The HEAD
+// version makes the key deterministic AND unique per event:
+// `<aggregateId>:<version>`. Deterministic (not Date.now()) so a
+// publish retry after a transient failure re-uses the same id and is
+// correctly de-duped rather than re-delivered.
+function publishWithVersionedId(
+  publish: (evt: PublishEnvelope) => void,
+  publishFor: (state: ApplicationState) => PublishEnvelope | null,
+  state: ApplicationState
+): void {
+  const evt = publishFor(state);
+  if (evt === null) {
+    return;
+  }
+  publish({ ...evt, id: `${evt.id}:${state.version}` });
 }
 
 // Create-flow counterpart to runCommand. StartDraft is the one command
@@ -125,10 +143,7 @@ export async function runCreateCommand(
 
     await projectReadModel(client, nextState);
 
-    const evt = publishFor(nextState);
-    if (evt !== null) {
-      publish(evt);
-    }
+    publishWithVersionedId(publish, publishFor, nextState);
 
     return nextState;
   });

--- a/services/applications/src/grpc/handlers.test.ts
+++ b/services/applications/src/grpc/handlers.test.ts
@@ -132,7 +132,14 @@ describe('saveDraftAnswers', () => {
     const data = JSON.parse(res.application.answersJson) as Record<string, unknown>;
     expect(data.hasYard).toBe(true);
     const publish = (deps as { _publish?: ReturnType<typeof vi.fn> })._publish!;
-    expect(publish.mock.calls[0][0]).toMatchObject({ type: 'applications.draftUpdated' });
+    // Idempotency key is per-event (aggregate:version), not the bare
+    // aggregate id — the bare id would collide across every event of the
+    // same aggregate under JetStream Nats-Msg-Id de-dup. Post-command
+    // version is 2 (draftCreated v1 + draftAnswersSaved v2).
+    expect(publish.mock.calls[0][0]).toMatchObject({
+      type: 'applications.draftUpdated',
+      id: 'app-1:2',
+    });
   });
 
   it('accepts a valid references_json array', async () => {
@@ -240,7 +247,11 @@ describe('submitDraft', () => {
       ApplicationsV1.ApplicationStatus.APPLICATION_STATUS_SUBMITTED
     );
     const publish = (deps as { _publish?: ReturnType<typeof vi.fn> })._publish!;
-    expect(publish.mock.calls[0][0]).toMatchObject({ type: 'applications.submitted' });
+    // Post-command version is 2 (draftCreated v1 + draftSubmitted v2).
+    expect(publish.mock.calls[0][0]).toMatchObject({
+      type: 'applications.submitted',
+      id: 'app-1:2',
+    });
   });
 
   it('surfaces a domain ILLEGAL_TRANSITION as INVALID_ARGUMENT (double submit)', async () => {

--- a/services/audit/src/grpc/handlers.test.ts
+++ b/services/audit/src/grpc/handlers.test.ts
@@ -266,17 +266,21 @@ describe('getGdprErasureRequest', () => {
     expect(res.request?.userId).toBe('usr-1');
   });
 
-  it('refuses a different user without admin.gdpr.read', async () => {
+  it('returns NOT_FOUND (not PERMISSION_DENIED) to a non-admin non-owner so the id existence is not leaked', async () => {
     const queryMock = vi.fn(() => Promise.resolve({ rows: [makeGdprRow()] }));
     const deps = {
       pool: { query: queryMock },
       nats: {},
     } as unknown as HandlerDeps;
+    // The row exists (user_id 'usr-1') but the caller is 'usr-2' without
+    // admin.gdpr.read. A PERMISSION_DENIED would confirm the id exists;
+    // an absent id returns NOT_FOUND — so a non-admin non-owner must get
+    // NOT_FOUND in both cases to avoid the existence oracle.
     await expect(
       getGdprErasureRequest(deps, makePrincipal({ userId: 'usr-2', permissions: [] }), {
         correlationId: 'corr-1',
       })
-    ).rejects.toMatchObject({ code: 'PERMISSION_DENIED' });
+    ).rejects.toMatchObject({ code: 'NOT_FOUND' });
   });
 
   it('rejects empty correlationId with INVALID_ARGUMENT', async () => {

--- a/services/audit/src/grpc/handlers.ts
+++ b/services/audit/src/grpc/handlers.ts
@@ -244,11 +244,14 @@ export async function getGdprErasureRequest(
     throw new HandlerError('NOT_FOUND', `erasure request ${correlationId} not found`);
   }
 
-  // Admin OR self can read. Anything else is denied.
+  // Admin OR self can read. A non-admin non-owner gets NOT_FOUND (the same
+  // error as an absent id) rather than PERMISSION_DENIED — a denial would
+  // confirm the id exists, an existence oracle. Returning NOT_FOUND keeps
+  // existence indistinguishable for callers who aren't entitled to the row.
   const isOwner = row.user_id === principal.userId;
   const isAdmin = requirePermission(principal, ADMIN_GDPR_READ);
   if (!isOwner && !isAdmin) {
-    throw new HandlerError('PERMISSION_DENIED', `'${ADMIN_GDPR_READ}' required`);
+    throw new HandlerError('NOT_FOUND', `erasure request ${correlationId} not found`);
   }
 
   return {

--- a/services/audit/src/grpc/reports-handlers.test.ts
+++ b/services/audit/src/grpc/reports-handlers.test.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { AuditV1 } from '@adopt-dont-shop/proto';
 
-import { HandlerError, type HandlerDeps } from './adapter.js';
+import { type HandlerDeps } from './adapter.js';
 import {
   createSavedReport,
   deleteSavedReport,
@@ -12,10 +12,10 @@ import {
   updateSavedReport,
 } from './reports-handlers.js';
 
-function makePrincipal(over: { userId?: string; permissions?: string[] } = {}) {
+function makePrincipal(over: { userId?: string; roles?: string[]; permissions?: string[] } = {}) {
   return {
     userId: over.userId ?? 'usr-1',
-    roles: ['admin'],
+    roles: over.roles ?? ['admin'],
     permissions: over.permissions ?? ['reports.read'],
     rescueId: undefined,
   } as unknown as Parameters<typeof listSavedReports>[1];
@@ -305,6 +305,42 @@ describe('deleteSavedReport', () => {
     );
     const sql = q.mock.calls[0][0] as string;
     expect(sql).toContain('user_id = $');
+  });
+});
+
+describe('super_admin role grant', () => {
+  // super_admin is a platform-wide superuser whose grant is on the role,
+  // not the permissions array. requirePermission honours it everywhere
+  // else in the service; these handlers must too.
+  function superAdmin(userId = 'usr-9') {
+    return makePrincipal({ userId, roles: ['super_admin'], permissions: [] });
+  }
+
+  it('reaches reads with no explicit reports.read permission', async () => {
+    const q = vi
+      .fn()
+      .mockResolvedValueOnce({ rows: [{ total: '0' }] })
+      .mockResolvedValueOnce({ rows: [] });
+    const { deps } = makeDeps(q);
+    await expect(
+      listSavedReports(deps, superAdmin(), { page: 1, limit: 20 })
+    ).resolves.toBeDefined();
+  });
+
+  it('reaches creates with no explicit reports.create permission', async () => {
+    const q = vi.fn().mockResolvedValue({ rows: [makeRow()] });
+    const { deps } = makeDeps(q);
+    await expect(
+      createSavedReport(deps, superAdmin(), { name: 'X', configJson: '{"widgets":[]}' })
+    ).resolves.toBeDefined();
+  });
+
+  it('updates any row (treated as :any) with no explicit permission', async () => {
+    const q = vi.fn().mockResolvedValue({ rows: [makeRow({ name: 'New' })] });
+    const { deps } = makeDeps(q);
+    await updateSavedReport(deps, superAdmin(), { savedReportId: 'rep-1', name: 'New' });
+    const sql = q.mock.calls[0][0] as string;
+    expect(sql).not.toContain('user_id = $');
   });
 });
 

--- a/services/audit/src/grpc/reports-handlers.ts
+++ b/services/audit/src/grpc/reports-handlers.ts
@@ -15,6 +15,7 @@
 //   reports.read for ListReportTemplates (no separate template perm —
 //     templates aren't sensitive)
 
+import { requirePermission, type Principal } from '@adopt-dont-shop/authz';
 import type { Permission } from '@adopt-dont-shop/lib.types';
 import {
   AuditV1,
@@ -33,7 +34,6 @@ import {
   type AuditUpdateSavedReportRequest,
   type AuditUpdateSavedReportResponse,
 } from '@adopt-dont-shop/proto';
-import type { Principal } from '@adopt-dont-shop/authz';
 
 import { HandlerError, type HandlerDeps } from './adapter.js';
 
@@ -54,8 +54,11 @@ const TEMPLATE_COLUMNS = `template_id, name, description, category, config, is_s
 const DEFAULT_LIMIT = 20;
 const MAX_LIMIT = 100;
 
+// Route through requirePermission (no scope) so the super_admin role grant
+// is honoured consistently with the rest of the service — super_admin's
+// permission isn't in the permissions array, it's implied by the role.
 function hasPerm(principal: Principal, p: Permission): boolean {
-  return principal.permissions.includes(p);
+  return requirePermission(principal, p);
 }
 
 function ensureRead(principal: Principal): void {

--- a/services/audit/src/nats/gdpr-subscribers.test.ts
+++ b/services/audit/src/nats/gdpr-subscribers.test.ts
@@ -154,8 +154,21 @@ describe('recordCompletion', () => {
     // completed_at must be gated on the number of completion entries
     // WITHOUT an `error` field, not the raw key count.
     expect(sql).toMatch(/jsonb_each/);
-    expect(sql).toMatch(/NOT\s*\(value \? 'error'\)/);
+    expect(sql).toMatch(/NOT\s*\(c\.value \? 'error'\)/);
     expect(sql).not.toContain('jsonb_object_keys');
+  });
+
+  it('counts only EXPECTED_SERVICES towards completed_at, not arbitrary error-free keys (no premature completion)', async () => {
+    const pool = makePool();
+    await recordCompletion(pool, COMPLETION_PAYLOAD, makeLogger());
+    const [[sql, params]] = capturedCalls(pool);
+    // The error-free count must be restricted to keys that ARE expected
+    // services — otherwise a stray completion from a non-expected service
+    // (e.g. 'gateway') could inflate the count and flip completed_at before
+    // every expected service has acked. The expected-services set is threaded
+    // in as a param so the SQL can intersect the blob keys against it.
+    expect(params).toContainEqual([...EXPECTED_SERVICES]);
+    expect(sql).toMatch(/= ANY\(/);
   });
 
   it('stamps failed_at (once) when a completion carries an error, on both insert and conflict paths', async () => {
@@ -218,7 +231,7 @@ describe('recordCompletion', () => {
     // Every statement gates completed_at on the count of error-free
     // entries reaching the full expected-services threshold...
     for (const [sql, params] of calls) {
-      expect(sql).toMatch(/NOT\s*\(value \? 'error'\)/);
+      expect(sql).toMatch(/NOT\s*\(c\.value \? 'error'\)/);
       expect(params[5]).toBe(EXPECTED_SERVICES.length);
     }
 

--- a/services/audit/src/nats/gdpr-subscribers.ts
+++ b/services/audit/src/nats/gdpr-subscribers.ts
@@ -148,7 +148,8 @@ export async function recordCompletion(
                SELECT count(*) FROM jsonb_each(
                  audit.gdpr_erasure_requests.completions
                    || jsonb_build_object($4::text, $5::jsonb)
-               ) WHERE NOT (value ? 'error')
+               ) AS c(key, value)
+               WHERE NOT (c.value ? 'error') AND c.key = ANY($7::text[])
              ) >= $6
                THEN now()
              ELSE NULL
@@ -165,6 +166,7 @@ export async function recordCompletion(
       payload.service,
       JSON.stringify(entry),
       EXPECTED_SERVICES.length,
+      [...EXPECTED_SERVICES],
     ]
   );
 }

--- a/services/auth/src/grpc/handlers.test.ts
+++ b/services/auth/src/grpc/handlers.test.ts
@@ -208,6 +208,44 @@ describe('login', () => {
     expect(bumpCall).toMatch(/UPDATE auth\.users.*login_attempts = login_attempts \+ 1/s);
   });
 
+  it('applies a progressive, capped soft-lock in the same failed-login UPDATE', async () => {
+    mocks.poolMock.query.mockResolvedValueOnce({ rows: [userRowFixture()] });
+    mocks.hasherMock.compare.mockResolvedValueOnce(false);
+    mocks.poolMock.query.mockResolvedValueOnce({ rows: [] }); // bump + lock
+
+    await expect(login(mocks.deps, null, BASE_LOGIN_REQ)).rejects.toMatchObject({
+      code: 'UNAUTHENTICATED',
+    });
+
+    const [sql, params] = mocks.poolMock.query.mock.calls[1] as [string, unknown[]];
+    // The lock is set atomically in the same UPDATE, only once the count
+    // crosses the threshold, and is capped — so a victim cannot be locked
+    // out indefinitely by deliberate failed logins.
+    expect(sql).toMatch(/locked_until = CASE/s);
+    expect(sql).toMatch(/login_attempts \+ 1 >= \$2/s);
+    expect(sql).toMatch(/LEAST\(/s);
+    expect(params).toEqual(['usr-adopter', 5, 60, 900]);
+  });
+
+  it('clears login_attempts AND locked_until on a successful login', async () => {
+    mocks.poolMock.query.mockResolvedValueOnce({ rows: [userRowFixture()] });
+    mocks.hasherMock.compare.mockResolvedValueOnce(true);
+    mocks.issuerMock.mint.mockResolvedValueOnce(mintedFixture());
+    mocks.clientMock.query.mockResolvedValue({ rows: [] });
+    mocks.poolMock.query
+      .mockResolvedValueOnce({ rows: [{ user_type: 'adopter' }] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [{ name: 'pets.read' }] });
+
+    await login(mocks.deps, null, BASE_LOGIN_REQ);
+
+    const resetCall = mocks.clientMock.query.mock.calls
+      .map(c => c[0] as string)
+      .find(s => /login_attempts = 0/.test(s));
+    expect(resetCall).toBeDefined();
+    expect(resetCall).toMatch(/locked_until = NULL/);
+  });
+
   it('mints tokens, persists refresh row inside transaction, publishes auth.userLoggedIn AFTER commit', async () => {
     mocks.poolMock.query.mockResolvedValueOnce({ rows: [userRowFixture()] });
     mocks.hasherMock.compare.mockResolvedValueOnce(true);

--- a/services/auth/src/grpc/handlers.test.ts
+++ b/services/auth/src/grpc/handlers.test.ts
@@ -302,6 +302,26 @@ describe('logout', () => {
     expect(res.revoked).toBe(true);
     expect(callOrder).toEqual(['BEGIN', 'INSERT', 'UPDATE', 'COMMIT', 'NATS_PUBLISH']);
   });
+
+  it('the refresh-row UPDATE flips both revoked_at AND is_revoked so the session list updates', async () => {
+    mocks.issuerMock.verifyRefresh.mockResolvedValueOnce({
+      sub: 'usr-1',
+      jti: 'jti-1',
+      iat: 0,
+      exp: Math.floor(Date.now() / 1000) + 1000,
+    });
+    mocks.poolMock.query.mockResolvedValueOnce({ rows: [] }); // not denylisted
+
+    const sqls: string[] = [];
+    mocks.clientMock.query.mockImplementation(async (sql: string) => {
+      sqls.push(sql);
+      return { rows: [] };
+    });
+
+    await logout(mocks.deps, ADOPTER_PRINCIPAL, { refreshToken: 'token' });
+    const update = sqls.find(s => s.includes('UPDATE auth.refresh_tokens'));
+    expect(update).toMatch(/is_revoked = true/);
+  });
 });
 
 // --- refreshToken ----------------------------------------------------
@@ -352,6 +372,90 @@ describe('refreshToken', () => {
     });
   });
 
+  it('UNAUTHENTICATED when the stored row was revoked via RevokeSession (is_revoked=true, revoked_at=null)', async () => {
+    // RevokeSession sets is_revoked but the refresh/logout path historically
+    // only stamped revoked_at. The refresh check must honour is_revoked, or a
+    // revoked session keeps minting fresh tokens.
+    mocks.issuerMock.verifyRefresh.mockResolvedValueOnce({
+      sub: 'u',
+      jti: 'j',
+      iat: 0,
+      exp: 9_000_000_000,
+    });
+    mocks.poolMock.query
+      .mockResolvedValueOnce({ rows: [] }) // not denylisted
+      .mockResolvedValueOnce({
+        rows: [{ token: 'tok', user_id: 'u', revoked_at: null, is_revoked: true, family_id: 'f' }],
+      });
+    await expect(refreshToken(mocks.deps, null, { refreshToken: 'tok' })).rejects.toMatchObject({
+      code: 'UNAUTHENTICATED',
+    });
+    // No rotation transaction is opened.
+    expect(mocks.clientMock.query).not.toHaveBeenCalled();
+  });
+
+  it('UNAUTHENTICATED when the user has been deactivated — refresh cannot extend access', async () => {
+    mocks.issuerMock.verifyRefresh.mockResolvedValueOnce({
+      sub: 'usr-1',
+      jti: 'old-jti',
+      iat: 0,
+      exp: 9_000_000_000,
+    });
+    mocks.poolMock.query
+      .mockResolvedValueOnce({ rows: [] }) // not denylisted
+      .mockResolvedValueOnce({
+        rows: [
+          { token: 'tok', user_id: 'usr-1', revoked_at: null, is_revoked: false, family_id: 'f' },
+        ],
+      })
+      .mockResolvedValueOnce({ rows: [{ status: 'deactivated' }] }); // status guard rejects
+    await expect(refreshToken(mocks.deps, null, { refreshToken: 'tok' })).rejects.toMatchObject({
+      code: 'UNAUTHENTICATED',
+    });
+    // No rotation transaction, no new tokens minted.
+    expect(mocks.clientMock.query).not.toHaveBeenCalled();
+    expect(mocks.issuerMock.mint).not.toHaveBeenCalled();
+  });
+
+  it('rotation inherits the old row family_id and flips is_revoked atomically', async () => {
+    mocks.issuerMock.verifyRefresh.mockResolvedValueOnce({
+      sub: 'usr-1',
+      jti: 'old-jti',
+      iat: 0,
+      exp: 9_000_000_000,
+    });
+    mocks.poolMock.query
+      .mockResolvedValueOnce({ rows: [] }) // not denylisted
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            token: 'tok',
+            user_id: 'usr-1',
+            revoked_at: null,
+            is_revoked: false,
+            family_id: 'fam-7',
+          },
+        ],
+      })
+      .mockResolvedValueOnce({ rows: [{ status: 'active' }] }); // status guard
+    mocks.issuerMock.mint.mockResolvedValueOnce(mintedFixture());
+
+    const calls: Array<{ verb: string; sql: string; params: unknown[] }> = [];
+    mocks.clientMock.query.mockImplementation(async (sql: string, params: unknown[] = []) => {
+      calls.push({ verb: sql.trim().split(/\s+/)[0], sql, params });
+      return { rows: [], rowCount: 1 };
+    });
+
+    await refreshToken(mocks.deps, null, { refreshToken: 'tok' });
+
+    const revoke = calls.find(c => c.verb === 'UPDATE');
+    expect(revoke?.sql).toMatch(/is_revoked = true/);
+    expect(revoke?.sql).toMatch(/revoked_at IS NULL AND is_revoked = false/);
+    const insertNew = calls.find(c => c.verb === 'INSERT' && c.sql.includes('refresh_tokens'));
+    // The new head row carries the SAME family so RevokeSession kills the chain.
+    expect(insertNew?.params).toContain('fam-7');
+  });
+
   it('rotates tokens and publishes auth.tokenRefreshed', async () => {
     mocks.issuerMock.verifyRefresh.mockResolvedValueOnce({
       sub: 'usr-1',
@@ -361,13 +465,16 @@ describe('refreshToken', () => {
     });
     mocks.poolMock.query
       .mockResolvedValueOnce({ rows: [] }) // not denylisted
-      .mockResolvedValueOnce({ rows: [{ token: 'tok', user_id: 'usr-1', revoked_at: null }] });
+      .mockResolvedValueOnce({ rows: [{ token: 'tok', user_id: 'usr-1', revoked_at: null }] })
+      .mockResolvedValueOnce({ rows: [{ status: 'active' }] }); // status guard
     mocks.issuerMock.mint.mockResolvedValueOnce(mintedFixture());
 
     const calls: string[] = [];
     mocks.clientMock.query.mockImplementation(async (sql: string) => {
       calls.push(sql.trim().split(/\s+/)[0]);
-      return { rows: [] };
+      // The conditional revoke UPDATE must report a row was flipped so the
+      // rotation proceeds.
+      return { rows: [], rowCount: 1 };
     });
     mocks.natsMock.publish.mockImplementation(() => {
       calls.push('NATS_PUBLISH');
@@ -377,6 +484,41 @@ describe('refreshToken', () => {
     expect(res.tokens.accessToken).toBe('access.jwt.token');
     // BEGIN → UPDATE old refresh → INSERT denylist → INSERT new refresh → COMMIT → NATS_PUBLISH
     expect(calls).toEqual(['BEGIN', 'UPDATE', 'INSERT', 'INSERT', 'COMMIT', 'NATS_PUBLISH']);
+  });
+
+  it('rejects a concurrent reuse: when the atomic revoke flips no rows it does not mint a second family', async () => {
+    mocks.issuerMock.verifyRefresh.mockResolvedValueOnce({
+      sub: 'usr-1',
+      jti: 'old-jti',
+      iat: 0,
+      exp: 9_000_000_000,
+    });
+    // Both pre-transaction checks pass (the row LOOKED active at read time),
+    // modelling the loser of a rotation race.
+    mocks.poolMock.query
+      .mockResolvedValueOnce({ rows: [] }) // not denylisted
+      .mockResolvedValueOnce({ rows: [{ token: 'tok', user_id: 'usr-1', revoked_at: null }] })
+      .mockResolvedValueOnce({ rows: [{ status: 'active' }] }); // status guard
+    mocks.issuerMock.mint.mockResolvedValueOnce(mintedFixture());
+
+    const sqls: string[] = [];
+    mocks.clientMock.query.mockImplementation(async (sql: string) => {
+      const verb = sql.trim().split(/\s+/)[0];
+      sqls.push(verb);
+      // The conditional revoke flips 0 rows — another request already rotated.
+      if (verb === 'UPDATE') {
+        return { rows: [], rowCount: 0 };
+      }
+      return { rows: [], rowCount: 1 };
+    });
+
+    await expect(refreshToken(mocks.deps, null, { refreshToken: 'tok' })).rejects.toMatchObject({
+      code: 'UNAUTHENTICATED',
+    });
+
+    // Critically: NO new refresh row is inserted and NO event is published.
+    expect(sqls).not.toContain('INSERT');
+    expect(mocks.natsMock.publish).not.toHaveBeenCalled();
   });
 });
 
@@ -423,6 +565,7 @@ describe('validateToken', () => {
     });
     mocks.poolMock.query
       .mockResolvedValueOnce({ rows: [] }) // not denylisted
+      .mockResolvedValueOnce({ rows: [{ status: 'active' }] }) // status guard
       .mockResolvedValueOnce({ rows: [{ user_type: 'rescue_staff' }] }) // primary role
       .mockResolvedValueOnce({ rows: [] }) // extra roles
       .mockResolvedValueOnce({ rows: [{ name: 'pets.read' }, { name: 'pets.update' }] });
@@ -432,6 +575,36 @@ describe('validateToken', () => {
     expect(res.principal.roles).toEqual([AuthV1.UserRole.USER_ROLE_RESCUE_STAFF]);
     expect(res.principal.permissions).toEqual(['pets.read', 'pets.update']);
     expect(res.expiresAt).toBe(new Date(9_000_000_000 * 1000).toISOString());
+  });
+
+  it('UNAUTHENTICATED when the user is suspended (no stale access window)', async () => {
+    mocks.issuerMock.verifyAccess.mockResolvedValueOnce({
+      sub: 'usr-1',
+      jti: 'j',
+      iat: 0,
+      exp: 9_000_000_000,
+    });
+    mocks.poolMock.query
+      .mockResolvedValueOnce({ rows: [] }) // not denylisted
+      .mockResolvedValueOnce({ rows: [{ status: 'suspended' }] }); // status guard rejects
+    await expect(validateToken(mocks.deps, null, { accessToken: 'tok' })).rejects.toMatchObject({
+      code: 'UNAUTHENTICATED',
+    });
+  });
+
+  it('UNAUTHENTICATED when the user row is gone (deleted)', async () => {
+    mocks.issuerMock.verifyAccess.mockResolvedValueOnce({
+      sub: 'usr-1',
+      jti: 'j',
+      iat: 0,
+      exp: 9_000_000_000,
+    });
+    mocks.poolMock.query
+      .mockResolvedValueOnce({ rows: [] }) // not denylisted
+      .mockResolvedValueOnce({ rows: [] }); // status guard finds no live row
+    await expect(validateToken(mocks.deps, null, { accessToken: 'tok' })).rejects.toMatchObject({
+      code: 'UNAUTHENTICATED',
+    });
   });
 });
 

--- a/services/auth/src/grpc/handlers.ts
+++ b/services/auth/src/grpc/handlers.ts
@@ -271,6 +271,18 @@ function rolesToProto(roles: UserRole[]): AuthV1.UserRole[] {
 // latency doesn't reveal whether an account exists.
 const DUMMY_PASSWORD_HASH = '$2a$12$0000000000000000000000000000000000000000000000000000u';
 
+// Progressive login throttle. Rather than a hard lockout (which lets an
+// attacker deny a victim access by deliberately failing logins), failed
+// attempts apply a SHORT, exponentially-growing soft-lock that clears on
+// its own. The first LOGIN_LOCK_THRESHOLD attempts only count; from there
+// each further failure locks the account for base * 2^(n - threshold)
+// seconds, capped at LOGIN_LOCK_MAX_SECONDS. A successful login resets the
+// counter and clears the lock. (Edge/IP rate-limiting is layered on top at
+// the gateway.)
+const LOGIN_LOCK_THRESHOLD = 5;
+const LOGIN_LOCK_BASE_SECONDS = 60;
+const LOGIN_LOCK_MAX_SECONDS = 900;
+
 export async function login(
   deps: HandlerDeps,
   _principal: Principal | null,
@@ -311,13 +323,27 @@ export async function login(
 
   const ok = await deps.passwordHasher.compare(req.password, user.password);
   if (!ok) {
-    // Increment login_attempts. We don't issue the 30-min lock here —
-    // that policy lands with the dedicated auth-policy module in a
-    // later phase. The counter is bumped synchronously so successive
-    // wrong attempts within a request burst are visible.
+    // Count the failure and, once past the threshold, apply a short
+    // exponential soft-lock. The lock is computed atomically from the
+    // incremented count so a burst of concurrent failures can't race the
+    // lock open, and from `login_attempts` (not wall clock) so it grows
+    // deterministically.
     await deps.pool.query(
-      `UPDATE auth.users SET login_attempts = login_attempts + 1, updated_at = now() WHERE user_id = $1`,
-      [user.user_id]
+      `UPDATE auth.users
+          SET login_attempts = login_attempts + 1,
+              locked_until = CASE
+                WHEN login_attempts + 1 >= $2
+                THEN now() + make_interval(
+                  secs => LEAST(
+                    $3::double precision * power(2, login_attempts + 1 - $2),
+                    $4::double precision
+                  )
+                )
+                ELSE locked_until
+              END,
+              updated_at = now()
+        WHERE user_id = $1`,
+      [user.user_id, LOGIN_LOCK_THRESHOLD, LOGIN_LOCK_BASE_SECONDS, LOGIN_LOCK_MAX_SECONDS]
     );
     throw new HandlerError('UNAUTHENTICATED', 'invalid credentials');
   }
@@ -333,7 +359,7 @@ export async function login(
       [minted.pair.refreshToken, user.user_id, minted.refreshExpiresAt]
     );
     await client.query(
-      `UPDATE auth.users SET last_login_at = now(), login_attempts = 0, updated_at = now() WHERE user_id = $1`,
+      `UPDATE auth.users SET last_login_at = now(), login_attempts = 0, locked_until = NULL, updated_at = now() WHERE user_id = $1`,
       [user.user_id]
     );
 

--- a/services/auth/src/grpc/handlers.ts
+++ b/services/auth/src/grpc/handlers.ts
@@ -153,8 +153,10 @@ export type UserRow = {
 type RefreshTokenRow = {
   token: string;
   user_id: string;
+  family_id: string;
   expires_at: Date;
   revoked_at: Date | null;
+  is_revoked: boolean;
 };
 
 export function rowToProtoUser(row: UserRow): AuthUser {
@@ -223,6 +225,27 @@ export async function loadPrincipal(
   const permissions = permsRes.rows.map(r => r.name as Permission);
 
   return { roles, permissions };
+}
+
+// Reject tokens for users who are no longer permitted to authenticate.
+// A token (access or refresh) stays cryptographically valid until it
+// expires, so a user suspended/deactivated/deleted mid-session would
+// otherwise keep access — and could refresh indefinitely — until the
+// token's own expiry. ValidateToken (every gateway request) and
+// RefreshToken both gate on this. A single indexed point-read on the PK.
+async function assertActiveUser(deps: HandlerDeps, userId: string): Promise<void> {
+  const res = await deps.pool.query<{ status: UserStatusDb }>(
+    `SELECT status FROM auth.users WHERE user_id = $1 AND deleted_at IS NULL`,
+    [userId]
+  );
+  const status = res.rows[0]?.status;
+  // Mirror Login's policy exactly: reject suspended/deactivated (and a
+  // missing row = deleted). `inactive` / `pending_verification` are NOT
+  // blocked here because Login lets them authenticate. We do NOT
+  // distinguish cases in the error — the caller only needs "not allowed".
+  if (status === undefined || status === 'suspended' || status === 'deactivated') {
+    throw new HandlerError('UNAUTHENTICATED', 'account is not active');
+  }
 }
 
 function uniqueRoles(roles: UserRole[]): UserRole[] {
@@ -376,7 +399,7 @@ export async function logout(
       [claims.jti, claims.sub, new Date(claims.exp * 1000)]
     );
     await client.query(
-      `UPDATE auth.refresh_tokens SET revoked_at = now(), updated_at = now() WHERE token = $1 AND revoked_at IS NULL`,
+      `UPDATE auth.refresh_tokens SET revoked_at = now(), is_revoked = true, updated_at = now() WHERE token = $1 AND revoked_at IS NULL`,
       [req.refreshToken]
     );
 
@@ -417,27 +440,53 @@ export async function refreshToken(
     throw new HandlerError('UNAUTHENTICATED', 'refresh token revoked');
   }
 
-  // Confirm the persisted refresh row is still active (covers the
-  // case where Logout revoked the row without the jti in the denylist
-  // — older monolith path).
+  // Confirm the persisted refresh row is still active. A row is active
+  // only when BOTH revocation columns agree: `revoked_at` (set by the
+  // refresh/logout path) AND `is_revoked` (set by RevokeSession). The two
+  // columns historically diverged — checking only `revoked_at` let a
+  // session revoked via RevokeSession keep refreshing (it sets is_revoked
+  // but never revoked_at). Honour both.
   const stored = await deps.pool.query<RefreshTokenRow>(
     `SELECT * FROM auth.refresh_tokens WHERE token = $1`,
     [req.refreshToken]
   );
-  if (stored.rows.length === 0 || stored.rows[0].revoked_at !== null) {
+  if (stored.rows.length === 0 || stored.rows[0].revoked_at !== null || stored.rows[0].is_revoked) {
     throw new HandlerError('UNAUTHENTICATED', 'refresh token revoked');
   }
+  const familyId = stored.rows[0].family_id;
+
+  // A suspended/deactivated/deleted user must not be able to rotate their
+  // refresh token into a fresh pair — otherwise admin deactivation only
+  // takes effect when the current refresh token finally expires (30d).
+  await assertActiveUser(deps, claims.sub);
 
   const minted = await deps.tokenIssuer.mint(claims.sub);
 
-  await withTransaction(deps, async ({ client, publish }) => {
-    // Mark the old refresh row revoked + add its jti to the denylist
-    // so a stolen old token can't replay even if the new one is also
-    // out in the wild.
-    await client.query(
-      `UPDATE auth.refresh_tokens SET revoked_at = now(), updated_at = now() WHERE token = $1`,
+  const rotated = await withTransaction(deps, async ({ client, publish }) => {
+    // Atomic rotation gate: revoke the old row ONLY if it is still active,
+    // and serialise concurrent refreshes on the same token through this
+    // conditional UPDATE. The `revoked_at IS NULL AND is_revoked = false`
+    // predicate makes the row its own lock — the second of two racing
+    // refreshes finds rowCount 0 (the first already flipped the row) and
+    // bails out below WITHOUT minting a second valid family. It also loses
+    // to a concurrent RevokeSession (which flips is_revoked). The
+    // pre-transaction SELECT above is a cheap fast-fail only; THIS is the
+    // authoritative check. We set BOTH columns so the sessions list and
+    // the refresh path stay consistent.
+    const revoke = await client.query(
+      `UPDATE auth.refresh_tokens
+       SET revoked_at = now(), is_revoked = true, updated_at = now()
+       WHERE token = $1 AND revoked_at IS NULL AND is_revoked = false`,
       [req.refreshToken]
     );
+    if (revoke.rowCount === 0) {
+      // The token was already rotated/revoked between our read and this
+      // write — concurrent reuse. Deny without issuing new tokens.
+      return false;
+    }
+
+    // Add the old jti to the denylist so a stolen old access/refresh token
+    // can't replay even if the new one is also out in the wild.
     await client.query(
       `
       INSERT INTO auth.revoked_tokens (jti, user_id, expires_at, revoked_at, updated_at)
@@ -446,12 +495,14 @@ export async function refreshToken(
       `,
       [claims.jti, claims.sub, new Date(claims.exp * 1000)]
     );
+    // Inherit the rotation family so RevokeSession can revoke the whole
+    // chain in one shot. The new row is the active head of the family.
     await client.query(
       `
-      INSERT INTO auth.refresh_tokens (token, user_id, expires_at, revoked_at, created_at, updated_at)
-      VALUES ($1, $2, $3, NULL, now(), now())
+      INSERT INTO auth.refresh_tokens (token, user_id, family_id, expires_at, revoked_at, is_revoked, created_at, updated_at)
+      VALUES ($1, $2, $3, $4, NULL, false, now(), now())
       `,
-      [minted.pair.refreshToken, claims.sub, minted.refreshExpiresAt]
+      [minted.pair.refreshToken, claims.sub, familyId, minted.refreshExpiresAt]
     );
 
     publish({
@@ -459,7 +510,12 @@ export async function refreshToken(
       id: `auth.tokenRefreshed.${minted.accessJti}`,
       payload: { userId: claims.sub, oldJti: claims.jti, newJti: minted.accessJti },
     });
+    return true;
   });
+
+  if (!rotated) {
+    throw new HandlerError('UNAUTHENTICATED', 'refresh token revoked');
+  }
 
   return { tokens: minted.pair };
 }
@@ -490,6 +546,12 @@ export async function validateToken(
   if (denied.rows.length > 0) {
     throw new HandlerError('UNAUTHENTICATED', 'access token revoked');
   }
+
+  // Reject the token if the user is no longer allowed to authenticate
+  // (suspended/deactivated/deleted) — a still-valid access token must not
+  // outlive an admin action. Checked BEFORE hydrating the principal so a
+  // blocked user never gets roles/permissions surfaced.
+  await assertActiveUser(deps, claims.sub);
 
   // Now (and only now) hydrate the principal. Single user_id read +
   // role/permission joins — same query loadPrincipal uses.

--- a/services/auth/src/grpc/session-handlers.test.ts
+++ b/services/auth/src/grpc/session-handlers.test.ts
@@ -140,5 +140,9 @@ describe('revokeSession', () => {
       return sql.includes('UPDATE') && sql.includes('refresh_tokens');
     });
     expect(updateCall?.[1]).toEqual(['fam-1']);
+    // Sets BOTH revocation columns so the refresh path (which reads
+    // revoked_at) also rejects a revoked session's tokens.
+    expect(String(updateCall?.[0])).toMatch(/revoked_at = now\(\)/);
+    expect(String(updateCall?.[0])).toMatch(/is_revoked = true/);
   });
 });

--- a/services/auth/src/grpc/session-handlers.ts
+++ b/services/auth/src/grpc/session-handlers.ts
@@ -124,7 +124,7 @@ export async function revokeSession(
     // middle of the chain must also stop working.
     await client.query(
       `UPDATE auth.refresh_tokens
-       SET is_revoked = true, updated_at = now()
+       SET is_revoked = true, revoked_at = now(), updated_at = now()
        WHERE family_id = $1 AND is_revoked = false`,
       [family_id]
     );

--- a/services/auth/src/migrations/012_reconcile_refresh_token_revocation.ts
+++ b/services/auth/src/migrations/012_reconcile_refresh_token_revocation.ts
@@ -1,0 +1,43 @@
+import type { MigrationBuilder } from 'node-pg-migrate';
+
+// Reconcile the two revocation columns on refresh_tokens.
+//
+// 006 created `is_revoked` (used by the sessions handlers); 010 added
+// `revoked_at` (used by the login / refresh / logout handlers). The two
+// columns tracked the same fact independently, so a row could be revoked
+// under one column and active under the other. In particular a session
+// revoked via RevokeSession set `is_revoked` but not `revoked_at`, and the
+// refresh path only checked `revoked_at` — so a revoked session kept
+// minting fresh tokens. The handlers now write BOTH columns and read BOTH;
+// this migration backfills existing rows so neither view is stale:
+//   - any row with a non-null revoked_at is also is_revoked = true
+//   - any row already is_revoked = true gets a revoked_at stamp so the
+//     refresh path's `revoked_at IS NULL` predicate agrees
+//
+// A partial index on the active head rows speeds the sessions list and the
+// refresh lookup, which both filter on (is_revoked = false).
+export const up = async (pgm: MigrationBuilder): Promise<void> => {
+  pgm.sql(`
+    UPDATE auth.refresh_tokens
+    SET is_revoked = true
+    WHERE revoked_at IS NOT NULL AND is_revoked = false
+  `);
+  pgm.sql(`
+    UPDATE auth.refresh_tokens
+    SET revoked_at = updated_at
+    WHERE is_revoked = true AND revoked_at IS NULL
+  `);
+  pgm.createIndex('refresh_tokens', ['user_id', 'family_id'], {
+    name: 'refresh_tokens_active_head_idx',
+    where: 'is_revoked = false',
+  });
+};
+
+export const down = async (pgm: MigrationBuilder): Promise<void> => {
+  // The backfill only reconciled two columns that already existed; the
+  // pre-backfill split-brain state is not recoverable and reintroducing it
+  // would be a regression, so down only reverses the structural change.
+  pgm.dropIndex('refresh_tokens', ['user_id', 'family_id'], {
+    name: 'refresh_tokens_active_head_idx',
+  });
+};

--- a/services/auth/src/migrations/013_index_user_lookup_tokens.ts
+++ b/services/auth/src/migrations/013_index_user_lookup_tokens.ts
@@ -1,0 +1,27 @@
+import type { MigrationBuilder } from 'node-pg-migrate';
+
+// Index the single-use credential tokens that the account handlers look
+// users up by. VerifyEmail does `WHERE verification_token = $1` and
+// ResetPassword does `WHERE reset_token = $1` — both were unindexed
+// (001 only indexed email/status/user_type/created_at/deleted_at), so each
+// email-verification and password-reset was a full table scan on auth.users.
+//
+// Partial indexes (token IS NOT NULL): the columns are NULL for the vast
+// majority of rows (a token only exists during an in-flight verify/reset),
+// so a partial index stays tiny and the planner uses it for the equality
+// lookup.
+export const up = async (pgm: MigrationBuilder): Promise<void> => {
+  pgm.createIndex('users', 'verification_token', {
+    name: 'users_verification_token_idx',
+    where: 'verification_token IS NOT NULL',
+  });
+  pgm.createIndex('users', 'reset_token', {
+    name: 'users_reset_token_idx',
+    where: 'reset_token IS NOT NULL',
+  });
+};
+
+export const down = async (pgm: MigrationBuilder): Promise<void> => {
+  pgm.dropIndex('users', 'reset_token', { name: 'users_reset_token_idx' });
+  pgm.dropIndex('users', 'verification_token', { name: 'users_verification_token_idx' });
+};

--- a/services/chat/src/grpc/handlers.test.ts
+++ b/services/chat/src/grpc/handlers.test.ts
@@ -396,6 +396,30 @@ describe('markRead', () => {
     expect(realClientQueries(mocks)).toEqual(['INSERT', 'UPDATE', 'SELECT']);
     expect(mocks.natsMock.publish.mock.calls[0][0]).toBe('chat.messageRead');
   });
+
+  it('advances last_read_at to the target message timestamp (not now()) and never backwards', async () => {
+    const targetCreatedAt = new Date('2026-06-01T00:01:00Z');
+    mocks.poolScript.push({ rows: [{ chat_participant_id: 'p-1' }] });
+    mocks.poolScript.push({ rows: [{ created_at: targetCreatedAt }] });
+    mocks.clientScript.push({ rows: [] });
+    mocks.clientScript.push({ rows: [] });
+    mocks.clientScript.push({
+      rows: [{ participant_id: 'usr-adopter' }, { participant_id: 'usr-rescue' }],
+    });
+
+    await markRead(mocks.deps, ADOPTER_PRINCIPAL, BASE_MARK);
+
+    const updateCall = mocks.clientMock.query.mock.calls.find(
+      ([sql]) => typeof sql === 'string' && sql.includes('UPDATE chat_participants')
+    ) as [string, unknown[]] | undefined;
+    expect(updateCall).toBeDefined();
+    // Watermark must be derived from the target's created_at, not wall-clock
+    // now(), so a message arriving mid-mark is not silently swallowed; and it
+    // must be monotonic (GREATEST) so out-of-order marks never rewind it.
+    expect(updateCall?.[0]).toMatch(/GREATEST\(last_read_at,/);
+    expect(updateCall?.[0]).not.toMatch(/last_read_at = now\(\)/);
+    expect(updateCall?.[1]).toContain(targetCreatedAt);
+  });
 });
 
 // --- React ----------------------------------------------------------
@@ -416,6 +440,14 @@ describe('react', () => {
     await expect(react(mocks.deps, UNPRIVILEGED_PRINCIPAL, BASE_REACT)).rejects.toMatchObject({
       code: 'PERMISSION_DENIED',
     });
+  });
+
+  it('rejects an emoji longer than the column bound before touching the DB', async () => {
+    await expect(
+      react(mocks.deps, ADOPTER_PRINCIPAL, { ...BASE_REACT, emoji: 'x'.repeat(33) })
+    ).rejects.toMatchObject({ code: 'INVALID_ARGUMENT' });
+    // No DB work attempted — validation precedes the message lookup.
+    expect(mocks.poolMock.query).not.toHaveBeenCalled();
   });
 
   it('rejects reacting in a chat the caller is not a member of', async () => {

--- a/services/chat/src/grpc/handlers.ts
+++ b/services/chat/src/grpc/handlers.ts
@@ -592,15 +592,18 @@ export async function markRead(
       [principal.userId, req.chatId, target.rows[0].created_at]
     );
 
-    // Bump the participant's last_read_at watermark for the chat-list
-    // unread badge calculation.
+    // Advance the participant's last_read_at watermark to the TARGET
+    // message's timestamp — not now(). now() would swallow any message that
+    // arrives between the target lookup and this write (its created_at falls
+    // in (target, now()] yet would read as "below the watermark"). GREATEST
+    // keeps the watermark monotonic so out-of-order marks never rewind it.
     await client.query(
       `
       UPDATE chat_participants
-      SET last_read_at = now(), updated_at = now()
+      SET last_read_at = GREATEST(last_read_at, $3), updated_at = now()
       WHERE chat_id = $1 AND participant_id = $2
       `,
-      [req.chatId, principal.userId]
+      [req.chatId, principal.userId, target.rows[0].created_at]
     );
 
     const participantUserIds = await loadChatParticipantsTx(client, req.chatId);
@@ -621,6 +624,12 @@ export async function markRead(
 
 // --- React -----------------------------------------------------------
 
+// The emoji column is varchar(32). Postgres counts code points; JS string
+// length counts UTF-16 code units (>= code points), so a length <= 32 here
+// can never overflow the column. Guarding in the handler turns a would-be
+// DB 22001 (surfaced as INTERNAL) into a clean INVALID_ARGUMENT.
+const MAX_EMOJI_LENGTH = 32;
+
 export async function react(
   deps: HandlerDeps,
   principal: Principal,
@@ -631,6 +640,9 @@ export async function react(
   }
   if (!req.emoji) {
     throw new HandlerError('INVALID_ARGUMENT', 'emoji is required');
+  }
+  if (req.emoji.length > MAX_EMOJI_LENGTH) {
+    throw new HandlerError('INVALID_ARGUMENT', `emoji exceeds ${MAX_EMOJI_LENGTH} character limit`);
   }
   if (!hasPermission(principal, CHAT_SEND)) {
     throw new HandlerError('PERMISSION_DENIED', `'${CHAT_SEND}' required`);

--- a/services/cms/src/gdpr/erase.test.ts
+++ b/services/cms/src/gdpr/erase.test.ts
@@ -1,0 +1,50 @@
+import type { PoolClient } from 'pg';
+import { describe, expect, it, vi } from 'vitest';
+
+import type { GdprErasureRequestedPayload } from '@adopt-dont-shop/events';
+
+import { eraseCms } from './erase.js';
+
+const PAYLOAD: GdprErasureRequestedPayload = {
+  userId: 'usr-42',
+  correlationId: 'corr-1',
+  requestedAt: '2026-06-15T00:00:00Z',
+};
+
+function makeClient(rowCounts: number[]) {
+  const calls: Array<{ sql: string; params: unknown[] }> = [];
+  let i = 0;
+  const client = {
+    query: vi.fn(async (sql: string, params: unknown[]) => {
+      calls.push({ sql, params });
+      return { rows: [], rowCount: rowCounts[i++] ?? 0 };
+    }),
+  };
+  return { client: client as unknown as PoolClient, calls };
+}
+
+describe('eraseCms', () => {
+  it('anonymises author_id and last_modified_by for the user and totals the rows', async () => {
+    const { client, calls } = makeClient([2, 3]);
+    const total = await eraseCms(client, PAYLOAD);
+
+    expect(total).toBe(5);
+    expect(calls).toHaveLength(2);
+    for (const { sql, params } of calls) {
+      expect(sql).toContain('SET');
+      expect(sql).toContain('NULL');
+      expect(params).toEqual(['usr-42']);
+    }
+    expect(calls[0].sql).toContain('author_id');
+    expect(calls[1].sql).toContain('last_modified_by');
+  });
+
+  it('uses unqualified table names so the pool search_path selects the schema', async () => {
+    const { client, calls } = makeClient([0, 0]);
+    await eraseCms(client, PAYLOAD);
+    for (const { sql } of calls) {
+      expect(sql).toContain('cms_content');
+      expect(sql).not.toContain('cms.cms_content');
+    }
+  });
+});

--- a/services/cms/src/gdpr/erase.ts
+++ b/services/cms/src/gdpr/erase.ts
@@ -14,13 +14,13 @@ export async function eraseCms(
   let total = 0;
 
   const a = await client.query(
-    `UPDATE cms.cms_content SET author_id = NULL, updated_at = now() WHERE author_id = $1`,
+    `UPDATE cms_content SET author_id = NULL, updated_at = now() WHERE author_id = $1`,
     [payload.userId]
   );
   total += a.rowCount ?? 0;
 
   const b = await client.query(
-    `UPDATE cms.cms_content
+    `UPDATE cms_content
         SET last_modified_by = NULL, updated_at = now()
       WHERE last_modified_by = $1`,
     [payload.userId]

--- a/services/cms/src/grpc/handlers.test.ts
+++ b/services/cms/src/grpc/handlers.test.ts
@@ -452,6 +452,7 @@ describe('workflow actions', () => {
   });
 
   it('publishContent: sets status=published + published_at', async () => {
+    mocks.clientScript.push({ rows: [contentRow({ status: 'draft' })] }); // SELECT FOR UPDATE
     mocks.clientScript.push({
       rows: [contentRow({ status: 'published', published_at: new Date() })],
     });
@@ -462,6 +463,7 @@ describe('workflow actions', () => {
   });
 
   it('unpublishContent: sets status=draft (NO published_at update)', async () => {
+    mocks.clientScript.push({ rows: [contentRow({ status: 'published' })] }); // SELECT FOR UPDATE
     mocks.clientScript.push({ rows: [contentRow({ status: 'draft' })] });
     await unpublishContent(mocks.deps, ADMIN, { contentId: 'c-1' });
     const call = mocks.clientMock.query.mock.calls.find(c => /^UPDATE/i.test(String(c[0])));
@@ -469,9 +471,71 @@ describe('workflow actions', () => {
   });
 
   it('archiveContent: sets status=archived', async () => {
+    mocks.clientScript.push({ rows: [contentRow({ status: 'published' })] }); // SELECT FOR UPDATE
     mocks.clientScript.push({ rows: [contentRow({ status: 'archived' })] });
     const res = await archiveContent(mocks.deps, ADMIN, { contentId: 'c-1' });
     expect(res.content?.status).toBe(CmsV1.ContentStatus.CONTENT_STATUS_ARCHIVED);
+  });
+
+  it('publishContent: 404 when content missing (no UPDATE attempted)', async () => {
+    mocks.clientScript.push({ rows: [] }); // SELECT FOR UPDATE finds nothing
+    await expect(publishContent(mocks.deps, ADMIN, { contentId: 'c-x' })).rejects.toMatchObject({
+      code: 'NOT_FOUND',
+    });
+    const updateCall = mocks.clientMock.query.mock.calls.find(c => /^UPDATE/i.test(String(c[0])));
+    expect(updateCall).toBeUndefined();
+  });
+});
+
+describe('status transition validation (state machine)', () => {
+  let mocks: ReturnType<typeof makeMocks>;
+  beforeEach(() => {
+    mocks = makeMocks();
+  });
+
+  it('reads the current status under FOR UPDATE before writing', async () => {
+    mocks.clientScript.push({ rows: [contentRow({ status: 'draft' })] });
+    mocks.clientScript.push({ rows: [contentRow({ status: 'published' })] });
+    await publishContent(mocks.deps, ADMIN, { contentId: 'c-1' });
+    const selectCall = mocks.clientMock.query.mock.calls.find(c => /^SELECT/i.test(String(c[0])));
+    expect(String(selectCall![0])).toContain('FOR UPDATE');
+  });
+
+  it('rejects publishing an already-published item (self-transition)', async () => {
+    mocks.clientScript.push({ rows: [contentRow({ status: 'published' })] });
+    await expect(publishContent(mocks.deps, ADMIN, { contentId: 'c-1' })).rejects.toMatchObject({
+      code: 'INVALID_ARGUMENT',
+    });
+    const updateCall = mocks.clientMock.query.mock.calls.find(c => /^UPDATE/i.test(String(c[0])));
+    expect(updateCall).toBeUndefined();
+  });
+
+  it('rejects re-publishing an archived item (illegal jump)', async () => {
+    mocks.clientScript.push({ rows: [contentRow({ status: 'archived' })] });
+    await expect(publishContent(mocks.deps, ADMIN, { contentId: 'c-1' })).rejects.toMatchObject({
+      code: 'INVALID_ARGUMENT',
+    });
+  });
+
+  it('rejects archiving an already-archived item', async () => {
+    mocks.clientScript.push({ rows: [contentRow({ status: 'archived' })] });
+    await expect(archiveContent(mocks.deps, ADMIN, { contentId: 'c-1' })).rejects.toMatchObject({
+      code: 'INVALID_ARGUMENT',
+    });
+  });
+
+  it('rejects unpublishing a draft (nothing to unpublish)', async () => {
+    mocks.clientScript.push({ rows: [contentRow({ status: 'draft' })] });
+    await expect(unpublishContent(mocks.deps, ADMIN, { contentId: 'c-1' })).rejects.toMatchObject({
+      code: 'INVALID_ARGUMENT',
+    });
+  });
+
+  it('allows restore: archived -> draft via unpublish', async () => {
+    mocks.clientScript.push({ rows: [contentRow({ status: 'archived' })] });
+    mocks.clientScript.push({ rows: [contentRow({ status: 'draft' })] });
+    const res = await unpublishContent(mocks.deps, ADMIN, { contentId: 'c-1' });
+    expect(res.content?.status).toBe(CmsV1.ContentStatus.CONTENT_STATUS_DRAFT);
   });
 });
 
@@ -506,12 +570,14 @@ describe('event idempotency keys (Nats-Msg-Id)', () => {
   });
 
   it('publish and unpublish of the same content do not share a msgID', async () => {
-    mocks.clientScript.push({ rows: [contentRow({ status: 'published' })] });
+    mocks.clientScript.push({ rows: [contentRow({ status: 'draft' })] }); // SELECT FOR UPDATE
+    mocks.clientScript.push({ rows: [contentRow({ status: 'published' })] }); // UPDATE
     await publishContent(mocks.deps, ADMIN, { contentId: 'c-1' });
     const publishId = msgIdFor('cms.contentPublished');
 
     mocks.natsMock.jetstream().publish.mockClear();
-    mocks.clientScript.push({ rows: [contentRow({ status: 'draft' })] });
+    mocks.clientScript.push({ rows: [contentRow({ status: 'published' })] }); // SELECT FOR UPDATE
+    mocks.clientScript.push({ rows: [contentRow({ status: 'draft' })] }); // UPDATE
     await unpublishContent(mocks.deps, ADMIN, { contentId: 'c-1' });
     const unpublishId = msgIdFor('cms.contentUnpublished');
 

--- a/services/cms/src/grpc/handlers.ts
+++ b/services/cms/src/grpc/handlers.ts
@@ -19,6 +19,8 @@
 import { hasPermission, type Principal } from '@adopt-dont-shop/authz';
 import { withTransaction, type WithTransactionDeps } from '@adopt-dont-shop/events';
 import type { Permission } from '@adopt-dont-shop/lib.types';
+
+import { isLegalTransition } from './status-machine.js';
 import {
   CmsV1,
   type CmsArchiveContentRequest,
@@ -655,6 +657,26 @@ async function setStatus(
   setPublishedAt: boolean
 ): Promise<ContentRow> {
   return withTransaction(deps, async ({ client, publish }) => {
+    // Lock the row and re-validate the transition against the *locked*
+    // status so two concurrent transitions can't both pass the gate
+    // (no TOCTOU): the second one blocks on FOR UPDATE, then sees the
+    // first one's committed status.
+    const currentResult = await client.query<ContentRow>(
+      `SELECT ${CONTENT_COLUMNS} FROM cms_content
+         WHERE content_id = $1 AND deleted_at IS NULL FOR UPDATE`,
+      [contentId]
+    );
+    const current = currentResult.rows[0];
+    if (!current) {
+      throw new HandlerError('NOT_FOUND', `content ${contentId} not found`);
+    }
+    if (!isLegalTransition(current.status, status)) {
+      throw new HandlerError(
+        'INVALID_ARGUMENT',
+        `illegal status transition: ${current.status} -> ${status}`
+      );
+    }
+
     const setExtra = setPublishedAt ? ', published_at = now()' : '';
     const result = await client.query<ContentRow>(
       `UPDATE cms_content

--- a/services/cms/src/grpc/status-machine.test.ts
+++ b/services/cms/src/grpc/status-machine.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+
+import { isLegalTransition, legalTargets } from './status-machine.js';
+
+const ALL = ['draft', 'published', 'archived', 'scheduled'] as const;
+
+describe('content status machine', () => {
+  it('allows the conventional lifecycle transitions', () => {
+    expect(isLegalTransition('draft', 'published')).toBe(true); // publish
+    expect(isLegalTransition('published', 'draft')).toBe(true); // unpublish
+    expect(isLegalTransition('draft', 'archived')).toBe(true); // archive
+    expect(isLegalTransition('published', 'archived')).toBe(true); // archive
+    expect(isLegalTransition('archived', 'draft')).toBe(true); // restore
+    expect(isLegalTransition('scheduled', 'published')).toBe(true);
+    expect(isLegalTransition('scheduled', 'draft')).toBe(true);
+    expect(isLegalTransition('scheduled', 'archived')).toBe(true);
+  });
+
+  it('rejects illegal jumps', () => {
+    expect(isLegalTransition('archived', 'published')).toBe(false); // can't re-publish directly
+    expect(isLegalTransition('archived', 'archived')).toBe(false);
+    expect(isLegalTransition('draft', 'scheduled')).toBe(false); // not via these handlers
+    expect(isLegalTransition('published', 'scheduled')).toBe(false);
+  });
+
+  it('rejects every self-transition', () => {
+    for (const s of ALL) {
+      expect(isLegalTransition(s, s)).toBe(false);
+    }
+  });
+
+  it('has a total transition table (every status has an entry)', () => {
+    for (const s of ALL) {
+      expect(Array.isArray(legalTargets(s))).toBe(true);
+    }
+  });
+});

--- a/services/cms/src/grpc/status-machine.ts
+++ b/services/cms/src/grpc/status-machine.ts
@@ -1,0 +1,41 @@
+// Pure content-status state machine.
+//
+// The legal-transition table is the single source of truth for which
+// status changes the publish/unpublish/archive handlers will accept.
+// Keeping it pure + I/O-free (no DB, no proto) mirrors the pets
+// service's status-machine and makes it trivially testable.
+//
+// Lifecycle (the verbs the handlers expose):
+//   draft               -> published   (publish)
+//   {draft, scheduled}  -> published   (publish)
+//   {published, scheduled} -> draft     (unpublish)
+//   {draft, published, scheduled} -> archived (archive)
+//   archived            -> draft        (restore)
+//
+// Self-transitions (status unchanged) are rejected as a no-op. Illegal
+// jumps (e.g. archived -> published, draft -> archived-then-published)
+// are rejected. `scheduled` is reachable only via the scheduler write
+// path, not these handlers, but it is a legal *source* so a scheduled
+// item can still be published / unpublished / archived by an admin.
+
+type ContentStatus = 'draft' | 'published' | 'archived' | 'scheduled';
+
+const LEGAL_TRANSITIONS: Record<ContentStatus, ReadonlyArray<ContentStatus>> = {
+  draft: ['published', 'archived'],
+  published: ['draft', 'archived'],
+  scheduled: ['published', 'draft', 'archived'],
+  archived: ['draft'],
+};
+
+export function isLegalTransition(from: ContentStatus, to: ContentStatus): boolean {
+  if (from === to) {
+    return false;
+  }
+  return LEGAL_TRANSITIONS[from].includes(to);
+}
+
+// Exported so the test can assert the table is total (every status has
+// an entry) without reaching into the private constant.
+export function legalTargets(from: ContentStatus): ReadonlyArray<ContentStatus> {
+  return LEGAL_TRANSITIONS[from];
+}

--- a/services/cms/src/migrations/003_cms_content_author_nullable.ts
+++ b/services/cms/src/migrations/003_cms_content_author_nullable.ts
@@ -1,0 +1,14 @@
+import type { MigrationBuilder } from 'node-pg-migrate';
+
+// GDPR erasure anonymises content authorship by NULLing author_id (and
+// last_modified_by). author_id was created NOT NULL, so eraseCms would
+// hit a constraint violation. Drop the NOT NULL so erasure can blank it.
+// last_modified_by was already nullable.
+
+export const up = async (pgm: MigrationBuilder): Promise<void> => {
+  pgm.alterColumn('cms_content', 'author_id', { notNull: false });
+};
+
+export const down = async (pgm: MigrationBuilder): Promise<void> => {
+  pgm.alterColumn('cms_content', 'author_id', { notNull: true });
+};

--- a/services/gateway/src/grpc-clients/resilience.test.ts
+++ b/services/gateway/src/grpc-clients/resilience.test.ts
@@ -258,6 +258,61 @@ describe('callWithResilience', () => {
     expect(fn.mock.calls.length).toBe(callsAfterProbe); // fn NOT called
   });
 
+  // ── circuit breaker: client-fault errors must NOT open it ────────
+
+  it('does NOT count client-fault errors (NOT_FOUND) toward opening the circuit', async () => {
+    // A healthy downstream returning a burst of NOT_FOUND is not a signal
+    // of unhealthiness. Counting them would let normal traffic trip the
+    // breaker and 503 a perfectly healthy service.
+    const err = makeGrpcError(GRPC_STATUS.NOT_FOUND);
+    const fn = vi.fn().mockRejectedValue(err);
+
+    // Far exceed the failure threshold (3) with client-fault errors.
+    for (let i = 0; i < 6; i++) {
+      await expect(callWithResilience(fn, opts)).rejects.toBe(err);
+    }
+
+    // Circuit must still be closed — the next call reaches fn and gets the
+    // real NOT_FOUND rather than a fast-fail UNAVAILABLE from an open breaker.
+    const callsBefore = fn.mock.calls.length;
+    await expect(callWithResilience(fn, opts)).rejects.toBe(err);
+    expect(fn.mock.calls.length).toBe(callsBefore + 1);
+  });
+
+  it('does NOT count UNAUTHENTICATED toward opening the circuit', async () => {
+    // Expired-token bursts (a very common, benign condition) must not take
+    // the auth service offline at the gateway.
+    const UNAUTHENTICATED = 16;
+    const err = makeGrpcError(UNAUTHENTICATED);
+    const fn = vi.fn().mockRejectedValue(err);
+
+    for (let i = 0; i < 6; i++) {
+      await expect(callWithResilience(fn, opts)).rejects.toBe(err);
+    }
+
+    const callsBefore = fn.mock.calls.length;
+    await expect(callWithResilience(fn, opts)).rejects.toBe(err);
+    expect(fn.mock.calls.length).toBe(callsBefore + 1);
+  });
+
+  it('counts errors with no gRPC code (transport failure) toward opening the circuit', async () => {
+    // A raw connection error (no numeric `code`) means the downstream
+    // couldn't be reached — that IS unhealthiness and must trip the breaker.
+    const err = new Error('ECONNREFUSED');
+    const fn = vi.fn().mockRejectedValue(err);
+
+    for (let i = 0; i < 3; i++) {
+      await expect(callWithResilience(fn, opts)).rejects.toBe(err);
+    }
+
+    // Circuit now open — next call fast-fails without reaching fn.
+    const callsBefore = fn.mock.calls.length;
+    await expect(callWithResilience(fn, opts)).rejects.toMatchObject({
+      code: GRPC_STATUS.UNAVAILABLE,
+    });
+    expect(fn.mock.calls.length).toBe(callsBefore);
+  });
+
   // ── circuit breaker: gauge ───────────────────────────────────────
 
   it('gauge is 0 (closed) initially', async () => {

--- a/services/gateway/src/grpc-clients/resilience.ts
+++ b/services/gateway/src/grpc-clients/resilience.ts
@@ -32,6 +32,27 @@ const STATUS_DEADLINE_EXCEEDED = 4;
 
 const RETRYABLE_CODES = new Set([STATUS_UNAVAILABLE, STATUS_DEADLINE_EXCEEDED]);
 
+// Codes that indicate the DOWNSTREAM is unhealthy and so should count
+// toward opening the circuit breaker. Client-fault codes
+// (INVALID_ARGUMENT, NOT_FOUND, ALREADY_EXISTS, PERMISSION_DENIED,
+// UNAUTHENTICATED, FAILED_PRECONDITION, ABORTED, …) are NOT faults: a
+// healthy service returning a burst of 404s or expired-token 401s must
+// never trip the breaker and 503 normal traffic. An error with no numeric
+// gRPC code (a raw transport/connection error) means the downstream
+// couldn't be reached and is treated as a fault.
+const STATUS_UNKNOWN = 2;
+const STATUS_RESOURCE_EXHAUSTED = 8;
+const STATUS_INTERNAL = 13;
+const STATUS_DATA_LOSS = 15;
+const FAULT_CODES = new Set([
+  STATUS_UNKNOWN,
+  STATUS_DEADLINE_EXCEEDED,
+  STATUS_RESOURCE_EXHAUSTED,
+  STATUS_INTERNAL,
+  STATUS_UNAVAILABLE,
+  STATUS_DATA_LOSS,
+]);
+
 // ── env-based defaults ────────────────────────────────────────────────
 
 const DEFAULT_MAX_RETRIES = parseInt(process.env['GRPC_RETRY_COUNT'] ?? '2', 10);
@@ -212,6 +233,24 @@ const isRetryableError = (err: unknown): boolean => {
   return false;
 };
 
+// Whether an error indicates the DOWNSTREAM is unhealthy and so should
+// count toward opening the circuit breaker. An error carrying one of the
+// FAULT_CODES is a fault; client-fault codes (NOT_FOUND, UNAUTHENTICATED,
+// INVALID_ARGUMENT, …) are not. An error with no numeric gRPC code is a
+// raw transport/connection failure — the downstream couldn't be reached,
+// which IS a fault.
+const isFaultError = (err: unknown): boolean => {
+  if (
+    err &&
+    typeof err === 'object' &&
+    'code' in err &&
+    typeof (err as { code?: unknown }).code === 'number'
+  ) {
+    return FAULT_CODES.has((err as { code: number }).code);
+  }
+  return true;
+};
+
 const makeUnavailableError = (): Error & { code: number } => {
   const err = new Error('circuit breaker open — service unavailable') as Error & { code: number };
   err.code = STATUS_UNAVAILABLE;
@@ -250,7 +289,12 @@ export const callWithResilience = async <T>(
       return result;
     } catch (err: unknown) {
       lastError = err;
-      breaker.onFailure();
+      // Only downstream-health faults trip the breaker. A burst of benign
+      // client-fault errors (404s, expired-token 401s) from a healthy
+      // service must never open the circuit and 503 normal traffic.
+      if (isFaultError(err)) {
+        breaker.onFailure();
+      }
 
       const shouldRetry = idempotent && isRetryableError(err) && attempt < maxAttempts - 1;
       if (!shouldRetry) {

--- a/services/gateway/src/routes/dashboard.test.ts
+++ b/services/gateway/src/routes/dashboard.test.ts
@@ -261,6 +261,29 @@ describe('GET /api/v1/dashboard/rescue', () => {
     expect(appStatsReq.rescueIdFilter).toBe('rsc-target');
   });
 
+  it('ignores ?rescueId= for a non-admin caller — scopes to their own rescue', async () => {
+    pets.getStatsMock.mockResolvedValueOnce(PET_STATS_FIXTURE);
+    apps.getStatsMock.mockResolvedValueOnce(APP_STATS_FIXTURE);
+    pets.listMock.mockResolvedValueOnce({ pets: [] });
+    apps.listMock.mockResolvedValueOnce({ applications: [] });
+    rescue.listStaffMembersMock.mockResolvedValueOnce({ staffMembers: [] });
+
+    await app.inject({
+      method: 'GET',
+      url: '/api/v1/dashboard/rescue?rescueId=rsc-other',
+      headers: {
+        'x-user-id': 'usr-staff',
+        'x-user-roles': 'rescue_staff',
+        'x-rescue-id': 'rsc-own',
+      },
+    });
+
+    const [petStatsReq] = pets.getStatsMock.mock.calls[0] as [{ rescueIdFilter: string }, Metadata];
+    expect(petStatsReq.rescueIdFilter).toBe('rsc-own');
+    const [appStatsReq] = apps.getStatsMock.mock.calls[0] as [{ rescueIdFilter: string }, Metadata];
+    expect(appStatsReq.rescueIdFilter).toBe('rsc-own');
+  });
+
   it('propagates an upstream PERMISSION_DENIED as a 403', async () => {
     pets.getStatsMock.mockRejectedValueOnce({
       code: status.PERMISSION_DENIED,

--- a/services/gateway/src/routes/dashboard.ts
+++ b/services/gateway/src/routes/dashboard.ts
@@ -58,11 +58,30 @@ const parseLimit = (raw: string | undefined): number => {
 // Pull the caller's rescue scope from the principal headers. We don't
 // look it up via getMyStaffMembership for the simple cases — the
 // gateway's authenticate middleware has already populated x-rescue-id
-// when the principal is rescue staff. Admins can override via
-// ?rescueId= in the query string.
+// when the principal is rescue staff. Admins (and super_admins) can
+// override via ?rescueId= in the query string to inspect any rescue's
+// dashboard; a non-admin's ?rescueId= is IGNORED, so rescue staff can
+// only ever read their OWN rescue regardless of the query string. The
+// override is an authorization decision the gateway makes here, so it
+// must verify the role — without the check, any rescue_staff member
+// could read another rescue's stats by passing a foreign rescueId.
+const ADMIN_ROLES = new Set(['admin', 'super_admin']);
+
+const callerIsAdmin = (req: FastifyRequest): boolean => {
+  const headers = req.headers as Record<string, string | string[] | undefined>;
+  const raw = headers['x-user-roles'];
+  if (typeof raw !== 'string') {
+    return false;
+  }
+  return raw
+    .split(',')
+    .map(r => r.trim())
+    .some(r => ADMIN_ROLES.has(r));
+};
+
 const resolveRescueScope = (req: FastifyRequest): string | null => {
   const query = req.query as Record<string, string | undefined>;
-  if (query.rescueId) {
+  if (query.rescueId && callerIsAdmin(req)) {
     return query.rescueId;
   }
   const headers = req.headers as Record<string, string | string[] | undefined>;

--- a/services/matching/src/gdpr/erase.test.ts
+++ b/services/matching/src/gdpr/erase.test.ts
@@ -43,6 +43,20 @@ describe('eraseMatching', () => {
     }
   });
 
+  it('erases swipe actions the user made even on anonymous (null-owner) sessions', async () => {
+    // recordSwipe lets an authenticated user swipe within a null-owner
+    // session (the owner guard passes when session.user_id IS NULL), so
+    // swipe_actions can carry user_id = X under a session with no owner.
+    // Deleting only via session ownership would orphan that personal
+    // data; the actions delete must also match swipe_actions.user_id.
+    const { client, query } = makeClient();
+
+    await eraseMatching(client, payload);
+
+    const actionsSql = query.mock.calls[0][0] as string;
+    expect(actionsSql).toMatch(/swipe_actions\.user_id = \$1/);
+  });
+
   it('returns the total rows erased across all statements', async () => {
     const { client, query } = makeClient();
     query.mockResolvedValueOnce({ rowCount: 4 }); // swipe_actions

--- a/services/matching/src/gdpr/erase.ts
+++ b/services/matching/src/gdpr/erase.ts
@@ -12,11 +12,16 @@ export async function eraseMatching(
 ): Promise<number> {
   let total = 0;
   // Order matters: swipe_actions FK swipe_sessions, so drop actions first.
+  // Match on EITHER the action's own user_id OR its parent session's
+  // owner: recordSwipe lets an authenticated user swipe within a
+  // null-owner (anonymous) session, so a personal swipe row can hang off
+  // a session the user doesn't own. Deleting only via session ownership
+  // would orphan that personal data and breach erasure completeness.
   for (const sql of [
     `DELETE FROM matching.swipe_actions
        USING matching.swipe_sessions s
        WHERE matching.swipe_actions.session_id = s.session_id
-         AND s.user_id = $1`,
+         AND (matching.swipe_actions.user_id = $1 OR s.user_id = $1)`,
     `DELETE FROM matching.swipe_sessions WHERE user_id = $1`,
     `DELETE FROM matching.adopter_match_profiles WHERE user_id = $1`,
   ]) {

--- a/services/matching/src/grpc/profile-stats-handlers.test.ts
+++ b/services/matching/src/grpc/profile-stats-handlers.test.ts
@@ -151,6 +151,20 @@ describe('getUserSwipeStats', () => {
     expect(query.mock.calls[0][1]).toEqual(['usr-1']);
   });
 
+  it('dedupes repeat swipes by pet, taking the latest action per pet', async () => {
+    // Append-only history (product decision keeps every row): a user who
+    // swiped the SAME pet three times must not be counted three times.
+    // The aggregate must collapse to one row per pet using the MOST
+    // RECENT action so a like→pass→like sequence counts as one like.
+    const { deps, query } = makeDeps([{ rows: [statsRow] }]);
+    await getUserSwipeStats(deps, makePrincipal(), {} as GetUserSwipeStatsRequest);
+    const sql = query.mock.calls[0][0] as string;
+    // Dedup by (user, pet) latest-wins: a window/DISTINCT ON over pet_id
+    // ordered by recency, aggregated on the outside.
+    expect(sql).toMatch(/DISTINCT ON \(pet_id\)/);
+    expect(sql).toMatch(/ORDER BY pet_id,\s*timestamp DESC/);
+  });
+
   it('rejects cross-user read without swipes:read:any', async () => {
     const { deps } = makeDeps([]);
     await expect(

--- a/services/matching/src/grpc/profile-stats-handlers.ts
+++ b/services/matching/src/grpc/profile-stats-handlers.ts
@@ -233,6 +233,23 @@ const STATS_AGG = `
   COUNT(*) FILTER (WHERE action = 'info') AS info_views
 `;
 
+// Swipes are append-only — the same pet can have many rows from repeat
+// swipes (product decision keeps the full history). User-level stats
+// must DEDUPE by (user, pet) at read time so a user who swiped the same
+// pet three times isn't counted three times, and the latest action per
+// pet wins (a like→pass→like sequence counts as one like). DISTINCT ON
+// (pet_id) ordered by recency collapses to the most-recent row per pet;
+// the outer aggregate then counts those deduped rows.
+const userLatestPerPetStatsSql = (placeholder: string): string => `
+  SELECT ${STATS_AGG}
+  FROM (
+    SELECT DISTINCT ON (pet_id) pet_id, action
+    FROM matching.swipe_actions
+    WHERE user_id = ${placeholder}
+    ORDER BY pet_id, timestamp DESC, swipe_action_id DESC
+  ) AS latest
+`;
+
 // --- GetUserSwipeStats -----------------------------------------------
 
 export async function getUserSwipeStats(
@@ -246,10 +263,7 @@ export async function getUserSwipeStats(
   if (target !== principal.userId && !hasPermission(principal, SWIPES_READ_ANY)) {
     throw new HandlerError('PERMISSION_DENIED', `'${SWIPES_READ_ANY}' required`);
   }
-  const res = await deps.pool.query<StatsRow>(
-    `SELECT ${STATS_AGG} FROM matching.swipe_actions WHERE user_id = $1`,
-    [target]
-  );
+  const res = await deps.pool.query<StatsRow>(userLatestPerPetStatsSql('$1'), [target]);
   return { stats: statsRowToProto(res.rows[0]) };
 }
 

--- a/services/matching/src/grpc/recommend-handlers.test.ts
+++ b/services/matching/src/grpc/recommend-handlers.test.ts
@@ -23,9 +23,23 @@ function makePrincipal(
   } as unknown as Parameters<ReturnType<typeof makeRecommend>>[1];
 }
 
-// Recommend + SearchPets are stateless reads — deps are unused, so an
-// empty object suffices.
+// SearchPets is a stateless read — deps are unused, so an empty object
+// suffices. Recommend reads the caller's swipe history from deps.pool to
+// exclude already-swiped pets; tests that exercise that inject a pool
+// stub via depsWithSwipes().
 const deps = {} as unknown as HandlerDeps;
+
+// Build a deps whose pool returns the given already-swiped pet_ids from
+// the swipe-history exclusion query. DISTINCT pet_id is the contract —
+// the stub returns whatever rows the test supplies.
+function depsWithSwipes(petIds: string[]): HandlerDeps {
+  const query = vi.fn().mockResolvedValue({ rows: petIds.map(pet_id => ({ pet_id })) });
+  return { pool: { query } } as unknown as HandlerDeps;
+}
+
+// Default deps for Recommend tests that don't care about swipe history —
+// the exclusion query returns no rows (user has swiped nothing).
+const recommendDeps = depsWithSwipes([]);
 
 function makePetsClient(listPets: ReturnType<typeof vi.fn>): PetsClient {
   return { listPets, close: vi.fn() } as unknown as PetsClient;
@@ -82,7 +96,7 @@ describe('makeRecommend', () => {
       );
     const recommend = makeRecommend(makePetsClient(listPets));
 
-    const res = await recommend(deps, makePrincipal(), { sessionId: 's-1', limit: 1 });
+    const res = await recommend(recommendDeps, makePrincipal(), { sessionId: 's-1', limit: 1 });
 
     // Only the available status is requested from service.pets.
     const listReq = listPets.mock.calls[0][0];
@@ -99,7 +113,10 @@ describe('makeRecommend', () => {
     const listPets = vi.fn().mockResolvedValue(listResponse([]));
     const recommend = makeRecommend(makePetsClient(listPets));
 
-    await recommend(deps, makePrincipal({ userId: 'usr-9' }), { sessionId: 's-1', limit: 10 });
+    await recommend(recommendDeps, makePrincipal({ userId: 'usr-9' }), {
+      sessionId: 's-1',
+      limit: 10,
+    });
 
     const metadata = listPets.mock.calls[0][1];
     expect(metadata.get('x-user-id')).toEqual(['usr-9']);
@@ -109,7 +126,7 @@ describe('makeRecommend', () => {
     const listPets = vi.fn().mockResolvedValue(listResponse([]));
     const recommend = makeRecommend(makePetsClient(listPets));
 
-    await recommend(deps, makePrincipal(), {
+    await recommend(recommendDeps, makePrincipal(), {
       sessionId: 's-1',
       limit: 10,
       filtersJsonOverride: '{"species":"cat"}',
@@ -124,14 +141,14 @@ describe('makeRecommend', () => {
       .mockResolvedValue(listResponse([makePet({ petId: 'a', rescueId: 'rsc-1' })]));
     const recommend = makeRecommend(makePetsClient(listPets));
 
-    const res = await recommend(deps, makePrincipal(), { sessionId: 's-1', limit: 10 });
+    const res = await recommend(recommendDeps, makePrincipal(), { sessionId: 's-1', limit: 10 });
     expect(res.exhausted).toBe(true);
   });
 
   it('throws INVALID_ARGUMENT on malformed filters override', async () => {
     const recommend = makeRecommend(makePetsClient(vi.fn()));
     await expect(
-      recommend(deps, makePrincipal(), {
+      recommend(recommendDeps, makePrincipal(), {
         sessionId: 's-1',
         limit: 10,
         filtersJsonOverride: 'not-json',
@@ -143,7 +160,7 @@ describe('makeRecommend', () => {
     const listPets = vi.fn().mockRejectedValue({ code: 7 });
     const recommend = makeRecommend(makePetsClient(listPets));
     await expect(
-      recommend(deps, makePrincipal(), { sessionId: 's-1', limit: 10 })
+      recommend(recommendDeps, makePrincipal(), { sessionId: 's-1', limit: 10 })
     ).rejects.toMatchObject({ code: 'PERMISSION_DENIED' });
   });
 
@@ -151,8 +168,50 @@ describe('makeRecommend', () => {
     const listPets = vi.fn().mockRejectedValue(new Error('boom'));
     const recommend = makeRecommend(makePetsClient(listPets));
     await expect(
-      recommend(deps, makePrincipal(), { sessionId: 's-1', limit: 10 })
+      recommend(recommendDeps, makePrincipal(), { sessionId: 's-1', limit: 10 })
     ).rejects.toMatchObject({ code: 'INTERNAL' });
+  });
+
+  it('excludes a pet the user has already swiped, deduping repeat swipe rows', async () => {
+    // Append-only history: the user swiped 'seen' THREE times (product
+    // decision keeps every row). The exclusion read must dedupe by
+    // pet so 'seen' is filtered out exactly once and never leaks back
+    // into the candidate set.
+    const listPets = vi
+      .fn()
+      .mockResolvedValue(
+        listResponse([
+          makePet({ petId: 'seen', rescueId: 'rsc-1' }),
+          makePet({ petId: 'fresh', rescueId: 'rsc-1' }),
+        ])
+      );
+    const recommend = makeRecommend(makePetsClient(listPets));
+    // DISTINCT pet_id query returns 'seen' once even though it was
+    // swiped three times.
+    const deps3 = depsWithSwipes(['seen']);
+
+    const res = await recommend(deps3, makePrincipal(), { sessionId: 's-1', limit: 10 });
+
+    const ids = res.candidates.map(c => c.petId);
+    expect(ids).toContain('fresh');
+    expect(ids).not.toContain('seen');
+  });
+
+  it('scopes the swipe-history exclusion query to the calling user', async () => {
+    const listPets = vi
+      .fn()
+      .mockResolvedValue(listResponse([makePet({ petId: 'fresh', rescueId: 'rsc-1' })]));
+    const recommend = makeRecommend(makePetsClient(listPets));
+    const query = vi.fn().mockResolvedValue({ rows: [] });
+    const depsUser = { pool: { query } } as unknown as HandlerDeps;
+
+    await recommend(depsUser, makePrincipal({ userId: 'usr-42' }), {
+      sessionId: 's-1',
+      limit: 10,
+    });
+
+    // The exclusion query is parameterised on the caller's userId.
+    expect(query.mock.calls[0][1]).toContain('usr-42');
   });
 });
 

--- a/services/matching/src/grpc/recommend-handlers.ts
+++ b/services/matching/src/grpc/recommend-handlers.ts
@@ -48,7 +48,7 @@ const MAX_SEARCH_LIMIT = 100;
 export function makeRecommend(
   petsClient: PetsClient
 ): (deps: HandlerDeps, principal: Principal, req: RecommendRequest) => Promise<RecommendResponse> {
-  return async (_deps, principal, req) => {
+  return async (deps, principal, req) => {
     ensureSwipePermission(principal);
 
     const limit = clamp(req.limit, DEFAULT_RECOMMEND_LIMIT, MAX_RECOMMEND_LIMIT);
@@ -64,18 +64,26 @@ export function makeRecommend(
 
     const pets = await listPets(petsClient, principal, listReq);
 
+    // Drop any pet the caller has already decided on (liked / passed /
+    // super-liked). Swipes are append-only — the same pet can appear
+    // across many rows — so the exclusion query DEDUPEs by pet_id and we
+    // match against a Set. 'info' views are NOT a decision and don't
+    // exclude.
+    const swiped = await fetchSwipedPetIds(deps, principal.userId);
+    const fresh = pets.filter(pet => !swiped.has(pet.petId));
+
     const preferences: RecommendPreferences = filters.ageGroup
       ? { ageGroup: filters.ageGroup }
       : {};
-    const ranked = scoreCandidates(pets, preferences).slice(0, limit);
+    const ranked = scoreCandidates(fresh, preferences).slice(0, limit);
 
     const candidates = ranked.map(({ pet, score }) => petToCandidate(pet, score));
 
     return {
       candidates,
-      // Exhausted when the candidate pool didn't even fill the request —
-      // the SPA can prompt the user to widen filters.
-      exhausted: pets.length <= limit,
+      // Exhausted when the post-exclusion pool didn't even fill the
+      // request — the SPA can prompt the user to widen filters.
+      exhausted: fresh.length <= limit,
     };
   };
 }
@@ -161,6 +169,21 @@ async function listPetsResponse(
     }
     throw new HandlerError('INTERNAL', 'failed to read candidate pets');
   }
+}
+
+// The set of pet_ids the caller has already DECIDED on (like / pass /
+// super_like). Returns DISTINCT pet_id so the append-only swipe history
+// — where the same pet can have many rows from repeat swipes — collapses
+// to one exclusion per pet. 'info' actions are trace views, not
+// decisions, so they don't exclude a pet from future recommendations.
+async function fetchSwipedPetIds(deps: HandlerDeps, userId: string): Promise<Set<string>> {
+  const { rows } = await deps.pool.query<{ pet_id: string }>(
+    `SELECT DISTINCT pet_id
+       FROM matching.swipe_actions
+      WHERE user_id = $1 AND action IN ('like', 'pass', 'super_like')`,
+    [userId]
+  );
+  return new Set(rows.map(r => r.pet_id));
 }
 
 type ParsedFilters = {

--- a/services/matching/src/migrations/004_swipe_actions_user_pet_recency_idx.ts
+++ b/services/matching/src/migrations/004_swipe_actions_user_pet_recency_idx.ts
@@ -1,0 +1,31 @@
+import type { MigrationBuilder } from 'node-pg-migrate';
+
+// Read-side dedupe support for the append-only swipe history.
+//
+// Re-swipes are append-only (product decision keeps every row), so two
+// hot read paths must collapse the duplicates per (user, pet):
+//
+//   1. fetchSwipedPetIds (Recommend exclusion) — SELECT DISTINCT pet_id
+//      WHERE user_id = $1 AND action IN (...). Scans every swipe row for
+//      the user.
+//   2. getUserSwipeStats — DISTINCT ON (pet_id) ... ORDER BY pet_id,
+//      timestamp DESC to take the latest action per pet, then aggregate.
+//
+// Both filter by user_id then need pet_id grouping (and recency order
+// for latest-wins). The existing (user_id, action) and standalone
+// timestamp indexes don't serve a per-pet-per-user latest scan. This
+// composite — (user_id, pet_id, timestamp DESC) — lets Postgres satisfy
+// the DISTINCT ON directly and keeps the exclusion scan index-only on
+// pet_id.
+
+const INDEX_NAME = 'swipe_actions_user_pet_recency_idx';
+
+export const up = async (pgm: MigrationBuilder): Promise<void> => {
+  pgm.createIndex('swipe_actions', ['user_id', 'pet_id', { name: 'timestamp', sort: 'DESC' }], {
+    name: INDEX_NAME,
+  });
+};
+
+export const down = async (pgm: MigrationBuilder): Promise<void> => {
+  pgm.dropIndex('swipe_actions', ['user_id', 'pet_id', 'timestamp'], { name: INDEX_NAME });
+};

--- a/services/matching/src/migrations/migrations.test.ts
+++ b/services/matching/src/migrations/migrations.test.ts
@@ -37,6 +37,7 @@ describe('matching migrations', () => {
     '001_create_swipe_sessions.ts',
     '002_create_swipe_actions.ts',
     '003_create_adopter_match_profiles.ts',
+    '004_swipe_actions_user_pet_recency_idx.ts',
   ])('%s exports `up` and `down` functions', async filename => {
     const mod = (await import(`./${filename}`)) as {
       up: unknown;

--- a/services/moderation/src/gdpr/erase.test.ts
+++ b/services/moderation/src/gdpr/erase.test.ts
@@ -1,0 +1,61 @@
+import type { PoolClient } from 'pg';
+import { describe, expect, it, vi } from 'vitest';
+
+import type { GdprErasureRequestedPayload } from '@adopt-dont-shop/events';
+
+import { eraseModeration } from './erase.js';
+
+const PAYLOAD: GdprErasureRequestedPayload = {
+  userId: 'usr-erase',
+  correlationId: 'corr-1',
+  requestedAt: '2026-06-15T00:00:00Z',
+};
+
+function makeClient(rowCounts: number[]): {
+  client: PoolClient;
+  calls: Array<{ text: string; values: unknown[] }>;
+} {
+  const calls: Array<{ text: string; values: unknown[] }> = [];
+  let i = 0;
+  const query = vi.fn(async (text: string, values: unknown[]) => {
+    calls.push({ text, values });
+    const rowCount = rowCounts[i] ?? 0;
+    i += 1;
+    return { rowCount, rows: [] };
+  });
+  return { client: { query } as unknown as PoolClient, calls };
+}
+
+describe('eraseModeration', () => {
+  it('anonymises reports filed by the user and deletes their support tickets', async () => {
+    const { client, calls } = makeClient([2, 1]);
+    const total = await eraseModeration(client, PAYLOAD);
+
+    expect(calls).toHaveLength(2);
+    expect(calls.every(c => c.values[0] === 'usr-erase')).toBe(true);
+    expect(calls.some(c => c.text.includes('reports'))).toBe(true);
+    expect(calls.some(c => c.text.includes('support_tickets'))).toBe(true);
+    // Sum of the row counts is reported back to the saga.
+    expect(total).toBe(3);
+  });
+
+  it('anonymises the reporter to NULL (keeping the row) and redacts the description', async () => {
+    const { client, calls } = makeClient([1, 0]);
+    await eraseModeration(client, PAYLOAD);
+
+    const reportCall = calls.find(c => c.text.includes('reports'));
+    expect(reportCall).toBeDefined();
+    // The row is kept so the reported party's moderation history survives:
+    // reporter_id is NULLed (requires the column be nullable — migration 010),
+    // not the row deleted.
+    expect(reportCall?.text).toMatch(/reporter_id\s*=\s*NULL/i);
+    expect(reportCall?.text).not.toMatch(/DELETE\s+FROM\s+moderation\.reports/i);
+    expect(reportCall?.text).toContain("'[erased]'");
+  });
+
+  it('returns 0 when the user has no data in this schema (idempotent re-run)', async () => {
+    const { client } = makeClient([0, 0]);
+    const total = await eraseModeration(client, PAYLOAD);
+    expect(total).toBe(0);
+  });
+});

--- a/services/moderation/src/migrations/010_make_reporter_id_nullable.ts
+++ b/services/moderation/src/migrations/010_make_reporter_id_nullable.ts
@@ -1,0 +1,23 @@
+import type { MigrationBuilder } from 'node-pg-migrate';
+
+// Make reports.reporter_id nullable so GDPR erasure can anonymise it.
+//
+// The baseline (001) declared reporter_id NOT NULL, but gdpr/erase.ts
+// anonymises a departing user's filed reports by setting
+// reporter_id = NULL (keeping the row so the reported party's history
+// stays intact). With the NOT NULL constraint that UPDATE throws a
+// constraint violation and tears down the whole erasure saga for any
+// user who has ever filed a report.
+//
+// Dropping NOT NULL is the minimal fix that matches the erase intent
+// (anonymise, don't reassign): we can't reassign to the SYSTEM sentinel
+// without colliding with the system-autoreport unique index (009) and
+// mislabelling the row as an auto-report.
+
+export const up = async (pgm: MigrationBuilder): Promise<void> => {
+  pgm.alterColumn('reports', 'reporter_id', { notNull: false });
+};
+
+export const down = async (pgm: MigrationBuilder): Promise<void> => {
+  pgm.alterColumn('reports', 'reporter_id', { notNull: true });
+};

--- a/services/moderation/src/migrations/migrations.test.ts
+++ b/services/moderation/src/migrations/migrations.test.ts
@@ -48,6 +48,7 @@ describe('moderation migrations', () => {
     '007_create_support_tickets.ts',
     '008_create_support_ticket_responses.ts',
     '009_add_system_autoreport_unique_index.ts',
+    '010_make_reporter_id_nullable.ts',
   ])('%s exports `up` and `down` functions', async filename => {
     const mod = (await import(`./${filename}`)) as {
       up: unknown;

--- a/services/moderation/src/nats/content-scanner.test.ts
+++ b/services/moderation/src/nats/content-scanner.test.ts
@@ -42,4 +42,40 @@ describe('scanContent', () => {
     // The scam check runs first by design.
     expect(scanContent('venmo me at https://venmo.com/x')?.category).toBe('scam');
   });
+
+  // --- Word-boundary matching (the in-house upgrade) -----------------
+
+  it('does NOT trip when a banned single-word term is a substring of an innocent word', () => {
+    // 'cashapp' must not match inside 'cashappraisal'; 'scam' must not
+    // match inside 'scamper'. Substring matching produced false positives.
+    expect(scanContent('We did a cashappraisal of the property.')).toBeNull();
+    expect(scanContent('The puppy loves to scamper around the garden.')).toBeNull();
+  });
+
+  it('DOES trip when the same term appears as a standalone token', () => {
+    expect(scanContent('Pay me via cashapp please')?.category).toBe('scam');
+  });
+
+  it('matches a banned term despite surrounding punctuation', () => {
+    expect(scanContent('cashapp! now')?.category).toBe('scam');
+    expect(scanContent('(cashapp)')?.category).toBe('scam');
+    expect(scanContent('"cashapp".')?.category).toBe('scam');
+  });
+
+  it('matches multi-word phrases as adjacent whole tokens, not as substrings', () => {
+    expect(scanContent('please send money now')?.category).toBe('scam');
+    // 'send money' must not trip inside 'resend moneymaker'.
+    expect(scanContent('I will resend moneymaker reports later')).toBeNull();
+  });
+
+  it('carries a severity through the hit', () => {
+    // Harassment is high severity; a bare URL is medium.
+    expect(scanContent('go kill yourself')?.severity).toBe('high');
+    expect(scanContent('see https://example.com')?.severity).toBe('medium');
+  });
+
+  it('carries per-category severity for scam (high) and spam (medium)', () => {
+    expect(scanContent('wire transfer the fee')?.severity).toBe('high');
+    expect(scanContent('call 555-123-4567')?.severity).toBe('medium');
+  });
 });

--- a/services/moderation/src/nats/content-scanner.ts
+++ b/services/moderation/src/nats/content-scanner.ts
@@ -1,5 +1,5 @@
-// First-cut content scanner — a deliberately simple keyword-and-pattern
-// matcher we can ship now and replace later. Pure: no I/O, no logger.
+// In-house content scanner — a keyword-and-pattern matcher we own and
+// tune (no external moderation provider). Pure: no I/O, no logger.
 // Returns `null` when content passes; a `ScanHit` when something
 // trips so the subscriber can file an auto-report with a clear reason.
 //
@@ -8,30 +8,89 @@
 //      payment-app handles, phone numbers in DMs.
 //   2. URLs in chat / pet descriptions (a known abuse vector for
 //      off-platform redirect).
-//   3. Profanity / hate slurs — minimal seed list; expanded over time.
+//   3. Profanity / hate / harassment phrases — minimal seed list,
+//      expanded over time via the term catalogue below.
 //
-// A richer scanner (ML moderation, regex catalogues, third-party APIs)
-// is a follow-up — this is the minimum that makes 8.4 useful today.
+// Matching is WORD-BOUNDARY based: a banned term matches as a whole
+// word/token (case-insensitive) and tolerates surrounding punctuation,
+// so a term embedded in a larger innocent word (e.g. "cashapp" inside
+// "cashappraisal") does NOT trip. This replaces the earlier naive
+// SUBSTRING matcher.
 
 export type ScanCategory = 'spam' | 'harassment' | 'inappropriate_content' | 'scam';
 
+// Per-hit severity, carried through to the auto-report. Mirrors the DB
+// report_severity enum values so the subscriber maps it 1:1.
+export type ScanSeverity = 'low' | 'medium' | 'high' | 'critical';
+
 export type ScanHit = {
   category: ScanCategory;
+  severity: ScanSeverity;
   // Short reason — appears in the report title.
   reason: string;
 };
 
-// Naive word boundaries: lowercased substring match with regex word
-// boundaries (\b). Sufficient for the seed list.
-const SCAM_PHRASES: ReadonlyArray<string> = [
-  'send money',
-  'wire transfer',
-  'venmo me',
-  'cashapp',
-  'paypal me',
-  'gift card',
-  'western union',
+// A configurable banned-term entry. `term` may be a single word or a
+// multi-word phrase; matching is whole-token (each word matched on a
+// word boundary, words separated by whitespace). Severity is per-term
+// so the catalogue can grade individual entries; absent that, callers
+// fall back to the category default.
+export type TermEntry = {
+  term: string;
+  category: ScanCategory;
+  severity?: ScanSeverity;
+};
+
+// Category-default severities — used when a TermEntry omits `severity`
+// and for the regex-driven URL / phone heuristics.
+const CATEGORY_SEVERITY: Record<ScanCategory, ScanSeverity> = {
+  scam: 'high',
+  harassment: 'high',
+  inappropriate_content: 'medium',
+  spam: 'medium',
+};
+
+// The configurable term catalogue. Scam + harassment seed lists; the
+// real catalogue grows here (or is loaded into this shape) without
+// touching the matcher. Order matters only for tie-breaking — the
+// scanner reports the FIRST tripped term in list order.
+const TERM_CATALOGUE: ReadonlyArray<TermEntry> = [
+  // Scam / solicitation.
+  { term: 'send money', category: 'scam' },
+  { term: 'wire transfer', category: 'scam' },
+  { term: 'venmo me', category: 'scam' },
+  { term: 'cashapp', category: 'scam' },
+  { term: 'paypal me', category: 'scam' },
+  { term: 'gift card', category: 'scam' },
+  { term: 'western union', category: 'scam' },
+  // Hateful / harassing seed list — kept minimal and uncontroversial.
+  // A real catalogue would load slurs from an external file in this
+  // same shape rather than enumerate them in source.
+  { term: 'go kill yourself', category: 'harassment' },
+  { term: 'die in a fire', category: 'harassment' },
 ];
+
+// Build a case-insensitive whole-token regex for a (possibly
+// multi-word) term: each word is bounded by \b, words joined by \s+ so
+// arbitrary whitespace between tokens still matches. \b handles
+// surrounding punctuation (e.g. "cashapp!", "(cashapp)").
+function termToRegex(term: string): RegExp {
+  const words = term
+    .trim()
+    .split(/\s+/)
+    .map(escapeRegExp)
+    .map(w => `\\b${w}\\b`);
+  return new RegExp(words.join('\\s+'), 'i');
+}
+
+function escapeRegExp(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+// Precompile the catalogue once at module load.
+const COMPILED_TERMS: ReadonlyArray<{ entry: TermEntry; pattern: RegExp }> = TERM_CATALOGUE.map(
+  entry => ({ entry, pattern: termToRegex(entry.term) })
+);
 
 // Common contact-leak patterns. The matcher is intentionally
 // permissive — false positives become a moderator decision, not a
@@ -41,42 +100,45 @@ const PHONE_PATTERN = /\b\d{3}[-\s.]?\d{3}[-\s.]?\d{4}\b/;
 // surfacing the URL to the moderator is the goal.
 const URL_PATTERN = /(https?:\/\/|\bwww\.|\b[\w-]+\.(com|net|org|io|co)\b)/i;
 
-// Hateful / harassing seed list — kept minimal and uncontroversial.
-// Expanded via the moderation team's catalogue when one is wired in.
-const HATE_PHRASES: ReadonlyArray<string> = [
-  'go kill yourself',
-  'die in a fire',
-  // Intentionally not enumerating slurs in source; a real catalogue
-  // would live in an external file the scanner loads.
-];
+function severityFor(entry: TermEntry): ScanSeverity {
+  return entry.severity ?? CATEGORY_SEVERITY[entry.category];
+}
 
 export function scanContent(content: string | undefined | null): ScanHit | null {
   if (content === undefined || content === null) {
     return null;
   }
-  const text = content.toLowerCase();
-  if (text.trim() === '') {
+  if (content.trim() === '') {
     return null;
   }
 
-  for (const phrase of SCAM_PHRASES) {
-    if (text.includes(phrase)) {
-      return { category: 'scam', reason: `matched scam pattern: "${phrase}"` };
+  // Catalogue terms — whole-token, case-insensitive. Scam entries lead
+  // the catalogue, so scam takes precedence over the URL heuristic when
+  // both are present (e.g. "venmo me at https://...").
+  for (const { entry, pattern } of COMPILED_TERMS) {
+    if (pattern.test(content)) {
+      return {
+        category: entry.category,
+        severity: severityFor(entry),
+        reason: `matched ${entry.category} term: "${entry.term}"`,
+      };
     }
   }
 
   if (URL_PATTERN.test(content)) {
-    return { category: 'spam', reason: 'contains a URL (off-platform link)' };
+    return {
+      category: 'spam',
+      severity: CATEGORY_SEVERITY.spam,
+      reason: 'contains a URL (off-platform link)',
+    };
   }
 
   if (PHONE_PATTERN.test(content)) {
-    return { category: 'spam', reason: 'contains a phone number' };
-  }
-
-  for (const phrase of HATE_PHRASES) {
-    if (text.includes(phrase)) {
-      return { category: 'harassment', reason: `matched harassment phrase: "${phrase}"` };
-    }
+    return {
+      category: 'spam',
+      severity: CATEGORY_SEVERITY.spam,
+      reason: 'contains a phone number',
+    };
   }
 
   return null;

--- a/services/moderation/src/nats/subscribers.test.ts
+++ b/services/moderation/src/nats/subscribers.test.ts
@@ -1,44 +1,44 @@
 import type { NatsConnection } from 'nats';
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { ModerationV1, type FileReportRequest } from '@adopt-dont-shop/proto';
 
 import type { HandlerDeps } from '../grpc/adapter.js';
 
-import { registerSubscribers } from './subscribers.js';
+// Capture the handler each subscribe() call registers so the behaviour
+// tests can drive a domain event straight through the real subscriber
+// closure (scan → category/severity map → fileAutoReport) without a live
+// JetStream consumer. The poison-pill / ack machinery itself lives in (and
+// is tested by) @adopt-dont-shop/events; here we verify the moderation
+// wiring on top of it.
+type Captured = {
+  subject: string;
+  durable: string;
+  handler: (event: unknown) => Promise<void> | void;
+};
+const captured: Captured[] = [];
 
-// subscribe() now binds durable JetStream consumers: it calls
-// jetstreamManager().consumers.add(...) then jetstream().consumers.get(...)
-// .consume(). We stub a JetStream connection whose consume() yields nothing
-// and capture the durable configs each subscriber requests.
-type AddedConsumer = { durable_name?: string; filter_subject?: string };
+vi.mock('@adopt-dont-shop/events', () => ({
+  subscribe: vi.fn(
+    (
+      _nats: unknown,
+      opts: { subject: string; durable: string },
+      handler: (event: unknown) => Promise<void> | void
+    ) => {
+      captured.push({ subject: opts.subject, durable: opts.durable, handler });
+      return { drain: vi.fn() };
+    }
+  ),
+}));
 
-function makeNats(): { nats: NatsConnection; consumersAdded: AddedConsumer[] } {
-  const consumersAdded: AddedConsumer[] = [];
-  const jsm = {
-    consumers: {
-      add: vi.fn(async (_stream: string, cfg: AddedConsumer) => {
-        consumersAdded.push(cfg);
-        return cfg;
-      }),
-    },
-  };
-  const js = {
-    consumers: {
-      get: vi.fn(async () => ({
-        consume: vi.fn(async () => ({
-          async *[Symbol.asyncIterator]() {
-            // no messages
-          },
-          close: vi.fn(),
-        })),
-      })),
-    },
-  };
-  const nats = {
-    jetstreamManager: vi.fn(async () => jsm),
-    jetstream: vi.fn(() => js),
-  } as unknown as NatsConnection;
-  return { nats, consumersAdded };
-}
+// Spy on the canonical FileReport handler the subscribers delegate to.
+const fileReportMock = vi.fn(async () => ({ report: undefined }));
+vi.mock('../grpc/handlers.js', () => ({
+  fileReport: (...args: unknown[]) => fileReportMock(...args),
+}));
+
+const { registerSubscribers } = await import('./subscribers.js');
+const { SYSTEM_PRINCIPAL } = await import('./system-principal.js');
 
 const deps = { pool: {}, nats: {} } as unknown as HandlerDeps;
 const logger = {
@@ -49,26 +49,92 @@ const logger = {
   silly: () => undefined,
 } as unknown as Parameters<typeof registerSubscribers>[0]['logger'];
 
-const flush = async (): Promise<void> => {
-  for (let i = 0; i < 20; i++) {
-    await new Promise(r => setImmediate(r));
+const nats = {} as unknown as NatsConnection;
+
+const handlerFor = (subject: string): ((event: unknown) => Promise<void> | void) => {
+  const entry = captured.find(c => c.subject === subject);
+  if (entry === undefined) {
+    throw new Error(`no handler registered for ${subject}`);
   }
+  return entry.handler;
 };
 
 describe('registerSubscribers', () => {
-  it('binds a durable consumer for chat.messageCreated + pets.created + applications.submitted under the moderation-workers prefix', async () => {
-    const { nats, consumersAdded } = makeNats();
+  beforeEach(() => {
+    captured.length = 0;
+    fileReportMock.mockClear();
+  });
+
+  it('subscribes chat.messageCreated + pets.created + applications.submitted', () => {
     const subs = registerSubscribers({ nats, deps, logger });
-    await flush();
 
     expect(subs).toHaveLength(3);
-    expect(consumersAdded.map(c => c.filter_subject)).toEqual([
+    expect(captured.map(c => c.subject)).toEqual([
       'chat.messageCreated',
       'pets.created',
       'applications.submitted',
     ]);
-    for (const cfg of consumersAdded) {
-      expect(cfg.durable_name).toMatch(/^moderation-workers-/);
+    // All replicas bind the same durable per subject so JetStream load-shares.
+    for (const c of captured) {
+      expect(c.durable).toMatch(/^moderation-workers-/);
     }
+  });
+
+  it('files an auto-report carrying the scanner severity + category when content trips', async () => {
+    registerSubscribers({ nats, deps, logger });
+
+    // 'go kill yourself' is a harassment term → high severity in the scanner.
+    await handlerFor('chat.messageCreated')({
+      messageId: 'msg-1',
+      chatId: 'chat-1',
+      senderId: 'usr-sender',
+      content: 'go kill yourself',
+    });
+
+    expect(fileReportMock).toHaveBeenCalledTimes(1);
+    const [, principal, req] = fileReportMock.mock.calls[0] as [
+      unknown,
+      unknown,
+      FileReportRequest,
+    ];
+    // Filed as the SYSTEM principal so the row is indistinguishable from a
+    // user report at the storage layer (and hits the auto-report unique index).
+    expect(principal).toBe(SYSTEM_PRINCIPAL);
+    expect(req.reportedEntityType).toBe(ModerationV1.ReportEntityType.REPORT_ENTITY_TYPE_MESSAGE);
+    expect(req.reportedEntityId).toBe('msg-1');
+    expect(req.category).toBe(ModerationV1.ReportCategory.REPORT_CATEGORY_HARASSMENT);
+    expect(req.severity).toBe(ModerationV1.Severity.SEVERITY_HIGH);
+  });
+
+  it('carries a distinct (medium) severity through for a spam-grade hit', async () => {
+    registerSubscribers({ nats, deps, logger });
+
+    // A bare URL is spam → medium severity. Proves severity is not hard-coded.
+    await handlerFor('pets.created')({
+      petId: 'pet-1',
+      rescueId: 'res-1',
+      longDescription: 'adopt me at https://example.com',
+    });
+
+    expect(fileReportMock).toHaveBeenCalledTimes(1);
+    const [, , req] = fileReportMock.mock.calls[0] as [unknown, unknown, FileReportRequest];
+    expect(req.category).toBe(ModerationV1.ReportCategory.REPORT_CATEGORY_SPAM);
+    expect(req.severity).toBe(ModerationV1.Severity.SEVERITY_MEDIUM);
+  });
+
+  it('files nothing when the content is clean', async () => {
+    registerSubscribers({ nats, deps, logger });
+
+    await handlerFor('applications.submitted')({
+      applicationId: 'app-1',
+      adopterId: 'usr-a',
+      petId: 'pet-1',
+      rescueId: 'res-1',
+      submittedAt: '2026-06-15T00:00:00Z',
+      message: 'We have a lovely fenced garden and two children.',
+      whyAdopt: 'We have always wanted to give a dog a loving home.',
+    });
+
+    expect(fileReportMock).not.toHaveBeenCalled();
   });
 });

--- a/services/moderation/src/nats/subscribers.ts
+++ b/services/moderation/src/nats/subscribers.ts
@@ -39,7 +39,7 @@ import type {
   ChatMessageCreatedEvent,
   PetCreatedEvent,
 } from './event-types.js';
-import { scanContent, type ScanCategory, type ScanHit } from './content-scanner.js';
+import { scanContent, type ScanCategory, type ScanSeverity } from './content-scanner.js';
 import { SYSTEM_PRINCIPAL } from './system-principal.js';
 
 export type RegisterSubscribersOptions = {
@@ -62,14 +62,13 @@ const CATEGORY_TO_PROTO: Record<ScanCategory, ModerationV1.ReportCategory> = {
   inappropriate_content: ModerationV1.ReportCategory.REPORT_CATEGORY_INAPPROPRIATE_CONTENT,
 };
 
-// Severity heuristic — content the scanner trips is at LEAST medium;
-// harassment + scam land higher. Tuneable as the catalogue grows.
-function severityFor(hit: ScanHit): ModerationV1.Severity {
-  if (hit.category === 'harassment' || hit.category === 'scam') {
-    return ModerationV1.Severity.SEVERITY_HIGH;
-  }
-  return ModerationV1.Severity.SEVERITY_MEDIUM;
-}
+// Map the scanner's per-hit severity onto the proto Severity enum.
+const SEVERITY_TO_PROTO: Record<ScanSeverity, ModerationV1.Severity> = {
+  low: ModerationV1.Severity.SEVERITY_LOW,
+  medium: ModerationV1.Severity.SEVERITY_MEDIUM,
+  high: ModerationV1.Severity.SEVERITY_HIGH,
+  critical: ModerationV1.Severity.SEVERITY_CRITICAL,
+};
 
 export const registerSubscribers = (opts: RegisterSubscribersOptions): SubscriptionHandle[] => {
   const { nats, deps, logger } = opts;
@@ -96,7 +95,7 @@ export const registerSubscribers = (opts: RegisterSubscribersOptions): Subscript
           reportedEntityId: event.messageId,
           reportedUserId: event.senderId,
           category: CATEGORY_TO_PROTO[hit.category],
-          severity: severityFor(hit),
+          severity: SEVERITY_TO_PROTO[hit.severity],
           title: `Auto-report: ${hit.reason}`,
           description: `Chat message ${event.messageId} from sender ${String(event.senderId)} matched the moderation scanner: ${hit.reason}. The content was: "${truncate(event.content, 300)}"`,
         });
@@ -120,7 +119,7 @@ export const registerSubscribers = (opts: RegisterSubscribersOptions): Subscript
           reportedEntityType: ModerationV1.ReportEntityType.REPORT_ENTITY_TYPE_PET,
           reportedEntityId: event.petId,
           category: CATEGORY_TO_PROTO[hit.category],
-          severity: severityFor(hit),
+          severity: SEVERITY_TO_PROTO[hit.severity],
           title: `Auto-report: pet listing — ${hit.reason}`,
           description: `Pet listing ${event.petId} (rescue ${event.rescueId ?? 'unknown'}) matched the moderation scanner: ${hit.reason}. Description excerpt: "${truncate(text, 300)}"`,
         });
@@ -145,7 +144,7 @@ export const registerSubscribers = (opts: RegisterSubscribersOptions): Subscript
           reportedEntityId: event.applicationId,
           reportedUserId: event.adopterId,
           category: CATEGORY_TO_PROTO[hit.category],
-          severity: severityFor(hit),
+          severity: SEVERITY_TO_PROTO[hit.severity],
           title: `Auto-report: application — ${hit.reason}`,
           description: `Adoption application ${event.applicationId} from adopter ${String(event.adopterId)} matched the moderation scanner: ${hit.reason}. Text excerpt: "${truncate(text, 300)}"`,
         });

--- a/services/notifications/src/email/queue.ts
+++ b/services/notifications/src/email/queue.ts
@@ -192,20 +192,46 @@ export const findByIdempotencyKey = async (
   return res.rows[0] ?? null;
 };
 
-// Claim up to `limit` rows that are due to send: status='queued' AND
-// (scheduled_for IS NULL OR scheduled_for <= now()). Sets them to
-// `sending` and stamps `last_attempt_at`. Returns the claimed rows.
+// How long a row may sit in `sending` before it's treated as orphaned by
+// a crashed worker and reclaimed. A process that dies between the claim
+// (status→'sending') and markSent/markFailed would otherwise leave the
+// row stuck forever — claimDueEmails only ever looked at 'queued'. The
+// reclaim path bumps current_retries so a row whose worker keeps crashing
+// mid-send still terminates as 'failed' once max_retries is exhausted,
+// rather than being retried forever.
+const DEFAULT_STALE_SENDING_MS = 120_000;
+
+// Claim up to `limit` rows that are due to send. Two sources:
+//   1. status='queued' AND (scheduled_for IS NULL OR scheduled_for <= now())
+//   2. status='sending' whose last_attempt_at is older than the stale
+//      timeout (orphaned by a crashed worker) AND still have retry budget.
+// Claimed rows are set to 'sending' and stamped `last_attempt_at`.
+// Reclaimed (source 2) rows additionally bump current_retries.
+//
+// Orphaned 'sending' rows that have exhausted max_retries are terminated
+// as 'failed' in the same statement (they are NOT returned for dispatch).
 //
 // SKIP LOCKED so multiple worker instances draining the same queue
 // don't block each other.
-export const claimDueEmails = async (conn: DbConn, limit: number): Promise<QueuedEmail[]> => {
+export const claimDueEmails = async (
+  conn: DbConn,
+  limit: number,
+  staleSendingMs: number = DEFAULT_STALE_SENDING_MS
+): Promise<QueuedEmail[]> => {
   const res = await conn.query<EmailQueueRow>(
     `
     WITH due AS (
       SELECT email_id
       FROM email_queue
-      WHERE status = 'queued'
-        AND (scheduled_for IS NULL OR scheduled_for <= now())
+      WHERE (
+          status = 'queued'
+          AND (scheduled_for IS NULL OR scheduled_for <= now())
+        )
+        OR (
+          status = 'sending'
+          AND last_attempt_at IS NOT NULL
+          AND last_attempt_at <= now() - make_interval(secs => $2 / 1000.0)
+        )
       ORDER BY
         CASE priority
           WHEN 'urgent' THEN 1
@@ -216,17 +242,37 @@ export const claimDueEmails = async (conn: DbConn, limit: number): Promise<Queue
         created_at
       LIMIT $1
       FOR UPDATE SKIP LOCKED
+    ),
+    -- Orphaned 'sending' rows with no retry budget left terminate as
+    -- 'failed' instead of being reclaimed — they never come back.
+    exhausted AS (
+      UPDATE email_queue q
+      SET status = 'failed',
+          current_retries = q.current_retries + 1,
+          failure_reason = 'reclaimed after stale send; max_retries exhausted',
+          updated_at = now(),
+          version = q.version + 1
+      FROM due
+      WHERE q.email_id = due.email_id
+        AND q.status = 'sending'
+        AND q.current_retries + 1 >= q.max_retries
+      RETURNING q.email_id
     )
     UPDATE email_queue q
     SET status = 'sending',
+        -- Reclaimed orphans count as a fresh attempt; fresh 'queued'
+        -- claims don't (markFailed already counts their retries).
+        current_retries = CASE WHEN q.status = 'sending'
+          THEN q.current_retries + 1 ELSE q.current_retries END,
         last_attempt_at = now(),
         updated_at = now(),
         version = q.version + 1
     FROM due
     WHERE q.email_id = due.email_id
+      AND q.email_id NOT IN (SELECT email_id FROM exhausted)
     RETURNING q.*
     `,
-    [limit]
+    [limit, staleSendingMs]
   );
   return res.rows.map(rowToQueuedEmail);
 };

--- a/services/notifications/src/email/worker.ts
+++ b/services/notifications/src/email/worker.ts
@@ -30,6 +30,11 @@ export type EmailWorkerOptions = {
   // Max rows claimed per tick. Default 25 — bounded so a backlog
   // doesn't monopolise the worker for one slow provider call.
   batchSize?: number;
+  // How long (ms) a row may sit in 'sending' before it's treated as
+  // orphaned by a crashed worker and reclaimed. Must comfortably exceed
+  // the provider send timeout (Resend's is 10s) so an in-flight send is
+  // never stolen. Default 120s.
+  staleSendingMs?: number;
 };
 
 export type RunningEmailWorker = {
@@ -41,6 +46,7 @@ export type RunningEmailWorker = {
 
 const DEFAULT_POLL_MS = 2_000;
 const DEFAULT_BATCH = 25;
+const DEFAULT_STALE_SENDING_MS = 120_000;
 
 const dispatchOne = async (
   pool: Pool,
@@ -92,6 +98,7 @@ const dispatchOne = async (
 export const startEmailWorker = (opts: EmailWorkerOptions): RunningEmailWorker => {
   const pollIntervalMs = opts.pollIntervalMs ?? DEFAULT_POLL_MS;
   const batchSize = opts.batchSize ?? DEFAULT_BATCH;
+  const staleSendingMs = opts.staleSendingMs ?? DEFAULT_STALE_SENDING_MS;
   let running = true;
   let timer: NodeJS.Timeout | undefined;
   let inflight = Promise.resolve<number>(0);
@@ -102,7 +109,7 @@ export const startEmailWorker = (opts: EmailWorkerOptions): RunningEmailWorker =
     }
     let claimed: QueuedEmail[] = [];
     try {
-      claimed = await claimDueEmails(opts.pool, batchSize);
+      claimed = await claimDueEmails(opts.pool, batchSize, staleSendingMs);
     } catch (err) {
       opts.logger.error('email.worker.claim_error', { err });
       return 0;

--- a/services/notifications/src/grpc/broadcast-handlers.test.ts
+++ b/services/notifications/src/grpc/broadcast-handlers.test.ts
@@ -407,6 +407,38 @@ describe('isInQuietHours', () => {
     ).toBe(false);
   });
 
+  it('handles Postgres time values that include seconds (HH:MM:SS)', () => {
+    // pg returns `time` columns as 'HH:MM:SS'; the localised "now" is
+    // HH:MM. Comparison must normalise so the boundary minute is correct.
+    // 22:00 UTC is the exact start of a 22:00:00 → 07:00:00 window.
+    const exactStart = new Date('2026-06-01T22:00:00Z');
+    expect(
+      isInQuietHours(
+        {
+          user_id: 'u',
+          quiet_hours_start: '22:00:00',
+          quiet_hours_end: '07:00:00',
+          timezone: 'UTC',
+        },
+        exactStart
+      )
+    ).toBe(true);
+
+    // 21:59 UTC is one minute before the window — must NOT be suppressed.
+    const justBefore = new Date('2026-06-01T21:59:00Z');
+    expect(
+      isInQuietHours(
+        {
+          user_id: 'u',
+          quiet_hours_start: '22:00:00',
+          quiet_hours_end: '07:00:00',
+          timezone: 'UTC',
+        },
+        justBefore
+      )
+    ).toBe(false);
+  });
+
   it('falls back to UTC when timezone is unknown', () => {
     expect(
       isInQuietHours(

--- a/services/notifications/src/grpc/broadcast-handlers.ts
+++ b/services/notifications/src/grpc/broadcast-handlers.ts
@@ -101,8 +101,12 @@ export function isInQuietHours(prefs: PrefsRow, now: Date = new Date()): boolean
       hourCycle: 'h23',
     }).format(now);
   }
-  const start = prefs.quiet_hours_start;
-  const end = prefs.quiet_hours_end;
+  // Postgres `time` columns come back as 'HH:MM:SS'; the localised `now`
+  // is 'HH:MM'. Normalise the stored bounds to 'HH:MM' so the boundary
+  // minute compares correctly (a raw 'HH:MM' < 'HH:MM:SS' string compare
+  // wrongly excludes the exact start minute).
+  const start = prefs.quiet_hours_start.slice(0, 5);
+  const end = prefs.quiet_hours_end.slice(0, 5);
   // Window may wrap midnight (e.g. 22:00 → 07:00).
   if (start <= end) {
     return hhmm >= start && hhmm < end;

--- a/services/notifications/src/migrations/007_email_queue_stale_sending_idx.ts
+++ b/services/notifications/src/migrations/007_email_queue_stale_sending_idx.ts
@@ -1,0 +1,25 @@
+import type { MigrationBuilder } from 'node-pg-migrate';
+
+// Partial index supporting the email-queue worker's stale-'sending'
+// reclaim predicate.
+//
+// claimDueEmails (src/email/queue.ts) was extended to also pick up rows
+// orphaned in status='sending' by a crashed worker, filtered on
+// `status = 'sending' AND last_attempt_at <= now() - <stale interval>`.
+// Without an index that branch sequentially scans the queue every poll.
+// A partial index over last_attempt_at, restricted to status='sending',
+// keeps the reclaim sweep cheap and is tiny in steady state (rows are
+// only transiently 'sending').
+
+export const up = async (pgm: MigrationBuilder): Promise<void> => {
+  pgm.createIndex('email_queue', 'last_attempt_at', {
+    name: 'email_queue_stale_sending_idx',
+    where: "status = 'sending'",
+  });
+};
+
+export const down = async (pgm: MigrationBuilder): Promise<void> => {
+  pgm.dropIndex('email_queue', 'last_attempt_at', {
+    name: 'email_queue_stale_sending_idx',
+  });
+};

--- a/services/pets/src/grpc/handlers.test.ts
+++ b/services/pets/src/grpc/handlers.test.ts
@@ -236,6 +236,12 @@ describe('listPets', () => {
     });
   });
 
+  it('rejects a negative limit (would otherwise emit a negative SQL LIMIT)', async () => {
+    await expect(listPets(mocks.deps, ADOPTER, { limit: -1 } as never)).rejects.toMatchObject({
+      code: 'INVALID_ARGUMENT',
+    });
+  });
+
   it('applies status + rescue filters to the query', async () => {
     mocks.poolMock.query.mockResolvedValueOnce({ rows: [] });
     await listPets(mocks.deps, STAFF, {
@@ -317,6 +323,21 @@ describe('updatePet', () => {
     expect(updateSql).toMatch(/name = \$1/);
     expect(updateSql).toMatch(/version = version \+ 1/);
   });
+
+  it('publishes pets.updated with a deterministic id keyed on the new version', async () => {
+    mocks.poolMock.query.mockResolvedValueOnce({ rows: [petRow({ version: 4 })] });
+    mocks.clientMock.query.mockResolvedValue({ rows: [petRow({ name: 'Rexy', version: 5 })] });
+
+    await updatePet(mocks.deps, STAFF, { petId: 'pet-1', name: 'Rexy' } as never);
+
+    const event = mocks.natsMock.publish.mock.calls[0][0] as string;
+    // JetStream Nats-Msg-Id derives from the event id — it must be
+    // deterministic (aggregateId:version) so a retried publish dedups.
+    expect(event).toBe('pets.updated');
+    // The DomainEvent.id is passed via the publish options (3rd arg).
+    const opts = mocks.natsMock.publish.mock.calls[0][2] as { msgID?: string } | undefined;
+    expect(opts?.msgID).toBe('pets.updated.pet-1.5');
+  });
 });
 
 // --- updatePetStatus -------------------------------------------------
@@ -361,6 +382,11 @@ describe('updatePetStatus', () => {
     const order: string[] = [];
     mocks.clientMock.query.mockImplementation(async (sql: string) => {
       order.push(sql.trim().split(/\s+/)[0]);
+      // The in-transaction lock read still sees `available`; the UPDATE
+      // returns the post-write `pending` row.
+      if (/FOR UPDATE/.test(sql)) {
+        return { rows: [petRow({ status: 'available' })] };
+      }
       return { rows: [petRow({ status: 'pending' })] };
     });
     mocks.natsMock.publish.mockImplementation(() => order.push('NATS_PUBLISH'));
@@ -374,8 +400,9 @@ describe('updatePetStatus', () => {
     expect(res.pet.status).toBe(PetsV1.PetStatus.PET_STATUS_PENDING);
     expect(res.transition.fromStatus).toBe(PetsV1.PetStatus.PET_STATUS_AVAILABLE);
     expect(res.transition.toStatus).toBe(PetsV1.PetStatus.PET_STATUS_PENDING);
-    // BEGIN → INSERT transition → UPDATE pet → COMMIT → publish
-    expect(order).toEqual(['BEGIN', 'INSERT', 'UPDATE', 'COMMIT', 'NATS_PUBLISH']);
+    // BEGIN → SELECT … FOR UPDATE (lock + re-validate) → INSERT transition →
+    // UPDATE pet → COMMIT → publish
+    expect(order).toEqual(['BEGIN', 'SELECT', 'INSERT', 'UPDATE', 'COMMIT', 'NATS_PUBLISH']);
   });
 
   it('PERMISSION_DENIED for staff at a different rescue', async () => {
@@ -386,6 +413,49 @@ describe('updatePetStatus', () => {
         toStatus: PetsV1.PetStatus.PET_STATUS_PENDING,
       } as never)
     ).rejects.toMatchObject({ code: 'PERMISSION_DENIED' });
+  });
+
+  it('locks the pet row FOR UPDATE inside the transaction before transitioning', async () => {
+    mocks.poolMock.query.mockResolvedValueOnce({ rows: [petRow({ status: 'available' })] });
+    const sqls: string[] = [];
+    mocks.clientMock.query.mockImplementation(async (sql: string) => {
+      sqls.push(sql);
+      // The in-transaction lock read returns the current (still available) row.
+      if (/FOR UPDATE/.test(sql)) {
+        return { rows: [petRow({ status: 'available' })] };
+      }
+      return { rows: [petRow({ status: 'pending' })] };
+    });
+
+    await updatePetStatus(mocks.deps, STAFF, {
+      petId: 'pet-1',
+      toStatus: PetsV1.PetStatus.PET_STATUS_PENDING,
+    } as never);
+
+    // A SELECT ... FOR UPDATE must run inside the txn (after BEGIN) so two
+    // concurrent transitions serialise on the row lock rather than both
+    // validating against a stale pre-transaction read.
+    expect(sqls.some(s => /SELECT[\s\S]*FOR UPDATE/.test(s))).toBe(true);
+  });
+
+  it('re-validates the transition against the locked row (loses a concurrent race)', async () => {
+    // Pre-transaction read sees `available` → pending looks legal.
+    mocks.poolMock.query.mockResolvedValueOnce({ rows: [petRow({ status: 'available' })] });
+    mocks.clientMock.query.mockImplementation(async (sql: string) => {
+      // But by the time we lock the row, a concurrent commit moved it to
+      // `adopted` — available is no longer reachable, so pending is illegal.
+      if (/FOR UPDATE/.test(sql)) {
+        return { rows: [petRow({ status: 'adopted' })] };
+      }
+      return { rows: [petRow()] };
+    });
+
+    await expect(
+      updatePetStatus(mocks.deps, STAFF, {
+        petId: 'pet-1',
+        toStatus: PetsV1.PetStatus.PET_STATUS_PENDING,
+      } as never)
+    ).rejects.toMatchObject({ code: 'INVALID_ARGUMENT' });
   });
 });
 

--- a/services/pets/src/grpc/handlers.ts
+++ b/services/pets/src/grpc/handlers.ts
@@ -126,6 +126,7 @@ type PetRow = {
   adopted_date: Date | null;
   created_at: Date;
   updated_at: Date;
+  version: number;
 };
 
 function rowToProto(row: PetRow): Pet {
@@ -182,7 +183,7 @@ const PETS_SELECT = `
   temperament, tags, good_with_children, good_with_dogs, good_with_cats,
   good_with_small_animals, medical_notes, behavioral_notes,
   view_count, favorite_count, application_count, available_since,
-  adopted_date, created_at, updated_at
+  adopted_date, created_at, updated_at, version
 `;
 
 const PETS_CREATE: Permission = 'pets.create' as Permission;
@@ -461,9 +462,15 @@ export async function updatePet(
       [...params, req.petId]
     );
     updated = result.rows[0];
+    if (!updated) {
+      throw new HandlerError('INTERNAL', 'update returned no rows');
+    }
+    // Deterministic idempotency key: aggregateId + the post-write version.
+    // A retried publish for the same write dedups in JetStream (vs. a
+    // Date.now() suffix, which minted a fresh id on every retry).
     publish({
       type: 'pets.updated',
-      id: `pets.updated.${req.petId}.${Date.now()}`,
+      id: `pets.updated.${req.petId}.${updated.version}`,
       payload: { petId: req.petId, rescueId: existing.rescue_id },
     });
   });
@@ -495,18 +502,43 @@ export async function updatePetStatus(
   assertRescueScopedUpdate(principal, existing);
 
   const toStatus = statusToDb(req.toStatus);
-  const fromStatus = existing.status;
-  if (!isLegalTransition(fromStatus, toStatus)) {
+
+  // Fast-fail on an obviously-illegal transition before opening a
+  // transaction. This read is unlocked, so the authoritative re-validation
+  // happens against the locked row inside withTransaction below.
+  if (!isLegalTransition(existing.status, toStatus)) {
     throw new HandlerError(
       'INVALID_ARGUMENT',
-      `illegal status transition ${fromStatus} → ${toStatus}`
+      `illegal status transition ${existing.status} → ${toStatus}`
     );
   }
 
   const transitionId = randomUUID();
   let updated: PetRow | undefined;
+  let fromStatus: PetStatusDb = existing.status;
 
   await withTransaction(deps, async ({ client, publish }) => {
+    // 0. Lock the row and re-read the authoritative status INSIDE the
+    //    transaction. The pre-transaction fetchPet read is unlocked, so two
+    //    concurrent transitions could both validate against the same stale
+    //    `from` status and both write. Locking + re-validating here serialises
+    //    them: the loser sees the winner's committed status and is rejected.
+    const locked = await client.query<{ status: PetStatusDb }>(
+      `SELECT status FROM pets.pets WHERE pet_id = $1 AND deleted_at IS NULL FOR UPDATE`,
+      [req.petId]
+    );
+    const lockedRow = locked.rows[0];
+    if (!lockedRow) {
+      throw new HandlerError('NOT_FOUND', `pet ${req.petId} not found`);
+    }
+    fromStatus = lockedRow.status;
+    if (!isLegalTransition(fromStatus, toStatus)) {
+      throw new HandlerError(
+        'INVALID_ARGUMENT',
+        `illegal status transition ${fromStatus} → ${toStatus}`
+      );
+    }
+
     // 1. Append the transition row (the event log).
     await client.query(
       `
@@ -635,6 +667,9 @@ function isPermittedRescueMutation(
 function clampLimit(requested: number): number {
   if (requested === 0) {
     return DEFAULT_LIST_LIMIT;
+  }
+  if (requested < 0) {
+    throw new HandlerError('INVALID_ARGUMENT', 'limit must be >= 0');
   }
   if (requested > MAX_LIST_LIMIT) {
     throw new HandlerError('INVALID_ARGUMENT', `limit must be <= ${MAX_LIST_LIMIT}`);

--- a/services/pets/src/migrations/007_pets_list_keyset_index.ts
+++ b/services/pets/src/migrations/007_pets_list_keyset_index.ts
@@ -1,0 +1,23 @@
+import type { MigrationBuilder } from 'node-pg-migrate';
+
+// Composite keyset index for the public List browse path.
+//
+// listPets orders by `created_at DESC, pet_id DESC` and paginates with the
+// keyset predicate `(created_at, pet_id) < ($cursorCreatedAt, $cursorPetId)`.
+// The pre-existing single-column `pets_created_at_idx` covers the leading
+// sort key but not the `pet_id` tiebreak, so deep pages still re-sort on the
+// secondary key. A matching `(created_at DESC, pet_id DESC)` index lets the
+// planner satisfy both the ORDER BY and the tuple comparison directly.
+
+const KEYSET_COLUMNS = [
+  { name: 'created_at', sort: 'DESC' },
+  { name: 'pet_id', sort: 'DESC' },
+] as const;
+
+export const up = async (pgm: MigrationBuilder): Promise<void> => {
+  pgm.createIndex('pets', [...KEYSET_COLUMNS], { name: 'pets_created_at_pet_id_keyset_idx' });
+};
+
+export const down = async (pgm: MigrationBuilder): Promise<void> => {
+  pgm.dropIndex('pets', [...KEYSET_COLUMNS], { name: 'pets_created_at_pet_id_keyset_idx' });
+};

--- a/services/pets/src/migrations/migrations.test.ts
+++ b/services/pets/src/migrations/migrations.test.ts
@@ -45,6 +45,7 @@ describe('pets migrations', () => {
     '004_create_pet_status_transitions.ts',
     '005_create_ratings.ts',
     '006_create_user_favorites.ts',
+    '007_pets_list_keyset_index.ts',
   ])('%s exports `up` and `down` functions', async filename => {
     const mod = (await import(`./${filename}`)) as {
       up: unknown;

--- a/services/rescue/src/grpc/handlers.test.ts
+++ b/services/rescue/src/grpc/handlers.test.ts
@@ -86,6 +86,7 @@ function rescueRow(overrides: Record<string, unknown> = {}) {
     verification_source: null,
     verification_failure_reason: null,
     settings: {},
+    version: 0,
     created_at: new Date('2026-06-01T00:00:00Z'),
     updated_at: new Date('2026-06-01T00:00:00Z'),
     ...overrides,
@@ -294,6 +295,20 @@ describe('updateRescue', () => {
     expect(sql).toMatch(/name = \$1/);
     expect(sql).toMatch(/version = version \+ 1/);
   });
+
+  it('keys rescue.updated on aggregateId:version (deterministic, replay-safe)', async () => {
+    mocks.poolMock.query.mockResolvedValueOnce({ rows: [rescueRow()] });
+    mocks.clientMock.query.mockResolvedValue({ rows: [rescueRow({ version: 3 })] });
+    let msgID: string | undefined;
+    mocks.natsMock.publish.mockImplementation(
+      (_subject: string, _data: unknown, opts: { msgID?: string }) => {
+        msgID = opts.msgID;
+      }
+    );
+
+    await updateRescue(mocks.deps, STAFF, { rescueId: 'rsc-1', name: 'Pawsome 2' } as never);
+    expect(msgID).toBe('rescue.updated.rsc-1:3');
+  });
 });
 
 // --- verifyRescue ----------------------------------------------------
@@ -443,6 +458,75 @@ describe('inviteStaff', () => {
     expect(res.invitation.invitationId).toBe('inv-1');
     expect(res.token).toMatch(/^[0-9a-f]{64}$/);
     expect(order).toEqual(['BEGIN', 'INSERT', 'COMMIT', 'NATS_PUBLISH']);
+  });
+
+  it('upserts on the pending-email conflict instead of inserting a duplicate row', async () => {
+    mocks.poolMock.query.mockResolvedValueOnce({ rows: [rescueRow()] });
+    let insertSql = '';
+    mocks.clientMock.query.mockImplementation(async (sql: string) => {
+      if (sql.trim().startsWith('INSERT')) {
+        insertSql = sql;
+      }
+      return {
+        rows: [
+          {
+            invitation_id: 'inv-existing',
+            email: 'dup@p.example',
+            rescue_id: 'rsc-1',
+            user_id: null,
+            title: 'Refreshed',
+            invited_by: STAFF.userId,
+            expiration: new Date('2026-06-15T00:00:00Z'),
+            used: false,
+            created_at: new Date('2026-06-01T00:00:00Z'),
+          },
+        ],
+      };
+    });
+
+    const res = await inviteStaff(mocks.deps, STAFF, {
+      rescueId: 'rsc-1',
+      email: 'dup@p.example',
+      title: 'Refreshed',
+    } as never);
+
+    // The write targets the partial-unique conflict and refreshes the
+    // existing row's token + expiry rather than inserting a second row.
+    expect(insertSql).toMatch(/ON CONFLICT/i);
+    expect(insertSql).toMatch(/lower\(email\)/i);
+    expect(insertSql).toMatch(/DO UPDATE/i);
+    expect(insertSql).toMatch(/token = EXCLUDED\.token/i);
+    expect(insertSql).toMatch(/expiration = EXCLUDED\.expiration/i);
+    // The returned invitation carries the EXISTING row's id (no duplicate).
+    expect(res.invitation.invitationId).toBe('inv-existing');
+  });
+
+  it('keys the published event on the persisted invitation id (stable on refresh)', async () => {
+    mocks.poolMock.query.mockResolvedValueOnce({ rows: [rescueRow()] });
+    mocks.clientMock.query.mockResolvedValue({
+      rows: [
+        {
+          invitation_id: 'inv-existing',
+          email: 'dup@p.example',
+          rescue_id: 'rsc-1',
+          user_id: null,
+          title: null,
+          invited_by: STAFF.userId,
+          expiration: new Date('2026-06-15T00:00:00Z'),
+          used: false,
+          created_at: new Date('2026-06-01T00:00:00Z'),
+        },
+      ],
+    });
+
+    await inviteStaff(mocks.deps, STAFF, {
+      rescueId: 'rsc-1',
+      email: 'dup@p.example',
+    } as never);
+
+    const published = mocks.natsMock.publish.mock.calls[0];
+    const opts = published[2] as { msgID?: string };
+    expect(opts.msgID).toBe('rescue.staffInvited.inv-existing');
   });
 });
 

--- a/services/rescue/src/grpc/handlers.ts
+++ b/services/rescue/src/grpc/handlers.ts
@@ -98,6 +98,7 @@ type RescueRow = {
   verification_source: RescueVerificationSourceDb | null;
   verification_failure_reason: string | null;
   settings: Record<string, unknown> | null;
+  version: number;
   created_at: Date;
   updated_at: Date;
 };
@@ -166,7 +167,7 @@ const RESCUES_SELECT = `
   website, description, mission, companies_house_number, charity_registration_number,
   contact_person, contact_title, contact_email, contact_phone,
   status, verified_at, verified_by, verification_source, verification_failure_reason,
-  settings, created_at, updated_at
+  settings, version, created_at, updated_at
 `;
 
 const RESCUES_CREATE: Permission = 'rescues.create' as Permission;
@@ -459,9 +460,12 @@ export async function updateRescue(
       [...params, req.rescueId]
     );
     updated = result.rows[0];
+    // Deterministic idempotency key: aggregateId:version. The UPDATE just
+    // bumped version, so each committed update maps to exactly one id and
+    // a replay de-dups in JetStream instead of minting a fresh id.
     publish({
       type: 'rescue.updated',
-      id: `rescue.updated.${req.rescueId}.${Date.now()}`,
+      id: `rescue.updated.${req.rescueId}:${updated?.version}`,
       payload: { rescueId: req.rescueId },
     });
   });
@@ -542,7 +546,7 @@ export async function verifyRescue(
           : `rescue.statusChanged`;
     publish({
       type: subject,
-      id: `${subject}.${req.rescueId}.${Date.now()}`,
+      id: `${subject}.${req.rescueId}:${updated?.version}`,
       payload: {
         rescueId: req.rescueId,
         fromStatus: existing.status,
@@ -592,6 +596,12 @@ export async function inviteStaff(
 
   let inserted: InvitationRow | undefined;
   await withTransaction(deps, async ({ client, publish }) => {
+    // Dedupe: a pending invite (used = false) to the same rescue+email is
+    // refreshed in place rather than duplicated. The partial unique index
+    // invitations_one_pending_per_email on (rescue_id, lower(email)) WHERE
+    // used = false is the conflict target; on hit we rotate the token,
+    // extend the expiry and update the title. Accepted invites (used =
+    // true) fall outside the index, so a fresh row is inserted normally.
     const result = await client.query<InvitationRow>(
       `
       INSERT INTO rescue.invitations (
@@ -599,6 +609,15 @@ export async function inviteStaff(
         expiration, used, created_by, version, created_at, updated_at
       )
       VALUES ($1, $2, $3, $4, $5, $6, $7, false, $6, 0, now(), now())
+      ON CONFLICT (rescue_id, lower(email)) WHERE used = false
+      DO UPDATE SET
+        token = EXCLUDED.token,
+        expiration = EXCLUDED.expiration,
+        title = EXCLUDED.title,
+        invited_by = EXCLUDED.invited_by,
+        updated_by = EXCLUDED.invited_by,
+        version = rescue.invitations.version + 1,
+        updated_at = now()
       RETURNING invitation_id, email, rescue_id, user_id, title, invited_by, expiration, used, created_at
       `,
       [
@@ -613,11 +632,14 @@ export async function inviteStaff(
     );
     inserted = result.rows[0];
 
+    // Key the event on the PERSISTED id (the existing row's id on a
+    // refresh), not the freshly-minted one, so a re-invite is idempotent.
+    const persistedId = inserted?.invitation_id ?? invitationId;
     publish({
       type: 'rescue.staffInvited',
-      id: `rescue.staffInvited.${invitationId}`,
+      id: `rescue.staffInvited.${persistedId}`,
       payload: {
-        invitationId,
+        invitationId: persistedId,
         rescueId: req.rescueId,
         email: req.email,
         invitedBy: principal.userId,

--- a/services/rescue/src/migrations/007_invitation_pending_unique.ts
+++ b/services/rescue/src/migrations/007_invitation_pending_unique.ts
@@ -1,0 +1,29 @@
+import type { MigrationBuilder } from 'node-pg-migrate';
+
+// Dedupe pending invitations.
+//
+// Re-inviting an email that already has a PENDING invitation must NOT
+// create a second row — the invite handler refreshes the existing row
+// (rotates token, extends expiry, updates title) instead. This partial
+// unique index makes that invariant enforceable at the database level
+// and gives the handler a single (rescue_id, lower(email)) conflict
+// target to upsert against.
+//
+// "Pending" = not yet accepted (`used = false`). Accepted invites
+// (`used = true`) drop out of the index so a fresh invite to the same
+// email is always allowed. Email is lower-cased so casing variants of
+// the same address collapse to one pending row.
+
+export const up = async (pgm: MigrationBuilder): Promise<void> => {
+  pgm.createIndex('invitations', ['rescue_id', 'lower(email)'], {
+    name: 'invitations_one_pending_per_email',
+    unique: true,
+    where: 'used = false',
+  });
+};
+
+export const down = async (pgm: MigrationBuilder): Promise<void> => {
+  pgm.dropIndex('invitations', ['rescue_id', 'lower(email)'], {
+    name: 'invitations_one_pending_per_email',
+  });
+};

--- a/services/rescue/src/migrations/migrations.test.ts
+++ b/services/rescue/src/migrations/migrations.test.ts
@@ -24,7 +24,7 @@ async function listMigrationFiles(): Promise<string[]> {
 describe('rescue migrations', () => {
   it('has migration files following the NNN_snake_case.ts naming convention', async () => {
     const files = await listMigrationFiles();
-    expect(files.length).toBeGreaterThanOrEqual(6);
+    expect(files.length).toBeGreaterThanOrEqual(7);
     for (const f of files) {
       expect(f).toMatch(MIGRATION_FILENAME_PATTERN);
     }
@@ -45,6 +45,7 @@ describe('rescue migrations', () => {
     '004_create_invitations.ts',
     '005_create_foster_placements.ts',
     '006_create_application_questions.ts',
+    '007_invitation_pending_unique.ts',
   ])('%s exports `up` and `down` functions', async filename => {
     const mod = (await import(`./${filename}`)) as {
       up: unknown;


### PR DESCRIPTION
## Deep code-quality review — pass 2

A second, deeper sweep of all 11 backend services (pass 1 is merged in #1038), plus several maintainer-approved decisions. Pass 2 targeted what a first pass misses: concurrency/transaction safety, crash recovery, query performance & missing indexes, access-control edges, and GDPR-erasure correctness.

Every database-facing fix was **independently verified against the real migration schema and `HEAD`** — the suites mock `pg`, so wrong column/table names and `NOT NULL` violations pass unit tests but throw in production. Full write-up: [`docs/services-code-quality-review-pass-2.md`](docs/services-code-quality-review-pass-2.md).

### Result
`pnpm exec turbo lint type-check test --filter='./services/*'` → **42/42 tasks pass**. **No shared-package code modified.**

| Service | Pass-2 fix |
|---|---|
| auth | **ADS-801**: split-brain token revocation, broken rotation-family chain, privilege-persistence after deactivation; token indexes (012/013). **+ progressive login soft-lock** |
| gateway | Broken access control (cross-rescue dashboard via `?rescueId=`); circuit breaker tripping on benign client-fault codes |
| applications | GDPR PII left in the append-only **event stream**; event idempotency-key collisions |
| notifications | Crashed-worker emails stuck in `sending` now reclaimed (retry budget/dead-letter, index 007); quiet-hours boundary |
| pets | Deterministic update event id; negative-limit guard; keyset index (007) |
| rescue | Invitation dedupe via partial unique index (007); deterministic event ids |
| matching | `Recommend` now excludes already-swiped pets; stats dedupe; anonymous-session GDPR erase; index (004) |
| moderation | Word-boundary scanner + severity; GDPR `reporter_id` NOT-NULL erase crash (010) |
| chat | Reaction emoji length bound → clean validation error |
| cms | Status transition state machine (`FOR UPDATE`); GDPR `author_id` NOT-NULL erase crash (003) |
| audit | GDPR `completed_at` premature-completion gap; existence-leak → NOT_FOUND; reports super_admin consistency |

### Cross-cutting theme
**GDPR erasure** was again the highest-risk area: four more runtime bugs mocked tests can't catch — `NOT NULL` columns set to `NULL` on erase (moderation, cms) that tear down the saga, PII in the applications event stream, and anonymous-session swipes in matching.

### Handoff — follow-up PRs (cross-package, each needs a decision)
Investigated and deliberately not forced in (cross-service/proto/RBAC blast radius):
- **A.** `GdprErasureRequestedPayload` lacks `email`, so email-keyed rows (rescue pending invites) can't be erased — gateway would fetch + broadcast email (PII-in-event call).
- **B.** chat `rescueId` via `OpenChatRequest` proto + gateway populate (needs `buf` codegen).
- **C.** `MODERATION_*` permissions in `lib.types` + a role-seeding migration (swapping the `ADMIN_DASHBOARD` placeholder naively would deny all moderators).

See the report for full specs.

https://claude.ai/code/session_014EbfJyKja1PmRfjcZWokaH