### PR TITLE
feat(notifications): enforce user notification preferences on push delivery

### DIFF
--- a/services/notifications/src/preferences-gate.test.ts
+++ b/services/notifications/src/preferences-gate.test.ts
@@ -1,0 +1,164 @@
+import type { Pool } from 'pg';
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  DEFAULT_PREFS,
+  inQuietHours,
+  loadNotificationPrefs,
+  shouldDeliver,
+  type NotificationPrefs,
+} from './preferences-gate.js';
+
+const prefs = (overrides: Partial<NotificationPrefs> = {}): NotificationPrefs => ({
+  ...DEFAULT_PREFS,
+  ...overrides,
+});
+
+describe('shouldDeliver', () => {
+  const now = new Date('2026-06-15T12:00:00Z');
+
+  it('always allows the in-app record regardless of channel/category prefs', () => {
+    const muted = prefs({ pushEnabled: false, chatMessages: false, applicationUpdates: false });
+    expect(shouldDeliver(muted, { type: 'message_received', channel: 'in_app', now })).toBe(true);
+  });
+
+  it('allows push when the channel and category are both enabled', () => {
+    expect(shouldDeliver(prefs(), { type: 'application_status', channel: 'push', now })).toBe(true);
+  });
+
+  it('suppresses push when push is disabled', () => {
+    expect(
+      shouldDeliver(prefs({ pushEnabled: false }), {
+        type: 'application_status',
+        channel: 'push',
+        now,
+      })
+    ).toBe(false);
+  });
+
+  it('suppresses push when the matching category is muted', () => {
+    expect(
+      shouldDeliver(prefs({ chatMessages: false }), {
+        type: 'message_received',
+        channel: 'push',
+        now,
+      })
+    ).toBe(false);
+  });
+
+  it('gates email on email_enabled, independent of push', () => {
+    const p = prefs({ emailEnabled: false, pushEnabled: true });
+    expect(shouldDeliver(p, { type: 'application_status', channel: 'email', now })).toBe(false);
+  });
+
+  it('gates sms on sms_enabled (off by default)', () => {
+    expect(shouldDeliver(prefs(), { type: 'application_status', channel: 'sms', now })).toBe(false);
+    expect(
+      shouldDeliver(prefs({ smsEnabled: true }), {
+        type: 'application_status',
+        channel: 'sms',
+        now,
+      })
+    ).toBe(true);
+  });
+
+  it('never category-mutes account_security, but still respects the channel toggle', () => {
+    // Category bypass: a security alert is not governed by any category flag.
+    expect(shouldDeliver(prefs(), { type: 'account_security', channel: 'push', now })).toBe(true);
+    // Channel toggle still applies — push off means no push, even for security.
+    expect(
+      shouldDeliver(prefs({ pushEnabled: false }), {
+        type: 'account_security',
+        channel: 'push',
+        now,
+      })
+    ).toBe(false);
+  });
+
+  it('suppresses push during quiet hours but not other channels', () => {
+    const p = prefs({ quietHoursStart: '22:00:00', quietHoursEnd: '07:00:00', timezone: 'UTC' });
+    const night = new Date('2026-06-15T23:30:00Z');
+    expect(shouldDeliver(p, { type: 'application_status', channel: 'push', now: night })).toBe(
+      false
+    );
+    // Email is not quiet-hours gated.
+    expect(shouldDeliver(p, { type: 'application_status', channel: 'email', now: night })).toBe(
+      true
+    );
+  });
+});
+
+describe('inQuietHours', () => {
+  it('returns false when no window is configured', () => {
+    expect(inQuietHours(prefs(), new Date('2026-06-15T23:30:00Z'))).toBe(false);
+  });
+
+  it('handles a window that wraps midnight (22:00 → 07:00)', () => {
+    const p = prefs({ quietHoursStart: '22:00:00', quietHoursEnd: '07:00:00', timezone: 'UTC' });
+    expect(inQuietHours(p, new Date('2026-06-15T23:30:00Z'))).toBe(true); // late night
+    expect(inQuietHours(p, new Date('2026-06-15T05:00:00Z'))).toBe(true); // early morning
+    expect(inQuietHours(p, new Date('2026-06-15T12:00:00Z'))).toBe(false); // midday
+  });
+
+  it('handles a same-day window (09:00 → 17:00)', () => {
+    const p = prefs({ quietHoursStart: '09:00:00', quietHoursEnd: '17:00:00', timezone: 'UTC' });
+    expect(inQuietHours(p, new Date('2026-06-15T12:00:00Z'))).toBe(true);
+    expect(inQuietHours(p, new Date('2026-06-15T20:00:00Z'))).toBe(false);
+  });
+
+  it('evaluates the window in the user timezone, not UTC', () => {
+    // 23:30 UTC is 19:30 in New York — outside a 22:00→07:00 NY window.
+    const p = prefs({
+      quietHoursStart: '22:00:00',
+      quietHoursEnd: '07:00:00',
+      timezone: 'America/New_York',
+    });
+    expect(inQuietHours(p, new Date('2026-06-15T23:30:00Z'))).toBe(false);
+    // 03:30 UTC is 23:30 the previous day in NY — inside the window.
+    expect(inQuietHours(p, new Date('2026-06-15T03:30:00Z'))).toBe(true);
+  });
+});
+
+describe('loadNotificationPrefs', () => {
+  it('maps a stored row to camelCase prefs', async () => {
+    const query = vi.fn().mockResolvedValue({
+      rows: [
+        {
+          email_enabled: false,
+          push_enabled: true,
+          sms_enabled: true,
+          application_updates: false,
+          pet_matches: true,
+          rescue_updates: true,
+          chat_messages: false,
+          quiet_hours_start: '22:00:00',
+          quiet_hours_end: '07:00:00',
+          timezone: 'Europe/London',
+        },
+      ],
+    });
+    const pool = { query } as unknown as Pool;
+
+    const result = await loadNotificationPrefs(pool, 'usr-1');
+
+    expect(result).toEqual({
+      emailEnabled: false,
+      pushEnabled: true,
+      smsEnabled: true,
+      applicationUpdates: false,
+      petMatches: true,
+      rescueUpdates: true,
+      chatMessages: false,
+      quietHoursStart: '22:00:00',
+      quietHoursEnd: '07:00:00',
+      timezone: 'Europe/London',
+    });
+  });
+
+  it('returns permissive defaults when the user has no prefs row', async () => {
+    const query = vi.fn().mockResolvedValue({ rows: [] });
+    const pool = { query } as unknown as Pool;
+
+    expect(await loadNotificationPrefs(pool, 'usr-new')).toEqual(DEFAULT_PREFS);
+  });
+});

--- a/services/notifications/src/preferences-gate.ts
+++ b/services/notifications/src/preferences-gate.ts
@@ -1,0 +1,180 @@
+// Preference gate for OUTBOUND delivery channels.
+//
+// The in-app notification row is the user's durable record and is always
+// written (createNotification). These preferences govern the INTERRUPTIVE
+// channels — push now, email once the email channel adapter lands — so a
+// user who disabled push, muted a category, or set quiet hours stops
+// getting those channels WITHOUT losing their in-app history. Stored prefs
+// (user_notification_prefs) were previously editable but never consulted
+// at dispatch; this is the consult point.
+
+import type { Pool } from 'pg';
+
+export type DeliveryChannel = 'in_app' | 'email' | 'push' | 'sms';
+
+export type NotificationPrefs = {
+  emailEnabled: boolean;
+  pushEnabled: boolean;
+  smsEnabled: boolean;
+  applicationUpdates: boolean;
+  petMatches: boolean;
+  rescueUpdates: boolean;
+  chatMessages: boolean;
+  quietHoursStart: string | null;
+  quietHoursEnd: string | null;
+  timezone: string;
+};
+
+// Permissive defaults — mirror the user_notification_prefs column defaults.
+// Used when a user has no prefs row yet (the row is created lazily by the
+// prefs RPCs, so a brand-new user has none).
+export const DEFAULT_PREFS: NotificationPrefs = {
+  emailEnabled: true,
+  pushEnabled: true,
+  smsEnabled: false,
+  applicationUpdates: true,
+  petMatches: true,
+  rescueUpdates: true,
+  chatMessages: true,
+  quietHoursStart: null,
+  quietHoursEnd: null,
+  timezone: 'UTC',
+};
+
+type PrefsRow = {
+  email_enabled: boolean;
+  push_enabled: boolean;
+  sms_enabled: boolean;
+  application_updates: boolean;
+  pet_matches: boolean;
+  rescue_updates: boolean;
+  chat_messages: boolean;
+  quiet_hours_start: string | null;
+  quiet_hours_end: string | null;
+  timezone: string;
+};
+
+export const loadNotificationPrefs = async (
+  pool: Pool,
+  userId: string
+): Promise<NotificationPrefs> => {
+  const res = await pool.query<PrefsRow>(
+    `SELECT email_enabled, push_enabled, sms_enabled,
+            application_updates, pet_matches, rescue_updates, chat_messages,
+            quiet_hours_start, quiet_hours_end, timezone
+     FROM notifications.user_notification_prefs
+     WHERE user_id = $1`,
+    [userId]
+  );
+  const row = res.rows[0];
+  if (!row) {
+    return DEFAULT_PREFS;
+  }
+  return {
+    emailEnabled: row.email_enabled,
+    pushEnabled: row.push_enabled,
+    smsEnabled: row.sms_enabled,
+    applicationUpdates: row.application_updates,
+    petMatches: row.pet_matches,
+    rescueUpdates: row.rescue_updates,
+    chatMessages: row.chat_messages,
+    quietHoursStart: row.quiet_hours_start,
+    quietHoursEnd: row.quiet_hours_end,
+    timezone: row.timezone,
+  };
+};
+
+// Map a notification type (the lowercase Postgres enum value) to the
+// category toggle that governs it. Types with no category (account
+// security, system announcements, reminders, marketing) are never
+// category-muted — account_security in particular must always reach the
+// user.
+const categoryEnabled = (prefs: NotificationPrefs, type: string): boolean => {
+  switch (type) {
+    case 'application_status':
+    case 'adoption_approved':
+    case 'adoption_rejected':
+    case 'home_visit_scheduled':
+    case 'interview_scheduled':
+    case 'reference_request':
+    case 'follow_up':
+      return prefs.applicationUpdates;
+    case 'pet_available':
+    case 'pet_update':
+      return prefs.petMatches;
+    case 'rescue_invitation':
+    case 'staff_assignment':
+      return prefs.rescueUpdates;
+    case 'message_received':
+      return prefs.chatMessages;
+    default:
+      return true;
+  }
+};
+
+const channelEnabled = (prefs: NotificationPrefs, channel: DeliveryChannel): boolean => {
+  switch (channel) {
+    case 'email':
+      return prefs.emailEnabled;
+    case 'push':
+      return prefs.pushEnabled;
+    case 'sms':
+      return prefs.smsEnabled;
+    case 'in_app':
+      return true;
+  }
+};
+
+const toMinutes = (hhmmss: string): number => {
+  const [h, m] = hhmmss.split(':');
+  return Number(h) * 60 + Number(m);
+};
+
+const minutesOfDayInTz = (now: Date, timezone: string): number => {
+  const parts = new Intl.DateTimeFormat('en-GB', {
+    timeZone: timezone,
+    hourCycle: 'h23',
+    hour: '2-digit',
+    minute: '2-digit',
+  }).formatToParts(now);
+  const hour = Number(parts.find(p => p.type === 'hour')?.value ?? '0');
+  const minute = Number(parts.find(p => p.type === 'minute')?.value ?? '0');
+  return hour * 60 + minute;
+};
+
+// Quiet hours apply only to interruptive channels (push). A window that
+// wraps midnight (start > end, e.g. 22:00 → 07:00) is handled.
+export const inQuietHours = (prefs: NotificationPrefs, now: Date): boolean => {
+  if (!prefs.quietHoursStart || !prefs.quietHoursEnd) {
+    return false;
+  }
+  const start = toMinutes(prefs.quietHoursStart);
+  const end = toMinutes(prefs.quietHoursEnd);
+  if (start === end) {
+    return false;
+  }
+  const current = minutesOfDayInTz(now, prefs.timezone || 'UTC');
+  return start < end ? current >= start && current < end : current >= start || current < end;
+};
+
+export type DeliveryDecision = { type: string; channel: DeliveryChannel; now: Date };
+
+// Whether to deliver a notification of `type` on `channel` to a user with
+// these prefs at `now`. in_app is always allowed (the durable record);
+// push/email/sms require the channel enabled AND the category un-muted, and
+// push additionally respects quiet hours.
+export const shouldDeliver = (prefs: NotificationPrefs, args: DeliveryDecision): boolean => {
+  if (args.channel === 'in_app') {
+    return true;
+  }
+  if (!channelEnabled(prefs, args.channel)) {
+    return false;
+  }
+  if (!categoryEnabled(prefs, args.type)) {
+    return false;
+  }
+  if (args.channel === 'push' && inQuietHours(prefs, args.now)) {
+    return false;
+  }
+  return true;
+};

--- a/services/notifications/src/push/worker.test.ts
+++ b/services/notifications/src/push/worker.test.ts
@@ -16,10 +16,13 @@ const flush = async (): Promise<void> => {
   }
 };
 
-const makePool = (claimRowCount: number) => {
+const makePool = (opts: { claimRowCount?: number; prefs?: Record<string, unknown> } = {}) => {
   const query = vi.fn(async (sql: string) => {
+    if (sql.includes('user_notification_prefs')) {
+      return { rows: opts.prefs ? [opts.prefs] : [] };
+    }
     if (sql.includes('processed_events')) {
-      return { rowCount: claimRowCount, rows: [] };
+      return { rowCount: opts.claimRowCount ?? 1, rows: [] };
     }
     if (sql.includes('device_tokens')) {
       return { rows: [{ token_id: 't1', device_token: 'tok-1', platform: 'ios' }] };
@@ -28,6 +31,9 @@ const makePool = (claimRowCount: number) => {
   });
   return { query, asPool: { query } as unknown as Pool };
 };
+
+const includesSql = (query: ReturnType<typeof vi.fn>, fragment: string): boolean =>
+  query.mock.calls.some(c => String(c[0]).includes(fragment));
 
 const makeProvider = () => {
   const send = vi.fn(async () => ({ success: true, messageId: 'm1' }));
@@ -92,33 +98,60 @@ const pushEvent = (overrides: Record<string, unknown> = {}) => ({
 
 describe('push worker dedup', () => {
   it('claims the event then fans out to device tokens on first delivery', async () => {
-    const { asPool, query } = makePool(1);
+    const { asPool, query } = makePool({ claimRowCount: 1 });
     const { provider, send } = makeProvider();
     const nats = makeNats([{ id: 'notifications.created.n-1', payload: pushEvent() }]);
 
     startPushWorker({ pool: asPool, nats, provider, logger });
     await flush();
 
-    expect(query.mock.calls[0][0]).toContain('processed_events');
+    expect(includesSql(query, 'processed_events')).toBe(true);
+    expect(includesSql(query, 'device_tokens')).toBe(true);
     expect(send).toHaveBeenCalledTimes(1);
   });
 
   it('does not fan out on a redelivery (claim loses the ON CONFLICT race)', async () => {
-    const { asPool, query } = makePool(0);
+    const { asPool, query } = makePool({ claimRowCount: 0 });
     const { provider, send } = makeProvider();
     const nats = makeNats([{ id: 'notifications.created.n-1', payload: pushEvent() }]);
 
     startPushWorker({ pool: asPool, nats, provider, logger });
     await flush();
 
-    expect(query.mock.calls[0][0]).toContain('processed_events');
+    expect(includesSql(query, 'processed_events')).toBe(true);
     // Claim failed → never reaches the device-token lookup or provider send.
-    expect(query.mock.calls.some(c => String(c[0]).includes('device_tokens'))).toBe(false);
+    expect(includesSql(query, 'device_tokens')).toBe(false);
     expect(send).not.toHaveBeenCalled();
   });
 
-  it('ignores non-push notifications without claiming the event', async () => {
-    const { asPool, query } = makePool(1);
+  it('suppresses the push (and does not claim) when push is disabled in prefs', async () => {
+    const { asPool, query } = makePool({
+      prefs: {
+        email_enabled: true,
+        push_enabled: false,
+        sms_enabled: false,
+        application_updates: true,
+        pet_matches: true,
+        rescue_updates: true,
+        chat_messages: true,
+        quiet_hours_start: null,
+        quiet_hours_end: null,
+        timezone: 'UTC',
+      },
+    });
+    const { provider, send } = makeProvider();
+    const nats = makeNats([{ id: 'notifications.created.n-1', payload: pushEvent() }]);
+
+    startPushWorker({ pool: asPool, nats, provider, logger });
+    await flush();
+
+    expect(includesSql(query, 'user_notification_prefs')).toBe(true);
+    expect(includesSql(query, 'processed_events')).toBe(false);
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it('ignores non-push notifications without loading prefs or claiming', async () => {
+    const { asPool, query } = makePool({ claimRowCount: 1 });
     const { provider, send } = makeProvider();
     const nats = makeNats([
       { id: 'notifications.created.n-2', payload: pushEvent({ channel: 'in_app' }) },

--- a/services/notifications/src/push/worker.ts
+++ b/services/notifications/src/push/worker.ts
@@ -14,6 +14,7 @@ import type { Logger } from 'winston';
 
 import { subscribe } from '@adopt-dont-shop/events';
 
+import { loadNotificationPrefs, shouldDeliver } from '../preferences-gate.js';
 import { claimEvent } from '../processed-events.js';
 
 import { listDeviceTokensForUser, markDeviceTokenInvalid } from './device-tokens.js';
@@ -100,6 +101,20 @@ export const startPushWorker = (opts: PushWorkerOptions): RunningPushWorker => {
         return;
       }
       if (!ev.userId) {
+        return;
+      }
+
+      // Preference gate — respect push_enabled, the category toggle, and
+      // quiet hours. A suppressed push leaves the in-app record intact;
+      // checked before the dedup claim so a redelivery re-evaluates to the
+      // same outcome rather than being silently swallowed.
+      const prefs = await loadNotificationPrefs(opts.pool, ev.userId);
+      if (!shouldDeliver(prefs, { type: ev.type, channel: 'push', now: new Date() })) {
+        opts.logger.info('push.worker.suppressed_by_prefs', {
+          userId: ev.userId,
+          notificationId: ev.notificationId,
+          type: ev.type,
+        });
         return;
       }
 


### PR DESCRIPTION
## P3 — Preference gate (stack 2/5)

Second of five stacked PRs. **Base: `claude/notif-p1-event-dedup` (#1047)** — review/merge that first. Diff here is P3 only.

### Problem
`user_notification_prefs` stores per-channel (`push_enabled`), per-category (`application_updates`, `pet_matches`, `rescue_updates`, `chat_messages`), and quiet-hours settings, all editable via the prefs RPCs — but **nothing consulted them at dispatch**. Only the email worker checked `email_enabled`. A user who disabled push or muted a category still got pushed.

### Change
- New `preferences-gate.ts`:
  - `loadNotificationPrefs(pool, userId)` — reads the row, returns permissive defaults when none exists.
  - `shouldDeliver(prefs, { type, channel, now })` — channel-enabled + category + quiet-hours gating.
  - `inQuietHours(prefs, now)` — wraps midnight, evaluated in the user's timezone (via `Intl`).
- Consulted in the **push worker** before fan-out (and before the dedup claim, so a redelivery re-evaluates to the same outcome).

### Design decisions
- **The in-app durable record is never gated.** Preferences govern *outbound interruptive channels* (push now, email in the next PR); the in-app inbox is always the user's record. This avoids the surprising "I muted push and lost my notification history" behaviour.
- **`account_security` bypasses category muting** (a security alert isn't governed by a category toggle) but still respects the channel toggle.
- **Quiet hours apply to push only** and **drop** rather than defer (the in-app record persists; deferral/scheduling is a possible future enhancement).
- The gate is deliberately reusable — the **email channel adapter (next PR, P2)** consults the same `shouldDeliver`.

### Tests
`shouldDeliver` (in-app always, push/email/sms channel gating, category mute, security bypass, quiet-hours), `inQuietHours` (no window / same-day / midnight-wrap / timezone), `loadNotificationPrefs` (row mapping + defaults), and push-worker suppression. `vitest` (238 passed), `type-check`, `lint` (0 errors) green.

> Note: the `Dependency Audit` check fails on this branch (and on `main`) due to a pre-existing transitive `ws` advisory via `apps/admin > socket.io-client`; unrelated to this change.

https://claude.ai/code/session_01LAJXPr3DARnLgzBdTTjYKr

---
_Generated by [Claude Code](https://claude.ai/code/session_01LAJXPr3DARnLgzBdTTjYKr)_