### PR TITLE
feat(events): carry email on GDPR erasure for email-keyed rows

### DIFF
--- a/packages/events/src/gdpr-saga.test.ts
+++ b/packages/events/src/gdpr-saga.test.ts
@@ -135,6 +135,29 @@ describe('registerGdprSubscriber', () => {
     expect(env.payload.error).toBeUndefined();
   });
 
+  it('forwards the optional email on the request payload to the erase callback', async () => {
+    const client = {
+      query: vi.fn(async () => ({ rows: [] })),
+      release: vi.fn(),
+    } as unknown as PoolClient;
+
+    const seen: Array<GdprErasureRequestedPayload> = [];
+    const bus = makeBus({ ...PAYLOAD, email: 'erased@example.com' });
+    registerGdprSubscriber({
+      nats: bus.nc,
+      pool: fakePool(client),
+      service: 'rescue',
+      erase: async (_c, payload) => {
+        seen.push(payload);
+        return 0;
+      },
+    });
+    await flush();
+
+    expect(seen).toHaveLength(1);
+    expect(seen[0].email).toBe('erased@example.com');
+  });
+
   it('rolls back and publishes a (durable) failure completion when erase throws', async () => {
     const client = {
       query: vi.fn(async () => ({ rows: [] })),

--- a/packages/events/src/gdpr.ts
+++ b/packages/events/src/gdpr.ts
@@ -20,6 +20,15 @@ export const GDPR_ERASURE_COMPLETED = 'gdpr.erasureCompleted';
 export type GdprErasureRequestedPayload = {
   // The user being erased — primary key in auth.users.
   userId: string;
+  // The user's email, resolved by the gateway from the auth record at
+  // request time. Optional because not every erasure has a resolvable
+  // email (e.g. the auth lookup failed). Consumers use it to erase
+  // email-keyed rows that carry no user_id — notably rescue pending
+  // invitations for a user who never registered. This deliberately
+  // broadcasts the email on the erasure event: the whole purpose of the
+  // event is erasure, so the scoped PII spread is the accepted tradeoff
+  // for erasure completeness.
+  email?: string;
   // Saga-wide correlation id. Mint at the gateway; every subscriber
   // echoes it on its completion event so the audit consumer can join.
   correlationId: string;

--- a/services/gateway/src/routes/gdpr.test.ts
+++ b/services/gateway/src/routes/gdpr.test.ts
@@ -8,6 +8,7 @@ import { status as grpcStatus } from '@grpc/grpc-js';
 import { GDPR_ERASURE_REQUESTED } from '@adopt-dont-shop/events';
 
 import type { AuditClient } from '../grpc-clients/audit-client.js';
+import type { AuthClient } from '../grpc-clients/auth-client.js';
 
 import { registerGdprRoutes, type ErasureStore } from './gdpr.js';
 
@@ -52,6 +53,10 @@ function fakeAuditClient(): { client: AuditClient; getGdpr: ReturnType<typeof vi
   const getGdpr = vi.fn();
   const client = { getGdprErasureRequest: getGdpr } as unknown as AuditClient;
   return { client, getGdpr };
+}
+
+function fakeAuthClient(getMe: ReturnType<typeof vi.fn>): AuthClient {
+  return { getMe } as unknown as AuthClient;
 }
 
 describe('POST /api/v1/users/me/erasure-request', () => {
@@ -326,5 +331,71 @@ describe('GET /api/v1/users/me/erasure-request/:correlationId', () => {
       headers: { 'x-user-id': 'usr-2' },
     });
     expect(res.statusCode).toBe(403);
+  });
+});
+
+describe('POST /api/v1/users/me/erasure-request — email resolution', () => {
+  let app: FastifyInstance;
+  let published: Array<{ subject: string; data: string }>;
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  const erasedEmail = (): string | undefined => {
+    const env = JSON.parse(published[0].data) as { payload: { email?: string } };
+    return env.payload.email;
+  };
+
+  it('resolves the email from auth.getMe and carries it on the payload', async () => {
+    app = Fastify({ logger: false });
+    const { nats, published: p } = fakeNats();
+    published = p;
+    const getMe = vi.fn().mockResolvedValue({ user: { email: 'erased@example.com' } });
+    await registerGdprRoutes(app, { nats, authClient: fakeAuthClient(getMe) });
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/v1/users/me/erasure-request',
+      headers: { 'x-user-id': 'usr-1' },
+      payload: {},
+    });
+    expect(res.statusCode).toBe(202);
+    // The email is resolved against the requesting principal's metadata.
+    expect(getMe).toHaveBeenCalledTimes(1);
+    expect(erasedEmail()).toBe('erased@example.com');
+  });
+
+  it('publishes a userId-only event when the auth lookup fails (erasure not blocked)', async () => {
+    app = Fastify({ logger: false });
+    const { nats, published: p } = fakeNats();
+    published = p;
+    const getMe = vi.fn().mockRejectedValue(new Error('auth unavailable'));
+    await registerGdprRoutes(app, { nats, authClient: fakeAuthClient(getMe) });
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/v1/users/me/erasure-request',
+      headers: { 'x-user-id': 'usr-1' },
+      payload: {},
+    });
+    expect(res.statusCode).toBe(202);
+    expect(erasedEmail()).toBeUndefined();
+  });
+
+  it('omits email when no authClient is wired', async () => {
+    app = Fastify({ logger: false });
+    const { nats, published: p } = fakeNats();
+    published = p;
+    await registerGdprRoutes(app, { nats });
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/v1/users/me/erasure-request',
+      headers: { 'x-user-id': 'usr-1' },
+      payload: {},
+    });
+    expect(res.statusCode).toBe(202);
+    expect(erasedEmail()).toBeUndefined();
   });
 });

--- a/services/gateway/src/routes/gdpr.ts
+++ b/services/gateway/src/routes/gdpr.ts
@@ -18,6 +18,7 @@ import type { NatsConnection } from 'nats';
 import type { FastifyInstance, FastifyRequest } from 'fastify';
 
 import type { AuditClient } from '../grpc-clients/audit-client.js';
+import type { AuthClient } from '../grpc-clients/auth-client.js';
 import { buildMetadata } from '../middleware/metadata.js';
 import { handleGrpcError } from '../middleware/grpc-error.js';
 
@@ -32,6 +33,11 @@ export type GdprRoutesOptions = {
   nats: NatsConnection;
   // Optional — when wired, the GET status endpoint is registered.
   auditClient?: AuditClient;
+  // When wired, the erasure event carries the user's email (resolved from
+  // auth) so consumers can erase email-keyed rows that have no user_id —
+  // e.g. rescue pending invitations. Best-effort: a failed lookup still
+  // publishes the userId-only event rather than blocking erasure.
+  authClient?: AuthClient;
   // When wired, used for per-user idempotency: a second POST within
   // ERASURE_IDEMPOTENCY_TTL_SECONDS returns the original correlationId.
   redis?: ErasureStore;
@@ -58,7 +64,7 @@ export const registerGdprRoutes = async (
   app: FastifyInstance,
   opts: GdprRoutesOptions
 ): Promise<void> => {
-  const { nats, auditClient, redis } = opts;
+  const { nats, auditClient, authClient, redis } = opts;
 
   app.post(
     '/api/v1/users/me/erasure-request',
@@ -90,10 +96,17 @@ export const registerGdprRoutes = async (
         }
       }
 
+      // Resolve the user's email so consumers can erase email-keyed rows
+      // that carry no user_id (e.g. rescue pending invitations). Best-
+      // effort: a failed lookup must not block the erasure saga, so we
+      // fall through to a userId-only event.
+      const email = authClient ? await resolveEmail(authClient, req) : undefined;
+
       const correlationId = randomUUID();
       const requestedAt = new Date().toISOString();
       const payload: GdprErasureRequestedPayload = {
         userId,
+        email,
         correlationId,
         requestedAt,
         reason,
@@ -184,4 +197,20 @@ function principalUserId(req: FastifyRequest): string | null {
   const headers = req.headers as Record<string, string | string[] | undefined>;
   const raw = headers['x-user-id'];
   return typeof raw === 'string' && raw.length > 0 ? raw : null;
+}
+
+// Resolve the requesting user's email via auth.GetMe (identified by the
+// x-user-id metadata buildMetadata forwards). Returns undefined on any
+// failure or missing email — erasure must proceed regardless.
+async function resolveEmail(
+  authClient: AuthClient,
+  req: FastifyRequest
+): Promise<string | undefined> {
+  try {
+    const res = await authClient.getMe({}, buildMetadata(req));
+    const email = res.user?.email;
+    return typeof email === 'string' && email.length > 0 ? email : undefined;
+  } catch {
+    return undefined;
+  }
 }

--- a/services/gateway/src/server.ts
+++ b/services/gateway/src/server.ts
@@ -539,6 +539,7 @@ export const createServer = async (opts: CreateServerOptions): Promise<FastifyIn
     await registerGdprRoutes(server, {
       nats: opts.nats,
       auditClient: opts.auditClient,
+      authClient: opts.authClient,
       redis: rateLimitRedis,
     });
   }

--- a/services/rescue/src/gdpr/erase.test.ts
+++ b/services/rescue/src/gdpr/erase.test.ts
@@ -63,4 +63,27 @@ describe('eraseRescue', () => {
     const total = await eraseRescue(client, PAYLOAD);
     expect(total).toBe(0);
   });
+
+  it('erases email-keyed pending invitations when the payload carries an email', async () => {
+    // The user_id-keyed deletes touch 0 rows (the invitee never registered);
+    // the email-keyed delete catches 2 pending invitations.
+    const { client, calls } = makeClient([0, 0, 0, 2]);
+    const total = await eraseRescue(client, { ...PAYLOAD, email: 'invitee@example.com' });
+
+    const emailCall = calls.find(
+      c => c.text.includes('invitations') && c.text.toLowerCase().includes('email')
+    );
+    expect(emailCall).toBeDefined();
+    // Case-insensitive match so casing variants of the same address are caught.
+    expect(emailCall?.text).toMatch(/lower\(email\)\s*=\s*lower\(\$1\)/i);
+    expect(emailCall?.values[0]).toBe('invitee@example.com');
+    expect(total).toBe(2);
+  });
+
+  it('does not run an email-keyed query when the payload has no email', async () => {
+    const { client, calls } = makeClient([0, 0, 0]);
+    await eraseRescue(client, PAYLOAD);
+    expect(calls).toHaveLength(3);
+    expect(calls.some(c => c.text.toLowerCase().includes('email'))).toBe(false);
+  });
 });

--- a/services/rescue/src/gdpr/erase.ts
+++ b/services/rescue/src/gdpr/erase.ts
@@ -5,6 +5,13 @@
 // org's history without retaining the erased user as an active foster),
 // and drop invitations linked to the user. Rescue rows themselves are
 // organisation records, not user-personal data.
+//
+// Pending invitations are keyed by EMAIL, not user_id: an invitee who
+// never created an account has a NULL user_id on their invitation row, so
+// the user_id-keyed delete misses them and leaves their email behind as
+// PII residue. When the erasure event carries the resolved email, we also
+// delete invitations matching it (case-insensitively, mirroring the
+// invitations_one_pending_per_email index which keys on lower(email)).
 
 import type { PoolClient } from 'pg';
 
@@ -23,5 +30,15 @@ export async function eraseRescue(
     const res = await client.query(sql, [payload.userId]);
     total += res.rowCount ?? 0;
   }
+
+  // Email-keyed pending invitations (NULL user_id on the row).
+  if (payload.email) {
+    const res = await client.query(
+      `DELETE FROM rescue.invitations WHERE lower(email) = lower($1)`,
+      [payload.email]
+    );
+    total += res.rowCount ?? 0;
+  }
+
   return total;
 }


### PR DESCRIPTION
## Problem

The `GdprErasureRequestedPayload` event carried only `userId`. Some rows that must be erased are keyed by **email, not userId** — specifically rescue **pending invitations**: a user invited by email who never created an account has a `NULL user_id` on their invitation row. Today the rescue consumer's `DELETE ... WHERE user_id = $1` misses those rows, leaving the invitee's email behind as PII residue. This is follow-up item **A** from the pass-2 services code-quality review.

## Change (3 parts)

1. **`packages/events`** — Add an optional `email` field to `GdprErasureRequestedPayload`. Optional because not every erasure has a resolvable email (e.g. the auth lookup fails). Existing consumers are unaffected (an added optional field cannot break a reader).

2. **`services/gateway`** (the erasure-event producer) — When publishing `gdpr.erasureRequested`, resolve the user's email via `auth.GetMe` (identified by the forwarded `x-user-id` metadata) and populate `email`. **Best-effort**: a failed/absent lookup still publishes the `userId`-only event rather than blocking the compliance-critical saga. Wired through `server.ts` so the existing `authClient` is passed to the route.

3. **`services/rescue`** (a consumer) — In addition to the existing `user_id`-keyed erasure, delete invitations matching the resolved email, case-insensitively (`lower(email) = lower($1)`) to mirror the `invitations_one_pending_per_email` partial index which keys on `lower(email)`. The email-keyed delete only runs when the payload carries an email.

## PII-in-event tradeoff

This deliberately broadcasts the user's email on the NATS erasure event. That is the maintainer-approved tradeoff: the whole purpose of the event is erasure, so erasure completeness outweighs the scoped PII spread. Captured in the schema comment and the rescue-erase comment.

## Verification

```
pnpm exec turbo lint type-check test \
  --filter=@adopt-dont-shop/events \
  --filter=@adopt-dont-shop/service.gateway \
  --filter=@adopt-dont-shop/service.rescue
```

Result: **18/18 tasks pass** (lint + type-check + test for all 3 packages). Per-package test totals after the change: events 66 tests, gateway 609 tests, rescue 115 tests — all green, including the new behaviour tests (saga forwards `email` to the erase callback; gateway resolves email / falls back on lookup failure / omits when no authClient; rescue erases email-keyed pending invitations / skips the query when no email).

Additionally type-checked all other `GdprErasureRequestedPayload` consumers (audit, applications, matching, auth, pets, cms, chat, moderation, notifications) — **17/17 type-check tasks pass**; the optional field breaks none of them.

Stacked on `claude/services-code-quality-review-pass-2` (base is that branch, not main).

https://claude.ai/code/session_014EbfJyKja1PmRfjcZWokaH

---
_Generated by [Claude Code](https://claude.ai/code/session_014EbfJyKja1PmRfjcZWokaH)_