### PR TITLE
feat(chat): record rescueId on OpenChat

### DIFF
--- a/packages/proto/proto/adopt_dont_shop/chat/v1/chat.proto
+++ b/packages/proto/proto/adopt_dont_shop/chat/v1/chat.proto
@@ -130,6 +130,11 @@ message OpenChatRequest {
   string application_id = 1;
   // Other participant — the calling principal is the first.
   string other_user_id = 2;
+  // Rescue the chat logically belongs to. The gateway populates this from
+  // the calling principal's rescue context so the chat row records its
+  // owning rescue — rescue-scoped chat search can then match gRPC-created
+  // chats instead of the previous null-UUID placeholder.
+  string rescue_id = 3;
 }
 
 message OpenChatResponse {

--- a/packages/proto/src/generated/proto/adopt_dont_shop/chat/v1/chat.ts
+++ b/packages/proto/src/generated/proto/adopt_dont_shop/chat/v1/chat.ts
@@ -5,7 +5,7 @@
 // source: proto/adopt_dont_shop/chat/v1/chat.proto
 
 /* eslint-disable */
-import { BinaryReader, BinaryWriter } from "@bufbuild/protobuf/wire";
+import { BinaryReader, BinaryWriter } from '@bufbuild/protobuf/wire';
 import {
   type CallOptions,
   type ChannelCredentials,
@@ -17,9 +17,9 @@ import {
   type Metadata,
   type ServiceError,
   type UntypedServiceImplementation,
-} from "@grpc/grpc-js";
+} from '@grpc/grpc-js';
 
-export const protobufPackage = "adopt_dont_shop.chat.v1";
+export const protobufPackage = 'adopt_dont_shop.chat.v1';
 
 /**
  * Chat mirrors the chat.chats row plus the participant ids. Last
@@ -78,12 +78,17 @@ export interface OpenChatRequest {
   applicationId: string;
   /** Other participant — the calling principal is the first. */
   otherUserId: string;
+  /**
+   * Rescue the chat logically belongs to. The gateway populates this from
+   * the calling principal's rescue context so the chat row records its
+   * owning rescue — rescue-scoped chat search can then match gRPC-created
+   * chats instead of the previous null-UUID placeholder.
+   */
+  rescueId: string;
 }
 
 export interface OpenChatResponse {
-  chat?:
-    | Chat
-    | undefined;
+  chat?: Chat | undefined;
   /**
    * True when this call created the chat; false when an existing
    * row was returned (idempotency signal).
@@ -103,9 +108,7 @@ export interface SendMessageResponse {
 export interface ListMessagesRequest {
   chatId: string;
   /** Opaque base64-JSON keyset cursor. */
-  cursor?:
-    | string
-    | undefined;
+  cursor?: string | undefined;
   /** Defaults to 50, max 200 — chat history is naturally chunkier. */
   limit: number;
 }
@@ -186,9 +189,7 @@ export interface SearchChatsRequest {
  * renders this as a search result card.
  */
 export interface SearchChatHit {
-  chat?:
-    | Chat
-    | undefined;
+  chat?: Chat | undefined;
   /**
    * The matching message preview. Present only when at least one
    * message in the chat matched — when this is unset, the chat row
@@ -249,23 +250,23 @@ export interface DeleteChatResponse {
 
 function createBaseChat(): Chat {
   return {
-    chatId: "",
-    applicationId: "",
+    chatId: '',
+    applicationId: '',
     participantUserIds: [],
     lastMessagePreview: undefined,
     lastMessageAt: undefined,
     lastMessageSenderId: undefined,
-    createdAt: "",
-    updatedAt: "",
+    createdAt: '',
+    updatedAt: '',
   };
 }
 
 export const Chat: MessageFns<Chat> = {
   encode(message: Chat, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    if (message.chatId !== "") {
+    if (message.chatId !== '') {
       writer.uint32(10).string(message.chatId);
     }
-    if (message.applicationId !== "") {
+    if (message.applicationId !== '') {
       writer.uint32(18).string(message.applicationId);
     }
     for (const v of message.participantUserIds) {
@@ -280,10 +281,10 @@ export const Chat: MessageFns<Chat> = {
     if (message.lastMessageSenderId !== undefined) {
       writer.uint32(50).string(message.lastMessageSenderId);
     }
-    if (message.createdAt !== "") {
+    if (message.createdAt !== '') {
       writer.uint32(58).string(message.createdAt);
     }
-    if (message.updatedAt !== "") {
+    if (message.updatedAt !== '') {
       writer.uint32(66).string(message.updatedAt);
     }
     return writer;
@@ -374,52 +375,52 @@ export const Chat: MessageFns<Chat> = {
       chatId: isSet(object.chatId)
         ? globalThis.String(object.chatId)
         : isSet(object.chat_id)
-        ? globalThis.String(object.chat_id)
-        : "",
+          ? globalThis.String(object.chat_id)
+          : '',
       applicationId: isSet(object.applicationId)
         ? globalThis.String(object.applicationId)
         : isSet(object.application_id)
-        ? globalThis.String(object.application_id)
-        : "",
+          ? globalThis.String(object.application_id)
+          : '',
       participantUserIds: globalThis.Array.isArray(object?.participantUserIds)
         ? object.participantUserIds.map((e: any) => globalThis.String(e))
         : globalThis.Array.isArray(object?.participant_user_ids)
-        ? object.participant_user_ids.map((e: any) => globalThis.String(e))
-        : [],
+          ? object.participant_user_ids.map((e: any) => globalThis.String(e))
+          : [],
       lastMessagePreview: isSet(object.lastMessagePreview)
         ? globalThis.String(object.lastMessagePreview)
         : isSet(object.last_message_preview)
-        ? globalThis.String(object.last_message_preview)
-        : undefined,
+          ? globalThis.String(object.last_message_preview)
+          : undefined,
       lastMessageAt: isSet(object.lastMessageAt)
         ? globalThis.String(object.lastMessageAt)
         : isSet(object.last_message_at)
-        ? globalThis.String(object.last_message_at)
-        : undefined,
+          ? globalThis.String(object.last_message_at)
+          : undefined,
       lastMessageSenderId: isSet(object.lastMessageSenderId)
         ? globalThis.String(object.lastMessageSenderId)
         : isSet(object.last_message_sender_id)
-        ? globalThis.String(object.last_message_sender_id)
-        : undefined,
+          ? globalThis.String(object.last_message_sender_id)
+          : undefined,
       createdAt: isSet(object.createdAt)
         ? globalThis.String(object.createdAt)
         : isSet(object.created_at)
-        ? globalThis.String(object.created_at)
-        : "",
+          ? globalThis.String(object.created_at)
+          : '',
       updatedAt: isSet(object.updatedAt)
         ? globalThis.String(object.updatedAt)
         : isSet(object.updated_at)
-        ? globalThis.String(object.updated_at)
-        : "",
+          ? globalThis.String(object.updated_at)
+          : '',
     };
   },
 
   toJSON(message: Chat): unknown {
     const obj: any = {};
-    if (message.chatId !== "") {
+    if (message.chatId !== '') {
       obj.chatId = message.chatId;
     }
-    if (message.applicationId !== "") {
+    if (message.applicationId !== '') {
       obj.applicationId = message.applicationId;
     }
     if (message.participantUserIds?.length) {
@@ -434,10 +435,10 @@ export const Chat: MessageFns<Chat> = {
     if (message.lastMessageSenderId !== undefined) {
       obj.lastMessageSenderId = message.lastMessageSenderId;
     }
-    if (message.createdAt !== "") {
+    if (message.createdAt !== '') {
       obj.createdAt = message.createdAt;
     }
-    if (message.updatedAt !== "") {
+    if (message.updatedAt !== '') {
       obj.updatedAt = message.updatedAt;
     }
     return obj;
@@ -448,43 +449,43 @@ export const Chat: MessageFns<Chat> = {
   },
   fromPartial<I extends Exact<DeepPartial<Chat>, I>>(object: I): Chat {
     const message = createBaseChat();
-    message.chatId = object.chatId ?? "";
-    message.applicationId = object.applicationId ?? "";
-    message.participantUserIds = object.participantUserIds?.map((e) => e) || [];
+    message.chatId = object.chatId ?? '';
+    message.applicationId = object.applicationId ?? '';
+    message.participantUserIds = object.participantUserIds?.map(e => e) || [];
     message.lastMessagePreview = object.lastMessagePreview ?? undefined;
     message.lastMessageAt = object.lastMessageAt ?? undefined;
     message.lastMessageSenderId = object.lastMessageSenderId ?? undefined;
-    message.createdAt = object.createdAt ?? "";
-    message.updatedAt = object.updatedAt ?? "";
+    message.createdAt = object.createdAt ?? '';
+    message.updatedAt = object.updatedAt ?? '';
     return message;
   },
 };
 
 function createBaseMessage(): Message {
   return {
-    messageId: "",
-    chatId: "",
-    senderUserId: "",
-    body: "",
+    messageId: '',
+    chatId: '',
+    senderUserId: '',
+    body: '',
     reactions: [],
     editedAt: undefined,
     deletedAt: undefined,
-    createdAt: "",
+    createdAt: '',
   };
 }
 
 export const Message: MessageFns<Message> = {
   encode(message: Message, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    if (message.messageId !== "") {
+    if (message.messageId !== '') {
       writer.uint32(10).string(message.messageId);
     }
-    if (message.chatId !== "") {
+    if (message.chatId !== '') {
       writer.uint32(18).string(message.chatId);
     }
-    if (message.senderUserId !== "") {
+    if (message.senderUserId !== '') {
       writer.uint32(26).string(message.senderUserId);
     }
-    if (message.body !== "") {
+    if (message.body !== '') {
       writer.uint32(34).string(message.body);
     }
     for (const v of message.reactions) {
@@ -496,7 +497,7 @@ export const Message: MessageFns<Message> = {
     if (message.deletedAt !== undefined) {
       writer.uint32(58).string(message.deletedAt);
     }
-    if (message.createdAt !== "") {
+    if (message.createdAt !== '') {
       writer.uint32(66).string(message.createdAt);
     }
     return writer;
@@ -587,56 +588,56 @@ export const Message: MessageFns<Message> = {
       messageId: isSet(object.messageId)
         ? globalThis.String(object.messageId)
         : isSet(object.message_id)
-        ? globalThis.String(object.message_id)
-        : "",
+          ? globalThis.String(object.message_id)
+          : '',
       chatId: isSet(object.chatId)
         ? globalThis.String(object.chatId)
         : isSet(object.chat_id)
-        ? globalThis.String(object.chat_id)
-        : "",
+          ? globalThis.String(object.chat_id)
+          : '',
       senderUserId: isSet(object.senderUserId)
         ? globalThis.String(object.senderUserId)
         : isSet(object.sender_user_id)
-        ? globalThis.String(object.sender_user_id)
-        : "",
-      body: isSet(object.body) ? globalThis.String(object.body) : "",
+          ? globalThis.String(object.sender_user_id)
+          : '',
+      body: isSet(object.body) ? globalThis.String(object.body) : '',
       reactions: globalThis.Array.isArray(object?.reactions)
         ? object.reactions.map((e: any) => MessageReaction.fromJSON(e))
         : [],
       editedAt: isSet(object.editedAt)
         ? globalThis.String(object.editedAt)
         : isSet(object.edited_at)
-        ? globalThis.String(object.edited_at)
-        : undefined,
+          ? globalThis.String(object.edited_at)
+          : undefined,
       deletedAt: isSet(object.deletedAt)
         ? globalThis.String(object.deletedAt)
         : isSet(object.deleted_at)
-        ? globalThis.String(object.deleted_at)
-        : undefined,
+          ? globalThis.String(object.deleted_at)
+          : undefined,
       createdAt: isSet(object.createdAt)
         ? globalThis.String(object.createdAt)
         : isSet(object.created_at)
-        ? globalThis.String(object.created_at)
-        : "",
+          ? globalThis.String(object.created_at)
+          : '',
     };
   },
 
   toJSON(message: Message): unknown {
     const obj: any = {};
-    if (message.messageId !== "") {
+    if (message.messageId !== '') {
       obj.messageId = message.messageId;
     }
-    if (message.chatId !== "") {
+    if (message.chatId !== '') {
       obj.chatId = message.chatId;
     }
-    if (message.senderUserId !== "") {
+    if (message.senderUserId !== '') {
       obj.senderUserId = message.senderUserId;
     }
-    if (message.body !== "") {
+    if (message.body !== '') {
       obj.body = message.body;
     }
     if (message.reactions?.length) {
-      obj.reactions = message.reactions.map((e) => MessageReaction.toJSON(e));
+      obj.reactions = message.reactions.map(e => MessageReaction.toJSON(e));
     }
     if (message.editedAt !== undefined) {
       obj.editedAt = message.editedAt;
@@ -644,7 +645,7 @@ export const Message: MessageFns<Message> = {
     if (message.deletedAt !== undefined) {
       obj.deletedAt = message.deletedAt;
     }
-    if (message.createdAt !== "") {
+    if (message.createdAt !== '') {
       obj.createdAt = message.createdAt;
     }
     return obj;
@@ -655,25 +656,25 @@ export const Message: MessageFns<Message> = {
   },
   fromPartial<I extends Exact<DeepPartial<Message>, I>>(object: I): Message {
     const message = createBaseMessage();
-    message.messageId = object.messageId ?? "";
-    message.chatId = object.chatId ?? "";
-    message.senderUserId = object.senderUserId ?? "";
-    message.body = object.body ?? "";
-    message.reactions = object.reactions?.map((e) => MessageReaction.fromPartial(e)) || [];
+    message.messageId = object.messageId ?? '';
+    message.chatId = object.chatId ?? '';
+    message.senderUserId = object.senderUserId ?? '';
+    message.body = object.body ?? '';
+    message.reactions = object.reactions?.map(e => MessageReaction.fromPartial(e)) || [];
     message.editedAt = object.editedAt ?? undefined;
     message.deletedAt = object.deletedAt ?? undefined;
-    message.createdAt = object.createdAt ?? "";
+    message.createdAt = object.createdAt ?? '';
     return message;
   },
 };
 
 function createBaseMessageReaction(): MessageReaction {
-  return { emoji: "", userIds: [] };
+  return { emoji: '', userIds: [] };
 }
 
 export const MessageReaction: MessageFns<MessageReaction> = {
   encode(message: MessageReaction, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    if (message.emoji !== "") {
+    if (message.emoji !== '') {
       writer.uint32(10).string(message.emoji);
     }
     for (const v of message.userIds) {
@@ -716,18 +717,18 @@ export const MessageReaction: MessageFns<MessageReaction> = {
 
   fromJSON(object: any): MessageReaction {
     return {
-      emoji: isSet(object.emoji) ? globalThis.String(object.emoji) : "",
+      emoji: isSet(object.emoji) ? globalThis.String(object.emoji) : '',
       userIds: globalThis.Array.isArray(object?.userIds)
         ? object.userIds.map((e: any) => globalThis.String(e))
         : globalThis.Array.isArray(object?.user_ids)
-        ? object.user_ids.map((e: any) => globalThis.String(e))
-        : [],
+          ? object.user_ids.map((e: any) => globalThis.String(e))
+          : [],
     };
   },
 
   toJSON(message: MessageReaction): unknown {
     const obj: any = {};
-    if (message.emoji !== "") {
+    if (message.emoji !== '') {
       obj.emoji = message.emoji;
     }
     if (message.userIds?.length) {
@@ -741,23 +742,26 @@ export const MessageReaction: MessageFns<MessageReaction> = {
   },
   fromPartial<I extends Exact<DeepPartial<MessageReaction>, I>>(object: I): MessageReaction {
     const message = createBaseMessageReaction();
-    message.emoji = object.emoji ?? "";
-    message.userIds = object.userIds?.map((e) => e) || [];
+    message.emoji = object.emoji ?? '';
+    message.userIds = object.userIds?.map(e => e) || [];
     return message;
   },
 };
 
 function createBaseOpenChatRequest(): OpenChatRequest {
-  return { applicationId: "", otherUserId: "" };
+  return { applicationId: '', otherUserId: '', rescueId: '' };
 }
 
 export const OpenChatRequest: MessageFns<OpenChatRequest> = {
   encode(message: OpenChatRequest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    if (message.applicationId !== "") {
+    if (message.applicationId !== '') {
       writer.uint32(10).string(message.applicationId);
     }
-    if (message.otherUserId !== "") {
+    if (message.otherUserId !== '') {
       writer.uint32(18).string(message.otherUserId);
+    }
+    if (message.rescueId !== '') {
+      writer.uint32(26).string(message.rescueId);
     }
     return writer;
   },
@@ -785,6 +789,14 @@ export const OpenChatRequest: MessageFns<OpenChatRequest> = {
           message.otherUserId = reader.string();
           continue;
         }
+        case 3: {
+          if (tag !== 26) {
+            break;
+          }
+
+          message.rescueId = reader.string();
+          continue;
+        }
       }
       if ((tag & 7) === 4 || tag === 0) {
         break;
@@ -799,23 +811,31 @@ export const OpenChatRequest: MessageFns<OpenChatRequest> = {
       applicationId: isSet(object.applicationId)
         ? globalThis.String(object.applicationId)
         : isSet(object.application_id)
-        ? globalThis.String(object.application_id)
-        : "",
+          ? globalThis.String(object.application_id)
+          : '',
       otherUserId: isSet(object.otherUserId)
         ? globalThis.String(object.otherUserId)
         : isSet(object.other_user_id)
-        ? globalThis.String(object.other_user_id)
-        : "",
+          ? globalThis.String(object.other_user_id)
+          : '',
+      rescueId: isSet(object.rescueId)
+        ? globalThis.String(object.rescueId)
+        : isSet(object.rescue_id)
+          ? globalThis.String(object.rescue_id)
+          : '',
     };
   },
 
   toJSON(message: OpenChatRequest): unknown {
     const obj: any = {};
-    if (message.applicationId !== "") {
+    if (message.applicationId !== '') {
       obj.applicationId = message.applicationId;
     }
-    if (message.otherUserId !== "") {
+    if (message.otherUserId !== '') {
       obj.otherUserId = message.otherUserId;
+    }
+    if (message.rescueId !== '') {
+      obj.rescueId = message.rescueId;
     }
     return obj;
   },
@@ -825,8 +845,9 @@ export const OpenChatRequest: MessageFns<OpenChatRequest> = {
   },
   fromPartial<I extends Exact<DeepPartial<OpenChatRequest>, I>>(object: I): OpenChatRequest {
     const message = createBaseOpenChatRequest();
-    message.applicationId = object.applicationId ?? "";
-    message.otherUserId = object.otherUserId ?? "";
+    message.applicationId = object.applicationId ?? '';
+    message.otherUserId = object.otherUserId ?? '';
+    message.rescueId = object.rescueId ?? '';
     return message;
   },
 };
@@ -901,22 +922,23 @@ export const OpenChatResponse: MessageFns<OpenChatResponse> = {
   },
   fromPartial<I extends Exact<DeepPartial<OpenChatResponse>, I>>(object: I): OpenChatResponse {
     const message = createBaseOpenChatResponse();
-    message.chat = (object.chat !== undefined && object.chat !== null) ? Chat.fromPartial(object.chat) : undefined;
+    message.chat =
+      object.chat !== undefined && object.chat !== null ? Chat.fromPartial(object.chat) : undefined;
     message.created = object.created ?? false;
     return message;
   },
 };
 
 function createBaseSendMessageRequest(): SendMessageRequest {
-  return { chatId: "", body: "" };
+  return { chatId: '', body: '' };
 }
 
 export const SendMessageRequest: MessageFns<SendMessageRequest> = {
   encode(message: SendMessageRequest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    if (message.chatId !== "") {
+    if (message.chatId !== '') {
       writer.uint32(10).string(message.chatId);
     }
-    if (message.body !== "") {
+    if (message.body !== '') {
       writer.uint32(18).string(message.body);
     }
     return writer;
@@ -959,18 +981,18 @@ export const SendMessageRequest: MessageFns<SendMessageRequest> = {
       chatId: isSet(object.chatId)
         ? globalThis.String(object.chatId)
         : isSet(object.chat_id)
-        ? globalThis.String(object.chat_id)
-        : "",
-      body: isSet(object.body) ? globalThis.String(object.body) : "",
+          ? globalThis.String(object.chat_id)
+          : '',
+      body: isSet(object.body) ? globalThis.String(object.body) : '',
     };
   },
 
   toJSON(message: SendMessageRequest): unknown {
     const obj: any = {};
-    if (message.chatId !== "") {
+    if (message.chatId !== '') {
       obj.chatId = message.chatId;
     }
-    if (message.body !== "") {
+    if (message.body !== '') {
       obj.body = message.body;
     }
     return obj;
@@ -981,8 +1003,8 @@ export const SendMessageRequest: MessageFns<SendMessageRequest> = {
   },
   fromPartial<I extends Exact<DeepPartial<SendMessageRequest>, I>>(object: I): SendMessageRequest {
     const message = createBaseSendMessageRequest();
-    message.chatId = object.chatId ?? "";
-    message.body = object.body ?? "";
+    message.chatId = object.chatId ?? '';
+    message.body = object.body ?? '';
     return message;
   },
 };
@@ -1038,22 +1060,25 @@ export const SendMessageResponse: MessageFns<SendMessageResponse> = {
   create<I extends Exact<DeepPartial<SendMessageResponse>, I>>(base?: I): SendMessageResponse {
     return SendMessageResponse.fromPartial(base ?? ({} as any));
   },
-  fromPartial<I extends Exact<DeepPartial<SendMessageResponse>, I>>(object: I): SendMessageResponse {
+  fromPartial<I extends Exact<DeepPartial<SendMessageResponse>, I>>(
+    object: I
+  ): SendMessageResponse {
     const message = createBaseSendMessageResponse();
-    message.message = (object.message !== undefined && object.message !== null)
-      ? Message.fromPartial(object.message)
-      : undefined;
+    message.message =
+      object.message !== undefined && object.message !== null
+        ? Message.fromPartial(object.message)
+        : undefined;
     return message;
   },
 };
 
 function createBaseListMessagesRequest(): ListMessagesRequest {
-  return { chatId: "", cursor: undefined, limit: 0 };
+  return { chatId: '', cursor: undefined, limit: 0 };
 }
 
 export const ListMessagesRequest: MessageFns<ListMessagesRequest> = {
   encode(message: ListMessagesRequest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    if (message.chatId !== "") {
+    if (message.chatId !== '') {
       writer.uint32(10).string(message.chatId);
     }
     if (message.cursor !== undefined) {
@@ -1110,8 +1135,8 @@ export const ListMessagesRequest: MessageFns<ListMessagesRequest> = {
       chatId: isSet(object.chatId)
         ? globalThis.String(object.chatId)
         : isSet(object.chat_id)
-        ? globalThis.String(object.chat_id)
-        : "",
+          ? globalThis.String(object.chat_id)
+          : '',
       cursor: isSet(object.cursor) ? globalThis.String(object.cursor) : undefined,
       limit: isSet(object.limit) ? globalThis.Number(object.limit) : 0,
     };
@@ -1119,7 +1144,7 @@ export const ListMessagesRequest: MessageFns<ListMessagesRequest> = {
 
   toJSON(message: ListMessagesRequest): unknown {
     const obj: any = {};
-    if (message.chatId !== "") {
+    if (message.chatId !== '') {
       obj.chatId = message.chatId;
     }
     if (message.cursor !== undefined) {
@@ -1134,9 +1159,11 @@ export const ListMessagesRequest: MessageFns<ListMessagesRequest> = {
   create<I extends Exact<DeepPartial<ListMessagesRequest>, I>>(base?: I): ListMessagesRequest {
     return ListMessagesRequest.fromPartial(base ?? ({} as any));
   },
-  fromPartial<I extends Exact<DeepPartial<ListMessagesRequest>, I>>(object: I): ListMessagesRequest {
+  fromPartial<I extends Exact<DeepPartial<ListMessagesRequest>, I>>(
+    object: I
+  ): ListMessagesRequest {
     const message = createBaseListMessagesRequest();
-    message.chatId = object.chatId ?? "";
+    message.chatId = object.chatId ?? '';
     message.cursor = object.cursor ?? undefined;
     message.limit = object.limit ?? 0;
     return message;
@@ -1192,19 +1219,21 @@ export const ListMessagesResponse: MessageFns<ListMessagesResponse> = {
 
   fromJSON(object: any): ListMessagesResponse {
     return {
-      messages: globalThis.Array.isArray(object?.messages) ? object.messages.map((e: any) => Message.fromJSON(e)) : [],
+      messages: globalThis.Array.isArray(object?.messages)
+        ? object.messages.map((e: any) => Message.fromJSON(e))
+        : [],
       nextCursor: isSet(object.nextCursor)
         ? globalThis.String(object.nextCursor)
         : isSet(object.next_cursor)
-        ? globalThis.String(object.next_cursor)
-        : undefined,
+          ? globalThis.String(object.next_cursor)
+          : undefined,
     };
   },
 
   toJSON(message: ListMessagesResponse): unknown {
     const obj: any = {};
     if (message.messages?.length) {
-      obj.messages = message.messages.map((e) => Message.toJSON(e));
+      obj.messages = message.messages.map(e => Message.toJSON(e));
     }
     if (message.nextCursor !== undefined) {
       obj.nextCursor = message.nextCursor;
@@ -1215,9 +1244,11 @@ export const ListMessagesResponse: MessageFns<ListMessagesResponse> = {
   create<I extends Exact<DeepPartial<ListMessagesResponse>, I>>(base?: I): ListMessagesResponse {
     return ListMessagesResponse.fromPartial(base ?? ({} as any));
   },
-  fromPartial<I extends Exact<DeepPartial<ListMessagesResponse>, I>>(object: I): ListMessagesResponse {
+  fromPartial<I extends Exact<DeepPartial<ListMessagesResponse>, I>>(
+    object: I
+  ): ListMessagesResponse {
     const message = createBaseListMessagesResponse();
-    message.messages = object.messages?.map((e) => Message.fromPartial(e)) || [];
+    message.messages = object.messages?.map(e => Message.fromPartial(e)) || [];
     message.nextCursor = object.nextCursor ?? undefined;
     return message;
   },
@@ -1288,8 +1319,8 @@ export const ListChatsRequest: MessageFns<ListChatsRequest> = {
       unreadOnly: isSet(object.unreadOnly)
         ? globalThis.Boolean(object.unreadOnly)
         : isSet(object.unread_only)
-        ? globalThis.Boolean(object.unread_only)
-        : false,
+          ? globalThis.Boolean(object.unread_only)
+          : false,
     };
   },
 
@@ -1368,19 +1399,21 @@ export const ListChatsResponse: MessageFns<ListChatsResponse> = {
 
   fromJSON(object: any): ListChatsResponse {
     return {
-      chats: globalThis.Array.isArray(object?.chats) ? object.chats.map((e: any) => Chat.fromJSON(e)) : [],
+      chats: globalThis.Array.isArray(object?.chats)
+        ? object.chats.map((e: any) => Chat.fromJSON(e))
+        : [],
       nextCursor: isSet(object.nextCursor)
         ? globalThis.String(object.nextCursor)
         : isSet(object.next_cursor)
-        ? globalThis.String(object.next_cursor)
-        : undefined,
+          ? globalThis.String(object.next_cursor)
+          : undefined,
     };
   },
 
   toJSON(message: ListChatsResponse): unknown {
     const obj: any = {};
     if (message.chats?.length) {
-      obj.chats = message.chats.map((e) => Chat.toJSON(e));
+      obj.chats = message.chats.map(e => Chat.toJSON(e));
     }
     if (message.nextCursor !== undefined) {
       obj.nextCursor = message.nextCursor;
@@ -1393,22 +1426,22 @@ export const ListChatsResponse: MessageFns<ListChatsResponse> = {
   },
   fromPartial<I extends Exact<DeepPartial<ListChatsResponse>, I>>(object: I): ListChatsResponse {
     const message = createBaseListChatsResponse();
-    message.chats = object.chats?.map((e) => Chat.fromPartial(e)) || [];
+    message.chats = object.chats?.map(e => Chat.fromPartial(e)) || [];
     message.nextCursor = object.nextCursor ?? undefined;
     return message;
   },
 };
 
 function createBaseMarkReadRequest(): MarkReadRequest {
-  return { chatId: "", upToMessageId: "" };
+  return { chatId: '', upToMessageId: '' };
 }
 
 export const MarkReadRequest: MessageFns<MarkReadRequest> = {
   encode(message: MarkReadRequest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    if (message.chatId !== "") {
+    if (message.chatId !== '') {
       writer.uint32(10).string(message.chatId);
     }
-    if (message.upToMessageId !== "") {
+    if (message.upToMessageId !== '') {
       writer.uint32(18).string(message.upToMessageId);
     }
     return writer;
@@ -1451,22 +1484,22 @@ export const MarkReadRequest: MessageFns<MarkReadRequest> = {
       chatId: isSet(object.chatId)
         ? globalThis.String(object.chatId)
         : isSet(object.chat_id)
-        ? globalThis.String(object.chat_id)
-        : "",
+          ? globalThis.String(object.chat_id)
+          : '',
       upToMessageId: isSet(object.upToMessageId)
         ? globalThis.String(object.upToMessageId)
         : isSet(object.up_to_message_id)
-        ? globalThis.String(object.up_to_message_id)
-        : "",
+          ? globalThis.String(object.up_to_message_id)
+          : '',
     };
   },
 
   toJSON(message: MarkReadRequest): unknown {
     const obj: any = {};
-    if (message.chatId !== "") {
+    if (message.chatId !== '') {
       obj.chatId = message.chatId;
     }
-    if (message.upToMessageId !== "") {
+    if (message.upToMessageId !== '') {
       obj.upToMessageId = message.upToMessageId;
     }
     return obj;
@@ -1477,19 +1510,19 @@ export const MarkReadRequest: MessageFns<MarkReadRequest> = {
   },
   fromPartial<I extends Exact<DeepPartial<MarkReadRequest>, I>>(object: I): MarkReadRequest {
     const message = createBaseMarkReadRequest();
-    message.chatId = object.chatId ?? "";
-    message.upToMessageId = object.upToMessageId ?? "";
+    message.chatId = object.chatId ?? '';
+    message.upToMessageId = object.upToMessageId ?? '';
     return message;
   },
 };
 
 function createBaseMarkReadResponse(): MarkReadResponse {
-  return { upToMessageId: "" };
+  return { upToMessageId: '' };
 }
 
 export const MarkReadResponse: MessageFns<MarkReadResponse> = {
   encode(message: MarkReadResponse, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    if (message.upToMessageId !== "") {
+    if (message.upToMessageId !== '') {
       writer.uint32(10).string(message.upToMessageId);
     }
     return writer;
@@ -1524,14 +1557,14 @@ export const MarkReadResponse: MessageFns<MarkReadResponse> = {
       upToMessageId: isSet(object.upToMessageId)
         ? globalThis.String(object.upToMessageId)
         : isSet(object.up_to_message_id)
-        ? globalThis.String(object.up_to_message_id)
-        : "",
+          ? globalThis.String(object.up_to_message_id)
+          : '',
     };
   },
 
   toJSON(message: MarkReadResponse): unknown {
     const obj: any = {};
-    if (message.upToMessageId !== "") {
+    if (message.upToMessageId !== '') {
       obj.upToMessageId = message.upToMessageId;
     }
     return obj;
@@ -1542,21 +1575,21 @@ export const MarkReadResponse: MessageFns<MarkReadResponse> = {
   },
   fromPartial<I extends Exact<DeepPartial<MarkReadResponse>, I>>(object: I): MarkReadResponse {
     const message = createBaseMarkReadResponse();
-    message.upToMessageId = object.upToMessageId ?? "";
+    message.upToMessageId = object.upToMessageId ?? '';
     return message;
   },
 };
 
 function createBaseReactRequest(): ReactRequest {
-  return { messageId: "", emoji: "", remove: false };
+  return { messageId: '', emoji: '', remove: false };
 }
 
 export const ReactRequest: MessageFns<ReactRequest> = {
   encode(message: ReactRequest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    if (message.messageId !== "") {
+    if (message.messageId !== '') {
       writer.uint32(10).string(message.messageId);
     }
-    if (message.emoji !== "") {
+    if (message.emoji !== '') {
       writer.uint32(18).string(message.emoji);
     }
     if (message.remove !== false) {
@@ -1610,19 +1643,19 @@ export const ReactRequest: MessageFns<ReactRequest> = {
       messageId: isSet(object.messageId)
         ? globalThis.String(object.messageId)
         : isSet(object.message_id)
-        ? globalThis.String(object.message_id)
-        : "",
-      emoji: isSet(object.emoji) ? globalThis.String(object.emoji) : "",
+          ? globalThis.String(object.message_id)
+          : '',
+      emoji: isSet(object.emoji) ? globalThis.String(object.emoji) : '',
       remove: isSet(object.remove) ? globalThis.Boolean(object.remove) : false,
     };
   },
 
   toJSON(message: ReactRequest): unknown {
     const obj: any = {};
-    if (message.messageId !== "") {
+    if (message.messageId !== '') {
       obj.messageId = message.messageId;
     }
-    if (message.emoji !== "") {
+    if (message.emoji !== '') {
       obj.emoji = message.emoji;
     }
     if (message.remove !== false) {
@@ -1636,8 +1669,8 @@ export const ReactRequest: MessageFns<ReactRequest> = {
   },
   fromPartial<I extends Exact<DeepPartial<ReactRequest>, I>>(object: I): ReactRequest {
     const message = createBaseReactRequest();
-    message.messageId = object.messageId ?? "";
-    message.emoji = object.emoji ?? "";
+    message.messageId = object.messageId ?? '';
+    message.emoji = object.emoji ?? '';
     message.remove = object.remove ?? false;
     return message;
   },
@@ -1696,20 +1729,21 @@ export const ReactResponse: MessageFns<ReactResponse> = {
   },
   fromPartial<I extends Exact<DeepPartial<ReactResponse>, I>>(object: I): ReactResponse {
     const message = createBaseReactResponse();
-    message.message = (object.message !== undefined && object.message !== null)
-      ? Message.fromPartial(object.message)
-      : undefined;
+    message.message =
+      object.message !== undefined && object.message !== null
+        ? Message.fromPartial(object.message)
+        : undefined;
     return message;
   },
 };
 
 function createBaseSearchChatsRequest(): SearchChatsRequest {
-  return { query: "", page: 0, limit: 0, rescueId: undefined };
+  return { query: '', page: 0, limit: 0, rescueId: undefined };
 }
 
 export const SearchChatsRequest: MessageFns<SearchChatsRequest> = {
   encode(message: SearchChatsRequest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    if (message.query !== "") {
+    if (message.query !== '') {
       writer.uint32(10).string(message.query);
     }
     if (message.page !== 0) {
@@ -1774,20 +1808,20 @@ export const SearchChatsRequest: MessageFns<SearchChatsRequest> = {
 
   fromJSON(object: any): SearchChatsRequest {
     return {
-      query: isSet(object.query) ? globalThis.String(object.query) : "",
+      query: isSet(object.query) ? globalThis.String(object.query) : '',
       page: isSet(object.page) ? globalThis.Number(object.page) : 0,
       limit: isSet(object.limit) ? globalThis.Number(object.limit) : 0,
       rescueId: isSet(object.rescueId)
         ? globalThis.String(object.rescueId)
         : isSet(object.rescue_id)
-        ? globalThis.String(object.rescue_id)
-        : undefined,
+          ? globalThis.String(object.rescue_id)
+          : undefined,
     };
   },
 
   toJSON(message: SearchChatsRequest): unknown {
     const obj: any = {};
-    if (message.query !== "") {
+    if (message.query !== '') {
       obj.query = message.query;
     }
     if (message.page !== 0) {
@@ -1807,7 +1841,7 @@ export const SearchChatsRequest: MessageFns<SearchChatsRequest> = {
   },
   fromPartial<I extends Exact<DeepPartial<SearchChatsRequest>, I>>(object: I): SearchChatsRequest {
     const message = createBaseSearchChatsRequest();
-    message.query = object.query ?? "";
+    message.query = object.query ?? '';
     message.page = object.page ?? 0;
     message.limit = object.limit ?? 0;
     message.rescueId = object.rescueId ?? undefined;
@@ -1885,10 +1919,12 @@ export const SearchChatHit: MessageFns<SearchChatHit> = {
   },
   fromPartial<I extends Exact<DeepPartial<SearchChatHit>, I>>(object: I): SearchChatHit {
     const message = createBaseSearchChatHit();
-    message.chat = (object.chat !== undefined && object.chat !== null) ? Chat.fromPartial(object.chat) : undefined;
-    message.match = (object.match !== undefined && object.match !== null)
-      ? Message.fromPartial(object.match)
-      : undefined;
+    message.chat =
+      object.chat !== undefined && object.chat !== null ? Chat.fromPartial(object.chat) : undefined;
+    message.match =
+      object.match !== undefined && object.match !== null
+        ? Message.fromPartial(object.match)
+        : undefined;
     return message;
   },
 };
@@ -1964,7 +2000,9 @@ export const SearchChatsResponse: MessageFns<SearchChatsResponse> = {
 
   fromJSON(object: any): SearchChatsResponse {
     return {
-      hits: globalThis.Array.isArray(object?.hits) ? object.hits.map((e: any) => SearchChatHit.fromJSON(e)) : [],
+      hits: globalThis.Array.isArray(object?.hits)
+        ? object.hits.map((e: any) => SearchChatHit.fromJSON(e))
+        : [],
       page: isSet(object.page) ? globalThis.Number(object.page) : 0,
       limit: isSet(object.limit) ? globalThis.Number(object.limit) : 0,
       total: isSet(object.total) ? globalThis.Number(object.total) : 0,
@@ -1974,7 +2012,7 @@ export const SearchChatsResponse: MessageFns<SearchChatsResponse> = {
   toJSON(message: SearchChatsResponse): unknown {
     const obj: any = {};
     if (message.hits?.length) {
-      obj.hits = message.hits.map((e) => SearchChatHit.toJSON(e));
+      obj.hits = message.hits.map(e => SearchChatHit.toJSON(e));
     }
     if (message.page !== 0) {
       obj.page = Math.round(message.page);
@@ -1991,9 +2029,11 @@ export const SearchChatsResponse: MessageFns<SearchChatsResponse> = {
   create<I extends Exact<DeepPartial<SearchChatsResponse>, I>>(base?: I): SearchChatsResponse {
     return SearchChatsResponse.fromPartial(base ?? ({} as any));
   },
-  fromPartial<I extends Exact<DeepPartial<SearchChatsResponse>, I>>(object: I): SearchChatsResponse {
+  fromPartial<I extends Exact<DeepPartial<SearchChatsResponse>, I>>(
+    object: I
+  ): SearchChatsResponse {
     const message = createBaseSearchChatsResponse();
-    message.hits = object.hits?.map((e) => SearchChatHit.fromPartial(e)) || [];
+    message.hits = object.hits?.map(e => SearchChatHit.fromPartial(e)) || [];
     message.page = object.page ?? 0;
     message.limit = object.limit ?? 0;
     message.total = object.total ?? 0;
@@ -2002,12 +2042,15 @@ export const SearchChatsResponse: MessageFns<SearchChatsResponse> = {
 };
 
 function createBaseGetChatUnreadCountRequest(): GetChatUnreadCountRequest {
-  return { chatId: "" };
+  return { chatId: '' };
 }
 
 export const GetChatUnreadCountRequest: MessageFns<GetChatUnreadCountRequest> = {
-  encode(message: GetChatUnreadCountRequest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    if (message.chatId !== "") {
+  encode(
+    message: GetChatUnreadCountRequest,
+    writer: BinaryWriter = new BinaryWriter()
+  ): BinaryWriter {
+    if (message.chatId !== '') {
       writer.uint32(10).string(message.chatId);
     }
     return writer;
@@ -2042,25 +2085,29 @@ export const GetChatUnreadCountRequest: MessageFns<GetChatUnreadCountRequest> = 
       chatId: isSet(object.chatId)
         ? globalThis.String(object.chatId)
         : isSet(object.chat_id)
-        ? globalThis.String(object.chat_id)
-        : "",
+          ? globalThis.String(object.chat_id)
+          : '',
     };
   },
 
   toJSON(message: GetChatUnreadCountRequest): unknown {
     const obj: any = {};
-    if (message.chatId !== "") {
+    if (message.chatId !== '') {
       obj.chatId = message.chatId;
     }
     return obj;
   },
 
-  create<I extends Exact<DeepPartial<GetChatUnreadCountRequest>, I>>(base?: I): GetChatUnreadCountRequest {
+  create<I extends Exact<DeepPartial<GetChatUnreadCountRequest>, I>>(
+    base?: I
+  ): GetChatUnreadCountRequest {
     return GetChatUnreadCountRequest.fromPartial(base ?? ({} as any));
   },
-  fromPartial<I extends Exact<DeepPartial<GetChatUnreadCountRequest>, I>>(object: I): GetChatUnreadCountRequest {
+  fromPartial<I extends Exact<DeepPartial<GetChatUnreadCountRequest>, I>>(
+    object: I
+  ): GetChatUnreadCountRequest {
     const message = createBaseGetChatUnreadCountRequest();
-    message.chatId = object.chatId ?? "";
+    message.chatId = object.chatId ?? '';
     return message;
   },
 };
@@ -2070,7 +2117,10 @@ function createBaseGetChatUnreadCountResponse(): GetChatUnreadCountResponse {
 }
 
 export const GetChatUnreadCountResponse: MessageFns<GetChatUnreadCountResponse> = {
-  encode(message: GetChatUnreadCountResponse, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+  encode(
+    message: GetChatUnreadCountResponse,
+    writer: BinaryWriter = new BinaryWriter()
+  ): BinaryWriter {
     if (message.unreadCount !== 0) {
       writer.uint32(8).uint32(message.unreadCount);
     }
@@ -2106,8 +2156,8 @@ export const GetChatUnreadCountResponse: MessageFns<GetChatUnreadCountResponse> 
       unreadCount: isSet(object.unreadCount)
         ? globalThis.Number(object.unreadCount)
         : isSet(object.unread_count)
-        ? globalThis.Number(object.unread_count)
-        : 0,
+          ? globalThis.Number(object.unread_count)
+          : 0,
     };
   },
 
@@ -2119,10 +2169,14 @@ export const GetChatUnreadCountResponse: MessageFns<GetChatUnreadCountResponse> 
     return obj;
   },
 
-  create<I extends Exact<DeepPartial<GetChatUnreadCountResponse>, I>>(base?: I): GetChatUnreadCountResponse {
+  create<I extends Exact<DeepPartial<GetChatUnreadCountResponse>, I>>(
+    base?: I
+  ): GetChatUnreadCountResponse {
     return GetChatUnreadCountResponse.fromPartial(base ?? ({} as any));
   },
-  fromPartial<I extends Exact<DeepPartial<GetChatUnreadCountResponse>, I>>(object: I): GetChatUnreadCountResponse {
+  fromPartial<I extends Exact<DeepPartial<GetChatUnreadCountResponse>, I>>(
+    object: I
+  ): GetChatUnreadCountResponse {
     const message = createBaseGetChatUnreadCountResponse();
     message.unreadCount = object.unreadCount ?? 0;
     return message;
@@ -2130,12 +2184,12 @@ export const GetChatUnreadCountResponse: MessageFns<GetChatUnreadCountResponse> 
 };
 
 function createBaseDeleteMessageRequest(): DeleteMessageRequest {
-  return { messageId: "", reason: undefined };
+  return { messageId: '', reason: undefined };
 }
 
 export const DeleteMessageRequest: MessageFns<DeleteMessageRequest> = {
   encode(message: DeleteMessageRequest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    if (message.messageId !== "") {
+    if (message.messageId !== '') {
       writer.uint32(10).string(message.messageId);
     }
     if (message.reason !== undefined) {
@@ -2181,15 +2235,15 @@ export const DeleteMessageRequest: MessageFns<DeleteMessageRequest> = {
       messageId: isSet(object.messageId)
         ? globalThis.String(object.messageId)
         : isSet(object.message_id)
-        ? globalThis.String(object.message_id)
-        : "",
+          ? globalThis.String(object.message_id)
+          : '',
       reason: isSet(object.reason) ? globalThis.String(object.reason) : undefined,
     };
   },
 
   toJSON(message: DeleteMessageRequest): unknown {
     const obj: any = {};
-    if (message.messageId !== "") {
+    if (message.messageId !== '') {
       obj.messageId = message.messageId;
     }
     if (message.reason !== undefined) {
@@ -2201,9 +2255,11 @@ export const DeleteMessageRequest: MessageFns<DeleteMessageRequest> = {
   create<I extends Exact<DeepPartial<DeleteMessageRequest>, I>>(base?: I): DeleteMessageRequest {
     return DeleteMessageRequest.fromPartial(base ?? ({} as any));
   },
-  fromPartial<I extends Exact<DeepPartial<DeleteMessageRequest>, I>>(object: I): DeleteMessageRequest {
+  fromPartial<I extends Exact<DeepPartial<DeleteMessageRequest>, I>>(
+    object: I
+  ): DeleteMessageRequest {
     const message = createBaseDeleteMessageRequest();
-    message.messageId = object.messageId ?? "";
+    message.messageId = object.messageId ?? '';
     message.reason = object.reason ?? undefined;
     return message;
   },
@@ -2260,22 +2316,25 @@ export const DeleteMessageResponse: MessageFns<DeleteMessageResponse> = {
   create<I extends Exact<DeepPartial<DeleteMessageResponse>, I>>(base?: I): DeleteMessageResponse {
     return DeleteMessageResponse.fromPartial(base ?? ({} as any));
   },
-  fromPartial<I extends Exact<DeepPartial<DeleteMessageResponse>, I>>(object: I): DeleteMessageResponse {
+  fromPartial<I extends Exact<DeepPartial<DeleteMessageResponse>, I>>(
+    object: I
+  ): DeleteMessageResponse {
     const message = createBaseDeleteMessageResponse();
-    message.message = (object.message !== undefined && object.message !== null)
-      ? Message.fromPartial(object.message)
-      : undefined;
+    message.message =
+      object.message !== undefined && object.message !== null
+        ? Message.fromPartial(object.message)
+        : undefined;
     return message;
   },
 };
 
 function createBaseGetChatRequest(): GetChatRequest {
-  return { chatId: "" };
+  return { chatId: '' };
 }
 
 export const GetChatRequest: MessageFns<GetChatRequest> = {
   encode(message: GetChatRequest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    if (message.chatId !== "") {
+    if (message.chatId !== '') {
       writer.uint32(10).string(message.chatId);
     }
     return writer;
@@ -2310,14 +2369,14 @@ export const GetChatRequest: MessageFns<GetChatRequest> = {
       chatId: isSet(object.chatId)
         ? globalThis.String(object.chatId)
         : isSet(object.chat_id)
-        ? globalThis.String(object.chat_id)
-        : "",
+          ? globalThis.String(object.chat_id)
+          : '',
     };
   },
 
   toJSON(message: GetChatRequest): unknown {
     const obj: any = {};
-    if (message.chatId !== "") {
+    if (message.chatId !== '') {
       obj.chatId = message.chatId;
     }
     return obj;
@@ -2328,7 +2387,7 @@ export const GetChatRequest: MessageFns<GetChatRequest> = {
   },
   fromPartial<I extends Exact<DeepPartial<GetChatRequest>, I>>(object: I): GetChatRequest {
     const message = createBaseGetChatRequest();
-    message.chatId = object.chatId ?? "";
+    message.chatId = object.chatId ?? '';
     return message;
   },
 };
@@ -2386,18 +2445,19 @@ export const GetChatResponse: MessageFns<GetChatResponse> = {
   },
   fromPartial<I extends Exact<DeepPartial<GetChatResponse>, I>>(object: I): GetChatResponse {
     const message = createBaseGetChatResponse();
-    message.chat = (object.chat !== undefined && object.chat !== null) ? Chat.fromPartial(object.chat) : undefined;
+    message.chat =
+      object.chat !== undefined && object.chat !== null ? Chat.fromPartial(object.chat) : undefined;
     return message;
   },
 };
 
 function createBaseDeleteChatRequest(): DeleteChatRequest {
-  return { chatId: "", reason: undefined };
+  return { chatId: '', reason: undefined };
 }
 
 export const DeleteChatRequest: MessageFns<DeleteChatRequest> = {
   encode(message: DeleteChatRequest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    if (message.chatId !== "") {
+    if (message.chatId !== '') {
       writer.uint32(10).string(message.chatId);
     }
     if (message.reason !== undefined) {
@@ -2443,15 +2503,15 @@ export const DeleteChatRequest: MessageFns<DeleteChatRequest> = {
       chatId: isSet(object.chatId)
         ? globalThis.String(object.chatId)
         : isSet(object.chat_id)
-        ? globalThis.String(object.chat_id)
-        : "",
+          ? globalThis.String(object.chat_id)
+          : '',
       reason: isSet(object.reason) ? globalThis.String(object.reason) : undefined,
     };
   },
 
   toJSON(message: DeleteChatRequest): unknown {
     const obj: any = {};
-    if (message.chatId !== "") {
+    if (message.chatId !== '') {
       obj.chatId = message.chatId;
     }
     if (message.reason !== undefined) {
@@ -2465,7 +2525,7 @@ export const DeleteChatRequest: MessageFns<DeleteChatRequest> = {
   },
   fromPartial<I extends Exact<DeepPartial<DeleteChatRequest>, I>>(object: I): DeleteChatRequest {
     const message = createBaseDeleteChatRequest();
-    message.chatId = object.chatId ?? "";
+    message.chatId = object.chatId ?? '';
     message.reason = object.reason ?? undefined;
     return message;
   },
@@ -2524,7 +2584,8 @@ export const DeleteChatResponse: MessageFns<DeleteChatResponse> = {
   },
   fromPartial<I extends Exact<DeepPartial<DeleteChatResponse>, I>>(object: I): DeleteChatResponse {
     const message = createBaseDeleteChatResponse();
-    message.chat = (object.chat !== undefined && object.chat !== null) ? Chat.fromPartial(object.chat) : undefined;
+    message.chat =
+      object.chat !== undefined && object.chat !== null ? Chat.fromPartial(object.chat) : undefined;
     return message;
   },
 };
@@ -2553,12 +2614,14 @@ export const ChatServiceService = {
    * existing chat. Publishes chat.created on first creation.
    */
   openChat: {
-    path: "/adopt_dont_shop.chat.v1.ChatService/OpenChat" as const,
+    path: '/adopt_dont_shop.chat.v1.ChatService/OpenChat' as const,
     requestStream: false as const,
     responseStream: false as const,
-    requestSerialize: (value: OpenChatRequest): Buffer => Buffer.from(OpenChatRequest.encode(value).finish()),
+    requestSerialize: (value: OpenChatRequest): Buffer =>
+      Buffer.from(OpenChatRequest.encode(value).finish()),
     requestDeserialize: (value: Buffer): OpenChatRequest => OpenChatRequest.decode(value),
-    responseSerialize: (value: OpenChatResponse): Buffer => Buffer.from(OpenChatResponse.encode(value).finish()),
+    responseSerialize: (value: OpenChatResponse): Buffer =>
+      Buffer.from(OpenChatResponse.encode(value).finish()),
     responseDeserialize: (value: Buffer): OpenChatResponse => OpenChatResponse.decode(value),
   },
   /**
@@ -2567,12 +2630,14 @@ export const ChatServiceService = {
    * fans this to the other participant's open sockets.
    */
   sendMessage: {
-    path: "/adopt_dont_shop.chat.v1.ChatService/SendMessage" as const,
+    path: '/adopt_dont_shop.chat.v1.ChatService/SendMessage' as const,
     requestStream: false as const,
     responseStream: false as const,
-    requestSerialize: (value: SendMessageRequest): Buffer => Buffer.from(SendMessageRequest.encode(value).finish()),
+    requestSerialize: (value: SendMessageRequest): Buffer =>
+      Buffer.from(SendMessageRequest.encode(value).finish()),
     requestDeserialize: (value: Buffer): SendMessageRequest => SendMessageRequest.decode(value),
-    responseSerialize: (value: SendMessageResponse): Buffer => Buffer.from(SendMessageResponse.encode(value).finish()),
+    responseSerialize: (value: SendMessageResponse): Buffer =>
+      Buffer.from(SendMessageResponse.encode(value).finish()),
     responseDeserialize: (value: Buffer): SendMessageResponse => SendMessageResponse.decode(value),
   },
   /**
@@ -2580,26 +2645,30 @@ export const ChatServiceService = {
    * Caller MUST be a participant or super_admin.
    */
   listMessages: {
-    path: "/adopt_dont_shop.chat.v1.ChatService/ListMessages" as const,
+    path: '/adopt_dont_shop.chat.v1.ChatService/ListMessages' as const,
     requestStream: false as const,
     responseStream: false as const,
-    requestSerialize: (value: ListMessagesRequest): Buffer => Buffer.from(ListMessagesRequest.encode(value).finish()),
+    requestSerialize: (value: ListMessagesRequest): Buffer =>
+      Buffer.from(ListMessagesRequest.encode(value).finish()),
     requestDeserialize: (value: Buffer): ListMessagesRequest => ListMessagesRequest.decode(value),
     responseSerialize: (value: ListMessagesResponse): Buffer =>
       Buffer.from(ListMessagesResponse.encode(value).finish()),
-    responseDeserialize: (value: Buffer): ListMessagesResponse => ListMessagesResponse.decode(value),
+    responseDeserialize: (value: Buffer): ListMessagesResponse =>
+      ListMessagesResponse.decode(value),
   },
   /**
    * List the chats the calling principal participates in (the SPA
    * chat picker).
    */
   listChats: {
-    path: "/adopt_dont_shop.chat.v1.ChatService/ListChats" as const,
+    path: '/adopt_dont_shop.chat.v1.ChatService/ListChats' as const,
     requestStream: false as const,
     responseStream: false as const,
-    requestSerialize: (value: ListChatsRequest): Buffer => Buffer.from(ListChatsRequest.encode(value).finish()),
+    requestSerialize: (value: ListChatsRequest): Buffer =>
+      Buffer.from(ListChatsRequest.encode(value).finish()),
     requestDeserialize: (value: Buffer): ListChatsRequest => ListChatsRequest.decode(value),
-    responseSerialize: (value: ListChatsResponse): Buffer => Buffer.from(ListChatsResponse.encode(value).finish()),
+    responseSerialize: (value: ListChatsResponse): Buffer =>
+      Buffer.from(ListChatsResponse.encode(value).finish()),
     responseDeserialize: (value: Buffer): ListChatsResponse => ListChatsResponse.decode(value),
   },
   /**
@@ -2607,12 +2676,14 @@ export const ChatServiceService = {
    * Publishes chat.messageRead.
    */
   markRead: {
-    path: "/adopt_dont_shop.chat.v1.ChatService/MarkRead" as const,
+    path: '/adopt_dont_shop.chat.v1.ChatService/MarkRead' as const,
     requestStream: false as const,
     responseStream: false as const,
-    requestSerialize: (value: MarkReadRequest): Buffer => Buffer.from(MarkReadRequest.encode(value).finish()),
+    requestSerialize: (value: MarkReadRequest): Buffer =>
+      Buffer.from(MarkReadRequest.encode(value).finish()),
     requestDeserialize: (value: Buffer): MarkReadRequest => MarkReadRequest.decode(value),
-    responseSerialize: (value: MarkReadResponse): Buffer => Buffer.from(MarkReadResponse.encode(value).finish()),
+    responseSerialize: (value: MarkReadResponse): Buffer =>
+      Buffer.from(MarkReadResponse.encode(value).finish()),
     responseDeserialize: (value: Buffer): MarkReadResponse => MarkReadResponse.decode(value),
   },
   /**
@@ -2621,12 +2692,14 @@ export const ChatServiceService = {
    * Idempotent. Publishes chat.reactionAdded or chat.reactionRemoved.
    */
   react: {
-    path: "/adopt_dont_shop.chat.v1.ChatService/React" as const,
+    path: '/adopt_dont_shop.chat.v1.ChatService/React' as const,
     requestStream: false as const,
     responseStream: false as const,
-    requestSerialize: (value: ReactRequest): Buffer => Buffer.from(ReactRequest.encode(value).finish()),
+    requestSerialize: (value: ReactRequest): Buffer =>
+      Buffer.from(ReactRequest.encode(value).finish()),
     requestDeserialize: (value: Buffer): ReactRequest => ReactRequest.decode(value),
-    responseSerialize: (value: ReactResponse): Buffer => Buffer.from(ReactResponse.encode(value).finish()),
+    responseSerialize: (value: ReactResponse): Buffer =>
+      Buffer.from(ReactResponse.encode(value).finish()),
     responseDeserialize: (value: Buffer): ReactResponse => ReactResponse.decode(value),
   },
   /**
@@ -2638,12 +2711,14 @@ export const ChatServiceService = {
    * search is a separate admin RPC).
    */
   searchChats: {
-    path: "/adopt_dont_shop.chat.v1.ChatService/SearchChats" as const,
+    path: '/adopt_dont_shop.chat.v1.ChatService/SearchChats' as const,
     requestStream: false as const,
     responseStream: false as const,
-    requestSerialize: (value: SearchChatsRequest): Buffer => Buffer.from(SearchChatsRequest.encode(value).finish()),
+    requestSerialize: (value: SearchChatsRequest): Buffer =>
+      Buffer.from(SearchChatsRequest.encode(value).finish()),
     requestDeserialize: (value: Buffer): SearchChatsRequest => SearchChatsRequest.decode(value),
-    responseSerialize: (value: SearchChatsResponse): Buffer => Buffer.from(SearchChatsResponse.encode(value).finish()),
+    responseSerialize: (value: SearchChatsResponse): Buffer =>
+      Buffer.from(SearchChatsResponse.encode(value).finish()),
     responseDeserialize: (value: Buffer): SearchChatsResponse => SearchChatsResponse.decode(value),
   },
   /**
@@ -2653,15 +2728,17 @@ export const ChatServiceService = {
    * membership (or super_admin).
    */
   getChatUnreadCount: {
-    path: "/adopt_dont_shop.chat.v1.ChatService/GetChatUnreadCount" as const,
+    path: '/adopt_dont_shop.chat.v1.ChatService/GetChatUnreadCount' as const,
     requestStream: false as const,
     responseStream: false as const,
     requestSerialize: (value: GetChatUnreadCountRequest): Buffer =>
       Buffer.from(GetChatUnreadCountRequest.encode(value).finish()),
-    requestDeserialize: (value: Buffer): GetChatUnreadCountRequest => GetChatUnreadCountRequest.decode(value),
+    requestDeserialize: (value: Buffer): GetChatUnreadCountRequest =>
+      GetChatUnreadCountRequest.decode(value),
     responseSerialize: (value: GetChatUnreadCountResponse): Buffer =>
       Buffer.from(GetChatUnreadCountResponse.encode(value).finish()),
-    responseDeserialize: (value: Buffer): GetChatUnreadCountResponse => GetChatUnreadCountResponse.decode(value),
+    responseDeserialize: (value: Buffer): GetChatUnreadCountResponse =>
+      GetChatUnreadCountResponse.decode(value),
   },
   /**
    * Soft-delete a message. Caller MUST be the message's sender OR
@@ -2672,14 +2749,16 @@ export const ChatServiceService = {
    * Publishes chat.messageDeleted.
    */
   deleteMessage: {
-    path: "/adopt_dont_shop.chat.v1.ChatService/DeleteMessage" as const,
+    path: '/adopt_dont_shop.chat.v1.ChatService/DeleteMessage' as const,
     requestStream: false as const,
     responseStream: false as const,
-    requestSerialize: (value: DeleteMessageRequest): Buffer => Buffer.from(DeleteMessageRequest.encode(value).finish()),
+    requestSerialize: (value: DeleteMessageRequest): Buffer =>
+      Buffer.from(DeleteMessageRequest.encode(value).finish()),
     requestDeserialize: (value: Buffer): DeleteMessageRequest => DeleteMessageRequest.decode(value),
     responseSerialize: (value: DeleteMessageResponse): Buffer =>
       Buffer.from(DeleteMessageResponse.encode(value).finish()),
-    responseDeserialize: (value: Buffer): DeleteMessageResponse => DeleteMessageResponse.decode(value),
+    responseDeserialize: (value: Buffer): DeleteMessageResponse =>
+      DeleteMessageResponse.decode(value),
   },
   /**
    * Fetch a chat by id. Returns the canonical Chat row + participant
@@ -2687,12 +2766,14 @@ export const ChatServiceService = {
    * super_admin; non-participants get NOT_FOUND (no enumeration).
    */
   getChat: {
-    path: "/adopt_dont_shop.chat.v1.ChatService/GetChat" as const,
+    path: '/adopt_dont_shop.chat.v1.ChatService/GetChat' as const,
     requestStream: false as const,
     responseStream: false as const,
-    requestSerialize: (value: GetChatRequest): Buffer => Buffer.from(GetChatRequest.encode(value).finish()),
+    requestSerialize: (value: GetChatRequest): Buffer =>
+      Buffer.from(GetChatRequest.encode(value).finish()),
     requestDeserialize: (value: Buffer): GetChatRequest => GetChatRequest.decode(value),
-    responseSerialize: (value: GetChatResponse): Buffer => Buffer.from(GetChatResponse.encode(value).finish()),
+    responseSerialize: (value: GetChatResponse): Buffer =>
+      Buffer.from(GetChatResponse.encode(value).finish()),
     responseDeserialize: (value: Buffer): GetChatResponse => GetChatResponse.decode(value),
   },
   /**
@@ -2702,12 +2783,14 @@ export const ChatServiceService = {
    * with the participant list for WS fan-out.
    */
   deleteChat: {
-    path: "/adopt_dont_shop.chat.v1.ChatService/DeleteChat" as const,
+    path: '/adopt_dont_shop.chat.v1.ChatService/DeleteChat' as const,
     requestStream: false as const,
     responseStream: false as const,
-    requestSerialize: (value: DeleteChatRequest): Buffer => Buffer.from(DeleteChatRequest.encode(value).finish()),
+    requestSerialize: (value: DeleteChatRequest): Buffer =>
+      Buffer.from(DeleteChatRequest.encode(value).finish()),
     requestDeserialize: (value: Buffer): DeleteChatRequest => DeleteChatRequest.decode(value),
-    responseSerialize: (value: DeleteChatResponse): Buffer => Buffer.from(DeleteChatResponse.encode(value).finish()),
+    responseSerialize: (value: DeleteChatResponse): Buffer =>
+      Buffer.from(DeleteChatResponse.encode(value).finish()),
     responseDeserialize: (value: Buffer): DeleteChatResponse => DeleteChatResponse.decode(value),
   },
 } as const;
@@ -2796,18 +2879,18 @@ export interface ChatServiceClient extends Client {
    */
   openChat(
     request: OpenChatRequest,
-    callback: (error: ServiceError | null, response: OpenChatResponse) => void,
+    callback: (error: ServiceError | null, response: OpenChatResponse) => void
   ): ClientUnaryCall;
   openChat(
     request: OpenChatRequest,
     metadata: Metadata,
-    callback: (error: ServiceError | null, response: OpenChatResponse) => void,
+    callback: (error: ServiceError | null, response: OpenChatResponse) => void
   ): ClientUnaryCall;
   openChat(
     request: OpenChatRequest,
     metadata: Metadata,
     options: Partial<CallOptions>,
-    callback: (error: ServiceError | null, response: OpenChatResponse) => void,
+    callback: (error: ServiceError | null, response: OpenChatResponse) => void
   ): ClientUnaryCall;
   /**
    * Send a text message into an existing chat. Publishes
@@ -2816,18 +2899,18 @@ export interface ChatServiceClient extends Client {
    */
   sendMessage(
     request: SendMessageRequest,
-    callback: (error: ServiceError | null, response: SendMessageResponse) => void,
+    callback: (error: ServiceError | null, response: SendMessageResponse) => void
   ): ClientUnaryCall;
   sendMessage(
     request: SendMessageRequest,
     metadata: Metadata,
-    callback: (error: ServiceError | null, response: SendMessageResponse) => void,
+    callback: (error: ServiceError | null, response: SendMessageResponse) => void
   ): ClientUnaryCall;
   sendMessage(
     request: SendMessageRequest,
     metadata: Metadata,
     options: Partial<CallOptions>,
-    callback: (error: ServiceError | null, response: SendMessageResponse) => void,
+    callback: (error: ServiceError | null, response: SendMessageResponse) => void
   ): ClientUnaryCall;
   /**
    * List the recent messages for a chat with keyset pagination.
@@ -2835,18 +2918,18 @@ export interface ChatServiceClient extends Client {
    */
   listMessages(
     request: ListMessagesRequest,
-    callback: (error: ServiceError | null, response: ListMessagesResponse) => void,
+    callback: (error: ServiceError | null, response: ListMessagesResponse) => void
   ): ClientUnaryCall;
   listMessages(
     request: ListMessagesRequest,
     metadata: Metadata,
-    callback: (error: ServiceError | null, response: ListMessagesResponse) => void,
+    callback: (error: ServiceError | null, response: ListMessagesResponse) => void
   ): ClientUnaryCall;
   listMessages(
     request: ListMessagesRequest,
     metadata: Metadata,
     options: Partial<CallOptions>,
-    callback: (error: ServiceError | null, response: ListMessagesResponse) => void,
+    callback: (error: ServiceError | null, response: ListMessagesResponse) => void
   ): ClientUnaryCall;
   /**
    * List the chats the calling principal participates in (the SPA
@@ -2854,18 +2937,18 @@ export interface ChatServiceClient extends Client {
    */
   listChats(
     request: ListChatsRequest,
-    callback: (error: ServiceError | null, response: ListChatsResponse) => void,
+    callback: (error: ServiceError | null, response: ListChatsResponse) => void
   ): ClientUnaryCall;
   listChats(
     request: ListChatsRequest,
     metadata: Metadata,
-    callback: (error: ServiceError | null, response: ListChatsResponse) => void,
+    callback: (error: ServiceError | null, response: ListChatsResponse) => void
   ): ClientUnaryCall;
   listChats(
     request: ListChatsRequest,
     metadata: Metadata,
     options: Partial<CallOptions>,
-    callback: (error: ServiceError | null, response: ListChatsResponse) => void,
+    callback: (error: ServiceError | null, response: ListChatsResponse) => void
   ): ClientUnaryCall;
   /**
    * Mark a message as read by the calling principal. Idempotent.
@@ -2873,18 +2956,18 @@ export interface ChatServiceClient extends Client {
    */
   markRead(
     request: MarkReadRequest,
-    callback: (error: ServiceError | null, response: MarkReadResponse) => void,
+    callback: (error: ServiceError | null, response: MarkReadResponse) => void
   ): ClientUnaryCall;
   markRead(
     request: MarkReadRequest,
     metadata: Metadata,
-    callback: (error: ServiceError | null, response: MarkReadResponse) => void,
+    callback: (error: ServiceError | null, response: MarkReadResponse) => void
   ): ClientUnaryCall;
   markRead(
     request: MarkReadRequest,
     metadata: Metadata,
     options: Partial<CallOptions>,
-    callback: (error: ServiceError | null, response: MarkReadResponse) => void,
+    callback: (error: ServiceError | null, response: MarkReadResponse) => void
   ): ClientUnaryCall;
   /**
    * Add or remove a reaction (emoji) on a message. The presence of
@@ -2893,18 +2976,18 @@ export interface ChatServiceClient extends Client {
    */
   react(
     request: ReactRequest,
-    callback: (error: ServiceError | null, response: ReactResponse) => void,
+    callback: (error: ServiceError | null, response: ReactResponse) => void
   ): ClientUnaryCall;
   react(
     request: ReactRequest,
     metadata: Metadata,
-    callback: (error: ServiceError | null, response: ReactResponse) => void,
+    callback: (error: ServiceError | null, response: ReactResponse) => void
   ): ClientUnaryCall;
   react(
     request: ReactRequest,
     metadata: Metadata,
     options: Partial<CallOptions>,
-    callback: (error: ServiceError | null, response: ReactResponse) => void,
+    callback: (error: ServiceError | null, response: ReactResponse) => void
   ): ClientUnaryCall;
   /**
    * Full-text search across the calling principal's chats. Matches on
@@ -2916,18 +2999,18 @@ export interface ChatServiceClient extends Client {
    */
   searchChats(
     request: SearchChatsRequest,
-    callback: (error: ServiceError | null, response: SearchChatsResponse) => void,
+    callback: (error: ServiceError | null, response: SearchChatsResponse) => void
   ): ClientUnaryCall;
   searchChats(
     request: SearchChatsRequest,
     metadata: Metadata,
-    callback: (error: ServiceError | null, response: SearchChatsResponse) => void,
+    callback: (error: ServiceError | null, response: SearchChatsResponse) => void
   ): ClientUnaryCall;
   searchChats(
     request: SearchChatsRequest,
     metadata: Metadata,
     options: Partial<CallOptions>,
-    callback: (error: ServiceError | null, response: SearchChatsResponse) => void,
+    callback: (error: ServiceError | null, response: SearchChatsResponse) => void
   ): ClientUnaryCall;
   /**
    * Per-chat unread count for the calling principal. Counts messages
@@ -2937,18 +3020,18 @@ export interface ChatServiceClient extends Client {
    */
   getChatUnreadCount(
     request: GetChatUnreadCountRequest,
-    callback: (error: ServiceError | null, response: GetChatUnreadCountResponse) => void,
+    callback: (error: ServiceError | null, response: GetChatUnreadCountResponse) => void
   ): ClientUnaryCall;
   getChatUnreadCount(
     request: GetChatUnreadCountRequest,
     metadata: Metadata,
-    callback: (error: ServiceError | null, response: GetChatUnreadCountResponse) => void,
+    callback: (error: ServiceError | null, response: GetChatUnreadCountResponse) => void
   ): ClientUnaryCall;
   getChatUnreadCount(
     request: GetChatUnreadCountRequest,
     metadata: Metadata,
     options: Partial<CallOptions>,
-    callback: (error: ServiceError | null, response: GetChatUnreadCountResponse) => void,
+    callback: (error: ServiceError | null, response: GetChatUnreadCountResponse) => void
   ): ClientUnaryCall;
   /**
    * Soft-delete a message. Caller MUST be the message's sender OR
@@ -2960,18 +3043,18 @@ export interface ChatServiceClient extends Client {
    */
   deleteMessage(
     request: DeleteMessageRequest,
-    callback: (error: ServiceError | null, response: DeleteMessageResponse) => void,
+    callback: (error: ServiceError | null, response: DeleteMessageResponse) => void
   ): ClientUnaryCall;
   deleteMessage(
     request: DeleteMessageRequest,
     metadata: Metadata,
-    callback: (error: ServiceError | null, response: DeleteMessageResponse) => void,
+    callback: (error: ServiceError | null, response: DeleteMessageResponse) => void
   ): ClientUnaryCall;
   deleteMessage(
     request: DeleteMessageRequest,
     metadata: Metadata,
     options: Partial<CallOptions>,
-    callback: (error: ServiceError | null, response: DeleteMessageResponse) => void,
+    callback: (error: ServiceError | null, response: DeleteMessageResponse) => void
   ): ClientUnaryCall;
   /**
    * Fetch a chat by id. Returns the canonical Chat row + participant
@@ -2980,18 +3063,18 @@ export interface ChatServiceClient extends Client {
    */
   getChat(
     request: GetChatRequest,
-    callback: (error: ServiceError | null, response: GetChatResponse) => void,
+    callback: (error: ServiceError | null, response: GetChatResponse) => void
   ): ClientUnaryCall;
   getChat(
     request: GetChatRequest,
     metadata: Metadata,
-    callback: (error: ServiceError | null, response: GetChatResponse) => void,
+    callback: (error: ServiceError | null, response: GetChatResponse) => void
   ): ClientUnaryCall;
   getChat(
     request: GetChatRequest,
     metadata: Metadata,
     options: Partial<CallOptions>,
-    callback: (error: ServiceError | null, response: GetChatResponse) => void,
+    callback: (error: ServiceError | null, response: GetChatResponse) => void
   ): ClientUnaryCall;
   /**
    * Soft-delete a chat (sets deleted_at). Caller MUST be a participant
@@ -3001,40 +3084,49 @@ export interface ChatServiceClient extends Client {
    */
   deleteChat(
     request: DeleteChatRequest,
-    callback: (error: ServiceError | null, response: DeleteChatResponse) => void,
+    callback: (error: ServiceError | null, response: DeleteChatResponse) => void
   ): ClientUnaryCall;
   deleteChat(
     request: DeleteChatRequest,
     metadata: Metadata,
-    callback: (error: ServiceError | null, response: DeleteChatResponse) => void,
+    callback: (error: ServiceError | null, response: DeleteChatResponse) => void
   ): ClientUnaryCall;
   deleteChat(
     request: DeleteChatRequest,
     metadata: Metadata,
     options: Partial<CallOptions>,
-    callback: (error: ServiceError | null, response: DeleteChatResponse) => void,
+    callback: (error: ServiceError | null, response: DeleteChatResponse) => void
   ): ClientUnaryCall;
 }
 
 export const ChatServiceClient = makeGenericClientConstructor(
   ChatServiceService,
-  "adopt_dont_shop.chat.v1.ChatService",
+  'adopt_dont_shop.chat.v1.ChatService'
 ) as unknown as {
-  new (address: string, credentials: ChannelCredentials, options?: Partial<ClientOptions>): ChatServiceClient;
+  new (
+    address: string,
+    credentials: ChannelCredentials,
+    options?: Partial<ClientOptions>
+  ): ChatServiceClient;
   service: typeof ChatServiceService;
   serviceName: string;
 };
 
 type Builtin = Date | Function | Uint8Array | string | number | boolean | undefined;
 
-export type DeepPartial<T> = T extends Builtin ? T
-  : T extends globalThis.Array<infer U> ? globalThis.Array<DeepPartial<U>>
-  : T extends ReadonlyArray<infer U> ? ReadonlyArray<DeepPartial<U>>
-  : T extends {} ? { [K in keyof T]?: DeepPartial<T[K]> }
-  : Partial<T>;
+export type DeepPartial<T> = T extends Builtin
+  ? T
+  : T extends globalThis.Array<infer U>
+    ? globalThis.Array<DeepPartial<U>>
+    : T extends ReadonlyArray<infer U>
+      ? ReadonlyArray<DeepPartial<U>>
+      : T extends {}
+        ? { [K in keyof T]?: DeepPartial<T[K]> }
+        : Partial<T>;
 
 type KeysOfUnion<T> = T extends T ? keyof T : never;
-export type Exact<P, I extends P> = P extends Builtin ? P
+export type Exact<P, I extends P> = P extends Builtin
+  ? P
   : P & { [K in keyof P]: Exact<P[K], I[K]> } & { [K in Exclude<keyof I, KeysOfUnion<P>>]: never };
 
 function isSet(value: any): boolean {

--- a/packages/proto/src/index.test.ts
+++ b/packages/proto/src/index.test.ts
@@ -561,6 +561,17 @@ describe('@adopt-dont-shop/proto', () => {
       expect(decoded).toEqual(original);
     });
 
+    it('carries rescueId on an OpenChatRequest through the binary wire format', () => {
+      const original = {
+        applicationId: 'app-1',
+        otherUserId: 'usr-2',
+        rescueId: 'rsc-1',
+      };
+      const buf = ChatV1.OpenChatRequest.encode(original).finish();
+      const decoded = ChatV1.OpenChatRequest.decode(buf);
+      expect(decoded.rescueId).toBe('rsc-1');
+    });
+
     it('flat type-only re-exports compile in type position', () => {
       const c: Chat = {
         chatId: 'c-1',

--- a/services/chat/src/grpc/handlers.test.ts
+++ b/services/chat/src/grpc/handlers.test.ts
@@ -187,6 +187,46 @@ describe('openChat', () => {
     expect(mocks.natsMock.publish).toHaveBeenCalledTimes(1);
     expect(mocks.natsMock.publish.mock.calls[0][0]).toBe('chat.created');
   });
+
+  const insertChatParams = (mocks: ReturnType<typeof makeMocks>): unknown[] => {
+    const call = (mocks.clientMock.query.mock.calls as Array<[string, unknown[]]>).find(([sql]) =>
+      sql.includes('INSERT INTO chats')
+    );
+    if (!call) {
+      throw new Error('no INSERT INTO chats call recorded');
+    }
+    return call[1];
+  };
+
+  it('persists the rescueId from the request on the new chat row', async () => {
+    mocks.poolScript.push({ rows: [] });
+    mocks.clientScript.push({
+      rows: [chatRowFixture({ chat_id: 'new-chat', rescue_id: 'rsc-1' })],
+    });
+    mocks.clientScript.push({ rows: [] });
+    mocks.poolScript.push({
+      rows: [{ participant_id: 'usr-adopter' }, { participant_id: 'usr-rescue' }],
+    });
+    mocks.poolScript.push({ rows: [] });
+
+    await openChat(mocks.deps, ADOPTER_PRINCIPAL, { ...BASE_OPEN, rescueId: 'rsc-1' });
+
+    expect(insertChatParams(mocks)).toContain('rsc-1');
+  });
+
+  it('falls back to the null-UUID placeholder when no rescueId is supplied', async () => {
+    mocks.poolScript.push({ rows: [] });
+    mocks.clientScript.push({ rows: [chatRowFixture({ chat_id: 'new-chat' })] });
+    mocks.clientScript.push({ rows: [] });
+    mocks.poolScript.push({
+      rows: [{ participant_id: 'usr-adopter' }, { participant_id: 'usr-rescue' }],
+    });
+    mocks.poolScript.push({ rows: [] });
+
+    await openChat(mocks.deps, ADOPTER_PRINCIPAL, { ...BASE_OPEN, rescueId: '' });
+
+    expect(insertChatParams(mocks)).toContain('00000000-0000-0000-0000-000000000000');
+  });
 });
 
 // --- SendMessage ----------------------------------------------------

--- a/services/chat/src/grpc/handlers.ts
+++ b/services/chat/src/grpc/handlers.ts
@@ -287,22 +287,21 @@ export async function openChat(
   const chatId = randomUUID();
   let inserted: ChatRow | undefined;
   await withTransaction(deps, async ({ client, publish }) => {
-    // rescue_id is required by the schema but we don't have it at this
-    // call. The monolith populates it from the application's rescue_id.
-    // For the gRPC path we accept that it's the caller's responsibility
-    // to either populate via a gateway translation or carry it in a
-    // future RPC field — for now we use a NULL UUID placeholder.
-    //
-    // TODO: route through gateway translator that fetches application
-    // → rescue_id before issuing OpenChat.
+    // rescue_id is required (NOT NULL) by the schema. The gateway resolves
+    // it from the caller's rescue context and threads it on the request so
+    // the chat row records its owning rescue — rescue-scoped chat search
+    // then matches gRPC-created chats. When the caller has no rescue
+    // context (e.g. an adopter), fall back to the NULL-UUID placeholder so
+    // the NOT NULL constraint still holds.
     const placeholderRescue = '00000000-0000-0000-0000-000000000000';
+    const rescueId = req.rescueId || placeholderRescue;
     const inserted0 = await client.query<ChatRow>(
       `
       INSERT INTO chats (chat_id, application_id, rescue_id, created_at, updated_at)
       VALUES ($1, $2, $3, now(), now())
       RETURNING *
       `,
-      [chatId, req.applicationId, placeholderRescue]
+      [chatId, req.applicationId, rescueId]
     );
     inserted = inserted0.rows[0];
 

--- a/services/gateway/src/routes/chat.test.ts
+++ b/services/gateway/src/routes/chat.test.ts
@@ -189,6 +189,30 @@ describe('POST /api/v1/chats — open', () => {
     expect(req.otherUserId).toBe('usr-2');
   });
 
+  it('populates rescueId from the x-rescue-id header', async () => {
+    client.openChatMock.mockResolvedValueOnce({ chat: CHAT_FIXTURE, created: true });
+    await app.inject({
+      method: 'POST',
+      url: '/api/v1/chats',
+      headers: { 'x-user-id': 'usr-1', 'x-user-roles': 'rescue_staff', 'x-rescue-id': 'rsc-1' },
+      payload: { applicationId: 'app-1', otherUserId: 'usr-2' },
+    });
+    const [req] = client.openChatMock.mock.calls[0] as [OpenChatRequest, Metadata];
+    expect(req.rescueId).toBe('rsc-1');
+  });
+
+  it('sends an empty rescueId when no x-rescue-id header is present', async () => {
+    client.openChatMock.mockResolvedValueOnce({ chat: CHAT_FIXTURE, created: true });
+    await app.inject({
+      method: 'POST',
+      url: '/api/v1/chats',
+      headers: { 'x-user-id': 'usr-1', 'x-user-roles': 'adopter' },
+      payload: { applicationId: 'app-1', otherUserId: 'usr-2' },
+    });
+    const [req] = client.openChatMock.mock.calls[0] as [OpenChatRequest, Metadata];
+    expect(req.rescueId).toBe('');
+  });
+
   it('maps gRPC PERMISSION_DENIED to HTTP 403', async () => {
     client.openChatMock.mockRejectedValueOnce({
       code: status.PERMISSION_DENIED,

--- a/services/gateway/src/routes/chat.ts
+++ b/services/gateway/src/routes/chat.ts
@@ -107,9 +107,15 @@ const registerChatRoutesForPrefix = (
       application_id?: string;
       other_user_id?: string;
     };
+    // rescueId is sourced from the principal's rescue context (the
+    // x-rescue-id header stamped by the authenticate middleware), not the
+    // request body — so the chat row records its owning rescue instead of
+    // the chat service's null-UUID placeholder.
+    const rescueIdHeader = req.headers['x-rescue-id'];
     const grpcReq: OpenChatRequest = {
       applicationId: body.applicationId ?? body.application_id ?? '',
       otherUserId: body.otherUserId ?? body.other_user_id ?? '',
+      rescueId: typeof rescueIdHeader === 'string' ? rescueIdHeader : '',
     };
 
     try {


### PR DESCRIPTION
## Problem

When a chat is opened over gRPC, the chat service had no way to receive the `rescueId` the chat logically belongs to. `openChat` inserted a null-UUID `rescue_id` placeholder, so rescue-scoped chat search (`SearchChats` with a `rescueId` filter) never matched gRPC-created chats. This is follow-up PR **B** from the pass-2 services code-quality review handoff.

> **Note:** This is a re-targeted version of #1040, which merged into the `claude/services-code-quality-review-pass-2` integration branch rather than `main`. This PR cherry-picks the same commit onto `main` so the change lands independently with full CI. Verified the change is **not already present in `main`** (`OpenChatRequest` on `main` has only fields 1–2) before opening.

## Change

- **`packages/proto`** — added `rescue_id` (field number **3**) to the `OpenChatRequest` message and regenerated the committed ts-proto output via `buf generate` (generated file committed, not hand-edited). Added an `OpenChatRequest` wire round-trip test proving `rescueId` survives encode/decode.
- **`services/gateway`** — the `POST /api/v1/chats` (and `/conversations`) handler now populates `rescueId` from the `x-rescue-id` header that the authenticate middleware stamps from the caller's rescue context. Tests for the populated and absent-header cases.
- **`services/chat`** — `openChat` now persists `req.rescueId` on the new chat row, falling back to the null-UUID placeholder when the caller has no rescue context (e.g. an adopter) so the `NOT NULL` constraint still holds. Tests prove the rescueId is recorded on INSERT and that the fallback applies.

## Migration

**None needed.** The `chats` table already has a `NOT NULL` `rescue_id` column (chat migration `001_create_chats.ts`) — this PR only stops writing the placeholder when a real rescueId is available.

## Known scope limit

`rescueId` is sourced from the gateway's `x-rescue-id` principal header. An adopter opening a chat with no rescue context still falls back to the placeholder; fully closing that gap for adopter-initiated chats would require the gateway to resolve the application's rescue, which is out of scope here.

## Verification

```
pnpm exec turbo lint type-check test \
  --filter=@adopt-dont-shop/proto \
  --filter=@adopt-dont-shop/service.gateway \
  --filter=@adopt-dont-shop/service.chat
```

Result: **18/18 tasks pass**. Additionally ran `turbo type-check --filter='./services/*'` → **20/20 pass**, confirming the shared proto change breaks no other consuming service.

https://claude.ai/code/session_014EbfJyKja1PmRfjcZWokaH

---
_Generated by [Claude Code](https://claude.ai/code/session_014EbfJyKja1PmRfjcZWokaH)_