### PR TITLE
feat(notifications): add email channel adapter for transactional emails

### DIFF
--- a/services/notifications/src/config.ts
+++ b/services/notifications/src/config.ts
@@ -43,6 +43,14 @@ export type NotificationsConfig = {
   // Toggle the email queue worker. Defaults to true. Tests + the
   // migrations-only smoke set this to false to keep the loop quiet.
   emailWorkerEnabled: boolean;
+  // Toggle the email CHANNEL adapter — the notifications.created subscriber
+  // that enqueues transactional emails. Distinct from emailWorkerEnabled
+  // (which drains the queue). Defaults to true, but only starts when an
+  // auth client is configured (it needs AdminGetUser to resolve addresses).
+  emailChannelEnabled: boolean;
+  // From-address for adapter-generated transactional emails.
+  defaultFromEmail: string;
+  defaultFromName: string;
   // Push provider selection — Phase 7.2. Same ADS-549 rule: production
   // refuses 'console' so an unconfigured push channel surfaces at boot.
   pushProvider: PushProviderConfig;
@@ -84,6 +92,9 @@ export const loadConfig = (env: NodeJS.ProcessEnv = process.env): NotificationsC
     natsUrl: env.NATS_URL?.trim() || DEFAULT_NATS_URL,
     emailProvider: loadEmailProviderConfig(env),
     emailWorkerEnabled: env.EMAIL_WORKER_ENABLED?.trim() !== 'false',
+    emailChannelEnabled: env.EMAIL_CHANNEL_ENABLED?.trim() !== 'false',
+    defaultFromEmail: env.DEFAULT_FROM_EMAIL?.trim() || 'noreply@adoptdontshop.com',
+    defaultFromName: env.DEFAULT_FROM_NAME?.trim() || "Adopt Don't Shop",
     pushProvider: loadPushProviderConfig(env),
     pushWorkerEnabled: env.PUSH_WORKER_ENABLED?.trim() !== 'false',
     schedulerEnabled: env.SCHEDULER_ENABLED?.trim() !== 'false',

--- a/services/notifications/src/email/channel-adapter.test.ts
+++ b/services/notifications/src/email/channel-adapter.test.ts
@@ -1,0 +1,203 @@
+import type { NatsConnection } from 'nats';
+import type { Pool } from 'pg';
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  startEmailChannelWorker,
+  type Recipient,
+  type ResolveRecipient,
+} from './channel-adapter.js';
+
+// --- Harness --------------------------------------------------------
+
+const flush = async (): Promise<void> => {
+  for (let i = 0; i < 20; i++) {
+    await new Promise(r => setImmediate(r));
+  }
+};
+
+const enabledPrefsRow = {
+  email_enabled: true,
+  push_enabled: true,
+  sms_enabled: false,
+  application_updates: true,
+  pet_matches: true,
+  rescue_updates: true,
+  chat_messages: true,
+  quiet_hours_start: null,
+  quiet_hours_end: null,
+  timezone: 'UTC',
+};
+
+const makePool = (
+  opts: {
+    prefs?: Record<string, unknown>;
+    notifRow?: { title: string; message: string } | null;
+    insertError?: unknown;
+  } = {}
+) => {
+  const query = vi.fn(async (sql: string) => {
+    if (sql.includes('user_notification_prefs')) {
+      return { rows: [opts.prefs ?? enabledPrefsRow] };
+    }
+    if (sql.includes('notifications.notifications')) {
+      return {
+        rows: opts.notifRow === null ? [] : [opts.notifRow ?? { title: 'T', message: 'M' }],
+      };
+    }
+    if (sql.includes('email_queue')) {
+      if (opts.insertError) {
+        throw opts.insertError;
+      }
+      return { rows: [{ email_id: 'e1' }] };
+    }
+    return { rows: [] };
+  });
+  return { query, asPool: { query } as unknown as Pool };
+};
+
+const includesSql = (query: ReturnType<typeof vi.fn>, fragment: string): boolean =>
+  query.mock.calls.some(c => String(c[0]).includes(fragment));
+
+const insertParams = (query: ReturnType<typeof vi.fn>): unknown[] => {
+  const call = query.mock.calls.find(c => String(c[0]).includes('INSERT INTO email_queue'));
+  return (call?.[1] as unknown[]) ?? [];
+};
+
+const logger = {
+  info: () => undefined,
+  warn: () => undefined,
+  error: () => undefined,
+} as unknown as Parameters<typeof startEmailChannelWorker>[0]['logger'];
+
+function makeNats(messages: { payload: unknown }[]): NatsConnection {
+  const encoder = new TextEncoder();
+  const jsm = { consumers: { add: vi.fn(async (_s: string, cfg: unknown) => cfg) } };
+  const js = {
+    consumers: {
+      get: vi.fn(async () => ({
+        consume: vi.fn(async () => ({
+          async *[Symbol.asyncIterator]() {
+            for (const m of messages) {
+              yield {
+                subject: 'notifications.created',
+                data: encoder.encode(
+                  JSON.stringify({
+                    id: 'evt',
+                    occurredAt: '2026-06-01T10:00:00Z',
+                    payload: m.payload,
+                  })
+                ),
+                ack: vi.fn(),
+                nak: vi.fn(),
+                term: vi.fn(),
+              };
+            }
+          },
+          close: vi.fn(),
+        })),
+      })),
+    },
+  };
+  return {
+    jetstreamManager: vi.fn(async () => jsm),
+    jetstream: vi.fn(() => js),
+  } as unknown as NatsConnection;
+}
+
+const event = (overrides: Record<string, unknown> = {}) => ({
+  notificationId: 'n-1',
+  userId: 'usr-1',
+  type: 'adoption_approved',
+  channel: 'in_app',
+  ...overrides,
+});
+
+const resolverTo = (
+  recipient: Recipient | null
+): { fn: ResolveRecipient; mock: ReturnType<typeof vi.fn> } => {
+  const mock = vi.fn(async () => recipient);
+  return { fn: mock, mock };
+};
+
+const start = (pool: Pool, nats: NatsConnection, resolveRecipient: ResolveRecipient) =>
+  startEmailChannelWorker({
+    pool,
+    nats,
+    logger,
+    resolveRecipient,
+    fromEmail: 'noreply@example.com',
+    fromName: 'Test',
+  });
+
+// --- Tests ----------------------------------------------------------
+
+describe('email channel adapter', () => {
+  it('enqueues a transactional email for an email-worthy type with a deterministic idempotency key', async () => {
+    const { asPool, query } = makePool({ notifRow: { title: 'Approved!', message: 'You did it' } });
+    const { fn, mock } = resolverTo({ email: 'adopter@example.com', name: 'Ada Lovelace' });
+    const nats = makeNats([{ payload: event() }]);
+
+    start(asPool, nats, fn);
+    await flush();
+
+    expect(mock).toHaveBeenCalledWith('usr-1');
+    const params = insertParams(query);
+    expect(params).toContain('adopter@example.com');
+    expect(params).toContain('Approved!');
+    expect(params).toContain('notif-email:n-1');
+  });
+
+  it('ignores non-email-worthy types without loading prefs or resolving a recipient', async () => {
+    const { asPool, query } = makePool();
+    const { fn, mock } = resolverTo({ email: 'adopter@example.com' });
+    const nats = makeNats([{ payload: event({ type: 'message_received' }) }]);
+
+    start(asPool, nats, fn);
+    await flush();
+
+    expect(query).not.toHaveBeenCalled();
+    expect(mock).not.toHaveBeenCalled();
+  });
+
+  it('does not enqueue when the user has disabled the email channel', async () => {
+    const { asPool, query } = makePool({ prefs: { ...enabledPrefsRow, email_enabled: false } });
+    const { fn, mock } = resolverTo({ email: 'adopter@example.com' });
+    const nats = makeNats([{ payload: event() }]);
+
+    start(asPool, nats, fn);
+    await flush();
+
+    expect(includesSql(query, 'user_notification_prefs')).toBe(true);
+    expect(includesSql(query, 'email_queue')).toBe(false);
+    expect(mock).not.toHaveBeenCalled();
+  });
+
+  it('skips when the recipient address cannot be resolved', async () => {
+    const { asPool, query } = makePool();
+    const { fn, mock } = resolverTo(null);
+    const nats = makeNats([{ payload: event() }]);
+
+    start(asPool, nats, fn);
+    await flush();
+
+    expect(mock).toHaveBeenCalledWith('usr-1');
+    expect(includesSql(query, 'email_queue')).toBe(false);
+  });
+
+  it('treats a redelivery (idempotency-key unique violation) as a no-op, not an error', async () => {
+    const { asPool } = makePool({
+      insertError: { code: '23505', constraint: 'email_queue_idempotency_key_unique' },
+    });
+    const { fn } = resolverTo({ email: 'adopter@example.com' });
+    const nats = makeNats([{ payload: event() }]);
+
+    // Should resolve cleanly — the worker swallows the unique violation.
+    await expect(
+      (async () => {
+        start(asPool, nats, fn);
+        await flush();
+      })()
+    ).resolves.toBeUndefined();
+  });
+});

--- a/services/notifications/src/email/channel-adapter.ts
+++ b/services/notifications/src/email/channel-adapter.ts
@@ -1,0 +1,150 @@
+// Email channel adapter — the missing sibling of the push worker.
+//
+// Subscribes to `notifications.created` and, for the transactional
+// notification types that warrant an email, enqueues one into email_queue
+// (the existing email worker then sends it). This is what makes domain
+// events (applications.approved, rescue.staffInvited, …) actually reach a
+// user's inbox; before this, the subscriber translators only ever wrote an
+// in-app row and the "email fires from a sibling worker" comment was a
+// promise with no implementation.
+//
+// Dedup is via the email_queue idempotency key (deterministic per
+// notification): a redelivered event hits the unique constraint instead of
+// enqueuing a second email — no processed_events row needed, the insert IS
+// the claim and it's atomic with the enqueue.
+
+import { randomUUID } from 'node:crypto';
+
+import type { NatsConnection } from 'nats';
+import type { Pool } from 'pg';
+import type { Logger } from 'winston';
+
+import { subscribe, type SubscriptionHandle } from '@adopt-dont-shop/events';
+
+import { loadNotificationPrefs, shouldDeliver } from '../preferences-gate.js';
+
+import { insertEmail } from './queue.js';
+
+const DURABLE = 'notifications-email-channel';
+
+// Types that warrant a transactional email alongside the in-app record.
+// High-frequency / low-importance types (chat messages, the pet feed,
+// marketing) are intentionally excluded — emailing each would be spam, and
+// the in-app channel + digest already cover them. Category + channel
+// preferences still gate everything below via shouldDeliver.
+const EMAIL_WORTHY_TYPES = new Set<string>([
+  'application_status',
+  'adoption_approved',
+  'adoption_rejected',
+  'home_visit_scheduled',
+  'interview_scheduled',
+  'reference_request',
+  'account_security',
+  'rescue_invitation',
+]);
+
+export type Recipient = { email: string; name?: string };
+export type ResolveRecipient = (userId: string) => Promise<Recipient | null>;
+
+type NotificationCreatedEvent = {
+  notificationId: string;
+  userId: string;
+  type: string;
+  channel: string;
+};
+
+type NotificationRowLite = {
+  title: string;
+  message: string;
+};
+
+export type EmailChannelWorkerOptions = {
+  pool: Pool;
+  nats: NatsConnection;
+  logger: Logger;
+  resolveRecipient: ResolveRecipient;
+  fromEmail: string;
+  fromName: string;
+};
+
+export type RunningEmailChannelWorker = { stop: () => Promise<void> };
+
+const escapeHtml = (s: string): string =>
+  s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+
+const renderHtml = (title: string, message: string): string =>
+  `<h1>${escapeHtml(title)}</h1><p>${escapeHtml(message)}</p>`;
+
+export const startEmailChannelWorker = (
+  opts: EmailChannelWorkerOptions
+): RunningEmailChannelWorker => {
+  const subscription: SubscriptionHandle = subscribe<NotificationCreatedEvent>(
+    opts.nats,
+    {
+      subject: 'notifications.created',
+      durable: DURABLE,
+      onError: err => opts.logger.error('email.channel.subscriber_error', { err }),
+    },
+    async ev => {
+      if (!ev.userId || !EMAIL_WORTHY_TYPES.has(ev.type)) {
+        return;
+      }
+
+      const prefs = await loadNotificationPrefs(opts.pool, ev.userId);
+      if (!shouldDeliver(prefs, { type: ev.type, channel: 'email', now: new Date() })) {
+        return;
+      }
+
+      const rows = await opts.pool.query<NotificationRowLite>(
+        `SELECT title, message FROM notifications.notifications WHERE notification_id = $1`,
+        [ev.notificationId]
+      );
+      const row = rows.rows[0];
+      if (!row) {
+        return;
+      }
+
+      const recipient = await opts.resolveRecipient(ev.userId);
+      if (!recipient) {
+        opts.logger.warn('email.channel.no_recipient', {
+          userId: ev.userId,
+          notificationId: ev.notificationId,
+        });
+        return;
+      }
+
+      try {
+        await insertEmail(opts.pool, {
+          emailId: randomUUID(),
+          fromEmail: opts.fromEmail,
+          fromName: opts.fromName,
+          toEmail: recipient.email,
+          toName: recipient.name ?? null,
+          subject: row.title,
+          htmlContent: renderHtml(row.title, row.message),
+          textContent: row.message,
+          type: 'notification',
+          priority: 'normal',
+          userId: ev.userId,
+          // Deterministic key → a redelivered notifications.created hits the
+          // unique constraint instead of enqueuing a duplicate email.
+          idempotencyKey: `notif-email:${ev.notificationId}`,
+        });
+      } catch (err) {
+        const pgErr = err as { code?: string; constraint?: string };
+        if (pgErr.code === '23505' && pgErr.constraint === 'email_queue_idempotency_key_unique') {
+          // Already enqueued for this notification — a redelivery no-op.
+          return;
+        }
+        throw err;
+      }
+    }
+  );
+
+  opts.logger.info('email channel worker started', { subject: 'notifications.created' });
+  return {
+    stop: async () => {
+      await subscription.drain().catch(() => undefined);
+    },
+  };
+};

--- a/services/notifications/src/grpc/auth-client.test.ts
+++ b/services/notifications/src/grpc/auth-client.test.ts
@@ -237,13 +237,13 @@ describe('createAuthCohortClient — signed system principal (ADS-800)', () => {
       // Legacy headers still present for services running without the key.
       expect(meta.get('x-user-id')).toEqual(['svc-notifications']);
       expect(meta.get('x-user-roles')).toEqual(['admin']);
-      expect(meta.get('x-user-permissions')).toEqual(['admin.users.broadcast']);
+      expect(meta.get('x-user-permissions')).toEqual(['admin.users.broadcast,admin.users.read']);
       // And the signed token carries the same principal.
       const token = String(meta.get(PRINCIPAL_TOKEN_HEADER)[0]);
       const principal = verifyPrincipalToken(token, SIGNING_KEY);
       expect(principal.userId).toBe('svc-notifications');
       expect(principal.roles).toEqual(['admin']);
-      expect(principal.permissions).toEqual(['admin.users.broadcast']);
+      expect(principal.permissions).toEqual(['admin.users.broadcast', 'admin.users.read']);
     } finally {
       client.close();
     }

--- a/services/notifications/src/grpc/auth-client.ts
+++ b/services/notifications/src/grpc/auth-client.ts
@@ -7,6 +7,8 @@ import { credentials, status, type CallOptions, Metadata } from '@grpc/grpc-js';
 
 import {
   AuthV1,
+  type AdminGetUserRequest,
+  type AdminGetUserResponse,
   type ListUserIdsByCohortRequest,
   type ListUserIdsByCohortResponse,
 } from '@adopt-dont-shop/proto';
@@ -66,9 +68,15 @@ const jitteredBackoff = (attempt: number, baseMs: number): number => {
   return base * (0.75 + Math.random() * 0.5);
 };
 
-export function createAuthCohortClient(opts: CreateAuthCohortClientOptions): AuthCohortClient & {
-  close(): void;
-} {
+// The email channel adapter resolves a recipient's address by user id.
+export type AuthUserClient = {
+  adminGetUser: (req: AdminGetUserRequest) => Promise<AdminGetUserResponse>;
+};
+
+export function createAuthCohortClient(opts: CreateAuthCohortClientOptions): AuthCohortClient &
+  AuthUserClient & {
+    close(): void;
+  } {
   const stub = new AuthV1.AuthServiceClient(opts.address, credentials.createInsecure());
   const deadlineMs = opts.deadlineMs ?? DEFAULT_DEADLINE_MS;
   const maxRetries = opts.maxRetries ?? DEFAULT_MAX_RETRIES;
@@ -76,7 +84,10 @@ export function createAuthCohortClient(opts: CreateAuthCohortClientOptions): Aut
   const systemPrincipal = {
     userId: opts.systemUserId ?? 'svc-notifications',
     roles: splitList(opts.systemRoles ?? 'admin'),
-    permissions: splitList(opts.systemPermissions ?? 'admin.users.broadcast'),
+    // admin.users.broadcast → Broadcast cohort expansion;
+    // admin.users.read → AdminGetUser, used by the email channel adapter to
+    // resolve a recipient's address from their user id.
+    permissions: splitList(opts.systemPermissions ?? 'admin.users.broadcast,admin.users.read'),
   };
 
   // Built per attempt, not once at client creation: the signed
@@ -133,6 +144,8 @@ export function createAuthCohortClient(opts: CreateAuthCohortClientOptions): Aut
   return {
     listUserIdsByCohort: (req: ListUserIdsByCohortRequest): Promise<ListUserIdsByCohortResponse> =>
       callWithRetry(stub.listUserIdsByCohort, req),
+    adminGetUser: (req: AdminGetUserRequest): Promise<AdminGetUserResponse> =>
+      callWithRetry(stub.adminGetUser, req),
     close: () => stub.close(),
   };
 }

--- a/services/notifications/src/index.ts
+++ b/services/notifications/src/index.ts
@@ -7,6 +7,11 @@ import { runServiceShutdown } from '@adopt-dont-shop/service-bootstrap';
 import { loadConfig } from './config.js';
 import { createAuthCohortClient } from './grpc/auth-client.js';
 import { validateAuthPrincipal } from './grpc/validate-auth-principal.js';
+import {
+  startEmailChannelWorker,
+  type ResolveRecipient,
+  type RunningEmailChannelWorker,
+} from './email/channel-adapter.js';
 import { createProvider } from './email/providers/factory.js';
 import { startEmailWorker, type RunningEmailWorker } from './email/worker.js';
 import { startGrpcServer, type RunningGrpcServer } from './grpc/server.js';
@@ -24,6 +29,7 @@ const main = async (): Promise<void> => {
   let pool: Awaited<ReturnType<typeof createDbClient>> | undefined;
   let grpc: RunningGrpcServer | undefined;
   let emailWorker: RunningEmailWorker | undefined;
+  let emailChannelWorker: RunningEmailChannelWorker | undefined;
   let pushWorker: RunningPushWorker | undefined;
   let scheduler: RunningScheduler | undefined;
   let grpcReady = false;
@@ -104,6 +110,32 @@ const main = async (): Promise<void> => {
       emailWorker = startEmailWorker({ pool, nats, provider, logger });
       logger.info('email worker started', { provider: provider.getName() });
     }
+    // Email channel adapter: turns notifications.created into enqueued
+    // transactional emails. Needs the auth client to resolve recipient
+    // addresses; without it, we skip rather than enqueue address-less rows.
+    if (config.emailChannelEnabled) {
+      if (authClient) {
+        const resolveRecipient: ResolveRecipient = async userId => {
+          const res = await authClient.adminGetUser({ userId });
+          const user = res.user;
+          if (!user || !user.email) {
+            return null;
+          }
+          const name = [user.firstName, user.lastName].filter(Boolean).join(' ');
+          return { email: user.email, name: name || undefined };
+        };
+        emailChannelWorker = startEmailChannelWorker({
+          pool,
+          nats,
+          logger,
+          resolveRecipient,
+          fromEmail: config.defaultFromEmail,
+          fromName: config.defaultFromName,
+        });
+      } else {
+        logger.warn('email channel adapter disabled — no AUTH_GRPC_URL to resolve recipients');
+      }
+    }
     if (config.pushWorkerEnabled) {
       const pushProviderConfig =
         config.pushProvider.kind === 'fcm'
@@ -157,6 +189,11 @@ const main = async (): Promise<void> => {
         await emailWorker?.stop();
       } catch (err) {
         logger.error('email worker stop error', { err });
+      }
+      try {
+        await emailChannelWorker?.stop();
+      } catch (err) {
+        logger.error('email channel worker stop error', { err });
       }
       try {
         await pushWorker?.stop();


### PR DESCRIPTION
## P2 — Email channel adapter (stack 3/5)

Third of five stacked PRs. **Base: `claude/notif-p3-preference-gate` (#1048)** → which bases on #1047. Diff here is P2 only.

### Problem
Every domain-event translator creates an **in-app** notification and the code comments promised *"the email channel will fire from a sibling worker on the same event"* — but **that worker never existed**. The `email_queue` was only ever fed by the explicit `SendEmail` gRPC, so adoption approvals, staff invites, application updates, etc. never emailed anyone. Push had its adapter; email didn't.

### Change
- New `email/channel-adapter.ts` — subscribes to `notifications.created` (mirroring the push worker) and, for transactional notification **types** (`EMAIL_WORTHY_TYPES` — excludes chat/feed/marketing to avoid spam):
  1. checks the **P3 preference gate** (`email_enabled` + category),
  2. loads the notification row for title/message,
  3. resolves the recipient address via **`AuthService.AdminGetUser`**,
  4. enqueues into `email_queue` (the existing worker sends it).
- **Dedup via the `email_queue` idempotency key** (`notif-email:<notificationId>`) — a redelivered event hits the unique constraint instead of double-sending. The insert *is* the claim, atomic with the enqueue, so no `processed_events` row is needed for this path; and on a transient auth failure nothing is claimed, so the email isn't lost.
- Auth client gains `adminGetUser`; the `svc-notifications` signed principal now asserts `admin.users.read` alongside `admin.users.broadcast` (self-asserted signed token — no auth-side seeding needed).
- New config: `EMAIL_CHANNEL_ENABLED` (default on), `DEFAULT_FROM_EMAIL/NAME`. The adapter only starts when `AUTH_GRPC_URL` is set (it needs `AdminGetUser`); otherwise it logs and skips rather than enqueue address-less rows.

### Why read the row instead of expanding the event
`notifications.created` only carries `{notificationId, userId, type, channel}`. Rather than widen the event contract (which would also touch push), the adapter reads the row for title/message — keeps the change self-contained.

### Tests
Adapter: enqueues for an email-worthy type with the right address/subject/idempotency key; ignores non-worthy types without any DB work; respects `email_enabled`; skips when no recipient; treats the idempotency unique-violation as a no-op. Auth-client signed-principal test updated for the new permission. `vitest` (243 passed), `type-check`, `lint` (0 errors) green.

> Note: the pre-existing `Dependency Audit` failure (`ws` advisory via `apps/admin`) is unrelated to this change and also fails on `main`.

https://claude.ai/code/session_01LAJXPr3DARnLgzBdTTjYKr

---
_Generated by [Claude Code](https://claude.ai/code/session_01LAJXPr3DARnLgzBdTTjYKr)_