### PR TITLE
feat(notifications): dedupe at-least-once events to stop duplicate notifications

### DIFF
--- a/services/notifications/src/grpc/handlers.test.ts
+++ b/services/notifications/src/grpc/handlers.test.ts
@@ -423,6 +423,73 @@ describe('dismissNotification', () => {
 
 // --- HandlerError ----------------------------------------------------
 
+describe('createNotification idempotency (dedup)', () => {
+  let mocks: ReturnType<typeof makeMocks>;
+
+  beforeEach(() => {
+    mocks = makeMocks();
+  });
+
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  // SQL-aware mock: the dedup claim hits processed_events; the row insert
+  // hits notifications.notifications. Order is recorded so we can assert the
+  // claim happens before the insert, inside the one transaction.
+  const wireClient = (claimRowCount: number, calls: string[]): void => {
+    mocks.clientMock.query.mockImplementation(async (sql: string) => {
+      if (sql.includes('processed_events')) {
+        calls.push('CLAIM');
+        return { rowCount: claimRowCount, rows: [] };
+      }
+      if (sql.trim().startsWith('INSERT')) {
+        calls.push('INSERT');
+        return { rows: [rowFixture()] };
+      }
+      calls.push(sql.trim().split(/\s+/)[0]);
+      return { rows: [] };
+    });
+    mocks.natsMock.publish.mockImplementation(() => {
+      calls.push('PUBLISH');
+    });
+  };
+
+  it('claims the event before inserting, then inserts + publishes on first delivery', async () => {
+    const calls: string[] = [];
+    wireClient(1, calls);
+
+    const res = await createNotification(mocks.deps, SYSTEM_PRINCIPAL, BASE_CREATE_REQ, {
+      dedup: { consumer: 'applications.approved', eventId: 'app-1' },
+    });
+
+    expect(calls).toEqual(['BEGIN', 'CLAIM', 'INSERT', 'COMMIT', 'PUBLISH']);
+    expect(res.notification?.notificationId).toBe('n-1');
+  });
+
+  it('skips the insert + publish on a redelivery (claim loses the ON CONFLICT race)', async () => {
+    const calls: string[] = [];
+    wireClient(0, calls);
+
+    const res = await createNotification(mocks.deps, SYSTEM_PRINCIPAL, BASE_CREATE_REQ, {
+      dedup: { consumer: 'applications.approved', eventId: 'app-1' },
+    });
+
+    expect(calls).toEqual(['BEGIN', 'CLAIM', 'COMMIT']);
+    expect(res.notification).toBeUndefined();
+    expect(mocks.natsMock.publish).not.toHaveBeenCalled();
+  });
+
+  it('does not claim anything when no dedup option is supplied (direct gRPC path)', async () => {
+    const calls: string[] = [];
+    wireClient(1, calls);
+
+    await createNotification(mocks.deps, SYSTEM_PRINCIPAL, BASE_CREATE_REQ);
+
+    expect(calls).toEqual(['BEGIN', 'INSERT', 'COMMIT', 'PUBLISH']);
+  });
+});
+
 describe('HandlerError', () => {
   it('carries the code field for downstream gRPC status mapping', () => {
     const err = new HandlerError('NOT_FOUND', 'gone');

--- a/services/notifications/src/grpc/handlers.ts
+++ b/services/notifications/src/grpc/handlers.ts
@@ -36,6 +36,8 @@ import {
   type Notification,
 } from '@adopt-dont-shop/proto';
 
+import { claimEvent } from '../processed-events.js';
+
 import {
   channelFromDb,
   channelToDb,
@@ -157,10 +159,20 @@ const NOTIFICATIONS_CREATE: Permission = 'notifications.create' as Permission;
 const NOTIFICATIONS_READ: Permission = 'notifications.read' as Permission;
 const NOTIFICATIONS_UPDATE: Permission = 'notifications.update' as Permission;
 
+// Subscriber-path idempotency. When set, the create claims (consumer,
+// eventId) in processed_events inside the same transaction as the insert,
+// so a redelivered upstream event is a no-op (returns `{ notification:
+// undefined }`). Direct gRPC callers omit it and keep the original
+// always-insert behaviour.
+export type CreateNotificationOptions = {
+  dedup?: { consumer: string; eventId: string };
+};
+
 export async function createNotification(
   deps: HandlerDeps,
   principal: Principal,
-  req: CreateNotificationRequest
+  req: CreateNotificationRequest,
+  opts?: CreateNotificationOptions
 ): Promise<CreateNotificationResponse> {
   // Input validation — INVALID_ARGUMENT for caller bugs.
   if (!req.userId) {
@@ -196,8 +208,20 @@ export async function createNotification(
       : req.priority;
 
   let inserted: NotificationRow | undefined;
+  let skipped = false;
 
   await withTransaction(deps, async ({ client, publish }) => {
+    // Idempotency claim FIRST — atomic with the insert below. A redelivered
+    // event loses the ON CONFLICT race, so we skip the insert + publish and
+    // the whole transaction is a no-op.
+    if (opts?.dedup) {
+      const claimed = await claimEvent(client, opts.dedup.consumer, opts.dedup.eventId);
+      if (!claimed) {
+        skipped = true;
+        return;
+      }
+    }
+
     const result = await client.query<NotificationRow>(
       `
       INSERT INTO notifications.notifications (
@@ -255,6 +279,12 @@ export async function createNotification(
       },
     });
   });
+
+  // Redelivery — the event was already processed, so there is no new row.
+  // Subscribers ignore the return value; this just makes the skip explicit.
+  if (skipped) {
+    return { notification: undefined };
+  }
 
   // `inserted` is guaranteed populated by the RETURNING clause —
   // withTransaction would have thrown if the query failed.

--- a/services/notifications/src/migrations/008_create_processed_events.ts
+++ b/services/notifications/src/migrations/008_create_processed_events.ts
@@ -1,0 +1,34 @@
+import type { MigrationBuilder } from 'node-pg-migrate';
+
+// Inbound-event idempotency ledger.
+//
+// `subscribe()` (@adopt-dont-shop/events) is at-least-once: a redelivered
+// JetStream message (replica restart, nak after a transient handler
+// failure, ack timeout) re-runs the handler. The canonical create handler
+// mints a fresh notification_id per call, so without a dedup ledger one
+// upstream event becomes N duplicate notification rows (and N pushes).
+// The subscriber path claims against this table inside the SAME
+// transaction as the notification insert, so a redelivery is a clean
+// no-op.
+//
+// Key is (consumer, event_id), NOT event_id alone: the applications
+// service publishes every lifecycle event for an application under the
+// SAME envelope id (the application id), so applications.approved and
+// applications.adopted for one application would collide on event_id.
+// The `consumer` column (the subject / durable consumer that handled the
+// event) keeps distinct subscribers — and distinct subjects — apart.
+
+export const up = async (pgm: MigrationBuilder): Promise<void> => {
+  pgm.createTable('processed_events', {
+    consumer: { type: 'text', notNull: true },
+    event_id: { type: 'text', notNull: true },
+    processed_at: { type: 'timestamptz', notNull: true, default: pgm.func('now()') },
+  });
+  pgm.addConstraint('processed_events', 'processed_events_pkey', {
+    primaryKey: ['consumer', 'event_id'],
+  });
+};
+
+export const down = async (pgm: MigrationBuilder): Promise<void> => {
+  pgm.dropTable('processed_events');
+};

--- a/services/notifications/src/migrations/migrations.test.ts
+++ b/services/notifications/src/migrations/migrations.test.ts
@@ -49,6 +49,8 @@ describe('notifications migrations', () => {
     '004_create_email_queue.ts',
     '005_create_email_templates.ts',
     '006_create_email_preferences.ts',
+    '007_email_queue_stale_sending_idx.ts',
+    '008_create_processed_events.ts',
   ])('%s exports `up` and `down` functions', async filename => {
     const mod = (await import(`./${filename}`)) as {
       up: unknown;

--- a/services/notifications/src/nats/subscribers.test.ts
+++ b/services/notifications/src/nats/subscribers.test.ts
@@ -1,8 +1,10 @@
 import type { NatsConnection } from 'nats';
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { UserId } from '@adopt-dont-shop/lib.types';
 import { NotificationsV1 } from '@adopt-dont-shop/proto';
+
+import { createNotification } from '../grpc/handlers.js';
 
 import {
   buildApplicationAdoptedCreate,
@@ -16,6 +18,15 @@ import {
   buildChatMessageReceivedCreate,
   registerSubscribers,
 } from './subscribers.js';
+
+// createNotification is mocked so the wiring tests can assert exactly what
+// dedup options each subscriber threads through, without standing up a DB.
+// The translation + registration tests below never deliver a message, so
+// the real handler is never needed there.
+vi.mock('../grpc/handlers.js', async importOriginal => {
+  const actual = await importOriginal<typeof import('../grpc/handlers.js')>();
+  return { ...actual, createNotification: vi.fn(async () => ({ notification: undefined })) };
+});
 
 // --- Translation tests (pure functions) ----------------------------
 
@@ -345,5 +356,156 @@ describe('registerSubscribers', () => {
     for (const cfg of consumersAdded) {
       expect(cfg.durable_name).toMatch(/^notifications-workers-/);
     }
+  });
+});
+
+describe('registerSubscribers idempotency wiring', () => {
+  const mockedCreate = vi.mocked(createNotification);
+
+  const deps = {
+    pool: {},
+    nats: {} as NatsConnection,
+  } as unknown as Parameters<typeof registerSubscribers>[0]['deps'];
+
+  const logger = {
+    info: () => undefined,
+    error: () => undefined,
+    warn: () => undefined,
+    debug: () => undefined,
+    silly: () => undefined,
+  } as unknown as Parameters<typeof registerSubscribers>[0]['logger'];
+
+  const flush = async (): Promise<void> => {
+    for (let i = 0; i < 20; i++) {
+      await new Promise(r => setImmediate(r));
+    }
+  };
+
+  type DeliveredMessage = { id?: string; payload: unknown };
+
+  // A NATS stub whose durable consumers replay the supplied messages for
+  // their subject, so a single event can be driven through the real
+  // subscribe() loop and we can observe what reaches createNotification.
+  function makeYieldingNats(messagesBySubject: Record<string, DeliveredMessage[]>): NatsConnection {
+    const durableToSubject = new Map<string, string>();
+    const encoder = new TextEncoder();
+    const jsm = {
+      consumers: {
+        add: vi.fn(
+          async (_stream: string, cfg: { durable_name?: string; filter_subject?: string }) => {
+            if (cfg.durable_name && cfg.filter_subject) {
+              durableToSubject.set(cfg.durable_name, cfg.filter_subject);
+            }
+            return cfg;
+          }
+        ),
+      },
+    };
+    const js = {
+      consumers: {
+        get: vi.fn(async (_stream: string, durable: string) => ({
+          consume: vi.fn(async () => {
+            const subject = durableToSubject.get(durable) ?? '';
+            const msgs = (messagesBySubject[subject] ?? []).map(m => ({
+              subject,
+              data: encoder.encode(
+                JSON.stringify({ id: m.id, occurredAt: '2026-06-01T10:00:00Z', payload: m.payload })
+              ),
+              ack: vi.fn(),
+              nak: vi.fn(),
+              term: vi.fn(),
+            }));
+            return {
+              async *[Symbol.asyncIterator]() {
+                for (const m of msgs) {
+                  yield m;
+                }
+              },
+              close: vi.fn(),
+            };
+          }),
+        })),
+      },
+    };
+    return {
+      jetstreamManager: vi.fn(async () => jsm),
+      jetstream: vi.fn(() => js),
+    } as unknown as NatsConnection;
+  }
+
+  beforeEach(() => {
+    mockedCreate.mockClear();
+  });
+
+  it('threads the subject + envelope id into the dedup claim for a single-recipient event', async () => {
+    const nats = makeYieldingNats({
+      'applications.approved': [
+        {
+          id: 'app-1',
+          payload: {
+            applicationId: 'app-1',
+            adopterId: 'usr-a',
+            petId: 'pet-1',
+            rescueId: 'res-1',
+            approvedAt: '2026-06-02T10:00:00Z',
+          },
+        },
+      ],
+    });
+
+    registerSubscribers({ nats, deps, logger });
+    await flush();
+
+    expect(mockedCreate).toHaveBeenCalledTimes(1);
+    expect(mockedCreate.mock.calls[0][3]).toEqual({
+      dedup: { consumer: 'applications.approved', eventId: 'app-1' },
+    });
+  });
+
+  it('keys the chat fan-out dedup per recipient so siblings are not suppressed', async () => {
+    const nats = makeYieldingNats({
+      'chat.messageCreated': [
+        {
+          id: 'msg-1',
+          payload: {
+            messageId: 'msg-1',
+            chatId: 'chat-1',
+            senderUserId: 'usr-sender',
+            body: 'hi',
+            participantUserIds: ['usr-sender', 'usr-r1', 'usr-r2'],
+          },
+        },
+      ],
+    });
+
+    registerSubscribers({ nats, deps, logger });
+    await flush();
+
+    expect(mockedCreate.mock.calls.map(c => c[3]?.dedup)).toEqual([
+      { consumer: 'chat.messageCreated', eventId: 'msg-1:usr-r1' },
+      { consumer: 'chat.messageCreated', eventId: 'msg-1:usr-r2' },
+    ]);
+  });
+
+  it('falls back to no dedup when the publisher omits the envelope id', async () => {
+    const nats = makeYieldingNats({
+      'applications.submitted': [
+        {
+          payload: {
+            applicationId: 'app-2',
+            adopterId: 'usr-a',
+            petId: 'pet-1',
+            rescueId: 'res-1',
+            submittedAt: '2026-06-01T10:00:00Z',
+          },
+        },
+      ],
+    });
+
+    registerSubscribers({ nats, deps, logger });
+    await flush();
+
+    expect(mockedCreate).toHaveBeenCalledTimes(1);
+    expect(mockedCreate.mock.calls[0][3]).toBeUndefined();
   });
 });

--- a/services/notifications/src/nats/subscribers.ts
+++ b/services/notifications/src/nats/subscribers.ts
@@ -67,6 +67,18 @@ const DURABLE_PREFIX = 'notifications-workers';
 
 const durableFor = (subject: string): string => `${DURABLE_PREFIX}-${subject.replace(/\./g, '-')}`;
 
+// Build the dedup options for a delivered event. `meta.id` is the
+// publisher's envelope id; the subject scopes the claim so lifecycle
+// events that reuse an aggregate id (applications.* publish every state
+// under the application id) don't collide. When a publisher omits the id
+// we cannot dedupe — fall back to always-create rather than silently
+// dropping a notification.
+const dedupFor = (
+  subject: string,
+  meta: { id?: string }
+): { dedup: { consumer: string; eventId: string } } | undefined =>
+  meta.id ? { dedup: { consumer: subject, eventId: meta.id } } : undefined;
+
 export const registerSubscribers = (opts: RegisterSubscribersOptions): SubscriptionHandle[] => {
   const { nats, deps, logger } = opts;
 
@@ -83,8 +95,13 @@ export const registerSubscribers = (opts: RegisterSubscribersOptions): Subscript
     subscribe<ApplicationSubmittedEvent>(
       nats,
       { subject: 'applications.submitted', durable: durableFor('applications.submitted'), onError },
-      async payload => {
-        await createNotification(deps, SYSTEM_PRINCIPAL, buildApplicationSubmittedCreate(payload));
+      async (payload, meta) => {
+        await createNotification(
+          deps,
+          SYSTEM_PRINCIPAL,
+          buildApplicationSubmittedCreate(payload),
+          dedupFor('applications.submitted', meta)
+        );
       }
     )
   );
@@ -93,8 +110,13 @@ export const registerSubscribers = (opts: RegisterSubscribersOptions): Subscript
     subscribe<ApplicationApprovedEvent>(
       nats,
       { subject: 'applications.approved', durable: durableFor('applications.approved'), onError },
-      async payload => {
-        await createNotification(deps, SYSTEM_PRINCIPAL, buildApplicationApprovedCreate(payload));
+      async (payload, meta) => {
+        await createNotification(
+          deps,
+          SYSTEM_PRINCIPAL,
+          buildApplicationApprovedCreate(payload),
+          dedupFor('applications.approved', meta)
+        );
       }
     )
   );
@@ -103,8 +125,13 @@ export const registerSubscribers = (opts: RegisterSubscribersOptions): Subscript
     subscribe<ApplicationRejectedEvent>(
       nats,
       { subject: 'applications.rejected', durable: durableFor('applications.rejected'), onError },
-      async payload => {
-        await createNotification(deps, SYSTEM_PRINCIPAL, buildApplicationRejectedCreate(payload));
+      async (payload, meta) => {
+        await createNotification(
+          deps,
+          SYSTEM_PRINCIPAL,
+          buildApplicationRejectedCreate(payload),
+          dedupFor('applications.rejected', meta)
+        );
       }
     )
   );
@@ -117,11 +144,12 @@ export const registerSubscribers = (opts: RegisterSubscribersOptions): Subscript
         durable: durableFor('applications.homeVisitScheduled'),
         onError,
       },
-      async payload => {
+      async (payload, meta) => {
         await createNotification(
           deps,
           SYSTEM_PRINCIPAL,
-          buildApplicationHomeVisitScheduledCreate(payload)
+          buildApplicationHomeVisitScheduledCreate(payload),
+          dedupFor('applications.homeVisitScheduled', meta)
         );
       }
     )
@@ -135,11 +163,12 @@ export const registerSubscribers = (opts: RegisterSubscribersOptions): Subscript
         durable: durableFor('applications.homeVisitCompleted'),
         onError,
       },
-      async payload => {
+      async (payload, meta) => {
         await createNotification(
           deps,
           SYSTEM_PRINCIPAL,
-          buildApplicationHomeVisitCompletedCreate(payload)
+          buildApplicationHomeVisitCompletedCreate(payload),
+          dedupFor('applications.homeVisitCompleted', meta)
         );
       }
     )
@@ -149,8 +178,13 @@ export const registerSubscribers = (opts: RegisterSubscribersOptions): Subscript
     subscribe<ApplicationAdoptedEvent>(
       nats,
       { subject: 'applications.adopted', durable: durableFor('applications.adopted'), onError },
-      async payload => {
-        await createNotification(deps, SYSTEM_PRINCIPAL, buildApplicationAdoptedCreate(payload));
+      async (payload, meta) => {
+        await createNotification(
+          deps,
+          SYSTEM_PRINCIPAL,
+          buildApplicationAdoptedCreate(payload),
+          dedupFor('applications.adopted', meta)
+        );
       }
     )
   );
@@ -159,8 +193,13 @@ export const registerSubscribers = (opts: RegisterSubscribersOptions): Subscript
     subscribe<AuthUserLoggedInEvent>(
       nats,
       { subject: 'auth.userLoggedIn', durable: durableFor('auth.userLoggedIn'), onError },
-      async payload => {
-        await createNotification(deps, SYSTEM_PRINCIPAL, buildAuthUserLoggedInCreate(payload));
+      async (payload, meta) => {
+        await createNotification(
+          deps,
+          SYSTEM_PRINCIPAL,
+          buildAuthUserLoggedInCreate(payload),
+          dedupFor('auth.userLoggedIn', meta)
+        );
       }
     )
   );
@@ -169,8 +208,13 @@ export const registerSubscribers = (opts: RegisterSubscribersOptions): Subscript
     subscribe<AuthRoleAssignedEvent>(
       nats,
       { subject: 'auth.roleAssigned', durable: durableFor('auth.roleAssigned'), onError },
-      async payload => {
-        await createNotification(deps, SYSTEM_PRINCIPAL, buildAuthRoleAssignedCreate(payload));
+      async (payload, meta) => {
+        await createNotification(
+          deps,
+          SYSTEM_PRINCIPAL,
+          buildAuthRoleAssignedCreate(payload),
+          dedupFor('auth.roleAssigned', meta)
+        );
       }
     )
   );
@@ -266,17 +310,24 @@ export const registerSubscribers = (opts: RegisterSubscribersOptions): Subscript
     subscribe<ChatMessageCreatedEvent>(
       nats,
       { subject: 'chat.messageCreated', durable: durableFor('chat.messageCreated'), onError },
-      async payload => {
+      async (payload, meta) => {
         const recipients = payload.participantUserIds.filter(id => id !== payload.senderUserId);
         // Each recipient gets one in-app notification. Errors from a
         // single recipient must not abort the others (CAD lesson #4 —
         // poison-pill subscribers); wrap each in its own try/catch.
         for (const userId of recipients) {
           try {
+            // One event fans out to N rows, so the dedup key includes the
+            // recipient — otherwise the first recipient's claim would
+            // suppress everyone else's notification.
+            const dedup = meta.id
+              ? { dedup: { consumer: 'chat.messageCreated', eventId: `${meta.id}:${userId}` } }
+              : undefined;
             await createNotification(
               deps,
               SYSTEM_PRINCIPAL,
-              buildChatMessageReceivedCreate(payload, userId)
+              buildChatMessageReceivedCreate(payload, userId),
+              dedup
             );
           } catch (err) {
             logger.warn('chat.messageCreated notification create failed', {

--- a/services/notifications/src/processed-events.test.ts
+++ b/services/notifications/src/processed-events.test.ts
@@ -1,0 +1,41 @@
+import type { Pool } from 'pg';
+import { describe, expect, it, vi } from 'vitest';
+
+import { claimEvent } from './processed-events.js';
+
+const makeConn = (rowCount: number) => {
+  const query = vi.fn().mockResolvedValue({ rowCount, rows: [] });
+  return { conn: { query } as unknown as Pool, query };
+};
+
+describe('claimEvent', () => {
+  it('returns true the first time an event is claimed (one row inserted)', async () => {
+    const { conn, query } = makeConn(1);
+
+    const claimed = await claimEvent(conn, 'applications.approved', 'app-1');
+
+    expect(claimed).toBe(true);
+    expect(query).toHaveBeenCalledWith(expect.stringContaining('processed_events'), [
+      'applications.approved',
+      'app-1',
+    ]);
+  });
+
+  it('returns false on a redelivery (ON CONFLICT inserts nothing)', async () => {
+    const { conn } = makeConn(0);
+
+    const claimed = await claimEvent(conn, 'applications.approved', 'app-1');
+
+    expect(claimed).toBe(false);
+  });
+
+  it('keys on (consumer, event_id) so the same id under different subjects both claim', async () => {
+    const { conn, query } = makeConn(1);
+
+    await claimEvent(conn, 'applications.approved', 'app-1');
+    await claimEvent(conn, 'applications.adopted', 'app-1');
+
+    expect(query.mock.calls[0][1]).toEqual(['applications.approved', 'app-1']);
+    expect(query.mock.calls[1][1]).toEqual(['applications.adopted', 'app-1']);
+  });
+});

--- a/services/notifications/src/processed-events.ts
+++ b/services/notifications/src/processed-events.ts
@@ -1,0 +1,33 @@
+// Inbound-event idempotency claim against `notifications.processed_events`.
+//
+// `subscribe()` delivers at-least-once, so every subscriber that turns an
+// upstream event into a durable side-effect (a notification row, a push
+// fan-out) must dedupe on the event id. `claimEvent` is that primitive:
+// it inserts a (consumer, event_id) row and reports whether THIS call won
+// the race. A redelivery hits the ON CONFLICT and returns false, so the
+// caller skips the work it already did.
+//
+// Pass a PoolClient when the claim must be atomic with the work (the
+// create handler claims inside the same transaction as the insert, so a
+// rolled-back handler also un-claims the event). Pass a Pool for
+// best-effort dedup where there is no DB write to be atomic with (the
+// push worker — a missed push on a mid-flight crash is acceptable, a
+// duplicate push is the thing we are suppressing).
+
+import type { Pool, PoolClient } from 'pg';
+
+export type DedupConn = Pool | PoolClient;
+
+export const claimEvent = async (
+  conn: DedupConn,
+  consumer: string,
+  eventId: string
+): Promise<boolean> => {
+  const res = await conn.query(
+    `INSERT INTO notifications.processed_events (consumer, event_id)
+     VALUES ($1, $2)
+     ON CONFLICT (consumer, event_id) DO NOTHING`,
+    [consumer, eventId]
+  );
+  return res.rowCount === 1;
+};

--- a/services/notifications/src/push/worker.test.ts
+++ b/services/notifications/src/push/worker.test.ts
@@ -1,0 +1,133 @@
+import type { NatsConnection } from 'nats';
+import type { Pool } from 'pg';
+import { describe, expect, it, vi } from 'vitest';
+
+import { startPushWorker } from './worker.js';
+
+import type { PushProvider } from './types.js';
+
+// --- Harness --------------------------------------------------------
+
+type DeliveredMessage = { id?: string; payload: unknown };
+
+const flush = async (): Promise<void> => {
+  for (let i = 0; i < 20; i++) {
+    await new Promise(r => setImmediate(r));
+  }
+};
+
+const makePool = (claimRowCount: number) => {
+  const query = vi.fn(async (sql: string) => {
+    if (sql.includes('processed_events')) {
+      return { rowCount: claimRowCount, rows: [] };
+    }
+    if (sql.includes('device_tokens')) {
+      return { rows: [{ token_id: 't1', device_token: 'tok-1', platform: 'ios' }] };
+    }
+    return { rows: [] };
+  });
+  return { query, asPool: { query } as unknown as Pool };
+};
+
+const makeProvider = () => {
+  const send = vi.fn(async () => ({ success: true, messageId: 'm1' }));
+  return { provider: { send, getName: () => 'console' } as unknown as PushProvider, send };
+};
+
+const logger = {
+  info: () => undefined,
+  warn: () => undefined,
+  error: () => undefined,
+} as unknown as Parameters<typeof startPushWorker>[0]['logger'];
+
+function makeNats(messages: DeliveredMessage[]): NatsConnection {
+  const encoder = new TextEncoder();
+  const jsm = {
+    consumers: { add: vi.fn(async (_s: string, cfg: unknown) => cfg) },
+  };
+  const js = {
+    consumers: {
+      get: vi.fn(async () => ({
+        consume: vi.fn(async () => ({
+          async *[Symbol.asyncIterator]() {
+            for (const m of messages) {
+              yield {
+                subject: 'notifications.created',
+                data: encoder.encode(
+                  JSON.stringify({
+                    id: m.id,
+                    occurredAt: '2026-06-01T10:00:00Z',
+                    payload: m.payload,
+                  })
+                ),
+                ack: vi.fn(),
+                nak: vi.fn(),
+                term: vi.fn(),
+              };
+            }
+          },
+          close: vi.fn(),
+        })),
+      })),
+    },
+  };
+  return {
+    jetstreamManager: vi.fn(async () => jsm),
+    jetstream: vi.fn(() => js),
+  } as unknown as NatsConnection;
+}
+
+const pushEvent = (overrides: Record<string, unknown> = {}) => ({
+  notificationId: 'n-1',
+  userId: 'usr-1',
+  type: 'message_received',
+  channel: 'push',
+  title: 'New message',
+  message: 'hi',
+  dataJson: '{}',
+  ...overrides,
+});
+
+// --- Tests ----------------------------------------------------------
+
+describe('push worker dedup', () => {
+  it('claims the event then fans out to device tokens on first delivery', async () => {
+    const { asPool, query } = makePool(1);
+    const { provider, send } = makeProvider();
+    const nats = makeNats([{ id: 'notifications.created.n-1', payload: pushEvent() }]);
+
+    startPushWorker({ pool: asPool, nats, provider, logger });
+    await flush();
+
+    expect(query.mock.calls[0][0]).toContain('processed_events');
+    expect(send).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not fan out on a redelivery (claim loses the ON CONFLICT race)', async () => {
+    const { asPool, query } = makePool(0);
+    const { provider, send } = makeProvider();
+    const nats = makeNats([{ id: 'notifications.created.n-1', payload: pushEvent() }]);
+
+    startPushWorker({ pool: asPool, nats, provider, logger });
+    await flush();
+
+    expect(query.mock.calls[0][0]).toContain('processed_events');
+    // Claim failed → never reaches the device-token lookup or provider send.
+    expect(query.mock.calls.some(c => String(c[0]).includes('device_tokens'))).toBe(false);
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it('ignores non-push notifications without claiming the event', async () => {
+    const { asPool, query } = makePool(1);
+    const { provider, send } = makeProvider();
+    const nats = makeNats([
+      { id: 'notifications.created.n-2', payload: pushEvent({ channel: 'in_app' }) },
+    ]);
+
+    startPushWorker({ pool: asPool, nats, provider, logger });
+    await flush();
+
+    expect(query).not.toHaveBeenCalled();
+    expect(send).not.toHaveBeenCalled();
+  });
+});

--- a/services/notifications/src/push/worker.ts
+++ b/services/notifications/src/push/worker.ts
@@ -14,6 +14,8 @@ import type { Logger } from 'winston';
 
 import { subscribe } from '@adopt-dont-shop/events';
 
+import { claimEvent } from '../processed-events.js';
+
 import { listDeviceTokensForUser, markDeviceTokenInvalid } from './device-tokens.js';
 import type { PushProvider, PushSendRequest } from './types.js';
 
@@ -90,7 +92,7 @@ export const startPushWorker = (opts: PushWorkerOptions): RunningPushWorker => {
         opts.logger.error('push.worker.subscriber_error', { err });
       },
     },
-    async ev => {
+    async (ev, meta) => {
       // Channel filter — only push-channel notifications fan out here.
       // The createNotification handler publishes the lowercase Postgres
       // value ('in_app' / 'email' / 'push' / 'sms'), not the proto enum.
@@ -99,6 +101,17 @@ export const startPushWorker = (opts: PushWorkerOptions): RunningPushWorker => {
       }
       if (!ev.userId) {
         return;
+      }
+
+      // Dedup BEFORE fanning out — subscribe() is at-least-once, so a
+      // redelivered notifications.created must not send the push twice.
+      // Best-effort (claim on the pool, not in a transaction): a missed
+      // push from a mid-flight crash is acceptable; a duplicate is not.
+      if (meta.id) {
+        const firstDelivery = await claimEvent(opts.pool, DURABLE, meta.id);
+        if (!firstDelivery) {
+          return;
+        }
       }
 
       const tokens = await listDeviceTokensForUser(opts.pool, ev.userId, false);


### PR DESCRIPTION
## P1 — Event dedup (stack 1/5)

First of five stacked PRs improving `service.notifications`. **Base: `main`.** The rest stack on top of this branch in order P1 → P3 → P2 → P4 → P5.

### Problem
`subscribe()` (`@adopt-dont-shop/events`) delivers **at-least-once** — its own contract says *"handlers are expected to be idempotent on the event id"* — but the notifications handlers were not. The canonical create handler mints a fresh `notification_id` per call and the push worker re-fires on every `notifications.created`, so a redelivered JetStream message (replica restart, `nak` after a transient failure, ack timeout) produced **duplicate notification rows and duplicate pushes**.

### Change
- New migration `008_create_processed_events` — an idempotency ledger keyed on **`(consumer, event_id)`**.
- `createNotification` takes an optional `dedup` and claims `(consumer, event_id)` **atomically inside the same transaction** as the insert (`ON CONFLICT DO NOTHING`); a redelivery is a clean no-op returning `{ notification: undefined }`. Direct gRPC callers are unchanged.
- The NATS subscribers thread `meta.id` + subject into the claim; the chat fan-out keys **per recipient** (`<eventId>:<userId>`) so one event still notifies every participant.
- The push worker claims before fanning out (best-effort, on the pool — a missed push from a mid-flight crash is acceptable; a duplicate is the thing we suppress).

### Why `(consumer, event_id)` not `event_id`
The applications service publishes **every** lifecycle event for an application under the same envelope id (the application id), so `applications.approved` and `applications.adopted` collide on `event_id`. Scoping the claim by subject keeps them distinct.

### Tests
- `claimEvent`: first-claim vs redelivery, and same-id-different-subject both claim.
- `createNotification`: claims-before-insert on first delivery; skips insert + publish on redelivery; no claim on the direct gRPC path.
- Subscriber wiring: subject + envelope id flow into the dedup key; chat keys per recipient; no-id fallback to always-create.
- New push worker test (the worker had none): claim-then-fan-out, redelivery skips, non-push ignored without claiming.

`vitest run` (223 passed), `type-check`, and `lint` (0 errors) all green for the service.

https://claude.ai/code/session_01LAJXPr3DARnLgzBdTTjYKr

---
_Generated by [Claude Code](https://claude.ai/code/session_01LAJXPr3DARnLgzBdTTjYKr)_