### PR TITLE
feat(notifications): land preference gate, email channel, fan-out & routing on main

### DIFF
--- a/packages/proto/proto/adopt_dont_shop/pets/v1/pet.proto
+++ b/packages/proto/proto/adopt_dont_shop/pets/v1/pet.proto
@@ -52,6 +52,13 @@ service PetService {
   // average-time-to-adoption. Drives the rescue dashboard widget.
   // Self-scoped to the caller's rescue unless they hold pets.read:any.
   rpc GetStats(GetPetStatsRequest) returns (GetPetStatsResponse);
+
+  // List the user_ids of every adopter who has FAVOURITED a pet. A
+  // service-to-service read for recipient discovery — service.notifications
+  // fans `pets.statusChanged` out to these users. Caller MUST have
+  // `pets.read`. Returns an empty list (not NOT_FOUND) when the pet has
+  // no favouriters or does not exist.
+  rpc ListFavoriters(ListPetFavoritersRequest) returns (ListPetFavoritersResponse);
 }
 
 // --- ENUMs — value lists mirror the Postgres types verbatim ----------
@@ -302,4 +309,14 @@ message GetPetStatsResponse {
   // Mean days between created_at and adopted_at across the most recent
   // 50 adoptions in scope. Zero when no adoptions have been recorded.
   uint32 average_days_to_adoption = 11;
+}
+
+// --- ListFavoriters --------------------------------------------------
+
+message ListPetFavoritersRequest {
+  string pet_id = 1;
+}
+
+message ListPetFavoritersResponse {
+  repeated string user_ids = 1;
 }

--- a/packages/proto/src/generated/proto/adopt_dont_shop/pets/v1/pet.ts
+++ b/packages/proto/src/generated/proto/adopt_dont_shop/pets/v1/pet.ts
@@ -5,7 +5,7 @@
 // source: proto/adopt_dont_shop/pets/v1/pet.proto
 
 /* eslint-disable */
-import { BinaryReader, BinaryWriter } from "@bufbuild/protobuf/wire";
+import { BinaryReader, BinaryWriter } from '@bufbuild/protobuf/wire';
 import {
   type CallOptions,
   type ChannelCredentials,
@@ -17,9 +17,9 @@ import {
   type Metadata,
   type ServiceError,
   type UntypedServiceImplementation,
-} from "@grpc/grpc-js";
+} from '@grpc/grpc-js';
 
-export const protobufPackage = "adopt_dont_shop.pets.v1";
+export const protobufPackage = 'adopt_dont_shop.pets.v1';
 
 export enum PetStatus {
   PET_STATUS_UNSPECIFIED = 0,
@@ -37,34 +37,34 @@ export enum PetStatus {
 export function petStatusFromJSON(object: any): PetStatus {
   switch (object) {
     case 0:
-    case "PET_STATUS_UNSPECIFIED":
+    case 'PET_STATUS_UNSPECIFIED':
       return PetStatus.PET_STATUS_UNSPECIFIED;
     case 1:
-    case "PET_STATUS_AVAILABLE":
+    case 'PET_STATUS_AVAILABLE':
       return PetStatus.PET_STATUS_AVAILABLE;
     case 2:
-    case "PET_STATUS_PENDING":
+    case 'PET_STATUS_PENDING':
       return PetStatus.PET_STATUS_PENDING;
     case 3:
-    case "PET_STATUS_ADOPTED":
+    case 'PET_STATUS_ADOPTED':
       return PetStatus.PET_STATUS_ADOPTED;
     case 4:
-    case "PET_STATUS_FOSTER":
+    case 'PET_STATUS_FOSTER':
       return PetStatus.PET_STATUS_FOSTER;
     case 5:
-    case "PET_STATUS_MEDICAL_HOLD":
+    case 'PET_STATUS_MEDICAL_HOLD':
       return PetStatus.PET_STATUS_MEDICAL_HOLD;
     case 6:
-    case "PET_STATUS_BEHAVIORAL_HOLD":
+    case 'PET_STATUS_BEHAVIORAL_HOLD':
       return PetStatus.PET_STATUS_BEHAVIORAL_HOLD;
     case 7:
-    case "PET_STATUS_NOT_AVAILABLE":
+    case 'PET_STATUS_NOT_AVAILABLE':
       return PetStatus.PET_STATUS_NOT_AVAILABLE;
     case 8:
-    case "PET_STATUS_DECEASED":
+    case 'PET_STATUS_DECEASED':
       return PetStatus.PET_STATUS_DECEASED;
     case -1:
-    case "UNRECOGNIZED":
+    case 'UNRECOGNIZED':
     default:
       return PetStatus.UNRECOGNIZED;
   }
@@ -73,26 +73,26 @@ export function petStatusFromJSON(object: any): PetStatus {
 export function petStatusToJSON(object: PetStatus): string {
   switch (object) {
     case PetStatus.PET_STATUS_UNSPECIFIED:
-      return "PET_STATUS_UNSPECIFIED";
+      return 'PET_STATUS_UNSPECIFIED';
     case PetStatus.PET_STATUS_AVAILABLE:
-      return "PET_STATUS_AVAILABLE";
+      return 'PET_STATUS_AVAILABLE';
     case PetStatus.PET_STATUS_PENDING:
-      return "PET_STATUS_PENDING";
+      return 'PET_STATUS_PENDING';
     case PetStatus.PET_STATUS_ADOPTED:
-      return "PET_STATUS_ADOPTED";
+      return 'PET_STATUS_ADOPTED';
     case PetStatus.PET_STATUS_FOSTER:
-      return "PET_STATUS_FOSTER";
+      return 'PET_STATUS_FOSTER';
     case PetStatus.PET_STATUS_MEDICAL_HOLD:
-      return "PET_STATUS_MEDICAL_HOLD";
+      return 'PET_STATUS_MEDICAL_HOLD';
     case PetStatus.PET_STATUS_BEHAVIORAL_HOLD:
-      return "PET_STATUS_BEHAVIORAL_HOLD";
+      return 'PET_STATUS_BEHAVIORAL_HOLD';
     case PetStatus.PET_STATUS_NOT_AVAILABLE:
-      return "PET_STATUS_NOT_AVAILABLE";
+      return 'PET_STATUS_NOT_AVAILABLE';
     case PetStatus.PET_STATUS_DECEASED:
-      return "PET_STATUS_DECEASED";
+      return 'PET_STATUS_DECEASED';
     case PetStatus.UNRECOGNIZED:
     default:
-      return "UNRECOGNIZED";
+      return 'UNRECOGNIZED';
   }
 }
 
@@ -112,34 +112,34 @@ export enum PetType {
 export function petTypeFromJSON(object: any): PetType {
   switch (object) {
     case 0:
-    case "PET_TYPE_UNSPECIFIED":
+    case 'PET_TYPE_UNSPECIFIED':
       return PetType.PET_TYPE_UNSPECIFIED;
     case 1:
-    case "PET_TYPE_DOG":
+    case 'PET_TYPE_DOG':
       return PetType.PET_TYPE_DOG;
     case 2:
-    case "PET_TYPE_CAT":
+    case 'PET_TYPE_CAT':
       return PetType.PET_TYPE_CAT;
     case 3:
-    case "PET_TYPE_RABBIT":
+    case 'PET_TYPE_RABBIT':
       return PetType.PET_TYPE_RABBIT;
     case 4:
-    case "PET_TYPE_BIRD":
+    case 'PET_TYPE_BIRD':
       return PetType.PET_TYPE_BIRD;
     case 5:
-    case "PET_TYPE_REPTILE":
+    case 'PET_TYPE_REPTILE':
       return PetType.PET_TYPE_REPTILE;
     case 6:
-    case "PET_TYPE_SMALL_MAMMAL":
+    case 'PET_TYPE_SMALL_MAMMAL':
       return PetType.PET_TYPE_SMALL_MAMMAL;
     case 7:
-    case "PET_TYPE_FISH":
+    case 'PET_TYPE_FISH':
       return PetType.PET_TYPE_FISH;
     case 8:
-    case "PET_TYPE_OTHER":
+    case 'PET_TYPE_OTHER':
       return PetType.PET_TYPE_OTHER;
     case -1:
-    case "UNRECOGNIZED":
+    case 'UNRECOGNIZED':
     default:
       return PetType.UNRECOGNIZED;
   }
@@ -148,26 +148,26 @@ export function petTypeFromJSON(object: any): PetType {
 export function petTypeToJSON(object: PetType): string {
   switch (object) {
     case PetType.PET_TYPE_UNSPECIFIED:
-      return "PET_TYPE_UNSPECIFIED";
+      return 'PET_TYPE_UNSPECIFIED';
     case PetType.PET_TYPE_DOG:
-      return "PET_TYPE_DOG";
+      return 'PET_TYPE_DOG';
     case PetType.PET_TYPE_CAT:
-      return "PET_TYPE_CAT";
+      return 'PET_TYPE_CAT';
     case PetType.PET_TYPE_RABBIT:
-      return "PET_TYPE_RABBIT";
+      return 'PET_TYPE_RABBIT';
     case PetType.PET_TYPE_BIRD:
-      return "PET_TYPE_BIRD";
+      return 'PET_TYPE_BIRD';
     case PetType.PET_TYPE_REPTILE:
-      return "PET_TYPE_REPTILE";
+      return 'PET_TYPE_REPTILE';
     case PetType.PET_TYPE_SMALL_MAMMAL:
-      return "PET_TYPE_SMALL_MAMMAL";
+      return 'PET_TYPE_SMALL_MAMMAL';
     case PetType.PET_TYPE_FISH:
-      return "PET_TYPE_FISH";
+      return 'PET_TYPE_FISH';
     case PetType.PET_TYPE_OTHER:
-      return "PET_TYPE_OTHER";
+      return 'PET_TYPE_OTHER';
     case PetType.UNRECOGNIZED:
     default:
-      return "UNRECOGNIZED";
+      return 'UNRECOGNIZED';
   }
 }
 
@@ -182,19 +182,19 @@ export enum PetGender {
 export function petGenderFromJSON(object: any): PetGender {
   switch (object) {
     case 0:
-    case "PET_GENDER_UNSPECIFIED":
+    case 'PET_GENDER_UNSPECIFIED':
       return PetGender.PET_GENDER_UNSPECIFIED;
     case 1:
-    case "PET_GENDER_MALE":
+    case 'PET_GENDER_MALE':
       return PetGender.PET_GENDER_MALE;
     case 2:
-    case "PET_GENDER_FEMALE":
+    case 'PET_GENDER_FEMALE':
       return PetGender.PET_GENDER_FEMALE;
     case 3:
-    case "PET_GENDER_UNKNOWN":
+    case 'PET_GENDER_UNKNOWN':
       return PetGender.PET_GENDER_UNKNOWN;
     case -1:
-    case "UNRECOGNIZED":
+    case 'UNRECOGNIZED':
     default:
       return PetGender.UNRECOGNIZED;
   }
@@ -203,16 +203,16 @@ export function petGenderFromJSON(object: any): PetGender {
 export function petGenderToJSON(object: PetGender): string {
   switch (object) {
     case PetGender.PET_GENDER_UNSPECIFIED:
-      return "PET_GENDER_UNSPECIFIED";
+      return 'PET_GENDER_UNSPECIFIED';
     case PetGender.PET_GENDER_MALE:
-      return "PET_GENDER_MALE";
+      return 'PET_GENDER_MALE';
     case PetGender.PET_GENDER_FEMALE:
-      return "PET_GENDER_FEMALE";
+      return 'PET_GENDER_FEMALE';
     case PetGender.PET_GENDER_UNKNOWN:
-      return "PET_GENDER_UNKNOWN";
+      return 'PET_GENDER_UNKNOWN';
     case PetGender.UNRECOGNIZED:
     default:
-      return "UNRECOGNIZED";
+      return 'UNRECOGNIZED';
   }
 }
 
@@ -229,25 +229,25 @@ export enum PetSize {
 export function petSizeFromJSON(object: any): PetSize {
   switch (object) {
     case 0:
-    case "PET_SIZE_UNSPECIFIED":
+    case 'PET_SIZE_UNSPECIFIED':
       return PetSize.PET_SIZE_UNSPECIFIED;
     case 1:
-    case "PET_SIZE_EXTRA_SMALL":
+    case 'PET_SIZE_EXTRA_SMALL':
       return PetSize.PET_SIZE_EXTRA_SMALL;
     case 2:
-    case "PET_SIZE_SMALL":
+    case 'PET_SIZE_SMALL':
       return PetSize.PET_SIZE_SMALL;
     case 3:
-    case "PET_SIZE_MEDIUM":
+    case 'PET_SIZE_MEDIUM':
       return PetSize.PET_SIZE_MEDIUM;
     case 4:
-    case "PET_SIZE_LARGE":
+    case 'PET_SIZE_LARGE':
       return PetSize.PET_SIZE_LARGE;
     case 5:
-    case "PET_SIZE_EXTRA_LARGE":
+    case 'PET_SIZE_EXTRA_LARGE':
       return PetSize.PET_SIZE_EXTRA_LARGE;
     case -1:
-    case "UNRECOGNIZED":
+    case 'UNRECOGNIZED':
     default:
       return PetSize.UNRECOGNIZED;
   }
@@ -256,20 +256,20 @@ export function petSizeFromJSON(object: any): PetSize {
 export function petSizeToJSON(object: PetSize): string {
   switch (object) {
     case PetSize.PET_SIZE_UNSPECIFIED:
-      return "PET_SIZE_UNSPECIFIED";
+      return 'PET_SIZE_UNSPECIFIED';
     case PetSize.PET_SIZE_EXTRA_SMALL:
-      return "PET_SIZE_EXTRA_SMALL";
+      return 'PET_SIZE_EXTRA_SMALL';
     case PetSize.PET_SIZE_SMALL:
-      return "PET_SIZE_SMALL";
+      return 'PET_SIZE_SMALL';
     case PetSize.PET_SIZE_MEDIUM:
-      return "PET_SIZE_MEDIUM";
+      return 'PET_SIZE_MEDIUM';
     case PetSize.PET_SIZE_LARGE:
-      return "PET_SIZE_LARGE";
+      return 'PET_SIZE_LARGE';
     case PetSize.PET_SIZE_EXTRA_LARGE:
-      return "PET_SIZE_EXTRA_LARGE";
+      return 'PET_SIZE_EXTRA_LARGE';
     case PetSize.UNRECOGNIZED:
     default:
-      return "UNRECOGNIZED";
+      return 'UNRECOGNIZED';
   }
 }
 
@@ -285,22 +285,22 @@ export enum PetAgeGroup {
 export function petAgeGroupFromJSON(object: any): PetAgeGroup {
   switch (object) {
     case 0:
-    case "PET_AGE_GROUP_UNSPECIFIED":
+    case 'PET_AGE_GROUP_UNSPECIFIED':
       return PetAgeGroup.PET_AGE_GROUP_UNSPECIFIED;
     case 1:
-    case "PET_AGE_GROUP_BABY":
+    case 'PET_AGE_GROUP_BABY':
       return PetAgeGroup.PET_AGE_GROUP_BABY;
     case 2:
-    case "PET_AGE_GROUP_YOUNG":
+    case 'PET_AGE_GROUP_YOUNG':
       return PetAgeGroup.PET_AGE_GROUP_YOUNG;
     case 3:
-    case "PET_AGE_GROUP_ADULT":
+    case 'PET_AGE_GROUP_ADULT':
       return PetAgeGroup.PET_AGE_GROUP_ADULT;
     case 4:
-    case "PET_AGE_GROUP_SENIOR":
+    case 'PET_AGE_GROUP_SENIOR':
       return PetAgeGroup.PET_AGE_GROUP_SENIOR;
     case -1:
-    case "UNRECOGNIZED":
+    case 'UNRECOGNIZED':
     default:
       return PetAgeGroup.UNRECOGNIZED;
   }
@@ -309,18 +309,18 @@ export function petAgeGroupFromJSON(object: any): PetAgeGroup {
 export function petAgeGroupToJSON(object: PetAgeGroup): string {
   switch (object) {
     case PetAgeGroup.PET_AGE_GROUP_UNSPECIFIED:
-      return "PET_AGE_GROUP_UNSPECIFIED";
+      return 'PET_AGE_GROUP_UNSPECIFIED';
     case PetAgeGroup.PET_AGE_GROUP_BABY:
-      return "PET_AGE_GROUP_BABY";
+      return 'PET_AGE_GROUP_BABY';
     case PetAgeGroup.PET_AGE_GROUP_YOUNG:
-      return "PET_AGE_GROUP_YOUNG";
+      return 'PET_AGE_GROUP_YOUNG';
     case PetAgeGroup.PET_AGE_GROUP_ADULT:
-      return "PET_AGE_GROUP_ADULT";
+      return 'PET_AGE_GROUP_ADULT';
     case PetAgeGroup.PET_AGE_GROUP_SENIOR:
-      return "PET_AGE_GROUP_SENIOR";
+      return 'PET_AGE_GROUP_SENIOR';
     case PetAgeGroup.UNRECOGNIZED:
     default:
-      return "UNRECOGNIZED";
+      return 'UNRECOGNIZED';
   }
 }
 
@@ -424,9 +424,7 @@ export interface GetPetResponse {
 
 export interface ListPetsRequest {
   /** Opaque base64-JSON keyset cursor — same shape as NotificationsV1. */
-  cursor?:
-    | string
-    | undefined;
+  cursor?: string | undefined;
   /** Defaults to 20, max 100 — server enforces the bound. */
   limit: number;
   /** Optional filters. UNSPECIFIED in each enum = "no filter". */
@@ -482,9 +480,7 @@ export interface UpdatePetStatusRequest {
 }
 
 export interface UpdatePetStatusResponse {
-  pet?:
-    | Pet
-    | undefined;
+  pet?: Pet | undefined;
   /** The transition row appended by this command. */
   transition?: PetStatusTransition | undefined;
 }
@@ -528,10 +524,18 @@ export interface GetPetStatsResponse {
   averageDaysToAdoption: number;
 }
 
+export interface ListPetFavoritersRequest {
+  petId: string;
+}
+
+export interface ListPetFavoritersResponse {
+  userIds: string[];
+}
+
 function createBasePet(): Pet {
   return {
-    petId: "",
-    name: "",
+    petId: '',
+    name: '',
     rescueId: undefined,
     type: 0,
     status: 0,
@@ -552,25 +556,25 @@ function createBasePet(): Pet {
     adoptionFeeCurrency: undefined,
     specialNeeds: false,
     houseTrained: false,
-    temperamentJson: "",
-    tagsJson: "",
-    extraJson: "",
+    temperamentJson: '',
+    tagsJson: '',
+    extraJson: '',
     viewCount: 0,
     favoriteCount: 0,
     applicationCount: 0,
     availableSince: undefined,
     adoptedDate: undefined,
-    createdAt: "",
-    updatedAt: "",
+    createdAt: '',
+    updatedAt: '',
   };
 }
 
 export const Pet: MessageFns<Pet> = {
   encode(message: Pet, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    if (message.petId !== "") {
+    if (message.petId !== '') {
       writer.uint32(10).string(message.petId);
     }
-    if (message.name !== "") {
+    if (message.name !== '') {
       writer.uint32(18).string(message.name);
     }
     if (message.rescueId !== undefined) {
@@ -633,13 +637,13 @@ export const Pet: MessageFns<Pet> = {
     if (message.houseTrained !== false) {
       writer.uint32(176).bool(message.houseTrained);
     }
-    if (message.temperamentJson !== "") {
+    if (message.temperamentJson !== '') {
       writer.uint32(186).string(message.temperamentJson);
     }
-    if (message.tagsJson !== "") {
+    if (message.tagsJson !== '') {
       writer.uint32(194).string(message.tagsJson);
     }
-    if (message.extraJson !== "") {
+    if (message.extraJson !== '') {
       writer.uint32(202).string(message.extraJson);
     }
     if (message.viewCount !== 0) {
@@ -657,10 +661,10 @@ export const Pet: MessageFns<Pet> = {
     if (message.adoptedDate !== undefined) {
       writer.uint32(242).string(message.adoptedDate);
     }
-    if (message.createdAt !== "") {
+    if (message.createdAt !== '') {
       writer.uint32(250).string(message.createdAt);
     }
-    if (message.updatedAt !== "") {
+    if (message.updatedAt !== '') {
       writer.uint32(258).string(message.updatedAt);
     }
     return writer;
@@ -943,14 +947,14 @@ export const Pet: MessageFns<Pet> = {
       petId: isSet(object.petId)
         ? globalThis.String(object.petId)
         : isSet(object.pet_id)
-        ? globalThis.String(object.pet_id)
-        : "",
-      name: isSet(object.name) ? globalThis.String(object.name) : "",
+          ? globalThis.String(object.pet_id)
+          : '',
+      name: isSet(object.name) ? globalThis.String(object.name) : '',
       rescueId: isSet(object.rescueId)
         ? globalThis.String(object.rescueId)
         : isSet(object.rescue_id)
-        ? globalThis.String(object.rescue_id)
-        : undefined,
+          ? globalThis.String(object.rescue_id)
+          : undefined,
       type: isSet(object.type) ? petTypeFromJSON(object.type) : 0,
       status: isSet(object.status) ? petStatusFromJSON(object.status) : 0,
       gender: isSet(object.gender) ? petGenderFromJSON(object.gender) : 0,
@@ -958,125 +962,125 @@ export const Pet: MessageFns<Pet> = {
       ageGroup: isSet(object.ageGroup)
         ? petAgeGroupFromJSON(object.ageGroup)
         : isSet(object.age_group)
-        ? petAgeGroupFromJSON(object.age_group)
-        : 0,
+          ? petAgeGroupFromJSON(object.age_group)
+          : 0,
       breedId: isSet(object.breedId)
         ? globalThis.String(object.breedId)
         : isSet(object.breed_id)
-        ? globalThis.String(object.breed_id)
-        : undefined,
+          ? globalThis.String(object.breed_id)
+          : undefined,
       secondaryBreedId: isSet(object.secondaryBreedId)
         ? globalThis.String(object.secondaryBreedId)
         : isSet(object.secondary_breed_id)
-        ? globalThis.String(object.secondary_breed_id)
-        : undefined,
+          ? globalThis.String(object.secondary_breed_id)
+          : undefined,
       shortDescription: isSet(object.shortDescription)
         ? globalThis.String(object.shortDescription)
         : isSet(object.short_description)
-        ? globalThis.String(object.short_description)
-        : undefined,
+          ? globalThis.String(object.short_description)
+          : undefined,
       longDescription: isSet(object.longDescription)
         ? globalThis.String(object.longDescription)
         : isSet(object.long_description)
-        ? globalThis.String(object.long_description)
-        : undefined,
+          ? globalThis.String(object.long_description)
+          : undefined,
       ageYears: isSet(object.ageYears)
         ? globalThis.Number(object.ageYears)
         : isSet(object.age_years)
-        ? globalThis.Number(object.age_years)
-        : undefined,
+          ? globalThis.Number(object.age_years)
+          : undefined,
       ageMonths: isSet(object.ageMonths)
         ? globalThis.Number(object.ageMonths)
         : isSet(object.age_months)
-        ? globalThis.Number(object.age_months)
-        : undefined,
+          ? globalThis.Number(object.age_months)
+          : undefined,
       color: isSet(object.color) ? globalThis.String(object.color) : undefined,
       archived: isSet(object.archived) ? globalThis.Boolean(object.archived) : false,
       featured: isSet(object.featured) ? globalThis.Boolean(object.featured) : false,
       priorityListing: isSet(object.priorityListing)
         ? globalThis.Boolean(object.priorityListing)
         : isSet(object.priority_listing)
-        ? globalThis.Boolean(object.priority_listing)
-        : false,
+          ? globalThis.Boolean(object.priority_listing)
+          : false,
       adoptionFeeMinor: isSet(object.adoptionFeeMinor)
         ? globalThis.Number(object.adoptionFeeMinor)
         : isSet(object.adoption_fee_minor)
-        ? globalThis.Number(object.adoption_fee_minor)
-        : undefined,
+          ? globalThis.Number(object.adoption_fee_minor)
+          : undefined,
       adoptionFeeCurrency: isSet(object.adoptionFeeCurrency)
         ? globalThis.String(object.adoptionFeeCurrency)
         : isSet(object.adoption_fee_currency)
-        ? globalThis.String(object.adoption_fee_currency)
-        : undefined,
+          ? globalThis.String(object.adoption_fee_currency)
+          : undefined,
       specialNeeds: isSet(object.specialNeeds)
         ? globalThis.Boolean(object.specialNeeds)
         : isSet(object.special_needs)
-        ? globalThis.Boolean(object.special_needs)
-        : false,
+          ? globalThis.Boolean(object.special_needs)
+          : false,
       houseTrained: isSet(object.houseTrained)
         ? globalThis.Boolean(object.houseTrained)
         : isSet(object.house_trained)
-        ? globalThis.Boolean(object.house_trained)
-        : false,
+          ? globalThis.Boolean(object.house_trained)
+          : false,
       temperamentJson: isSet(object.temperamentJson)
         ? globalThis.String(object.temperamentJson)
         : isSet(object.temperament_json)
-        ? globalThis.String(object.temperament_json)
-        : "",
+          ? globalThis.String(object.temperament_json)
+          : '',
       tagsJson: isSet(object.tagsJson)
         ? globalThis.String(object.tagsJson)
         : isSet(object.tags_json)
-        ? globalThis.String(object.tags_json)
-        : "",
+          ? globalThis.String(object.tags_json)
+          : '',
       extraJson: isSet(object.extraJson)
         ? globalThis.String(object.extraJson)
         : isSet(object.extra_json)
-        ? globalThis.String(object.extra_json)
-        : "",
+          ? globalThis.String(object.extra_json)
+          : '',
       viewCount: isSet(object.viewCount)
         ? globalThis.Number(object.viewCount)
         : isSet(object.view_count)
-        ? globalThis.Number(object.view_count)
-        : 0,
+          ? globalThis.Number(object.view_count)
+          : 0,
       favoriteCount: isSet(object.favoriteCount)
         ? globalThis.Number(object.favoriteCount)
         : isSet(object.favorite_count)
-        ? globalThis.Number(object.favorite_count)
-        : 0,
+          ? globalThis.Number(object.favorite_count)
+          : 0,
       applicationCount: isSet(object.applicationCount)
         ? globalThis.Number(object.applicationCount)
         : isSet(object.application_count)
-        ? globalThis.Number(object.application_count)
-        : 0,
+          ? globalThis.Number(object.application_count)
+          : 0,
       availableSince: isSet(object.availableSince)
         ? globalThis.String(object.availableSince)
         : isSet(object.available_since)
-        ? globalThis.String(object.available_since)
-        : undefined,
+          ? globalThis.String(object.available_since)
+          : undefined,
       adoptedDate: isSet(object.adoptedDate)
         ? globalThis.String(object.adoptedDate)
         : isSet(object.adopted_date)
-        ? globalThis.String(object.adopted_date)
-        : undefined,
+          ? globalThis.String(object.adopted_date)
+          : undefined,
       createdAt: isSet(object.createdAt)
         ? globalThis.String(object.createdAt)
         : isSet(object.created_at)
-        ? globalThis.String(object.created_at)
-        : "",
+          ? globalThis.String(object.created_at)
+          : '',
       updatedAt: isSet(object.updatedAt)
         ? globalThis.String(object.updatedAt)
         : isSet(object.updated_at)
-        ? globalThis.String(object.updated_at)
-        : "",
+          ? globalThis.String(object.updated_at)
+          : '',
     };
   },
 
   toJSON(message: Pet): unknown {
     const obj: any = {};
-    if (message.petId !== "") {
+    if (message.petId !== '') {
       obj.petId = message.petId;
     }
-    if (message.name !== "") {
+    if (message.name !== '') {
       obj.name = message.name;
     }
     if (message.rescueId !== undefined) {
@@ -1139,13 +1143,13 @@ export const Pet: MessageFns<Pet> = {
     if (message.houseTrained !== false) {
       obj.houseTrained = message.houseTrained;
     }
-    if (message.temperamentJson !== "") {
+    if (message.temperamentJson !== '') {
       obj.temperamentJson = message.temperamentJson;
     }
-    if (message.tagsJson !== "") {
+    if (message.tagsJson !== '') {
       obj.tagsJson = message.tagsJson;
     }
-    if (message.extraJson !== "") {
+    if (message.extraJson !== '') {
       obj.extraJson = message.extraJson;
     }
     if (message.viewCount !== 0) {
@@ -1163,10 +1167,10 @@ export const Pet: MessageFns<Pet> = {
     if (message.adoptedDate !== undefined) {
       obj.adoptedDate = message.adoptedDate;
     }
-    if (message.createdAt !== "") {
+    if (message.createdAt !== '') {
       obj.createdAt = message.createdAt;
     }
-    if (message.updatedAt !== "") {
+    if (message.updatedAt !== '') {
       obj.updatedAt = message.updatedAt;
     }
     return obj;
@@ -1177,8 +1181,8 @@ export const Pet: MessageFns<Pet> = {
   },
   fromPartial<I extends Exact<DeepPartial<Pet>, I>>(object: I): Pet {
     const message = createBasePet();
-    message.petId = object.petId ?? "";
-    message.name = object.name ?? "";
+    message.petId = object.petId ?? '';
+    message.name = object.name ?? '';
     message.rescueId = object.rescueId ?? undefined;
     message.type = object.type ?? 0;
     message.status = object.status ?? 0;
@@ -1199,27 +1203,27 @@ export const Pet: MessageFns<Pet> = {
     message.adoptionFeeCurrency = object.adoptionFeeCurrency ?? undefined;
     message.specialNeeds = object.specialNeeds ?? false;
     message.houseTrained = object.houseTrained ?? false;
-    message.temperamentJson = object.temperamentJson ?? "";
-    message.tagsJson = object.tagsJson ?? "";
-    message.extraJson = object.extraJson ?? "";
+    message.temperamentJson = object.temperamentJson ?? '';
+    message.tagsJson = object.tagsJson ?? '';
+    message.extraJson = object.extraJson ?? '';
     message.viewCount = object.viewCount ?? 0;
     message.favoriteCount = object.favoriteCount ?? 0;
     message.applicationCount = object.applicationCount ?? 0;
     message.availableSince = object.availableSince ?? undefined;
     message.adoptedDate = object.adoptedDate ?? undefined;
-    message.createdAt = object.createdAt ?? "";
-    message.updatedAt = object.updatedAt ?? "";
+    message.createdAt = object.createdAt ?? '';
+    message.updatedAt = object.updatedAt ?? '';
     return message;
   },
 };
 
 function createBasePetStatusTransition(): PetStatusTransition {
   return {
-    transitionId: "",
-    petId: "",
+    transitionId: '',
+    petId: '',
     fromStatus: undefined,
     toStatus: 0,
-    transitionedAt: "",
+    transitionedAt: '',
     transitionedBy: undefined,
     reason: undefined,
   };
@@ -1227,10 +1231,10 @@ function createBasePetStatusTransition(): PetStatusTransition {
 
 export const PetStatusTransition: MessageFns<PetStatusTransition> = {
   encode(message: PetStatusTransition, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    if (message.transitionId !== "") {
+    if (message.transitionId !== '') {
       writer.uint32(10).string(message.transitionId);
     }
-    if (message.petId !== "") {
+    if (message.petId !== '') {
       writer.uint32(18).string(message.petId);
     }
     if (message.fromStatus !== undefined) {
@@ -1239,7 +1243,7 @@ export const PetStatusTransition: MessageFns<PetStatusTransition> = {
     if (message.toStatus !== 0) {
       writer.uint32(32).int32(message.toStatus);
     }
-    if (message.transitionedAt !== "") {
+    if (message.transitionedAt !== '') {
       writer.uint32(42).string(message.transitionedAt);
     }
     if (message.transitionedBy !== undefined) {
@@ -1328,43 +1332,43 @@ export const PetStatusTransition: MessageFns<PetStatusTransition> = {
       transitionId: isSet(object.transitionId)
         ? globalThis.String(object.transitionId)
         : isSet(object.transition_id)
-        ? globalThis.String(object.transition_id)
-        : "",
+          ? globalThis.String(object.transition_id)
+          : '',
       petId: isSet(object.petId)
         ? globalThis.String(object.petId)
         : isSet(object.pet_id)
-        ? globalThis.String(object.pet_id)
-        : "",
+          ? globalThis.String(object.pet_id)
+          : '',
       fromStatus: isSet(object.fromStatus)
         ? petStatusFromJSON(object.fromStatus)
         : isSet(object.from_status)
-        ? petStatusFromJSON(object.from_status)
-        : undefined,
+          ? petStatusFromJSON(object.from_status)
+          : undefined,
       toStatus: isSet(object.toStatus)
         ? petStatusFromJSON(object.toStatus)
         : isSet(object.to_status)
-        ? petStatusFromJSON(object.to_status)
-        : 0,
+          ? petStatusFromJSON(object.to_status)
+          : 0,
       transitionedAt: isSet(object.transitionedAt)
         ? globalThis.String(object.transitionedAt)
         : isSet(object.transitioned_at)
-        ? globalThis.String(object.transitioned_at)
-        : "",
+          ? globalThis.String(object.transitioned_at)
+          : '',
       transitionedBy: isSet(object.transitionedBy)
         ? globalThis.String(object.transitionedBy)
         : isSet(object.transitioned_by)
-        ? globalThis.String(object.transitioned_by)
-        : undefined,
+          ? globalThis.String(object.transitioned_by)
+          : undefined,
       reason: isSet(object.reason) ? globalThis.String(object.reason) : undefined,
     };
   },
 
   toJSON(message: PetStatusTransition): unknown {
     const obj: any = {};
-    if (message.transitionId !== "") {
+    if (message.transitionId !== '') {
       obj.transitionId = message.transitionId;
     }
-    if (message.petId !== "") {
+    if (message.petId !== '') {
       obj.petId = message.petId;
     }
     if (message.fromStatus !== undefined) {
@@ -1373,7 +1377,7 @@ export const PetStatusTransition: MessageFns<PetStatusTransition> = {
     if (message.toStatus !== 0) {
       obj.toStatus = petStatusToJSON(message.toStatus);
     }
-    if (message.transitionedAt !== "") {
+    if (message.transitionedAt !== '') {
       obj.transitionedAt = message.transitionedAt;
     }
     if (message.transitionedBy !== undefined) {
@@ -1388,13 +1392,15 @@ export const PetStatusTransition: MessageFns<PetStatusTransition> = {
   create<I extends Exact<DeepPartial<PetStatusTransition>, I>>(base?: I): PetStatusTransition {
     return PetStatusTransition.fromPartial(base ?? ({} as any));
   },
-  fromPartial<I extends Exact<DeepPartial<PetStatusTransition>, I>>(object: I): PetStatusTransition {
+  fromPartial<I extends Exact<DeepPartial<PetStatusTransition>, I>>(
+    object: I
+  ): PetStatusTransition {
     const message = createBasePetStatusTransition();
-    message.transitionId = object.transitionId ?? "";
-    message.petId = object.petId ?? "";
+    message.transitionId = object.transitionId ?? '';
+    message.petId = object.petId ?? '';
     message.fromStatus = object.fromStatus ?? undefined;
     message.toStatus = object.toStatus ?? 0;
-    message.transitionedAt = object.transitionedAt ?? "";
+    message.transitionedAt = object.transitionedAt ?? '';
     message.transitionedBy = object.transitionedBy ?? undefined;
     message.reason = object.reason ?? undefined;
     return message;
@@ -1403,8 +1409,8 @@ export const PetStatusTransition: MessageFns<PetStatusTransition> = {
 
 function createBaseCreatePetRequest(): CreatePetRequest {
   return {
-    name: "",
-    rescueId: "",
+    name: '',
+    rescueId: '',
     type: 0,
     gender: 0,
     size: 0,
@@ -1419,18 +1425,18 @@ function createBaseCreatePetRequest(): CreatePetRequest {
     adoptionFeeCurrency: undefined,
     specialNeeds: false,
     houseTrained: false,
-    temperamentJson: "",
-    tagsJson: "",
-    extraJson: "",
+    temperamentJson: '',
+    tagsJson: '',
+    extraJson: '',
   };
 }
 
 export const CreatePetRequest: MessageFns<CreatePetRequest> = {
   encode(message: CreatePetRequest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    if (message.name !== "") {
+    if (message.name !== '') {
       writer.uint32(10).string(message.name);
     }
-    if (message.rescueId !== "") {
+    if (message.rescueId !== '') {
       writer.uint32(18).string(message.rescueId);
     }
     if (message.type !== 0) {
@@ -1475,13 +1481,13 @@ export const CreatePetRequest: MessageFns<CreatePetRequest> = {
     if (message.houseTrained !== false) {
       writer.uint32(128).bool(message.houseTrained);
     }
-    if (message.temperamentJson !== "") {
+    if (message.temperamentJson !== '') {
       writer.uint32(138).string(message.temperamentJson);
     }
-    if (message.tagsJson !== "") {
+    if (message.tagsJson !== '') {
       writer.uint32(146).string(message.tagsJson);
     }
-    if (message.extraJson !== "") {
+    if (message.extraJson !== '') {
       writer.uint32(154).string(message.extraJson);
     }
     return writer;
@@ -1657,94 +1663,94 @@ export const CreatePetRequest: MessageFns<CreatePetRequest> = {
 
   fromJSON(object: any): CreatePetRequest {
     return {
-      name: isSet(object.name) ? globalThis.String(object.name) : "",
+      name: isSet(object.name) ? globalThis.String(object.name) : '',
       rescueId: isSet(object.rescueId)
         ? globalThis.String(object.rescueId)
         : isSet(object.rescue_id)
-        ? globalThis.String(object.rescue_id)
-        : "",
+          ? globalThis.String(object.rescue_id)
+          : '',
       type: isSet(object.type) ? petTypeFromJSON(object.type) : 0,
       gender: isSet(object.gender) ? petGenderFromJSON(object.gender) : 0,
       size: isSet(object.size) ? petSizeFromJSON(object.size) : 0,
       ageGroup: isSet(object.ageGroup)
         ? petAgeGroupFromJSON(object.ageGroup)
         : isSet(object.age_group)
-        ? petAgeGroupFromJSON(object.age_group)
-        : 0,
+          ? petAgeGroupFromJSON(object.age_group)
+          : 0,
       breedId: isSet(object.breedId)
         ? globalThis.String(object.breedId)
         : isSet(object.breed_id)
-        ? globalThis.String(object.breed_id)
-        : undefined,
+          ? globalThis.String(object.breed_id)
+          : undefined,
       secondaryBreedId: isSet(object.secondaryBreedId)
         ? globalThis.String(object.secondaryBreedId)
         : isSet(object.secondary_breed_id)
-        ? globalThis.String(object.secondary_breed_id)
-        : undefined,
+          ? globalThis.String(object.secondary_breed_id)
+          : undefined,
       shortDescription: isSet(object.shortDescription)
         ? globalThis.String(object.shortDescription)
         : isSet(object.short_description)
-        ? globalThis.String(object.short_description)
-        : undefined,
+          ? globalThis.String(object.short_description)
+          : undefined,
       longDescription: isSet(object.longDescription)
         ? globalThis.String(object.longDescription)
         : isSet(object.long_description)
-        ? globalThis.String(object.long_description)
-        : undefined,
+          ? globalThis.String(object.long_description)
+          : undefined,
       ageYears: isSet(object.ageYears)
         ? globalThis.Number(object.ageYears)
         : isSet(object.age_years)
-        ? globalThis.Number(object.age_years)
-        : undefined,
+          ? globalThis.Number(object.age_years)
+          : undefined,
       ageMonths: isSet(object.ageMonths)
         ? globalThis.Number(object.ageMonths)
         : isSet(object.age_months)
-        ? globalThis.Number(object.age_months)
-        : undefined,
+          ? globalThis.Number(object.age_months)
+          : undefined,
       adoptionFeeMinor: isSet(object.adoptionFeeMinor)
         ? globalThis.Number(object.adoptionFeeMinor)
         : isSet(object.adoption_fee_minor)
-        ? globalThis.Number(object.adoption_fee_minor)
-        : undefined,
+          ? globalThis.Number(object.adoption_fee_minor)
+          : undefined,
       adoptionFeeCurrency: isSet(object.adoptionFeeCurrency)
         ? globalThis.String(object.adoptionFeeCurrency)
         : isSet(object.adoption_fee_currency)
-        ? globalThis.String(object.adoption_fee_currency)
-        : undefined,
+          ? globalThis.String(object.adoption_fee_currency)
+          : undefined,
       specialNeeds: isSet(object.specialNeeds)
         ? globalThis.Boolean(object.specialNeeds)
         : isSet(object.special_needs)
-        ? globalThis.Boolean(object.special_needs)
-        : false,
+          ? globalThis.Boolean(object.special_needs)
+          : false,
       houseTrained: isSet(object.houseTrained)
         ? globalThis.Boolean(object.houseTrained)
         : isSet(object.house_trained)
-        ? globalThis.Boolean(object.house_trained)
-        : false,
+          ? globalThis.Boolean(object.house_trained)
+          : false,
       temperamentJson: isSet(object.temperamentJson)
         ? globalThis.String(object.temperamentJson)
         : isSet(object.temperament_json)
-        ? globalThis.String(object.temperament_json)
-        : "",
+          ? globalThis.String(object.temperament_json)
+          : '',
       tagsJson: isSet(object.tagsJson)
         ? globalThis.String(object.tagsJson)
         : isSet(object.tags_json)
-        ? globalThis.String(object.tags_json)
-        : "",
+          ? globalThis.String(object.tags_json)
+          : '',
       extraJson: isSet(object.extraJson)
         ? globalThis.String(object.extraJson)
         : isSet(object.extra_json)
-        ? globalThis.String(object.extra_json)
-        : "",
+          ? globalThis.String(object.extra_json)
+          : '',
     };
   },
 
   toJSON(message: CreatePetRequest): unknown {
     const obj: any = {};
-    if (message.name !== "") {
+    if (message.name !== '') {
       obj.name = message.name;
     }
-    if (message.rescueId !== "") {
+    if (message.rescueId !== '') {
       obj.rescueId = message.rescueId;
     }
     if (message.type !== 0) {
@@ -1789,13 +1795,13 @@ export const CreatePetRequest: MessageFns<CreatePetRequest> = {
     if (message.houseTrained !== false) {
       obj.houseTrained = message.houseTrained;
     }
-    if (message.temperamentJson !== "") {
+    if (message.temperamentJson !== '') {
       obj.temperamentJson = message.temperamentJson;
     }
-    if (message.tagsJson !== "") {
+    if (message.tagsJson !== '') {
       obj.tagsJson = message.tagsJson;
     }
-    if (message.extraJson !== "") {
+    if (message.extraJson !== '') {
       obj.extraJson = message.extraJson;
     }
     return obj;
@@ -1806,8 +1812,8 @@ export const CreatePetRequest: MessageFns<CreatePetRequest> = {
   },
   fromPartial<I extends Exact<DeepPartial<CreatePetRequest>, I>>(object: I): CreatePetRequest {
     const message = createBaseCreatePetRequest();
-    message.name = object.name ?? "";
-    message.rescueId = object.rescueId ?? "";
+    message.name = object.name ?? '';
+    message.rescueId = object.rescueId ?? '';
     message.type = object.type ?? 0;
     message.gender = object.gender ?? 0;
     message.size = object.size ?? 0;
@@ -1822,9 +1828,9 @@ export const CreatePetRequest: MessageFns<CreatePetRequest> = {
     message.adoptionFeeCurrency = object.adoptionFeeCurrency ?? undefined;
     message.specialNeeds = object.specialNeeds ?? false;
     message.houseTrained = object.houseTrained ?? false;
-    message.temperamentJson = object.temperamentJson ?? "";
-    message.tagsJson = object.tagsJson ?? "";
-    message.extraJson = object.extraJson ?? "";
+    message.temperamentJson = object.temperamentJson ?? '';
+    message.tagsJson = object.tagsJson ?? '';
+    message.extraJson = object.extraJson ?? '';
     return message;
   },
 };
@@ -1882,18 +1888,19 @@ export const CreatePetResponse: MessageFns<CreatePetResponse> = {
   },
   fromPartial<I extends Exact<DeepPartial<CreatePetResponse>, I>>(object: I): CreatePetResponse {
     const message = createBaseCreatePetResponse();
-    message.pet = (object.pet !== undefined && object.pet !== null) ? Pet.fromPartial(object.pet) : undefined;
+    message.pet =
+      object.pet !== undefined && object.pet !== null ? Pet.fromPartial(object.pet) : undefined;
     return message;
   },
 };
 
 function createBaseGetPetRequest(): GetPetRequest {
-  return { petId: "" };
+  return { petId: '' };
 }
 
 export const GetPetRequest: MessageFns<GetPetRequest> = {
   encode(message: GetPetRequest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    if (message.petId !== "") {
+    if (message.petId !== '') {
       writer.uint32(10).string(message.petId);
     }
     return writer;
@@ -1928,14 +1935,14 @@ export const GetPetRequest: MessageFns<GetPetRequest> = {
       petId: isSet(object.petId)
         ? globalThis.String(object.petId)
         : isSet(object.pet_id)
-        ? globalThis.String(object.pet_id)
-        : "",
+          ? globalThis.String(object.pet_id)
+          : '',
     };
   },
 
   toJSON(message: GetPetRequest): unknown {
     const obj: any = {};
-    if (message.petId !== "") {
+    if (message.petId !== '') {
       obj.petId = message.petId;
     }
     return obj;
@@ -1946,7 +1953,7 @@ export const GetPetRequest: MessageFns<GetPetRequest> = {
   },
   fromPartial<I extends Exact<DeepPartial<GetPetRequest>, I>>(object: I): GetPetRequest {
     const message = createBaseGetPetRequest();
-    message.petId = object.petId ?? "";
+    message.petId = object.petId ?? '';
     return message;
   },
 };
@@ -2004,13 +2011,21 @@ export const GetPetResponse: MessageFns<GetPetResponse> = {
   },
   fromPartial<I extends Exact<DeepPartial<GetPetResponse>, I>>(object: I): GetPetResponse {
     const message = createBaseGetPetResponse();
-    message.pet = (object.pet !== undefined && object.pet !== null) ? Pet.fromPartial(object.pet) : undefined;
+    message.pet =
+      object.pet !== undefined && object.pet !== null ? Pet.fromPartial(object.pet) : undefined;
     return message;
   },
 };
 
 function createBaseListPetsRequest(): ListPetsRequest {
-  return { cursor: undefined, limit: 0, statusFilter: 0, typeFilter: 0, sizeFilter: 0, rescueIdFilter: undefined };
+  return {
+    cursor: undefined,
+    limit: 0,
+    statusFilter: 0,
+    typeFilter: 0,
+    sizeFilter: 0,
+    rescueIdFilter: undefined,
+  };
 }
 
 export const ListPetsRequest: MessageFns<ListPetsRequest> = {
@@ -2107,23 +2122,23 @@ export const ListPetsRequest: MessageFns<ListPetsRequest> = {
       statusFilter: isSet(object.statusFilter)
         ? petStatusFromJSON(object.statusFilter)
         : isSet(object.status_filter)
-        ? petStatusFromJSON(object.status_filter)
-        : 0,
+          ? petStatusFromJSON(object.status_filter)
+          : 0,
       typeFilter: isSet(object.typeFilter)
         ? petTypeFromJSON(object.typeFilter)
         : isSet(object.type_filter)
-        ? petTypeFromJSON(object.type_filter)
-        : 0,
+          ? petTypeFromJSON(object.type_filter)
+          : 0,
       sizeFilter: isSet(object.sizeFilter)
         ? petSizeFromJSON(object.sizeFilter)
         : isSet(object.size_filter)
-        ? petSizeFromJSON(object.size_filter)
-        : 0,
+          ? petSizeFromJSON(object.size_filter)
+          : 0,
       rescueIdFilter: isSet(object.rescueIdFilter)
         ? globalThis.String(object.rescueIdFilter)
         : isSet(object.rescue_id_filter)
-        ? globalThis.String(object.rescue_id_filter)
-        : undefined,
+          ? globalThis.String(object.rescue_id_filter)
+          : undefined,
     };
   },
 
@@ -2214,19 +2229,21 @@ export const ListPetsResponse: MessageFns<ListPetsResponse> = {
 
   fromJSON(object: any): ListPetsResponse {
     return {
-      pets: globalThis.Array.isArray(object?.pets) ? object.pets.map((e: any) => Pet.fromJSON(e)) : [],
+      pets: globalThis.Array.isArray(object?.pets)
+        ? object.pets.map((e: any) => Pet.fromJSON(e))
+        : [],
       nextCursor: isSet(object.nextCursor)
         ? globalThis.String(object.nextCursor)
         : isSet(object.next_cursor)
-        ? globalThis.String(object.next_cursor)
-        : undefined,
+          ? globalThis.String(object.next_cursor)
+          : undefined,
     };
   },
 
   toJSON(message: ListPetsResponse): unknown {
     const obj: any = {};
     if (message.pets?.length) {
-      obj.pets = message.pets.map((e) => Pet.toJSON(e));
+      obj.pets = message.pets.map(e => Pet.toJSON(e));
     }
     if (message.nextCursor !== undefined) {
       obj.nextCursor = message.nextCursor;
@@ -2239,7 +2256,7 @@ export const ListPetsResponse: MessageFns<ListPetsResponse> = {
   },
   fromPartial<I extends Exact<DeepPartial<ListPetsResponse>, I>>(object: I): ListPetsResponse {
     const message = createBaseListPetsResponse();
-    message.pets = object.pets?.map((e) => Pet.fromPartial(e)) || [];
+    message.pets = object.pets?.map(e => Pet.fromPartial(e)) || [];
     message.nextCursor = object.nextCursor ?? undefined;
     return message;
   },
@@ -2247,7 +2264,7 @@ export const ListPetsResponse: MessageFns<ListPetsResponse> = {
 
 function createBaseUpdatePetRequest(): UpdatePetRequest {
   return {
-    petId: "",
+    petId: '',
     name: undefined,
     shortDescription: undefined,
     longDescription: undefined,
@@ -2270,7 +2287,7 @@ function createBaseUpdatePetRequest(): UpdatePetRequest {
 
 export const UpdatePetRequest: MessageFns<UpdatePetRequest> = {
   encode(message: UpdatePetRequest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    if (message.petId !== "") {
+    if (message.petId !== '') {
       writer.uint32(10).string(message.petId);
     }
     if (message.name !== undefined) {
@@ -2492,83 +2509,83 @@ export const UpdatePetRequest: MessageFns<UpdatePetRequest> = {
       petId: isSet(object.petId)
         ? globalThis.String(object.petId)
         : isSet(object.pet_id)
-        ? globalThis.String(object.pet_id)
-        : "",
+          ? globalThis.String(object.pet_id)
+          : '',
       name: isSet(object.name) ? globalThis.String(object.name) : undefined,
       shortDescription: isSet(object.shortDescription)
         ? globalThis.String(object.shortDescription)
         : isSet(object.short_description)
-        ? globalThis.String(object.short_description)
-        : undefined,
+          ? globalThis.String(object.short_description)
+          : undefined,
       longDescription: isSet(object.longDescription)
         ? globalThis.String(object.longDescription)
         : isSet(object.long_description)
-        ? globalThis.String(object.long_description)
-        : undefined,
+          ? globalThis.String(object.long_description)
+          : undefined,
       gender: isSet(object.gender) ? petGenderFromJSON(object.gender) : undefined,
       size: isSet(object.size) ? petSizeFromJSON(object.size) : undefined,
       ageGroup: isSet(object.ageGroup)
         ? petAgeGroupFromJSON(object.ageGroup)
         : isSet(object.age_group)
-        ? petAgeGroupFromJSON(object.age_group)
-        : undefined,
+          ? petAgeGroupFromJSON(object.age_group)
+          : undefined,
       breedId: isSet(object.breedId)
         ? globalThis.String(object.breedId)
         : isSet(object.breed_id)
-        ? globalThis.String(object.breed_id)
-        : undefined,
+          ? globalThis.String(object.breed_id)
+          : undefined,
       secondaryBreedId: isSet(object.secondaryBreedId)
         ? globalThis.String(object.secondaryBreedId)
         : isSet(object.secondary_breed_id)
-        ? globalThis.String(object.secondary_breed_id)
-        : undefined,
+          ? globalThis.String(object.secondary_breed_id)
+          : undefined,
       adoptionFeeMinor: isSet(object.adoptionFeeMinor)
         ? globalThis.Number(object.adoptionFeeMinor)
         : isSet(object.adoption_fee_minor)
-        ? globalThis.Number(object.adoption_fee_minor)
-        : undefined,
+          ? globalThis.Number(object.adoption_fee_minor)
+          : undefined,
       adoptionFeeCurrency: isSet(object.adoptionFeeCurrency)
         ? globalThis.String(object.adoptionFeeCurrency)
         : isSet(object.adoption_fee_currency)
-        ? globalThis.String(object.adoption_fee_currency)
-        : undefined,
+          ? globalThis.String(object.adoption_fee_currency)
+          : undefined,
       specialNeeds: isSet(object.specialNeeds)
         ? globalThis.Boolean(object.specialNeeds)
         : isSet(object.special_needs)
-        ? globalThis.Boolean(object.special_needs)
-        : undefined,
+          ? globalThis.Boolean(object.special_needs)
+          : undefined,
       houseTrained: isSet(object.houseTrained)
         ? globalThis.Boolean(object.houseTrained)
         : isSet(object.house_trained)
-        ? globalThis.Boolean(object.house_trained)
-        : undefined,
+          ? globalThis.Boolean(object.house_trained)
+          : undefined,
       featured: isSet(object.featured) ? globalThis.Boolean(object.featured) : undefined,
       priorityListing: isSet(object.priorityListing)
         ? globalThis.Boolean(object.priorityListing)
         : isSet(object.priority_listing)
-        ? globalThis.Boolean(object.priority_listing)
-        : undefined,
+          ? globalThis.Boolean(object.priority_listing)
+          : undefined,
       temperamentJson: isSet(object.temperamentJson)
         ? globalThis.String(object.temperamentJson)
         : isSet(object.temperament_json)
-        ? globalThis.String(object.temperament_json)
-        : undefined,
+          ? globalThis.String(object.temperament_json)
+          : undefined,
       tagsJson: isSet(object.tagsJson)
         ? globalThis.String(object.tagsJson)
         : isSet(object.tags_json)
-        ? globalThis.String(object.tags_json)
-        : undefined,
+          ? globalThis.String(object.tags_json)
+          : undefined,
       extraJson: isSet(object.extraJson)
         ? globalThis.String(object.extraJson)
         : isSet(object.extra_json)
-        ? globalThis.String(object.extra_json)
-        : undefined,
+          ? globalThis.String(object.extra_json)
+          : undefined,
     };
   },
 
   toJSON(message: UpdatePetRequest): unknown {
     const obj: any = {};
-    if (message.petId !== "") {
+    if (message.petId !== '') {
       obj.petId = message.petId;
     }
     if (message.name !== undefined) {
@@ -2630,7 +2647,7 @@ export const UpdatePetRequest: MessageFns<UpdatePetRequest> = {
   },
   fromPartial<I extends Exact<DeepPartial<UpdatePetRequest>, I>>(object: I): UpdatePetRequest {
     const message = createBaseUpdatePetRequest();
-    message.petId = object.petId ?? "";
+    message.petId = object.petId ?? '';
     message.name = object.name ?? undefined;
     message.shortDescription = object.shortDescription ?? undefined;
     message.longDescription = object.longDescription ?? undefined;
@@ -2705,18 +2722,19 @@ export const UpdatePetResponse: MessageFns<UpdatePetResponse> = {
   },
   fromPartial<I extends Exact<DeepPartial<UpdatePetResponse>, I>>(object: I): UpdatePetResponse {
     const message = createBaseUpdatePetResponse();
-    message.pet = (object.pet !== undefined && object.pet !== null) ? Pet.fromPartial(object.pet) : undefined;
+    message.pet =
+      object.pet !== undefined && object.pet !== null ? Pet.fromPartial(object.pet) : undefined;
     return message;
   },
 };
 
 function createBaseUpdatePetStatusRequest(): UpdatePetStatusRequest {
-  return { petId: "", toStatus: 0, reason: undefined };
+  return { petId: '', toStatus: 0, reason: undefined };
 }
 
 export const UpdatePetStatusRequest: MessageFns<UpdatePetStatusRequest> = {
   encode(message: UpdatePetStatusRequest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    if (message.petId !== "") {
+    if (message.petId !== '') {
       writer.uint32(10).string(message.petId);
     }
     if (message.toStatus !== 0) {
@@ -2773,20 +2791,20 @@ export const UpdatePetStatusRequest: MessageFns<UpdatePetStatusRequest> = {
       petId: isSet(object.petId)
         ? globalThis.String(object.petId)
         : isSet(object.pet_id)
-        ? globalThis.String(object.pet_id)
-        : "",
+          ? globalThis.String(object.pet_id)
+          : '',
       toStatus: isSet(object.toStatus)
         ? petStatusFromJSON(object.toStatus)
         : isSet(object.to_status)
-        ? petStatusFromJSON(object.to_status)
-        : 0,
+          ? petStatusFromJSON(object.to_status)
+          : 0,
       reason: isSet(object.reason) ? globalThis.String(object.reason) : undefined,
     };
   },
 
   toJSON(message: UpdatePetStatusRequest): unknown {
     const obj: any = {};
-    if (message.petId !== "") {
+    if (message.petId !== '') {
       obj.petId = message.petId;
     }
     if (message.toStatus !== 0) {
@@ -2798,12 +2816,16 @@ export const UpdatePetStatusRequest: MessageFns<UpdatePetStatusRequest> = {
     return obj;
   },
 
-  create<I extends Exact<DeepPartial<UpdatePetStatusRequest>, I>>(base?: I): UpdatePetStatusRequest {
+  create<I extends Exact<DeepPartial<UpdatePetStatusRequest>, I>>(
+    base?: I
+  ): UpdatePetStatusRequest {
     return UpdatePetStatusRequest.fromPartial(base ?? ({} as any));
   },
-  fromPartial<I extends Exact<DeepPartial<UpdatePetStatusRequest>, I>>(object: I): UpdatePetStatusRequest {
+  fromPartial<I extends Exact<DeepPartial<UpdatePetStatusRequest>, I>>(
+    object: I
+  ): UpdatePetStatusRequest {
     const message = createBaseUpdatePetStatusRequest();
-    message.petId = object.petId ?? "";
+    message.petId = object.petId ?? '';
     message.toStatus = object.toStatus ?? 0;
     message.reason = object.reason ?? undefined;
     return message;
@@ -2815,7 +2837,10 @@ function createBaseUpdatePetStatusResponse(): UpdatePetStatusResponse {
 }
 
 export const UpdatePetStatusResponse: MessageFns<UpdatePetStatusResponse> = {
-  encode(message: UpdatePetStatusResponse, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+  encode(
+    message: UpdatePetStatusResponse,
+    writer: BinaryWriter = new BinaryWriter()
+  ): BinaryWriter {
     if (message.pet !== undefined) {
       Pet.encode(message.pet, writer.uint32(10).fork()).join();
     }
@@ -2860,7 +2885,9 @@ export const UpdatePetStatusResponse: MessageFns<UpdatePetStatusResponse> = {
   fromJSON(object: any): UpdatePetStatusResponse {
     return {
       pet: isSet(object.pet) ? Pet.fromJSON(object.pet) : undefined,
-      transition: isSet(object.transition) ? PetStatusTransition.fromJSON(object.transition) : undefined,
+      transition: isSet(object.transition)
+        ? PetStatusTransition.fromJSON(object.transition)
+        : undefined,
     };
   },
 
@@ -2875,26 +2902,32 @@ export const UpdatePetStatusResponse: MessageFns<UpdatePetStatusResponse> = {
     return obj;
   },
 
-  create<I extends Exact<DeepPartial<UpdatePetStatusResponse>, I>>(base?: I): UpdatePetStatusResponse {
+  create<I extends Exact<DeepPartial<UpdatePetStatusResponse>, I>>(
+    base?: I
+  ): UpdatePetStatusResponse {
     return UpdatePetStatusResponse.fromPartial(base ?? ({} as any));
   },
-  fromPartial<I extends Exact<DeepPartial<UpdatePetStatusResponse>, I>>(object: I): UpdatePetStatusResponse {
+  fromPartial<I extends Exact<DeepPartial<UpdatePetStatusResponse>, I>>(
+    object: I
+  ): UpdatePetStatusResponse {
     const message = createBaseUpdatePetStatusResponse();
-    message.pet = (object.pet !== undefined && object.pet !== null) ? Pet.fromPartial(object.pet) : undefined;
-    message.transition = (object.transition !== undefined && object.transition !== null)
-      ? PetStatusTransition.fromPartial(object.transition)
-      : undefined;
+    message.pet =
+      object.pet !== undefined && object.pet !== null ? Pet.fromPartial(object.pet) : undefined;
+    message.transition =
+      object.transition !== undefined && object.transition !== null
+        ? PetStatusTransition.fromPartial(object.transition)
+        : undefined;
     return message;
   },
 };
 
 function createBaseDeletePetRequest(): DeletePetRequest {
-  return { petId: "" };
+  return { petId: '' };
 }
 
 export const DeletePetRequest: MessageFns<DeletePetRequest> = {
   encode(message: DeletePetRequest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    if (message.petId !== "") {
+    if (message.petId !== '') {
       writer.uint32(10).string(message.petId);
     }
     return writer;
@@ -2929,14 +2962,14 @@ export const DeletePetRequest: MessageFns<DeletePetRequest> = {
       petId: isSet(object.petId)
         ? globalThis.String(object.petId)
         : isSet(object.pet_id)
-        ? globalThis.String(object.pet_id)
-        : "",
+          ? globalThis.String(object.pet_id)
+          : '',
     };
   },
 
   toJSON(message: DeletePetRequest): unknown {
     const obj: any = {};
-    if (message.petId !== "") {
+    if (message.petId !== '') {
       obj.petId = message.petId;
     }
     return obj;
@@ -2947,7 +2980,7 @@ export const DeletePetRequest: MessageFns<DeletePetRequest> = {
   },
   fromPartial<I extends Exact<DeepPartial<DeletePetRequest>, I>>(object: I): DeletePetRequest {
     const message = createBaseDeletePetRequest();
-    message.petId = object.petId ?? "";
+    message.petId = object.petId ?? '';
     return message;
   },
 };
@@ -3051,8 +3084,8 @@ export const GetPetStatsRequest: MessageFns<GetPetStatsRequest> = {
       rescueIdFilter: isSet(object.rescueIdFilter)
         ? globalThis.String(object.rescueIdFilter)
         : isSet(object.rescue_id_filter)
-        ? globalThis.String(object.rescue_id_filter)
-        : undefined,
+          ? globalThis.String(object.rescue_id_filter)
+          : undefined,
     };
   },
 
@@ -3242,29 +3275,29 @@ export const GetPetStatsResponse: MessageFns<GetPetStatsResponse> = {
       medicalHold: isSet(object.medicalHold)
         ? globalThis.Number(object.medicalHold)
         : isSet(object.medical_hold)
-        ? globalThis.Number(object.medical_hold)
-        : 0,
+          ? globalThis.Number(object.medical_hold)
+          : 0,
       behavioralHold: isSet(object.behavioralHold)
         ? globalThis.Number(object.behavioralHold)
         : isSet(object.behavioral_hold)
-        ? globalThis.Number(object.behavioral_hold)
-        : 0,
+          ? globalThis.Number(object.behavioral_hold)
+          : 0,
       notAvailable: isSet(object.notAvailable)
         ? globalThis.Number(object.notAvailable)
         : isSet(object.not_available)
-        ? globalThis.Number(object.not_available)
-        : 0,
+          ? globalThis.Number(object.not_available)
+          : 0,
       deceased: isSet(object.deceased) ? globalThis.Number(object.deceased) : 0,
       monthlyAdoptions: isSet(object.monthlyAdoptions)
         ? globalThis.Number(object.monthlyAdoptions)
         : isSet(object.monthly_adoptions)
-        ? globalThis.Number(object.monthly_adoptions)
-        : 0,
+          ? globalThis.Number(object.monthly_adoptions)
+          : 0,
       averageDaysToAdoption: isSet(object.averageDaysToAdoption)
         ? globalThis.Number(object.averageDaysToAdoption)
         : isSet(object.average_days_to_adoption)
-        ? globalThis.Number(object.average_days_to_adoption)
-        : 0,
+          ? globalThis.Number(object.average_days_to_adoption)
+          : 0,
     };
   },
 
@@ -3309,7 +3342,9 @@ export const GetPetStatsResponse: MessageFns<GetPetStatsResponse> = {
   create<I extends Exact<DeepPartial<GetPetStatsResponse>, I>>(base?: I): GetPetStatsResponse {
     return GetPetStatsResponse.fromPartial(base ?? ({} as any));
   },
-  fromPartial<I extends Exact<DeepPartial<GetPetStatsResponse>, I>>(object: I): GetPetStatsResponse {
+  fromPartial<I extends Exact<DeepPartial<GetPetStatsResponse>, I>>(
+    object: I
+  ): GetPetStatsResponse {
     const message = createBaseGetPetStatsResponse();
     message.total = object.total ?? 0;
     message.available = object.available ?? 0;
@@ -3322,6 +3357,148 @@ export const GetPetStatsResponse: MessageFns<GetPetStatsResponse> = {
     message.deceased = object.deceased ?? 0;
     message.monthlyAdoptions = object.monthlyAdoptions ?? 0;
     message.averageDaysToAdoption = object.averageDaysToAdoption ?? 0;
+    return message;
+  },
+};
+
+function createBaseListPetFavoritersRequest(): ListPetFavoritersRequest {
+  return { petId: '' };
+}
+
+export const ListPetFavoritersRequest: MessageFns<ListPetFavoritersRequest> = {
+  encode(
+    message: ListPetFavoritersRequest,
+    writer: BinaryWriter = new BinaryWriter()
+  ): BinaryWriter {
+    if (message.petId !== '') {
+      writer.uint32(10).string(message.petId);
+    }
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): ListPetFavoritersRequest {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseListPetFavoritersRequest();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1: {
+          if (tag !== 10) {
+            break;
+          }
+
+          message.petId = reader.string();
+          continue;
+        }
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): ListPetFavoritersRequest {
+    return {
+      petId: isSet(object.petId)
+        ? globalThis.String(object.petId)
+        : isSet(object.pet_id)
+          ? globalThis.String(object.pet_id)
+          : '',
+    };
+  },
+
+  toJSON(message: ListPetFavoritersRequest): unknown {
+    const obj: any = {};
+    if (message.petId !== '') {
+      obj.petId = message.petId;
+    }
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<ListPetFavoritersRequest>, I>>(
+    base?: I
+  ): ListPetFavoritersRequest {
+    return ListPetFavoritersRequest.fromPartial(base ?? ({} as any));
+  },
+  fromPartial<I extends Exact<DeepPartial<ListPetFavoritersRequest>, I>>(
+    object: I
+  ): ListPetFavoritersRequest {
+    const message = createBaseListPetFavoritersRequest();
+    message.petId = object.petId ?? '';
+    return message;
+  },
+};
+
+function createBaseListPetFavoritersResponse(): ListPetFavoritersResponse {
+  return { userIds: [] };
+}
+
+export const ListPetFavoritersResponse: MessageFns<ListPetFavoritersResponse> = {
+  encode(
+    message: ListPetFavoritersResponse,
+    writer: BinaryWriter = new BinaryWriter()
+  ): BinaryWriter {
+    for (const v of message.userIds) {
+      writer.uint32(10).string(v!);
+    }
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): ListPetFavoritersResponse {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseListPetFavoritersResponse();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1: {
+          if (tag !== 10) {
+            break;
+          }
+
+          message.userIds.push(reader.string());
+          continue;
+        }
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): ListPetFavoritersResponse {
+    return {
+      userIds: globalThis.Array.isArray(object?.userIds)
+        ? object.userIds.map((e: any) => globalThis.String(e))
+        : globalThis.Array.isArray(object?.user_ids)
+          ? object.user_ids.map((e: any) => globalThis.String(e))
+          : [],
+    };
+  },
+
+  toJSON(message: ListPetFavoritersResponse): unknown {
+    const obj: any = {};
+    if (message.userIds?.length) {
+      obj.userIds = message.userIds;
+    }
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<ListPetFavoritersResponse>, I>>(
+    base?: I
+  ): ListPetFavoritersResponse {
+    return ListPetFavoritersResponse.fromPartial(base ?? ({} as any));
+  },
+  fromPartial<I extends Exact<DeepPartial<ListPetFavoritersResponse>, I>>(
+    object: I
+  ): ListPetFavoritersResponse {
+    const message = createBaseListPetFavoritersResponse();
+    message.userIds = object.userIds?.map(e => e) || [];
     return message;
   },
 };
@@ -3350,22 +3527,26 @@ export const PetServiceService = {
    * the target rescue. Publishes `pets.created` on NATS after commit.
    */
   create: {
-    path: "/adopt_dont_shop.pets.v1.PetService/Create" as const,
+    path: '/adopt_dont_shop.pets.v1.PetService/Create' as const,
     requestStream: false as const,
     responseStream: false as const,
-    requestSerialize: (value: CreatePetRequest): Buffer => Buffer.from(CreatePetRequest.encode(value).finish()),
+    requestSerialize: (value: CreatePetRequest): Buffer =>
+      Buffer.from(CreatePetRequest.encode(value).finish()),
     requestDeserialize: (value: Buffer): CreatePetRequest => CreatePetRequest.decode(value),
-    responseSerialize: (value: CreatePetResponse): Buffer => Buffer.from(CreatePetResponse.encode(value).finish()),
+    responseSerialize: (value: CreatePetResponse): Buffer =>
+      Buffer.from(CreatePetResponse.encode(value).finish()),
     responseDeserialize: (value: Buffer): CreatePetResponse => CreatePetResponse.decode(value),
   },
   /** Fetch a single pet by id. NOT_FOUND when missing or soft-deleted. */
   get: {
-    path: "/adopt_dont_shop.pets.v1.PetService/Get" as const,
+    path: '/adopt_dont_shop.pets.v1.PetService/Get' as const,
     requestStream: false as const,
     responseStream: false as const,
-    requestSerialize: (value: GetPetRequest): Buffer => Buffer.from(GetPetRequest.encode(value).finish()),
+    requestSerialize: (value: GetPetRequest): Buffer =>
+      Buffer.from(GetPetRequest.encode(value).finish()),
     requestDeserialize: (value: Buffer): GetPetRequest => GetPetRequest.decode(value),
-    responseSerialize: (value: GetPetResponse): Buffer => Buffer.from(GetPetResponse.encode(value).finish()),
+    responseSerialize: (value: GetPetResponse): Buffer =>
+      Buffer.from(GetPetResponse.encode(value).finish()),
     responseDeserialize: (value: Buffer): GetPetResponse => GetPetResponse.decode(value),
   },
   /**
@@ -3374,12 +3555,14 @@ export const PetServiceService = {
    * their own rescue via the rescue_id filter.
    */
   list: {
-    path: "/adopt_dont_shop.pets.v1.PetService/List" as const,
+    path: '/adopt_dont_shop.pets.v1.PetService/List' as const,
     requestStream: false as const,
     responseStream: false as const,
-    requestSerialize: (value: ListPetsRequest): Buffer => Buffer.from(ListPetsRequest.encode(value).finish()),
+    requestSerialize: (value: ListPetsRequest): Buffer =>
+      Buffer.from(ListPetsRequest.encode(value).finish()),
     requestDeserialize: (value: Buffer): ListPetsRequest => ListPetsRequest.decode(value),
-    responseSerialize: (value: ListPetsResponse): Buffer => Buffer.from(ListPetsResponse.encode(value).finish()),
+    responseSerialize: (value: ListPetsResponse): Buffer =>
+      Buffer.from(ListPetsResponse.encode(value).finish()),
     responseDeserialize: (value: Buffer): ListPetsResponse => ListPetsResponse.decode(value),
   },
   /**
@@ -3388,12 +3571,14 @@ export const PetServiceService = {
    * `pets.update` scoped to the pet's rescue. Publishes `pets.updated`.
    */
   update: {
-    path: "/adopt_dont_shop.pets.v1.PetService/Update" as const,
+    path: '/adopt_dont_shop.pets.v1.PetService/Update' as const,
     requestStream: false as const,
     responseStream: false as const,
-    requestSerialize: (value: UpdatePetRequest): Buffer => Buffer.from(UpdatePetRequest.encode(value).finish()),
+    requestSerialize: (value: UpdatePetRequest): Buffer =>
+      Buffer.from(UpdatePetRequest.encode(value).finish()),
     requestDeserialize: (value: Buffer): UpdatePetRequest => UpdatePetRequest.decode(value),
-    responseSerialize: (value: UpdatePetResponse): Buffer => Buffer.from(UpdatePetResponse.encode(value).finish()),
+    responseSerialize: (value: UpdatePetResponse): Buffer =>
+      Buffer.from(UpdatePetResponse.encode(value).finish()),
     responseDeserialize: (value: Buffer): UpdatePetResponse => UpdatePetResponse.decode(value),
   },
   /**
@@ -3405,27 +3590,31 @@ export const PetServiceService = {
    * the handler). Caller MUST have `pets.update` scoped to the rescue.
    */
   updateStatus: {
-    path: "/adopt_dont_shop.pets.v1.PetService/UpdateStatus" as const,
+    path: '/adopt_dont_shop.pets.v1.PetService/UpdateStatus' as const,
     requestStream: false as const,
     responseStream: false as const,
     requestSerialize: (value: UpdatePetStatusRequest): Buffer =>
       Buffer.from(UpdatePetStatusRequest.encode(value).finish()),
-    requestDeserialize: (value: Buffer): UpdatePetStatusRequest => UpdatePetStatusRequest.decode(value),
+    requestDeserialize: (value: Buffer): UpdatePetStatusRequest =>
+      UpdatePetStatusRequest.decode(value),
     responseSerialize: (value: UpdatePetStatusResponse): Buffer =>
       Buffer.from(UpdatePetStatusResponse.encode(value).finish()),
-    responseDeserialize: (value: Buffer): UpdatePetStatusResponse => UpdatePetStatusResponse.decode(value),
+    responseDeserialize: (value: Buffer): UpdatePetStatusResponse =>
+      UpdatePetStatusResponse.decode(value),
   },
   /**
    * Soft-delete a pet (sets deleted_at). Caller MUST have `pets.delete`
    * scoped to the rescue. Publishes `pets.deleted` after commit.
    */
   delete: {
-    path: "/adopt_dont_shop.pets.v1.PetService/Delete" as const,
+    path: '/adopt_dont_shop.pets.v1.PetService/Delete' as const,
     requestStream: false as const,
     responseStream: false as const,
-    requestSerialize: (value: DeletePetRequest): Buffer => Buffer.from(DeletePetRequest.encode(value).finish()),
+    requestSerialize: (value: DeletePetRequest): Buffer =>
+      Buffer.from(DeletePetRequest.encode(value).finish()),
     requestDeserialize: (value: Buffer): DeletePetRequest => DeletePetRequest.decode(value),
-    responseSerialize: (value: DeletePetResponse): Buffer => Buffer.from(DeletePetResponse.encode(value).finish()),
+    responseSerialize: (value: DeletePetResponse): Buffer =>
+      Buffer.from(DeletePetResponse.encode(value).finish()),
     responseDeserialize: (value: Buffer): DeletePetResponse => DeletePetResponse.decode(value),
   },
   /**
@@ -3435,13 +3624,35 @@ export const PetServiceService = {
    * Self-scoped to the caller's rescue unless they hold pets.read:any.
    */
   getStats: {
-    path: "/adopt_dont_shop.pets.v1.PetService/GetStats" as const,
+    path: '/adopt_dont_shop.pets.v1.PetService/GetStats' as const,
     requestStream: false as const,
     responseStream: false as const,
-    requestSerialize: (value: GetPetStatsRequest): Buffer => Buffer.from(GetPetStatsRequest.encode(value).finish()),
+    requestSerialize: (value: GetPetStatsRequest): Buffer =>
+      Buffer.from(GetPetStatsRequest.encode(value).finish()),
     requestDeserialize: (value: Buffer): GetPetStatsRequest => GetPetStatsRequest.decode(value),
-    responseSerialize: (value: GetPetStatsResponse): Buffer => Buffer.from(GetPetStatsResponse.encode(value).finish()),
+    responseSerialize: (value: GetPetStatsResponse): Buffer =>
+      Buffer.from(GetPetStatsResponse.encode(value).finish()),
     responseDeserialize: (value: Buffer): GetPetStatsResponse => GetPetStatsResponse.decode(value),
+  },
+  /**
+   * List the user_ids of every adopter who has FAVOURITED a pet. A
+   * service-to-service read for recipient discovery — service.notifications
+   * fans `pets.statusChanged` out to these users. Caller MUST have
+   * `pets.read`. Returns an empty list (not NOT_FOUND) when the pet has
+   * no favouriters or does not exist.
+   */
+  listFavoriters: {
+    path: '/adopt_dont_shop.pets.v1.PetService/ListFavoriters' as const,
+    requestStream: false as const,
+    responseStream: false as const,
+    requestSerialize: (value: ListPetFavoritersRequest): Buffer =>
+      Buffer.from(ListPetFavoritersRequest.encode(value).finish()),
+    requestDeserialize: (value: Buffer): ListPetFavoritersRequest =>
+      ListPetFavoritersRequest.decode(value),
+    responseSerialize: (value: ListPetFavoritersResponse): Buffer =>
+      Buffer.from(ListPetFavoritersResponse.encode(value).finish()),
+    responseDeserialize: (value: Buffer): ListPetFavoritersResponse =>
+      ListPetFavoritersResponse.decode(value),
   },
 } as const;
 
@@ -3486,6 +3697,14 @@ export interface PetServiceServer extends UntypedServiceImplementation {
    * Self-scoped to the caller's rescue unless they hold pets.read:any.
    */
   getStats: handleUnaryCall<GetPetStatsRequest, GetPetStatsResponse>;
+  /**
+   * List the user_ids of every adopter who has FAVOURITED a pet. A
+   * service-to-service read for recipient discovery — service.notifications
+   * fans `pets.statusChanged` out to these users. Caller MUST have
+   * `pets.read`. Returns an empty list (not NOT_FOUND) when the pet has
+   * no favouriters or does not exist.
+   */
+  listFavoriters: handleUnaryCall<ListPetFavoritersRequest, ListPetFavoritersResponse>;
 }
 
 export interface PetServiceClient extends Client {
@@ -3495,34 +3714,34 @@ export interface PetServiceClient extends Client {
    */
   create(
     request: CreatePetRequest,
-    callback: (error: ServiceError | null, response: CreatePetResponse) => void,
+    callback: (error: ServiceError | null, response: CreatePetResponse) => void
   ): ClientUnaryCall;
   create(
     request: CreatePetRequest,
     metadata: Metadata,
-    callback: (error: ServiceError | null, response: CreatePetResponse) => void,
+    callback: (error: ServiceError | null, response: CreatePetResponse) => void
   ): ClientUnaryCall;
   create(
     request: CreatePetRequest,
     metadata: Metadata,
     options: Partial<CallOptions>,
-    callback: (error: ServiceError | null, response: CreatePetResponse) => void,
+    callback: (error: ServiceError | null, response: CreatePetResponse) => void
   ): ClientUnaryCall;
   /** Fetch a single pet by id. NOT_FOUND when missing or soft-deleted. */
   get(
     request: GetPetRequest,
-    callback: (error: ServiceError | null, response: GetPetResponse) => void,
+    callback: (error: ServiceError | null, response: GetPetResponse) => void
   ): ClientUnaryCall;
   get(
     request: GetPetRequest,
     metadata: Metadata,
-    callback: (error: ServiceError | null, response: GetPetResponse) => void,
+    callback: (error: ServiceError | null, response: GetPetResponse) => void
   ): ClientUnaryCall;
   get(
     request: GetPetRequest,
     metadata: Metadata,
     options: Partial<CallOptions>,
-    callback: (error: ServiceError | null, response: GetPetResponse) => void,
+    callback: (error: ServiceError | null, response: GetPetResponse) => void
   ): ClientUnaryCall;
   /**
    * List pets with keyset pagination + optional filters. Public-ish
@@ -3531,18 +3750,18 @@ export interface PetServiceClient extends Client {
    */
   list(
     request: ListPetsRequest,
-    callback: (error: ServiceError | null, response: ListPetsResponse) => void,
+    callback: (error: ServiceError | null, response: ListPetsResponse) => void
   ): ClientUnaryCall;
   list(
     request: ListPetsRequest,
     metadata: Metadata,
-    callback: (error: ServiceError | null, response: ListPetsResponse) => void,
+    callback: (error: ServiceError | null, response: ListPetsResponse) => void
   ): ClientUnaryCall;
   list(
     request: ListPetsRequest,
     metadata: Metadata,
     options: Partial<CallOptions>,
-    callback: (error: ServiceError | null, response: ListPetsResponse) => void,
+    callback: (error: ServiceError | null, response: ListPetsResponse) => void
   ): ClientUnaryCall;
   /**
    * Update mutable listing fields (descriptions, flags, fee, …). Does
@@ -3551,18 +3770,18 @@ export interface PetServiceClient extends Client {
    */
   update(
     request: UpdatePetRequest,
-    callback: (error: ServiceError | null, response: UpdatePetResponse) => void,
+    callback: (error: ServiceError | null, response: UpdatePetResponse) => void
   ): ClientUnaryCall;
   update(
     request: UpdatePetRequest,
     metadata: Metadata,
-    callback: (error: ServiceError | null, response: UpdatePetResponse) => void,
+    callback: (error: ServiceError | null, response: UpdatePetResponse) => void
   ): ClientUnaryCall;
   update(
     request: UpdatePetRequest,
     metadata: Metadata,
     options: Partial<CallOptions>,
-    callback: (error: ServiceError | null, response: UpdatePetResponse) => void,
+    callback: (error: ServiceError | null, response: UpdatePetResponse) => void
   ): ClientUnaryCall;
   /**
    * Drive the status state machine
@@ -3574,18 +3793,18 @@ export interface PetServiceClient extends Client {
    */
   updateStatus(
     request: UpdatePetStatusRequest,
-    callback: (error: ServiceError | null, response: UpdatePetStatusResponse) => void,
+    callback: (error: ServiceError | null, response: UpdatePetStatusResponse) => void
   ): ClientUnaryCall;
   updateStatus(
     request: UpdatePetStatusRequest,
     metadata: Metadata,
-    callback: (error: ServiceError | null, response: UpdatePetStatusResponse) => void,
+    callback: (error: ServiceError | null, response: UpdatePetStatusResponse) => void
   ): ClientUnaryCall;
   updateStatus(
     request: UpdatePetStatusRequest,
     metadata: Metadata,
     options: Partial<CallOptions>,
-    callback: (error: ServiceError | null, response: UpdatePetStatusResponse) => void,
+    callback: (error: ServiceError | null, response: UpdatePetStatusResponse) => void
   ): ClientUnaryCall;
   /**
    * Soft-delete a pet (sets deleted_at). Caller MUST have `pets.delete`
@@ -3593,18 +3812,18 @@ export interface PetServiceClient extends Client {
    */
   delete(
     request: DeletePetRequest,
-    callback: (error: ServiceError | null, response: DeletePetResponse) => void,
+    callback: (error: ServiceError | null, response: DeletePetResponse) => void
   ): ClientUnaryCall;
   delete(
     request: DeletePetRequest,
     metadata: Metadata,
-    callback: (error: ServiceError | null, response: DeletePetResponse) => void,
+    callback: (error: ServiceError | null, response: DeletePetResponse) => void
   ): ClientUnaryCall;
   delete(
     request: DeletePetRequest,
     metadata: Metadata,
     options: Partial<CallOptions>,
-    callback: (error: ServiceError | null, response: DeletePetResponse) => void,
+    callback: (error: ServiceError | null, response: DeletePetResponse) => void
   ): ClientUnaryCall;
   /**
    * Per-rescue (or platform-wide for admin) counts: total + per-status
@@ -3614,40 +3833,71 @@ export interface PetServiceClient extends Client {
    */
   getStats(
     request: GetPetStatsRequest,
-    callback: (error: ServiceError | null, response: GetPetStatsResponse) => void,
+    callback: (error: ServiceError | null, response: GetPetStatsResponse) => void
   ): ClientUnaryCall;
   getStats(
     request: GetPetStatsRequest,
     metadata: Metadata,
-    callback: (error: ServiceError | null, response: GetPetStatsResponse) => void,
+    callback: (error: ServiceError | null, response: GetPetStatsResponse) => void
   ): ClientUnaryCall;
   getStats(
     request: GetPetStatsRequest,
     metadata: Metadata,
     options: Partial<CallOptions>,
-    callback: (error: ServiceError | null, response: GetPetStatsResponse) => void,
+    callback: (error: ServiceError | null, response: GetPetStatsResponse) => void
+  ): ClientUnaryCall;
+  /**
+   * List the user_ids of every adopter who has FAVOURITED a pet. A
+   * service-to-service read for recipient discovery — service.notifications
+   * fans `pets.statusChanged` out to these users. Caller MUST have
+   * `pets.read`. Returns an empty list (not NOT_FOUND) when the pet has
+   * no favouriters or does not exist.
+   */
+  listFavoriters(
+    request: ListPetFavoritersRequest,
+    callback: (error: ServiceError | null, response: ListPetFavoritersResponse) => void
+  ): ClientUnaryCall;
+  listFavoriters(
+    request: ListPetFavoritersRequest,
+    metadata: Metadata,
+    callback: (error: ServiceError | null, response: ListPetFavoritersResponse) => void
+  ): ClientUnaryCall;
+  listFavoriters(
+    request: ListPetFavoritersRequest,
+    metadata: Metadata,
+    options: Partial<CallOptions>,
+    callback: (error: ServiceError | null, response: ListPetFavoritersResponse) => void
   ): ClientUnaryCall;
 }
 
 export const PetServiceClient = makeGenericClientConstructor(
   PetServiceService,
-  "adopt_dont_shop.pets.v1.PetService",
+  'adopt_dont_shop.pets.v1.PetService'
 ) as unknown as {
-  new (address: string, credentials: ChannelCredentials, options?: Partial<ClientOptions>): PetServiceClient;
+  new (
+    address: string,
+    credentials: ChannelCredentials,
+    options?: Partial<ClientOptions>
+  ): PetServiceClient;
   service: typeof PetServiceService;
   serviceName: string;
 };
 
 type Builtin = Date | Function | Uint8Array | string | number | boolean | undefined;
 
-export type DeepPartial<T> = T extends Builtin ? T
-  : T extends globalThis.Array<infer U> ? globalThis.Array<DeepPartial<U>>
-  : T extends ReadonlyArray<infer U> ? ReadonlyArray<DeepPartial<U>>
-  : T extends {} ? { [K in keyof T]?: DeepPartial<T[K]> }
-  : Partial<T>;
+export type DeepPartial<T> = T extends Builtin
+  ? T
+  : T extends globalThis.Array<infer U>
+    ? globalThis.Array<DeepPartial<U>>
+    : T extends ReadonlyArray<infer U>
+      ? ReadonlyArray<DeepPartial<U>>
+      : T extends {}
+        ? { [K in keyof T]?: DeepPartial<T[K]> }
+        : Partial<T>;
 
 type KeysOfUnion<T> = T extends T ? keyof T : never;
-export type Exact<P, I extends P> = P extends Builtin ? P
+export type Exact<P, I extends P> = P extends Builtin
+  ? P
   : P & { [K in keyof P]: Exact<P[K], I[K]> } & { [K in Exclude<keyof I, KeysOfUnion<P>>]: never };
 
 function isSet(value: any): boolean {

--- a/packages/proto/src/index.ts
+++ b/packages/proto/src/index.ts
@@ -188,6 +188,8 @@ export type {
   DeletePetResponse,
   GetPetStatsRequest,
   GetPetStatsResponse,
+  ListPetFavoritersRequest,
+  ListPetFavoritersResponse,
   PetServiceServer,
   PetServiceClient,
 } from './generated/proto/adopt_dont_shop/pets/v1/pet.js';

--- a/services/notifications/src/config.ts
+++ b/services/notifications/src/config.ts
@@ -24,6 +24,14 @@ export type NotificationsConfig = {
   // concrete user_ids. Optional in tests / migrations smokes; Broadcast
   // returns INTERNAL when unset.
   authGrpcUrl?: string;
+  // service.pets gRPC URL — needed by the pets.statusChanged fan-out
+  // (PetService.ListFavoriters discovers who favourited the pet). Optional;
+  // when unset the fan-out no-ops gracefully, like Broadcast without auth.
+  petsGrpcUrl?: string;
+  // service.rescue gRPC URL — needed by the rescue.verified / rescue.rejected
+  // fan-out (RescueService.ListStaffMembers + Get discover the rescue's
+  // staff). Optional; when unset the fan-out no-ops gracefully.
+  rescueGrpcUrl?: string;
   // Environment label, surfaced in health responses and on log lines.
   environment: string;
   // Postgres connection string. Required for migrations + the runtime
@@ -85,6 +93,8 @@ export const loadConfig = (env: NodeJS.ProcessEnv = process.env): NotificationsC
     port,
     grpcPort,
     authGrpcUrl: env.AUTH_GRPC_URL?.trim() || undefined,
+    petsGrpcUrl: env.PETS_GRPC_URL?.trim() || undefined,
+    rescueGrpcUrl: env.RESCUE_GRPC_URL?.trim() || undefined,
     host: env.NOTIFICATIONS_HOST?.trim() || DEFAULT_HOST,
     environment: env.NODE_ENV?.trim() || 'development',
     databaseUrl,

--- a/services/notifications/src/config.ts
+++ b/services/notifications/src/config.ts
@@ -43,6 +43,14 @@ export type NotificationsConfig = {
   // Toggle the email queue worker. Defaults to true. Tests + the
   // migrations-only smoke set this to false to keep the loop quiet.
   emailWorkerEnabled: boolean;
+  // Toggle the email CHANNEL adapter — the notifications.created subscriber
+  // that enqueues transactional emails. Distinct from emailWorkerEnabled
+  // (which drains the queue). Defaults to true, but only starts when an
+  // auth client is configured (it needs AdminGetUser to resolve addresses).
+  emailChannelEnabled: boolean;
+  // From-address for adapter-generated transactional emails.
+  defaultFromEmail: string;
+  defaultFromName: string;
   // Push provider selection — Phase 7.2. Same ADS-549 rule: production
   // refuses 'console' so an unconfigured push channel surfaces at boot.
   pushProvider: PushProviderConfig;
@@ -84,6 +92,9 @@ export const loadConfig = (env: NodeJS.ProcessEnv = process.env): NotificationsC
     natsUrl: env.NATS_URL?.trim() || DEFAULT_NATS_URL,
     emailProvider: loadEmailProviderConfig(env),
     emailWorkerEnabled: env.EMAIL_WORKER_ENABLED?.trim() !== 'false',
+    emailChannelEnabled: env.EMAIL_CHANNEL_ENABLED?.trim() !== 'false',
+    defaultFromEmail: env.DEFAULT_FROM_EMAIL?.trim() || 'noreply@adoptdontshop.com',
+    defaultFromName: env.DEFAULT_FROM_NAME?.trim() || "Adopt Don't Shop",
     pushProvider: loadPushProviderConfig(env),
     pushWorkerEnabled: env.PUSH_WORKER_ENABLED?.trim() !== 'false',
     schedulerEnabled: env.SCHEDULER_ENABLED?.trim() !== 'false',

--- a/services/notifications/src/email/channel-adapter.test.ts
+++ b/services/notifications/src/email/channel-adapter.test.ts
@@ -1,0 +1,203 @@
+import type { NatsConnection } from 'nats';
+import type { Pool } from 'pg';
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  startEmailChannelWorker,
+  type Recipient,
+  type ResolveRecipient,
+} from './channel-adapter.js';
+
+// --- Harness --------------------------------------------------------
+
+const flush = async (): Promise<void> => {
+  for (let i = 0; i < 20; i++) {
+    await new Promise(r => setImmediate(r));
+  }
+};
+
+const enabledPrefsRow = {
+  email_enabled: true,
+  push_enabled: true,
+  sms_enabled: false,
+  application_updates: true,
+  pet_matches: true,
+  rescue_updates: true,
+  chat_messages: true,
+  quiet_hours_start: null,
+  quiet_hours_end: null,
+  timezone: 'UTC',
+};
+
+const makePool = (
+  opts: {
+    prefs?: Record<string, unknown>;
+    notifRow?: { title: string; message: string } | null;
+    insertError?: unknown;
+  } = {}
+) => {
+  const query = vi.fn(async (sql: string) => {
+    if (sql.includes('user_notification_prefs')) {
+      return { rows: [opts.prefs ?? enabledPrefsRow] };
+    }
+    if (sql.includes('notifications.notifications')) {
+      return {
+        rows: opts.notifRow === null ? [] : [opts.notifRow ?? { title: 'T', message: 'M' }],
+      };
+    }
+    if (sql.includes('email_queue')) {
+      if (opts.insertError) {
+        throw opts.insertError;
+      }
+      return { rows: [{ email_id: 'e1' }] };
+    }
+    return { rows: [] };
+  });
+  return { query, asPool: { query } as unknown as Pool };
+};
+
+const includesSql = (query: ReturnType<typeof vi.fn>, fragment: string): boolean =>
+  query.mock.calls.some(c => String(c[0]).includes(fragment));
+
+const insertParams = (query: ReturnType<typeof vi.fn>): unknown[] => {
+  const call = query.mock.calls.find(c => String(c[0]).includes('INSERT INTO email_queue'));
+  return (call?.[1] as unknown[]) ?? [];
+};
+
+const logger = {
+  info: () => undefined,
+  warn: () => undefined,
+  error: () => undefined,
+} as unknown as Parameters<typeof startEmailChannelWorker>[0]['logger'];
+
+function makeNats(messages: { payload: unknown }[]): NatsConnection {
+  const encoder = new TextEncoder();
+  const jsm = { consumers: { add: vi.fn(async (_s: string, cfg: unknown) => cfg) } };
+  const js = {
+    consumers: {
+      get: vi.fn(async () => ({
+        consume: vi.fn(async () => ({
+          async *[Symbol.asyncIterator]() {
+            for (const m of messages) {
+              yield {
+                subject: 'notifications.created',
+                data: encoder.encode(
+                  JSON.stringify({
+                    id: 'evt',
+                    occurredAt: '2026-06-01T10:00:00Z',
+                    payload: m.payload,
+                  })
+                ),
+                ack: vi.fn(),
+                nak: vi.fn(),
+                term: vi.fn(),
+              };
+            }
+          },
+          close: vi.fn(),
+        })),
+      })),
+    },
+  };
+  return {
+    jetstreamManager: vi.fn(async () => jsm),
+    jetstream: vi.fn(() => js),
+  } as unknown as NatsConnection;
+}
+
+const event = (overrides: Record<string, unknown> = {}) => ({
+  notificationId: 'n-1',
+  userId: 'usr-1',
+  type: 'adoption_approved',
+  channel: 'in_app',
+  ...overrides,
+});
+
+const resolverTo = (
+  recipient: Recipient | null
+): { fn: ResolveRecipient; mock: ReturnType<typeof vi.fn> } => {
+  const mock = vi.fn(async () => recipient);
+  return { fn: mock, mock };
+};
+
+const start = (pool: Pool, nats: NatsConnection, resolveRecipient: ResolveRecipient) =>
+  startEmailChannelWorker({
+    pool,
+    nats,
+    logger,
+    resolveRecipient,
+    fromEmail: 'noreply@example.com',
+    fromName: 'Test',
+  });
+
+// --- Tests ----------------------------------------------------------
+
+describe('email channel adapter', () => {
+  it('enqueues a transactional email for an email-worthy type with a deterministic idempotency key', async () => {
+    const { asPool, query } = makePool({ notifRow: { title: 'Approved!', message: 'You did it' } });
+    const { fn, mock } = resolverTo({ email: 'adopter@example.com', name: 'Ada Lovelace' });
+    const nats = makeNats([{ payload: event() }]);
+
+    start(asPool, nats, fn);
+    await flush();
+
+    expect(mock).toHaveBeenCalledWith('usr-1');
+    const params = insertParams(query);
+    expect(params).toContain('adopter@example.com');
+    expect(params).toContain('Approved!');
+    expect(params).toContain('notif-email:n-1');
+  });
+
+  it('ignores non-email-worthy types without loading prefs or resolving a recipient', async () => {
+    const { asPool, query } = makePool();
+    const { fn, mock } = resolverTo({ email: 'adopter@example.com' });
+    const nats = makeNats([{ payload: event({ type: 'message_received' }) }]);
+
+    start(asPool, nats, fn);
+    await flush();
+
+    expect(query).not.toHaveBeenCalled();
+    expect(mock).not.toHaveBeenCalled();
+  });
+
+  it('does not enqueue when the user has disabled the email channel', async () => {
+    const { asPool, query } = makePool({ prefs: { ...enabledPrefsRow, email_enabled: false } });
+    const { fn, mock } = resolverTo({ email: 'adopter@example.com' });
+    const nats = makeNats([{ payload: event() }]);
+
+    start(asPool, nats, fn);
+    await flush();
+
+    expect(includesSql(query, 'user_notification_prefs')).toBe(true);
+    expect(includesSql(query, 'email_queue')).toBe(false);
+    expect(mock).not.toHaveBeenCalled();
+  });
+
+  it('skips when the recipient address cannot be resolved', async () => {
+    const { asPool, query } = makePool();
+    const { fn, mock } = resolverTo(null);
+    const nats = makeNats([{ payload: event() }]);
+
+    start(asPool, nats, fn);
+    await flush();
+
+    expect(mock).toHaveBeenCalledWith('usr-1');
+    expect(includesSql(query, 'email_queue')).toBe(false);
+  });
+
+  it('treats a redelivery (idempotency-key unique violation) as a no-op, not an error', async () => {
+    const { asPool } = makePool({
+      insertError: { code: '23505', constraint: 'email_queue_idempotency_key_unique' },
+    });
+    const { fn } = resolverTo({ email: 'adopter@example.com' });
+    const nats = makeNats([{ payload: event() }]);
+
+    // Should resolve cleanly — the worker swallows the unique violation.
+    await expect(
+      (async () => {
+        start(asPool, nats, fn);
+        await flush();
+      })()
+    ).resolves.toBeUndefined();
+  });
+});

--- a/services/notifications/src/email/channel-adapter.ts
+++ b/services/notifications/src/email/channel-adapter.ts
@@ -1,0 +1,150 @@
+// Email channel adapter — the missing sibling of the push worker.
+//
+// Subscribes to `notifications.created` and, for the transactional
+// notification types that warrant an email, enqueues one into email_queue
+// (the existing email worker then sends it). This is what makes domain
+// events (applications.approved, rescue.staffInvited, …) actually reach a
+// user's inbox; before this, the subscriber translators only ever wrote an
+// in-app row and the "email fires from a sibling worker" comment was a
+// promise with no implementation.
+//
+// Dedup is via the email_queue idempotency key (deterministic per
+// notification): a redelivered event hits the unique constraint instead of
+// enqueuing a second email — no processed_events row needed, the insert IS
+// the claim and it's atomic with the enqueue.
+
+import { randomUUID } from 'node:crypto';
+
+import type { NatsConnection } from 'nats';
+import type { Pool } from 'pg';
+import type { Logger } from 'winston';
+
+import { subscribe, type SubscriptionHandle } from '@adopt-dont-shop/events';
+
+import { loadNotificationPrefs, shouldDeliver } from '../preferences-gate.js';
+
+import { insertEmail } from './queue.js';
+
+const DURABLE = 'notifications-email-channel';
+
+// Types that warrant a transactional email alongside the in-app record.
+// High-frequency / low-importance types (chat messages, the pet feed,
+// marketing) are intentionally excluded — emailing each would be spam, and
+// the in-app channel + digest already cover them. Category + channel
+// preferences still gate everything below via shouldDeliver.
+const EMAIL_WORTHY_TYPES = new Set<string>([
+  'application_status',
+  'adoption_approved',
+  'adoption_rejected',
+  'home_visit_scheduled',
+  'interview_scheduled',
+  'reference_request',
+  'account_security',
+  'rescue_invitation',
+]);
+
+export type Recipient = { email: string; name?: string };
+export type ResolveRecipient = (userId: string) => Promise<Recipient | null>;
+
+type NotificationCreatedEvent = {
+  notificationId: string;
+  userId: string;
+  type: string;
+  channel: string;
+};
+
+type NotificationRowLite = {
+  title: string;
+  message: string;
+};
+
+export type EmailChannelWorkerOptions = {
+  pool: Pool;
+  nats: NatsConnection;
+  logger: Logger;
+  resolveRecipient: ResolveRecipient;
+  fromEmail: string;
+  fromName: string;
+};
+
+export type RunningEmailChannelWorker = { stop: () => Promise<void> };
+
+const escapeHtml = (s: string): string =>
+  s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+
+const renderHtml = (title: string, message: string): string =>
+  `<h1>${escapeHtml(title)}</h1><p>${escapeHtml(message)}</p>`;
+
+export const startEmailChannelWorker = (
+  opts: EmailChannelWorkerOptions
+): RunningEmailChannelWorker => {
+  const subscription: SubscriptionHandle = subscribe<NotificationCreatedEvent>(
+    opts.nats,
+    {
+      subject: 'notifications.created',
+      durable: DURABLE,
+      onError: err => opts.logger.error('email.channel.subscriber_error', { err }),
+    },
+    async ev => {
+      if (!ev.userId || !EMAIL_WORTHY_TYPES.has(ev.type)) {
+        return;
+      }
+
+      const prefs = await loadNotificationPrefs(opts.pool, ev.userId);
+      if (!shouldDeliver(prefs, { type: ev.type, channel: 'email', now: new Date() })) {
+        return;
+      }
+
+      const rows = await opts.pool.query<NotificationRowLite>(
+        `SELECT title, message FROM notifications.notifications WHERE notification_id = $1`,
+        [ev.notificationId]
+      );
+      const row = rows.rows[0];
+      if (!row) {
+        return;
+      }
+
+      const recipient = await opts.resolveRecipient(ev.userId);
+      if (!recipient) {
+        opts.logger.warn('email.channel.no_recipient', {
+          userId: ev.userId,
+          notificationId: ev.notificationId,
+        });
+        return;
+      }
+
+      try {
+        await insertEmail(opts.pool, {
+          emailId: randomUUID(),
+          fromEmail: opts.fromEmail,
+          fromName: opts.fromName,
+          toEmail: recipient.email,
+          toName: recipient.name ?? null,
+          subject: row.title,
+          htmlContent: renderHtml(row.title, row.message),
+          textContent: row.message,
+          type: 'notification',
+          priority: 'normal',
+          userId: ev.userId,
+          // Deterministic key → a redelivered notifications.created hits the
+          // unique constraint instead of enqueuing a duplicate email.
+          idempotencyKey: `notif-email:${ev.notificationId}`,
+        });
+      } catch (err) {
+        const pgErr = err as { code?: string; constraint?: string };
+        if (pgErr.code === '23505' && pgErr.constraint === 'email_queue_idempotency_key_unique') {
+          // Already enqueued for this notification — a redelivery no-op.
+          return;
+        }
+        throw err;
+      }
+    }
+  );
+
+  opts.logger.info('email channel worker started', { subject: 'notifications.created' });
+  return {
+    stop: async () => {
+      await subscription.drain().catch(() => undefined);
+    },
+  };
+};

--- a/services/notifications/src/grpc/auth-client.test.ts
+++ b/services/notifications/src/grpc/auth-client.test.ts
@@ -237,13 +237,13 @@ describe('createAuthCohortClient — signed system principal (ADS-800)', () => {
       // Legacy headers still present for services running without the key.
       expect(meta.get('x-user-id')).toEqual(['svc-notifications']);
       expect(meta.get('x-user-roles')).toEqual(['admin']);
-      expect(meta.get('x-user-permissions')).toEqual(['admin.users.broadcast']);
+      expect(meta.get('x-user-permissions')).toEqual(['admin.users.broadcast,admin.users.read']);
       // And the signed token carries the same principal.
       const token = String(meta.get(PRINCIPAL_TOKEN_HEADER)[0]);
       const principal = verifyPrincipalToken(token, SIGNING_KEY);
       expect(principal.userId).toBe('svc-notifications');
       expect(principal.roles).toEqual(['admin']);
-      expect(principal.permissions).toEqual(['admin.users.broadcast']);
+      expect(principal.permissions).toEqual(['admin.users.broadcast', 'admin.users.read']);
     } finally {
       client.close();
     }

--- a/services/notifications/src/grpc/auth-client.ts
+++ b/services/notifications/src/grpc/auth-client.ts
@@ -7,6 +7,8 @@ import { credentials, status, type CallOptions, Metadata } from '@grpc/grpc-js';
 
 import {
   AuthV1,
+  type AdminGetUserRequest,
+  type AdminGetUserResponse,
   type ListUserIdsByCohortRequest,
   type ListUserIdsByCohortResponse,
 } from '@adopt-dont-shop/proto';
@@ -66,9 +68,15 @@ const jitteredBackoff = (attempt: number, baseMs: number): number => {
   return base * (0.75 + Math.random() * 0.5);
 };
 
-export function createAuthCohortClient(opts: CreateAuthCohortClientOptions): AuthCohortClient & {
-  close(): void;
-} {
+// The email channel adapter resolves a recipient's address by user id.
+export type AuthUserClient = {
+  adminGetUser: (req: AdminGetUserRequest) => Promise<AdminGetUserResponse>;
+};
+
+export function createAuthCohortClient(opts: CreateAuthCohortClientOptions): AuthCohortClient &
+  AuthUserClient & {
+    close(): void;
+  } {
   const stub = new AuthV1.AuthServiceClient(opts.address, credentials.createInsecure());
   const deadlineMs = opts.deadlineMs ?? DEFAULT_DEADLINE_MS;
   const maxRetries = opts.maxRetries ?? DEFAULT_MAX_RETRIES;
@@ -76,7 +84,10 @@ export function createAuthCohortClient(opts: CreateAuthCohortClientOptions): Aut
   const systemPrincipal = {
     userId: opts.systemUserId ?? 'svc-notifications',
     roles: splitList(opts.systemRoles ?? 'admin'),
-    permissions: splitList(opts.systemPermissions ?? 'admin.users.broadcast'),
+    // admin.users.broadcast → Broadcast cohort expansion;
+    // admin.users.read → AdminGetUser, used by the email channel adapter to
+    // resolve a recipient's address from their user id.
+    permissions: splitList(opts.systemPermissions ?? 'admin.users.broadcast,admin.users.read'),
   };
 
   // Built per attempt, not once at client creation: the signed
@@ -133,6 +144,8 @@ export function createAuthCohortClient(opts: CreateAuthCohortClientOptions): Aut
   return {
     listUserIdsByCohort: (req: ListUserIdsByCohortRequest): Promise<ListUserIdsByCohortResponse> =>
       callWithRetry(stub.listUserIdsByCohort, req),
+    adminGetUser: (req: AdminGetUserRequest): Promise<AdminGetUserResponse> =>
+      callWithRetry(stub.adminGetUser, req),
     close: () => stub.close(),
   };
 }

--- a/services/notifications/src/grpc/pets-client.test.ts
+++ b/services/notifications/src/grpc/pets-client.test.ts
@@ -1,0 +1,163 @@
+// Behaviour tests for the notifications pets-client. Mirrors the
+// auth-client test: a real @grpc/grpc-js Server bound to 127.0.0.1:0 so
+// there are no port conflicts; the server is torn down in afterEach.
+
+import {
+  Metadata,
+  Server,
+  ServerCredentials,
+  ServerUnaryCall,
+  sendUnaryData,
+  ServiceError,
+  status,
+} from '@grpc/grpc-js';
+
+import {
+  PetsV1,
+  type ListPetFavoritersRequest,
+  type ListPetFavoritersResponse,
+} from '@adopt-dont-shop/proto';
+import {
+  PRINCIPAL_TOKEN_HEADER,
+  resetDefaultPrincipalSigningKeyForTests,
+  verifyPrincipalToken,
+} from '@adopt-dont-shop/service-bootstrap';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { createPetsClient } from './pets-client.js';
+
+const makeServiceError = (code: number, details: string): ServiceError => {
+  const err = new Error(details) as ServiceError;
+  err.code = code;
+  err.details = details;
+  err.metadata = new Metadata();
+  return err;
+};
+
+describe('createPetsClient — deadline + retry behaviour', () => {
+  let server: Server;
+  let port: number;
+
+  beforeEach(() => {
+    server = new Server();
+  });
+
+  afterEach(async () => {
+    await new Promise<void>(resolve => server.tryShutdown(() => resolve()));
+  });
+
+  const startServer = async (): Promise<number> =>
+    new Promise<number>((resolve, reject) => {
+      server.bindAsync('127.0.0.1:0', ServerCredentials.createInsecure(), (err, boundPort) =>
+        err ? reject(err) : resolve(boundPort)
+      );
+    });
+
+  it('rejects with DEADLINE_EXCEEDED when the server never responds', async () => {
+    server.addService(PetsV1.PetServiceService, {
+      listFavoriters: (
+        _call: ServerUnaryCall<ListPetFavoritersRequest, ListPetFavoritersResponse>,
+        _cb: sendUnaryData<ListPetFavoritersResponse>
+      ) => {
+        // Never call _cb — hung server.
+      },
+    });
+
+    port = await startServer();
+    const client = createPetsClient({
+      address: `127.0.0.1:${port}`,
+      deadlineMs: 200,
+      maxRetries: 0,
+    });
+
+    try {
+      await client.listFavoriters('pet-1');
+      expect.fail('expected rejection');
+    } catch (err: unknown) {
+      expect((err as { code?: number }).code).toBe(status.DEADLINE_EXCEEDED);
+    } finally {
+      client.close();
+    }
+  });
+
+  it('resolves with the user_ids on the second attempt after a transient UNAVAILABLE', async () => {
+    let callCount = 0;
+    server.addService(PetsV1.PetServiceService, {
+      listFavoriters: (
+        _call: ServerUnaryCall<ListPetFavoritersRequest, ListPetFavoritersResponse>,
+        cb: sendUnaryData<ListPetFavoritersResponse>
+      ) => {
+        callCount += 1;
+        if (callCount === 1) {
+          cb(makeServiceError(status.UNAVAILABLE, 'service unavailable'), null);
+        } else {
+          cb(null, { userIds: ['usr-1', 'usr-2'] });
+        }
+      },
+    });
+
+    port = await startServer();
+    const client = createPetsClient({ address: `127.0.0.1:${port}`, deadlineMs: 2_000 });
+
+    try {
+      const result = await client.listFavoriters('pet-1');
+      expect(result).toEqual(['usr-1', 'usr-2']);
+      expect(callCount).toBe(2);
+    } finally {
+      client.close();
+    }
+  });
+});
+
+describe('createPetsClient — signed system principal (ADS-800)', () => {
+  const SIGNING_KEY = 'notifications-test-signing-key';
+  let server: Server;
+
+  beforeEach(() => {
+    server = new Server();
+  });
+
+  afterEach(async () => {
+    delete process.env.PRINCIPAL_SIGNING_KEY;
+    resetDefaultPrincipalSigningKeyForTests();
+    await new Promise<void>(resolve => server.tryShutdown(() => resolve()));
+  });
+
+  const startCapturingServer = async (): Promise<{ port: number; captured: Metadata[] }> => {
+    const captured: Metadata[] = [];
+    server.addService(PetsV1.PetServiceService, {
+      listFavoriters: (
+        call: ServerUnaryCall<ListPetFavoritersRequest, ListPetFavoritersResponse>,
+        cb: sendUnaryData<ListPetFavoritersResponse>
+      ) => {
+        captured.push(call.metadata);
+        cb(null, { userIds: [] });
+      },
+    });
+    const port = await new Promise<number>((resolve, reject) => {
+      server.bindAsync('127.0.0.1:0', ServerCredentials.createInsecure(), (err, boundPort) =>
+        err ? reject(err) : resolve(boundPort)
+      );
+    });
+    return { port, captured };
+  };
+
+  it('stamps a verifiable x-principal-token carrying pets.read', async () => {
+    process.env.PRINCIPAL_SIGNING_KEY = SIGNING_KEY;
+    resetDefaultPrincipalSigningKeyForTests();
+
+    const { port, captured } = await startCapturingServer();
+    const client = createPetsClient({ address: `127.0.0.1:${port}` });
+    try {
+      await client.listFavoriters('pet-1');
+      expect(captured).toHaveLength(1);
+      const token = String(captured[0].get(PRINCIPAL_TOKEN_HEADER)[0]);
+      const principal = verifyPrincipalToken(token, SIGNING_KEY);
+      expect(principal.userId).toBe('svc-notifications');
+      expect(principal.permissions).toEqual(['pets.read']);
+    } finally {
+      client.close();
+    }
+  });
+});

--- a/services/notifications/src/grpc/pets-client.ts
+++ b/services/notifications/src/grpc/pets-client.ts
@@ -1,0 +1,134 @@
+// Promise-wrapped client for service.pets — just the favouriter-discovery
+// RPC the pets.statusChanged fan-out needs. Mirrors auth-client.ts:
+// signed system-principal metadata (ADS-800), retry on UNAVAILABLE /
+// DEADLINE_EXCEEDED, a per-call deadline. Defining the slice locally keeps
+// the notifications service decoupled from the gateway's full PetsClient.
+
+import { credentials, status, type CallOptions, Metadata } from '@grpc/grpc-js';
+
+import {
+  PetsV1,
+  type ListPetFavoritersRequest,
+  type ListPetFavoritersResponse,
+} from '@adopt-dont-shop/proto';
+import {
+  getDefaultPrincipalSigningKey,
+  PRINCIPAL_TOKEN_HEADER,
+  signPrincipalToken,
+} from '@adopt-dont-shop/service-bootstrap';
+
+export type CreatePetsClientOptions = {
+  address: string;
+  // System principal metadata — PetService.ListFavoriters gates on
+  // `pets.read`. The notifications service runs as `svc-notifications`;
+  // stamping the permission here means the fan-out handler doesn't thread
+  // metadata through.
+  systemUserId?: string;
+  systemRoles?: string;
+  systemPermissions?: string;
+  deadlineMs?: number;
+  maxRetries?: number;
+};
+
+const DEFAULT_DEADLINE_MS = 5_000;
+const DEFAULT_MAX_RETRIES = 2;
+const RETRYABLE_CODES = new Set([status.UNAVAILABLE, status.DEADLINE_EXCEEDED]);
+
+const isRetryableError = (err: unknown): boolean => {
+  if (err === null || typeof err !== 'object') {
+    return false;
+  }
+  const code = (err as { code?: unknown }).code;
+  return typeof code === 'number' && RETRYABLE_CODES.has(code);
+};
+
+const sleep = (ms: number): Promise<void> => new Promise(resolve => setTimeout(resolve, ms));
+
+const splitList = (raw: string): string[] =>
+  raw
+    .split(',')
+    .map(s => s.trim())
+    .filter(Boolean);
+
+const jitteredBackoff = (attempt: number, baseMs: number): number => {
+  const base = baseMs * Math.pow(2, attempt - 1);
+  return base * (0.75 + Math.random() * 0.5);
+};
+
+// The slice of the pets stub the fan-out handler consumes.
+export type PetsFavoritersClient = {
+  listFavoriters: (petId: string) => Promise<string[]>;
+  close(): void;
+};
+
+export function createPetsClient(opts: CreatePetsClientOptions): PetsFavoritersClient {
+  const stub = new PetsV1.PetServiceClient(opts.address, credentials.createInsecure());
+  const deadlineMs = opts.deadlineMs ?? DEFAULT_DEADLINE_MS;
+  const maxRetries = opts.maxRetries ?? DEFAULT_MAX_RETRIES;
+
+  const systemPrincipal = {
+    userId: opts.systemUserId ?? 'svc-notifications',
+    roles: splitList(opts.systemRoles ?? 'admin'),
+    // pets.read → ListFavoriters (recipient discovery for the
+    // pets.statusChanged fan-out).
+    permissions: splitList(opts.systemPermissions ?? 'pets.read'),
+  };
+
+  // Built per attempt — the signed x-principal-token (ADS-800) carries a
+  // short TTL, so a metadata object minted at boot would expire.
+  const buildSystemMetadata = (): Metadata => {
+    const meta = new Metadata();
+    meta.set('x-user-id', systemPrincipal.userId);
+    meta.set('x-user-roles', systemPrincipal.roles.join(','));
+    meta.set('x-user-permissions', systemPrincipal.permissions.join(','));
+    const signingKey = getDefaultPrincipalSigningKey();
+    if (signingKey) {
+      meta.set(PRINCIPAL_TOKEN_HEADER, signPrincipalToken(systemPrincipal, signingKey));
+    }
+    return meta;
+  };
+
+  const callWithRetry = <Req, Res>(
+    fn: (
+      req: Req,
+      metadata: Metadata,
+      options: Partial<CallOptions>,
+      cb: (err: unknown, res: Res) => void
+    ) => unknown,
+    req: Req
+  ): Promise<Res> => {
+    const attempt = (remaining: number): Promise<Res> =>
+      new Promise<Res>((resolve, reject) => {
+        const options: Partial<CallOptions> = {
+          deadline: new Date(Date.now() + deadlineMs),
+        };
+        fn.call(stub, req, buildSystemMetadata(), options, (err: unknown, res: Res) => {
+          if (err) {
+            if (remaining > 0 && isRetryableError(err)) {
+              const retryIndex = maxRetries - remaining + 1;
+              sleep(jitteredBackoff(retryIndex, 100))
+                .then(() => attempt(remaining - 1))
+                .then(resolve, reject);
+            } else {
+              reject(err);
+            }
+            return;
+          }
+          resolve(res);
+        });
+      });
+
+    return attempt(maxRetries);
+  };
+
+  return {
+    listFavoriters: async (petId: string): Promise<string[]> => {
+      const res = await callWithRetry<ListPetFavoritersRequest, ListPetFavoritersResponse>(
+        stub.listFavoriters,
+        { petId }
+      );
+      return res.userIds;
+    },
+    close: () => stub.close(),
+  };
+}

--- a/services/notifications/src/grpc/rescue-client.test.ts
+++ b/services/notifications/src/grpc/rescue-client.test.ts
@@ -1,0 +1,198 @@
+// Behaviour tests for the notifications rescue-client. Mirrors the
+// auth-client test: a real @grpc/grpc-js Server bound to 127.0.0.1:0; torn
+// down in afterEach.
+
+import {
+  Metadata,
+  Server,
+  ServerCredentials,
+  ServerUnaryCall,
+  sendUnaryData,
+  ServiceError,
+  status,
+} from '@grpc/grpc-js';
+
+import {
+  RescueV1,
+  type GetRescueRequest,
+  type GetRescueResponse,
+  type ListStaffMembersRequest,
+  type ListStaffMembersResponse,
+} from '@adopt-dont-shop/proto';
+import {
+  PRINCIPAL_TOKEN_HEADER,
+  resetDefaultPrincipalSigningKeyForTests,
+  verifyPrincipalToken,
+} from '@adopt-dont-shop/service-bootstrap';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { createRescueClient } from './rescue-client.js';
+
+const makeServiceError = (code: number, details: string): ServiceError => {
+  const err = new Error(details) as ServiceError;
+  err.code = code;
+  err.details = details;
+  err.metadata = new Metadata();
+  return err;
+};
+
+describe('createRescueClient — staff + rescue lookups', () => {
+  let server: Server;
+  let port: number;
+
+  beforeEach(() => {
+    server = new Server();
+  });
+
+  afterEach(async () => {
+    await new Promise<void>(resolve => server.tryShutdown(() => resolve()));
+  });
+
+  const startServer = async (): Promise<number> =>
+    new Promise<number>((resolve, reject) => {
+      server.bindAsync('127.0.0.1:0', ServerCredentials.createInsecure(), (err, boundPort) =>
+        err ? reject(err) : resolve(boundPort)
+      );
+    });
+
+  it('maps ListStaffMembers down to the staff user_ids', async () => {
+    server.addService(RescueV1.RescueServiceService, {
+      listStaffMembers: (
+        _call: ServerUnaryCall<ListStaffMembersRequest, ListStaffMembersResponse>,
+        cb: sendUnaryData<ListStaffMembersResponse>
+      ) => {
+        cb(null, {
+          staffMembers: [
+            {
+              staffMemberId: 'sm-1',
+              userId: 'usr-1',
+              rescueId: 'res-1',
+              isVerified: true,
+              addedBy: 'usr-admin',
+              addedAt: '2026-01-01T00:00:00Z',
+              createdAt: '2026-01-01T00:00:00Z',
+              updatedAt: '2026-01-01T00:00:00Z',
+            },
+            {
+              staffMemberId: 'sm-2',
+              userId: 'usr-2',
+              rescueId: 'res-1',
+              isVerified: true,
+              addedBy: 'usr-admin',
+              addedAt: '2026-01-02T00:00:00Z',
+              createdAt: '2026-01-02T00:00:00Z',
+              updatedAt: '2026-01-02T00:00:00Z',
+            },
+          ],
+        });
+      },
+    });
+
+    port = await startServer();
+    const client = createRescueClient({ address: `127.0.0.1:${port}`, deadlineMs: 2_000 });
+    try {
+      expect(await client.listStaffMembers('res-1')).toEqual(['usr-1', 'usr-2']);
+    } finally {
+      client.close();
+    }
+  });
+
+  it('returns the rescue name from Get', async () => {
+    server.addService(RescueV1.RescueServiceService, {
+      get: (
+        _call: ServerUnaryCall<GetRescueRequest, GetRescueResponse>,
+        cb: sendUnaryData<GetRescueResponse>
+      ) => {
+        // fromPartial fills every required scalar (e.g. the status enum) so
+        // the proto serializer doesn't choke on undefined int32 fields.
+        cb(null, {
+          rescue: RescueV1.Rescue.fromPartial({ rescueId: 'res-1', name: 'Happy Tails' }),
+        });
+      },
+    });
+
+    port = await startServer();
+    const client = createRescueClient({ address: `127.0.0.1:${port}`, deadlineMs: 2_000 });
+    try {
+      expect(await client.getRescueName('res-1')).toBe('Happy Tails');
+    } finally {
+      client.close();
+    }
+  });
+
+  it('retries ListStaffMembers on a transient UNAVAILABLE', async () => {
+    let callCount = 0;
+    server.addService(RescueV1.RescueServiceService, {
+      listStaffMembers: (
+        _call: ServerUnaryCall<ListStaffMembersRequest, ListStaffMembersResponse>,
+        cb: sendUnaryData<ListStaffMembersResponse>
+      ) => {
+        callCount += 1;
+        if (callCount === 1) {
+          cb(makeServiceError(status.UNAVAILABLE, 'service unavailable'), null);
+        } else {
+          cb(null, { staffMembers: [] });
+        }
+      },
+    });
+
+    port = await startServer();
+    const client = createRescueClient({ address: `127.0.0.1:${port}`, deadlineMs: 2_000 });
+    try {
+      expect(await client.listStaffMembers('res-1')).toEqual([]);
+      expect(callCount).toBe(2);
+    } finally {
+      client.close();
+    }
+  });
+});
+
+describe('createRescueClient — signed system principal (ADS-800)', () => {
+  const SIGNING_KEY = 'notifications-test-signing-key';
+  let server: Server;
+
+  beforeEach(() => {
+    server = new Server();
+  });
+
+  afterEach(async () => {
+    delete process.env.PRINCIPAL_SIGNING_KEY;
+    resetDefaultPrincipalSigningKeyForTests();
+    await new Promise<void>(resolve => server.tryShutdown(() => resolve()));
+  });
+
+  it('stamps a super_admin principal carrying staff.read + rescues.read so it can read any rescue', async () => {
+    process.env.PRINCIPAL_SIGNING_KEY = SIGNING_KEY;
+    resetDefaultPrincipalSigningKeyForTests();
+
+    const captured: Metadata[] = [];
+    server.addService(RescueV1.RescueServiceService, {
+      listStaffMembers: (
+        call: ServerUnaryCall<ListStaffMembersRequest, ListStaffMembersResponse>,
+        cb: sendUnaryData<ListStaffMembersResponse>
+      ) => {
+        captured.push(call.metadata);
+        cb(null, { staffMembers: [] });
+      },
+    });
+    const port = await new Promise<number>((resolve, reject) => {
+      server.bindAsync('127.0.0.1:0', ServerCredentials.createInsecure(), (err, boundPort) =>
+        err ? reject(err) : resolve(boundPort)
+      );
+    });
+
+    const client = createRescueClient({ address: `127.0.0.1:${port}` });
+    try {
+      await client.listStaffMembers('res-1');
+      expect(captured).toHaveLength(1);
+      const token = String(captured[0].get(PRINCIPAL_TOKEN_HEADER)[0]);
+      const principal = verifyPrincipalToken(token, SIGNING_KEY);
+      expect(principal.userId).toBe('svc-notifications');
+      expect(principal.roles).toEqual(['super_admin']);
+      expect(principal.permissions).toEqual(['staff.read', 'rescues.read']);
+    } finally {
+      client.close();
+    }
+  });
+});

--- a/services/notifications/src/grpc/rescue-client.ts
+++ b/services/notifications/src/grpc/rescue-client.ts
@@ -1,0 +1,142 @@
+// Promise-wrapped client for service.rescue — the staff-membership +
+// rescue-lookup RPCs the rescue.verified / rescue.rejected fan-out needs.
+// Mirrors auth-client.ts: signed system-principal metadata (ADS-800),
+// retry on UNAVAILABLE / DEADLINE_EXCEEDED, a per-call deadline.
+
+import { credentials, status, type CallOptions, Metadata } from '@grpc/grpc-js';
+
+import {
+  RescueV1,
+  type GetRescueRequest,
+  type GetRescueResponse,
+  type ListStaffMembersRequest,
+  type ListStaffMembersResponse,
+} from '@adopt-dont-shop/proto';
+import {
+  getDefaultPrincipalSigningKey,
+  PRINCIPAL_TOKEN_HEADER,
+  signPrincipalToken,
+} from '@adopt-dont-shop/service-bootstrap';
+
+export type CreateRescueClientOptions = {
+  address: string;
+  // System principal metadata. ListStaffMembers gates on `staff.read` AND,
+  // for an explicit rescue_id, requires the caller to be a member of that
+  // rescue UNLESS they are super_admin — so the system principal carries
+  // the super_admin role to look up any rescue's staff. Get gates on
+  // `rescues.read`.
+  systemUserId?: string;
+  systemRoles?: string;
+  systemPermissions?: string;
+  deadlineMs?: number;
+  maxRetries?: number;
+};
+
+const DEFAULT_DEADLINE_MS = 5_000;
+const DEFAULT_MAX_RETRIES = 2;
+const RETRYABLE_CODES = new Set([status.UNAVAILABLE, status.DEADLINE_EXCEEDED]);
+
+const isRetryableError = (err: unknown): boolean => {
+  if (err === null || typeof err !== 'object') {
+    return false;
+  }
+  const code = (err as { code?: unknown }).code;
+  return typeof code === 'number' && RETRYABLE_CODES.has(code);
+};
+
+const sleep = (ms: number): Promise<void> => new Promise(resolve => setTimeout(resolve, ms));
+
+const splitList = (raw: string): string[] =>
+  raw
+    .split(',')
+    .map(s => s.trim())
+    .filter(Boolean);
+
+const jitteredBackoff = (attempt: number, baseMs: number): number => {
+  const base = baseMs * Math.pow(2, attempt - 1);
+  return base * (0.75 + Math.random() * 0.5);
+};
+
+// The slice of the rescue stub the fan-out handler consumes: the staff
+// user_ids to notify, plus the rescue's name for the notification body.
+export type RescueStaffClient = {
+  listStaffMembers: (rescueId: string) => Promise<string[]>;
+  getRescueName: (rescueId: string) => Promise<string | null>;
+  close(): void;
+};
+
+export function createRescueClient(opts: CreateRescueClientOptions): RescueStaffClient {
+  const stub = new RescueV1.RescueServiceClient(opts.address, credentials.createInsecure());
+  const deadlineMs = opts.deadlineMs ?? DEFAULT_DEADLINE_MS;
+  const maxRetries = opts.maxRetries ?? DEFAULT_MAX_RETRIES;
+
+  const systemPrincipal = {
+    userId: opts.systemUserId ?? 'svc-notifications',
+    // super_admin so ListStaffMembers lets us list ANY rescue's staff (the
+    // handler restricts explicit rescue_id to members otherwise).
+    roles: splitList(opts.systemRoles ?? 'super_admin'),
+    permissions: splitList(opts.systemPermissions ?? 'staff.read,rescues.read'),
+  };
+
+  const buildSystemMetadata = (): Metadata => {
+    const meta = new Metadata();
+    meta.set('x-user-id', systemPrincipal.userId);
+    meta.set('x-user-roles', systemPrincipal.roles.join(','));
+    meta.set('x-user-permissions', systemPrincipal.permissions.join(','));
+    const signingKey = getDefaultPrincipalSigningKey();
+    if (signingKey) {
+      meta.set(PRINCIPAL_TOKEN_HEADER, signPrincipalToken(systemPrincipal, signingKey));
+    }
+    return meta;
+  };
+
+  const callWithRetry = <Req, Res>(
+    fn: (
+      req: Req,
+      metadata: Metadata,
+      options: Partial<CallOptions>,
+      cb: (err: unknown, res: Res) => void
+    ) => unknown,
+    req: Req
+  ): Promise<Res> => {
+    const attempt = (remaining: number): Promise<Res> =>
+      new Promise<Res>((resolve, reject) => {
+        const options: Partial<CallOptions> = {
+          deadline: new Date(Date.now() + deadlineMs),
+        };
+        fn.call(stub, req, buildSystemMetadata(), options, (err: unknown, res: Res) => {
+          if (err) {
+            if (remaining > 0 && isRetryableError(err)) {
+              const retryIndex = maxRetries - remaining + 1;
+              sleep(jitteredBackoff(retryIndex, 100))
+                .then(() => attempt(remaining - 1))
+                .then(resolve, reject);
+            } else {
+              reject(err);
+            }
+            return;
+          }
+          resolve(res);
+        });
+      });
+
+    return attempt(maxRetries);
+  };
+
+  return {
+    listStaffMembers: async (rescueId: string): Promise<string[]> => {
+      const res = await callWithRetry<ListStaffMembersRequest, ListStaffMembersResponse>(
+        stub.listStaffMembers,
+        { rescueId }
+      );
+      return res.staffMembers.map(member => member.userId);
+    },
+    getRescueName: async (rescueId: string): Promise<string | null> => {
+      const res = await callWithRetry<GetRescueRequest, GetRescueResponse>(stub.get, {
+        rescueId,
+      });
+      return res.rescue?.name ?? null;
+    },
+    close: () => stub.close(),
+  };
+}

--- a/services/notifications/src/index.ts
+++ b/services/notifications/src/index.ts
@@ -6,6 +6,8 @@ import { runServiceShutdown } from '@adopt-dont-shop/service-bootstrap';
 
 import { loadConfig } from './config.js';
 import { createAuthCohortClient } from './grpc/auth-client.js';
+import { createPetsClient } from './grpc/pets-client.js';
+import { createRescueClient } from './grpc/rescue-client.js';
 import { validateAuthPrincipal } from './grpc/validate-auth-principal.js';
 import {
   startEmailChannelWorker,
@@ -67,13 +69,25 @@ const main = async (): Promise<void> => {
       await validateAuthPrincipal(authClient, logger);
     }
 
+    // Cross-service clients for the cross-service event fan-out:
+    //   - pets → pets.statusChanged (notify favouriters)
+    //   - rescue → rescue.verified / rescue.rejected (notify staff)
+    // Only created when their gRPC URL is set; without it the matching
+    // fan-out no-ops gracefully (same degradation as Broadcast without auth).
+    const petsClient = config.petsGrpcUrl
+      ? createPetsClient({ address: config.petsGrpcUrl })
+      : undefined;
+    const rescueClient = config.rescueGrpcUrl
+      ? createRescueClient({ address: config.rescueGrpcUrl })
+      : undefined;
+
     grpc = await startGrpcServer({ config, pool, nats, logger, authClient });
     grpcReady = true;
     // NATS subscribers register AFTER gRPC so a fast event arriving on
     // applications.submitted before we're ready to handle gRPC calls
     // can't race against partially-constructed deps. Shutdown drains the
     // whole NATS connection later, which transparently cancels these.
-    registerSubscribers({ nats, deps: { pool, nats }, logger });
+    registerSubscribers({ nats, deps: { pool, nats }, logger, petsClient, rescueClient });
 
     // GDPR erasure subscriber — drops the user's notifications + prefs
     // + device tokens. Reported back via gdpr.erasureCompleted.

--- a/services/notifications/src/index.ts
+++ b/services/notifications/src/index.ts
@@ -7,6 +7,11 @@ import { runServiceShutdown } from '@adopt-dont-shop/service-bootstrap';
 import { loadConfig } from './config.js';
 import { createAuthCohortClient } from './grpc/auth-client.js';
 import { validateAuthPrincipal } from './grpc/validate-auth-principal.js';
+import {
+  startEmailChannelWorker,
+  type ResolveRecipient,
+  type RunningEmailChannelWorker,
+} from './email/channel-adapter.js';
 import { createProvider } from './email/providers/factory.js';
 import { startEmailWorker, type RunningEmailWorker } from './email/worker.js';
 import { startGrpcServer, type RunningGrpcServer } from './grpc/server.js';
@@ -24,6 +29,7 @@ const main = async (): Promise<void> => {
   let pool: Awaited<ReturnType<typeof createDbClient>> | undefined;
   let grpc: RunningGrpcServer | undefined;
   let emailWorker: RunningEmailWorker | undefined;
+  let emailChannelWorker: RunningEmailChannelWorker | undefined;
   let pushWorker: RunningPushWorker | undefined;
   let scheduler: RunningScheduler | undefined;
   let grpcReady = false;
@@ -104,6 +110,32 @@ const main = async (): Promise<void> => {
       emailWorker = startEmailWorker({ pool, nats, provider, logger });
       logger.info('email worker started', { provider: provider.getName() });
     }
+    // Email channel adapter: turns notifications.created into enqueued
+    // transactional emails. Needs the auth client to resolve recipient
+    // addresses; without it, we skip rather than enqueue address-less rows.
+    if (config.emailChannelEnabled) {
+      if (authClient) {
+        const resolveRecipient: ResolveRecipient = async userId => {
+          const res = await authClient.adminGetUser({ userId });
+          const user = res.user;
+          if (!user || !user.email) {
+            return null;
+          }
+          const name = [user.firstName, user.lastName].filter(Boolean).join(' ');
+          return { email: user.email, name: name || undefined };
+        };
+        emailChannelWorker = startEmailChannelWorker({
+          pool,
+          nats,
+          logger,
+          resolveRecipient,
+          fromEmail: config.defaultFromEmail,
+          fromName: config.defaultFromName,
+        });
+      } else {
+        logger.warn('email channel adapter disabled — no AUTH_GRPC_URL to resolve recipients');
+      }
+    }
     if (config.pushWorkerEnabled) {
       const pushProviderConfig =
         config.pushProvider.kind === 'fcm'
@@ -157,6 +189,11 @@ const main = async (): Promise<void> => {
         await emailWorker?.stop();
       } catch (err) {
         logger.error('email worker stop error', { err });
+      }
+      try {
+        await emailChannelWorker?.stop();
+      } catch (err) {
+        logger.error('email channel worker stop error', { err });
       }
       try {
         await pushWorker?.stop();

--- a/services/notifications/src/nats/subscribers.test.ts
+++ b/services/notifications/src/nats/subscribers.test.ts
@@ -16,6 +16,9 @@ import {
   buildAuthRoleAssignedCreate,
   buildAuthUserLoggedInCreate,
   buildChatMessageReceivedCreate,
+  buildPetStatusChangedCreate,
+  buildRescueRejectedCreate,
+  buildRescueVerifiedCreate,
   registerSubscribers,
 } from './subscribers.js';
 
@@ -255,6 +258,104 @@ describe('event → CreateNotificationRequest translation', () => {
       // 139 chars of body + the ellipsis terminator = 140 total preview.
       expect(req.message.length).toBe(140);
       expect(req.message.endsWith('…')).toBe(true);
+    });
+  });
+
+  describe('buildPetStatusChangedCreate', () => {
+    it('targets the favouriter with an in-app PET_UPDATE row at NORMAL priority', () => {
+      const req = buildPetStatusChangedCreate(
+        {
+          petId: 'pet-1',
+          rescueId: 'res-1',
+          fromStatus: 'available',
+          toStatus: 'adopted',
+          reason: null,
+        },
+        'usr-fav'
+      );
+
+      expect(req.userId).toBe('usr-fav');
+      expect(req.type).toBe(NotificationsV1.NotificationType.NOTIFICATION_TYPE_PET_UPDATE);
+      expect(req.channel).toBe(NotificationsV1.NotificationChannel.NOTIFICATION_CHANNEL_IN_APP);
+      expect(req.priority).toBe(NotificationsV1.NotificationPriority.NOTIFICATION_PRIORITY_NORMAL);
+      expect(req.relatedEntityType).toBe(
+        NotificationsV1.NotificationRelatedEntityType.NOTIFICATION_RELATED_ENTITY_TYPE_PET
+      );
+      expect(req.relatedEntityId).toBe('pet-1');
+
+      // The raw status enum stays out of the body, but rides in data_json.
+      expect(req.message).not.toContain('adopted');
+      const data = JSON.parse(req.dataJson) as Record<string, unknown>;
+      expect(data).toEqual({
+        petId: 'pet-1',
+        rescueId: 'res-1',
+        fromStatus: 'available',
+        toStatus: 'adopted',
+      });
+    });
+  });
+
+  describe('buildRescueVerifiedCreate', () => {
+    it('produces a HIGH-priority SYSTEM_ANNOUNCEMENT to the staff member with the rescue name', () => {
+      const req = buildRescueVerifiedCreate(
+        { rescueId: 'res-1', fromStatus: 'pending', toStatus: 'verified', reason: null },
+        'Happy Tails',
+        'usr-staff'
+      );
+
+      expect(req.userId).toBe('usr-staff');
+      expect(req.type).toBe(NotificationsV1.NotificationType.NOTIFICATION_TYPE_SYSTEM_ANNOUNCEMENT);
+      expect(req.priority).toBe(NotificationsV1.NotificationPriority.NOTIFICATION_PRIORITY_HIGH);
+      expect(req.message).toContain('Happy Tails');
+      expect(req.relatedEntityType).toBe(
+        NotificationsV1.NotificationRelatedEntityType.NOTIFICATION_RELATED_ENTITY_TYPE_RESCUE
+      );
+      expect(req.relatedEntityId).toBe('res-1');
+    });
+
+    it('falls back to a generic body when the rescue name is unavailable', () => {
+      const req = buildRescueVerifiedCreate(
+        { rescueId: 'res-1', fromStatus: 'pending', toStatus: 'verified', reason: null },
+        null,
+        'usr-staff'
+      );
+      expect(req.message).not.toContain('null');
+      expect(req.message).toMatch(/verified/i);
+    });
+  });
+
+  describe('buildRescueRejectedCreate', () => {
+    it('surfaces the rejection reason when present', () => {
+      const req = buildRescueRejectedCreate(
+        {
+          rescueId: 'res-1',
+          fromStatus: 'pending',
+          toStatus: 'rejected',
+          reason: 'incomplete charity registration',
+        },
+        'Happy Tails',
+        'usr-staff'
+      );
+
+      expect(req.type).toBe(NotificationsV1.NotificationType.NOTIFICATION_TYPE_SYSTEM_ANNOUNCEMENT);
+      expect(req.priority).toBe(NotificationsV1.NotificationPriority.NOTIFICATION_PRIORITY_NORMAL);
+      expect(req.message).toContain('incomplete charity registration');
+      expect(req.relatedEntityType).toBe(
+        NotificationsV1.NotificationRelatedEntityType.NOTIFICATION_RELATED_ENTITY_TYPE_RESCUE
+      );
+      const data = JSON.parse(req.dataJson) as Record<string, unknown>;
+      expect(data.reason).toBe('incomplete charity registration');
+    });
+
+    it('falls back to a generic body when no reason is supplied', () => {
+      const req = buildRescueRejectedCreate(
+        { rescueId: 'res-1', fromStatus: 'pending', toStatus: 'rejected', reason: null },
+        'Happy Tails',
+        'usr-staff'
+      );
+      expect(req.message).not.toContain('Reason:');
+      const data = JSON.parse(req.dataJson) as Record<string, unknown>;
+      expect(data.reason).toBeNull();
     });
   });
 });
@@ -507,5 +608,87 @@ describe('registerSubscribers idempotency wiring', () => {
 
     expect(mockedCreate).toHaveBeenCalledTimes(1);
     expect(mockedCreate.mock.calls[0][3]).toBeUndefined();
+  });
+
+  it('fans pets.statusChanged out to every favouriter with a per-recipient dedup key', async () => {
+    const nats = makeYieldingNats({
+      'pets.statusChanged': [
+        {
+          id: 'evt-1',
+          payload: {
+            petId: 'pet-1',
+            rescueId: 'res-1',
+            fromStatus: 'available',
+            toStatus: 'adopted',
+            reason: null,
+          },
+        },
+      ],
+    });
+    const petsClient = {
+      listFavoriters: vi.fn(async () => ['usr-f1', 'usr-f2']),
+      close: vi.fn(),
+    };
+
+    registerSubscribers({ nats, deps, logger, petsClient });
+    await flush();
+
+    expect(petsClient.listFavoriters).toHaveBeenCalledWith('pet-1');
+    expect(mockedCreate.mock.calls.map(c => [c[2].userId, c[3]?.dedup])).toEqual([
+      ['usr-f1', { consumer: 'pets.statusChanged', eventId: 'evt-1:usr-f1' }],
+      ['usr-f2', { consumer: 'pets.statusChanged', eventId: 'evt-1:usr-f2' }],
+    ]);
+  });
+
+  it('no-ops the pets.statusChanged fan-out when no pets client is configured', async () => {
+    const nats = makeYieldingNats({
+      'pets.statusChanged': [
+        {
+          id: 'evt-1',
+          payload: {
+            petId: 'pet-1',
+            rescueId: 'res-1',
+            fromStatus: 'available',
+            toStatus: 'adopted',
+            reason: null,
+          },
+        },
+      ],
+    });
+
+    registerSubscribers({ nats, deps, logger });
+    await flush();
+
+    expect(mockedCreate).not.toHaveBeenCalled();
+  });
+
+  it('fans rescue.verified out to every staff member with a per-recipient dedup key', async () => {
+    const nats = makeYieldingNats({
+      'rescue.verified': [
+        {
+          id: 'evt-r',
+          payload: {
+            rescueId: 'res-1',
+            fromStatus: 'pending',
+            toStatus: 'verified',
+            reason: null,
+          },
+        },
+      ],
+    });
+    const rescueClient = {
+      listStaffMembers: vi.fn(async () => ['usr-s1', 'usr-s2']),
+      getRescueName: vi.fn(async () => 'Happy Tails'),
+      close: vi.fn(),
+    };
+
+    registerSubscribers({ nats, deps, logger, rescueClient });
+    await flush();
+
+    expect(rescueClient.listStaffMembers).toHaveBeenCalledWith('res-1');
+    expect(mockedCreate.mock.calls.map(c => [c[2].userId, c[3]?.dedup])).toEqual([
+      ['usr-s1', { consumer: 'rescue.verified', eventId: 'evt-r:usr-s1' }],
+      ['usr-s2', { consumer: 'rescue.verified', eventId: 'evt-r:usr-s2' }],
+    ]);
   });
 });

--- a/services/notifications/src/nats/subscribers.ts
+++ b/services/notifications/src/nats/subscribers.ts
@@ -32,6 +32,8 @@ import { subscribe, type SubscriptionHandle } from '@adopt-dont-shop/events';
 import { NotificationsV1, type CreateNotificationRequest } from '@adopt-dont-shop/proto';
 
 import { createNotification, type HandlerDeps } from '../grpc/handlers.js';
+import type { PetsFavoritersClient } from '../grpc/pets-client.js';
+import type { RescueStaffClient } from '../grpc/rescue-client.js';
 
 import type {
   ApplicationAdoptedEvent,
@@ -55,6 +57,12 @@ export type RegisterSubscribersOptions = {
   nats: NatsConnection;
   deps: HandlerDeps;
   logger: Logger;
+  // Cross-service clients for recipient discovery. Optional — when a
+  // client is absent (its gRPC URL isn't configured) the corresponding
+  // fan-out no-ops gracefully, exactly like Broadcast degrades without
+  // authGrpcUrl. The wire path stays subscribed either way.
+  petsClient?: PetsFavoritersClient;
+  rescueClient?: RescueStaffClient;
 };
 
 // Durable-consumer name prefix so multiple replicas of service.notifications
@@ -79,8 +87,19 @@ const dedupFor = (
 ): { dedup: { consumer: string; eventId: string } } | undefined =>
   meta.id ? { dedup: { consumer: subject, eventId: meta.id } } : undefined;
 
+// Per-recipient dedup key for fan-out subjects (one event → N rows). The
+// recipient is appended to the event id so the first recipient's claim
+// doesn't suppress everyone else's notification. Mirrors the chat handler's
+// inline `${meta.id}:${userId}` key.
+const perRecipientDedup = (
+  subject: string,
+  meta: { id?: string },
+  recipientUserId: string
+): { dedup: { consumer: string; eventId: string } } | undefined =>
+  meta.id ? { dedup: { consumer: subject, eventId: `${meta.id}:${recipientUserId}` } } : undefined;
+
 export const registerSubscribers = (opts: RegisterSubscribersOptions): SubscriptionHandle[] => {
-  const { nats, deps, logger } = opts;
+  const { nats, deps, logger, petsClient, rescueClient } = opts;
 
   const onError = (err: unknown, ctx: { subject: string }): void => {
     logger.error('subscriber handler failed', {
@@ -219,24 +238,41 @@ export const registerSubscribers = (opts: RegisterSubscribersOptions): Subscript
     )
   );
 
-  // pets.statusChanged / pets.deleted (Phase 3.4): the subjects are
-  // wired here so the wire path is exercised end-to-end, but we do
-  // not yet create user-facing notification rows — see event-types.ts
-  // for the recipient-discovery deferral. Subscribing keeps the
-  // contract anchored on the consumer side and means upcoming changes
-  // (rescue staff lookup, favourite fan-out) only need to fill in the
-  // translator, not the registration.
+  // pets.statusChanged — fan a pet_update notification out to every user
+  // who FAVOURITED the pet. Recipient discovery is PetService.ListFavoriters
+  // (a system-principal gRPC read). When the pets client isn't configured
+  // the fan-out no-ops gracefully — the wire path stays subscribed either
+  // way. pets.deleted stays log-only (no recipient derivable here).
   subscriptions.push(
     subscribe<PetStatusChangedEvent>(
       nats,
       { subject: 'pets.statusChanged', durable: durableFor('pets.statusChanged'), onError },
-      async payload => {
-        logger.info('pets.statusChanged received', {
-          petId: payload.petId,
-          rescueId: payload.rescueId,
-          fromStatus: payload.fromStatus,
-          toStatus: payload.toStatus,
-        });
+      async (payload, meta) => {
+        if (!petsClient) {
+          logger.warn('pets.statusChanged fan-out skipped — no PETS_GRPC_URL configured', {
+            petId: payload.petId,
+          });
+          return;
+        }
+        const favouriters = await petsClient.listFavoriters(payload.petId);
+        // Each favouriter gets one row; one recipient's failure must not
+        // abort the rest (poison-pill protection — same as the chat handler).
+        for (const userId of favouriters) {
+          try {
+            await createNotification(
+              deps,
+              SYSTEM_PRINCIPAL,
+              buildPetStatusChangedCreate(payload, userId),
+              perRecipientDedup('pets.statusChanged', meta, userId)
+            );
+          } catch (err) {
+            logger.warn('pets.statusChanged notification create failed', {
+              petId: payload.petId,
+              recipientUserId: userId,
+              err: (err as Error)?.message ?? String(err),
+            });
+          }
+        }
       }
     )
   );
@@ -254,20 +290,42 @@ export const registerSubscribers = (opts: RegisterSubscribersOptions): Subscript
     )
   );
 
-  // rescue.verified / rescue.rejected / rescue.staffInvited (Phase 4.4):
-  // log-only on the consumer side, same pattern as the pets.* events.
-  // Recipient-discovery (rescue.contact_person, invitee email worker)
-  // lands when those upstream lookups exist.
+  // rescue.verified / rescue.rejected — fan a system-announcement
+  // notification out to the rescue's staff. Recipient discovery is
+  // RescueService.ListStaffMembers (a system-principal gRPC read); the
+  // rescue name (for the body) comes from RescueService.Get. When the
+  // rescue client isn't configured the fan-out no-ops gracefully.
+  // rescue.staffInvited stays log-only — it carries an email for a
+  // possibly-not-yet-user, which is out of scope for the staff fan-out.
   subscriptions.push(
     subscribe<RescueVerifiedEvent>(
       nats,
       { subject: 'rescue.verified', durable: durableFor('rescue.verified'), onError },
-      async payload => {
-        logger.info('rescue.verified received', {
-          rescueId: payload.rescueId,
-          fromStatus: payload.fromStatus,
-          toStatus: payload.toStatus,
-        });
+      async (payload, meta) => {
+        if (!rescueClient) {
+          logger.warn('rescue.verified fan-out skipped — no RESCUE_GRPC_URL configured', {
+            rescueId: payload.rescueId,
+          });
+          return;
+        }
+        const staff = await rescueClient.listStaffMembers(payload.rescueId);
+        const rescueName = await rescueClient.getRescueName(payload.rescueId);
+        for (const userId of staff) {
+          try {
+            await createNotification(
+              deps,
+              SYSTEM_PRINCIPAL,
+              buildRescueVerifiedCreate(payload, rescueName, userId),
+              perRecipientDedup('rescue.verified', meta, userId)
+            );
+          } catch (err) {
+            logger.warn('rescue.verified notification create failed', {
+              rescueId: payload.rescueId,
+              recipientUserId: userId,
+              err: (err as Error)?.message ?? String(err),
+            });
+          }
+        }
       }
     )
   );
@@ -276,11 +334,31 @@ export const registerSubscribers = (opts: RegisterSubscribersOptions): Subscript
     subscribe<RescueRejectedEvent>(
       nats,
       { subject: 'rescue.rejected', durable: durableFor('rescue.rejected'), onError },
-      async payload => {
-        logger.info('rescue.rejected received', {
-          rescueId: payload.rescueId,
-          reason: payload.reason,
-        });
+      async (payload, meta) => {
+        if (!rescueClient) {
+          logger.warn('rescue.rejected fan-out skipped — no RESCUE_GRPC_URL configured', {
+            rescueId: payload.rescueId,
+          });
+          return;
+        }
+        const staff = await rescueClient.listStaffMembers(payload.rescueId);
+        const rescueName = await rescueClient.getRescueName(payload.rescueId);
+        for (const userId of staff) {
+          try {
+            await createNotification(
+              deps,
+              SYSTEM_PRINCIPAL,
+              buildRescueRejectedCreate(payload, rescueName, userId),
+              perRecipientDedup('rescue.rejected', meta, userId)
+            );
+          } catch (err) {
+            logger.warn('rescue.rejected notification create failed', {
+              rescueId: payload.rescueId,
+              recipientUserId: userId,
+              err: (err as Error)?.message ?? String(err),
+            });
+          }
+        }
       }
     )
   );
@@ -574,3 +652,86 @@ export const buildChatMessageReceivedCreate = (
     relatedEntityId: event.messageId,
   };
 };
+
+// pets.statusChanged — fan an in-app update out to every user who
+// favourited the pet. Type PET_UPDATE (the closest existing fit for a
+// favourite-pet status change). The from/to status pair rides in
+// data_json so the SPA frames "now available" vs "adopted" appropriately
+// rather than the raw enum landing in the body.
+export const buildPetStatusChangedCreate = (
+  event: PetStatusChangedEvent,
+  recipientUserId: string
+): CreateNotificationRequest => ({
+  userId: recipientUserId,
+  type: NotificationsV1.NotificationType.NOTIFICATION_TYPE_PET_UPDATE,
+  channel: NotificationsV1.NotificationChannel.NOTIFICATION_CHANNEL_IN_APP,
+  priority: NotificationsV1.NotificationPriority.NOTIFICATION_PRIORITY_NORMAL,
+  title: 'A pet you favourited was updated',
+  message: 'The status of a pet on your favourites list has changed.',
+  dataJson: JSON.stringify({
+    petId: event.petId,
+    rescueId: event.rescueId,
+    fromStatus: event.fromStatus,
+    toStatus: event.toStatus,
+  }),
+  templateVariablesJson: '{}',
+  relatedEntityType:
+    NotificationsV1.NotificationRelatedEntityType.NOTIFICATION_RELATED_ENTITY_TYPE_PET,
+  relatedEntityId: event.petId,
+});
+
+// rescue.verified — tell the rescue's staff their organisation was
+// verified. There is no dedicated "rescue updates" NotificationType, so
+// we use NOTIFICATION_TYPE_SYSTEM_ANNOUNCEMENT — the generic system /
+// platform-news type — which is the closest existing fit for rescue-org
+// status news. HIGH priority: verification unblocks the rescue's ability
+// to list pets, so staff should see it promptly.
+export const buildRescueVerifiedCreate = (
+  event: RescueVerifiedEvent,
+  rescueName: string | null,
+  recipientUserId: string
+): CreateNotificationRequest => ({
+  userId: recipientUserId,
+  type: NotificationsV1.NotificationType.NOTIFICATION_TYPE_SYSTEM_ANNOUNCEMENT,
+  channel: NotificationsV1.NotificationChannel.NOTIFICATION_CHANNEL_IN_APP,
+  priority: NotificationsV1.NotificationPriority.NOTIFICATION_PRIORITY_HIGH,
+  title: 'Your rescue has been verified',
+  message: rescueName
+    ? `${rescueName} has been verified. You can now publish pet listings.`
+    : 'Your rescue has been verified. You can now publish pet listings.',
+  dataJson: JSON.stringify({
+    rescueId: event.rescueId,
+    fromStatus: event.fromStatus,
+    toStatus: event.toStatus,
+  }),
+  templateVariablesJson: '{}',
+  relatedEntityType:
+    NotificationsV1.NotificationRelatedEntityType.NOTIFICATION_RELATED_ENTITY_TYPE_RESCUE,
+  relatedEntityId: event.rescueId,
+});
+
+// rescue.rejected — same SYSTEM_ANNOUNCEMENT type + RESCUE related-entity
+// as rescue.verified, different translation. The reason rides in the
+// message body when present so staff understand the decision.
+export const buildRescueRejectedCreate = (
+  event: RescueRejectedEvent,
+  rescueName: string | null,
+  recipientUserId: string
+): CreateNotificationRequest => ({
+  userId: recipientUserId,
+  type: NotificationsV1.NotificationType.NOTIFICATION_TYPE_SYSTEM_ANNOUNCEMENT,
+  channel: NotificationsV1.NotificationChannel.NOTIFICATION_CHANNEL_IN_APP,
+  priority: NotificationsV1.NotificationPriority.NOTIFICATION_PRIORITY_NORMAL,
+  title: 'Your rescue application was not approved',
+  message: event.reason
+    ? `Your rescue application was not approved. Reason: ${event.reason}`
+    : 'Your rescue application was not approved.',
+  dataJson: JSON.stringify({
+    rescueId: event.rescueId,
+    reason: event.reason ?? null,
+  }),
+  templateVariablesJson: '{}',
+  relatedEntityType:
+    NotificationsV1.NotificationRelatedEntityType.NOTIFICATION_RELATED_ENTITY_TYPE_RESCUE,
+  relatedEntityId: event.rescueId,
+});

--- a/services/notifications/src/nats/subscribers.ts
+++ b/services/notifications/src/nats/subscribers.ts
@@ -98,6 +98,43 @@ const perRecipientDedup = (
 ): { dedup: { consumer: string; eventId: string } } | undefined =>
   meta.id ? { dedup: { consumer: subject, eventId: `${meta.id}:${recipientUserId}` } } : undefined;
 
+// A simple-event route descriptor: a subject paired with the pure
+// translator that turns its payload into a CreateNotificationRequest.
+// `defineRoute` captures the payload type T per row so each `build` stays
+// strongly typed to its own event shape (no `any`, no widening). The
+// generic registrar below consumes these uniformly.
+type SimpleEventRoute = {
+  subject: string;
+  register: (ctx: SimpleRouteContext) => SubscriptionHandle;
+};
+
+type SimpleRouteContext = {
+  nats: NatsConnection;
+  deps: HandlerDeps;
+  onError: (err: unknown, ctx: { subject: string }) => void;
+};
+
+const defineRoute = <TPayload>(
+  subject: string,
+  build: (payload: TPayload) => CreateNotificationRequest
+): SimpleEventRoute => ({
+  subject,
+  register: ({ nats, deps, onError }) =>
+    subscribe<TPayload>(
+      nats,
+      { subject, durable: durableFor(subject), onError },
+      async (payload, meta) => {
+        await createNotification(deps, SYSTEM_PRINCIPAL, build(payload), dedupFor(subject, meta));
+      }
+    ),
+});
+
+// The table itself (SIMPLE_EVENT_ROUTES) is declared at the bottom of
+// the file, after the build* translators it references — those are
+// `const` declarations and so live in the temporal dead zone until then.
+// registerSubscribers only READS the table at call time, by which point
+// the module is fully initialised, so its forward reference is safe.
+
 export const registerSubscribers = (opts: RegisterSubscribersOptions): SubscriptionHandle[] => {
   const { nats, deps, logger, petsClient, rescueClient } = opts;
 
@@ -110,133 +147,10 @@ export const registerSubscribers = (opts: RegisterSubscribersOptions): Subscript
 
   const subscriptions: SubscriptionHandle[] = [];
 
-  subscriptions.push(
-    subscribe<ApplicationSubmittedEvent>(
-      nats,
-      { subject: 'applications.submitted', durable: durableFor('applications.submitted'), onError },
-      async (payload, meta) => {
-        await createNotification(
-          deps,
-          SYSTEM_PRINCIPAL,
-          buildApplicationSubmittedCreate(payload),
-          dedupFor('applications.submitted', meta)
-        );
-      }
-    )
-  );
-
-  subscriptions.push(
-    subscribe<ApplicationApprovedEvent>(
-      nats,
-      { subject: 'applications.approved', durable: durableFor('applications.approved'), onError },
-      async (payload, meta) => {
-        await createNotification(
-          deps,
-          SYSTEM_PRINCIPAL,
-          buildApplicationApprovedCreate(payload),
-          dedupFor('applications.approved', meta)
-        );
-      }
-    )
-  );
-
-  subscriptions.push(
-    subscribe<ApplicationRejectedEvent>(
-      nats,
-      { subject: 'applications.rejected', durable: durableFor('applications.rejected'), onError },
-      async (payload, meta) => {
-        await createNotification(
-          deps,
-          SYSTEM_PRINCIPAL,
-          buildApplicationRejectedCreate(payload),
-          dedupFor('applications.rejected', meta)
-        );
-      }
-    )
-  );
-
-  subscriptions.push(
-    subscribe<ApplicationHomeVisitScheduledEvent>(
-      nats,
-      {
-        subject: 'applications.homeVisitScheduled',
-        durable: durableFor('applications.homeVisitScheduled'),
-        onError,
-      },
-      async (payload, meta) => {
-        await createNotification(
-          deps,
-          SYSTEM_PRINCIPAL,
-          buildApplicationHomeVisitScheduledCreate(payload),
-          dedupFor('applications.homeVisitScheduled', meta)
-        );
-      }
-    )
-  );
-
-  subscriptions.push(
-    subscribe<ApplicationHomeVisitCompletedEvent>(
-      nats,
-      {
-        subject: 'applications.homeVisitCompleted',
-        durable: durableFor('applications.homeVisitCompleted'),
-        onError,
-      },
-      async (payload, meta) => {
-        await createNotification(
-          deps,
-          SYSTEM_PRINCIPAL,
-          buildApplicationHomeVisitCompletedCreate(payload),
-          dedupFor('applications.homeVisitCompleted', meta)
-        );
-      }
-    )
-  );
-
-  subscriptions.push(
-    subscribe<ApplicationAdoptedEvent>(
-      nats,
-      { subject: 'applications.adopted', durable: durableFor('applications.adopted'), onError },
-      async (payload, meta) => {
-        await createNotification(
-          deps,
-          SYSTEM_PRINCIPAL,
-          buildApplicationAdoptedCreate(payload),
-          dedupFor('applications.adopted', meta)
-        );
-      }
-    )
-  );
-
-  subscriptions.push(
-    subscribe<AuthUserLoggedInEvent>(
-      nats,
-      { subject: 'auth.userLoggedIn', durable: durableFor('auth.userLoggedIn'), onError },
-      async (payload, meta) => {
-        await createNotification(
-          deps,
-          SYSTEM_PRINCIPAL,
-          buildAuthUserLoggedInCreate(payload),
-          dedupFor('auth.userLoggedIn', meta)
-        );
-      }
-    )
-  );
-
-  subscriptions.push(
-    subscribe<AuthRoleAssignedEvent>(
-      nats,
-      { subject: 'auth.roleAssigned', durable: durableFor('auth.roleAssigned'), onError },
-      async (payload, meta) => {
-        await createNotification(
-          deps,
-          SYSTEM_PRINCIPAL,
-          buildAuthRoleAssignedCreate(payload),
-          dedupFor('auth.roleAssigned', meta)
-        );
-      }
-    )
-  );
+  // Simple single-recipient events first — same order as the table.
+  for (const route of SIMPLE_EVENT_ROUTES) {
+    subscriptions.push(route.register({ nats, deps, onError }));
+  }
 
   // pets.statusChanged — fan a pet_update notification out to every user
   // who FAVOURITED the pet. Recipient discovery is PetService.ListFavoriters
@@ -735,3 +649,33 @@ export const buildRescueRejectedCreate = (
     NotificationsV1.NotificationRelatedEntityType.NOTIFICATION_RELATED_ENTITY_TYPE_RESCUE,
   relatedEntityId: event.rescueId,
 });
+
+// --- Declarative routing table for simple single-recipient events ----
+//
+// Each row pairs a subject with its (unchanged) build* translator;
+// registerSubscribers iterates this table to register the boilerplate
+// subscribers in order. Declared here, AFTER the build* functions, so
+// the const references aren't in the temporal dead zone at module load.
+//
+// The single-recipient events whose registration is pure boilerplate:
+// subscribe to the subject, translate, create with subject-scoped dedup.
+// Adding a new simple event is "write a build* + add one row here". The
+// table ORDER is the registration order — it stays aligned with the
+// fan-out handlers in registerSubscribers to preserve the overall subject
+// ordering.
+const SIMPLE_EVENT_ROUTES: readonly SimpleEventRoute[] = [
+  defineRoute<ApplicationSubmittedEvent>('applications.submitted', buildApplicationSubmittedCreate),
+  defineRoute<ApplicationApprovedEvent>('applications.approved', buildApplicationApprovedCreate),
+  defineRoute<ApplicationRejectedEvent>('applications.rejected', buildApplicationRejectedCreate),
+  defineRoute<ApplicationHomeVisitScheduledEvent>(
+    'applications.homeVisitScheduled',
+    buildApplicationHomeVisitScheduledCreate
+  ),
+  defineRoute<ApplicationHomeVisitCompletedEvent>(
+    'applications.homeVisitCompleted',
+    buildApplicationHomeVisitCompletedCreate
+  ),
+  defineRoute<ApplicationAdoptedEvent>('applications.adopted', buildApplicationAdoptedCreate),
+  defineRoute<AuthUserLoggedInEvent>('auth.userLoggedIn', buildAuthUserLoggedInCreate),
+  defineRoute<AuthRoleAssignedEvent>('auth.roleAssigned', buildAuthRoleAssignedCreate),
+];

--- a/services/notifications/src/preferences-gate.test.ts
+++ b/services/notifications/src/preferences-gate.test.ts
@@ -1,0 +1,164 @@
+import type { Pool } from 'pg';
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  DEFAULT_PREFS,
+  inQuietHours,
+  loadNotificationPrefs,
+  shouldDeliver,
+  type NotificationPrefs,
+} from './preferences-gate.js';
+
+const prefs = (overrides: Partial<NotificationPrefs> = {}): NotificationPrefs => ({
+  ...DEFAULT_PREFS,
+  ...overrides,
+});
+
+describe('shouldDeliver', () => {
+  const now = new Date('2026-06-15T12:00:00Z');
+
+  it('always allows the in-app record regardless of channel/category prefs', () => {
+    const muted = prefs({ pushEnabled: false, chatMessages: false, applicationUpdates: false });
+    expect(shouldDeliver(muted, { type: 'message_received', channel: 'in_app', now })).toBe(true);
+  });
+
+  it('allows push when the channel and category are both enabled', () => {
+    expect(shouldDeliver(prefs(), { type: 'application_status', channel: 'push', now })).toBe(true);
+  });
+
+  it('suppresses push when push is disabled', () => {
+    expect(
+      shouldDeliver(prefs({ pushEnabled: false }), {
+        type: 'application_status',
+        channel: 'push',
+        now,
+      })
+    ).toBe(false);
+  });
+
+  it('suppresses push when the matching category is muted', () => {
+    expect(
+      shouldDeliver(prefs({ chatMessages: false }), {
+        type: 'message_received',
+        channel: 'push',
+        now,
+      })
+    ).toBe(false);
+  });
+
+  it('gates email on email_enabled, independent of push', () => {
+    const p = prefs({ emailEnabled: false, pushEnabled: true });
+    expect(shouldDeliver(p, { type: 'application_status', channel: 'email', now })).toBe(false);
+  });
+
+  it('gates sms on sms_enabled (off by default)', () => {
+    expect(shouldDeliver(prefs(), { type: 'application_status', channel: 'sms', now })).toBe(false);
+    expect(
+      shouldDeliver(prefs({ smsEnabled: true }), {
+        type: 'application_status',
+        channel: 'sms',
+        now,
+      })
+    ).toBe(true);
+  });
+
+  it('never category-mutes account_security, but still respects the channel toggle', () => {
+    // Category bypass: a security alert is not governed by any category flag.
+    expect(shouldDeliver(prefs(), { type: 'account_security', channel: 'push', now })).toBe(true);
+    // Channel toggle still applies — push off means no push, even for security.
+    expect(
+      shouldDeliver(prefs({ pushEnabled: false }), {
+        type: 'account_security',
+        channel: 'push',
+        now,
+      })
+    ).toBe(false);
+  });
+
+  it('suppresses push during quiet hours but not other channels', () => {
+    const p = prefs({ quietHoursStart: '22:00:00', quietHoursEnd: '07:00:00', timezone: 'UTC' });
+    const night = new Date('2026-06-15T23:30:00Z');
+    expect(shouldDeliver(p, { type: 'application_status', channel: 'push', now: night })).toBe(
+      false
+    );
+    // Email is not quiet-hours gated.
+    expect(shouldDeliver(p, { type: 'application_status', channel: 'email', now: night })).toBe(
+      true
+    );
+  });
+});
+
+describe('inQuietHours', () => {
+  it('returns false when no window is configured', () => {
+    expect(inQuietHours(prefs(), new Date('2026-06-15T23:30:00Z'))).toBe(false);
+  });
+
+  it('handles a window that wraps midnight (22:00 → 07:00)', () => {
+    const p = prefs({ quietHoursStart: '22:00:00', quietHoursEnd: '07:00:00', timezone: 'UTC' });
+    expect(inQuietHours(p, new Date('2026-06-15T23:30:00Z'))).toBe(true); // late night
+    expect(inQuietHours(p, new Date('2026-06-15T05:00:00Z'))).toBe(true); // early morning
+    expect(inQuietHours(p, new Date('2026-06-15T12:00:00Z'))).toBe(false); // midday
+  });
+
+  it('handles a same-day window (09:00 → 17:00)', () => {
+    const p = prefs({ quietHoursStart: '09:00:00', quietHoursEnd: '17:00:00', timezone: 'UTC' });
+    expect(inQuietHours(p, new Date('2026-06-15T12:00:00Z'))).toBe(true);
+    expect(inQuietHours(p, new Date('2026-06-15T20:00:00Z'))).toBe(false);
+  });
+
+  it('evaluates the window in the user timezone, not UTC', () => {
+    // 23:30 UTC is 19:30 in New York — outside a 22:00→07:00 NY window.
+    const p = prefs({
+      quietHoursStart: '22:00:00',
+      quietHoursEnd: '07:00:00',
+      timezone: 'America/New_York',
+    });
+    expect(inQuietHours(p, new Date('2026-06-15T23:30:00Z'))).toBe(false);
+    // 03:30 UTC is 23:30 the previous day in NY — inside the window.
+    expect(inQuietHours(p, new Date('2026-06-15T03:30:00Z'))).toBe(true);
+  });
+});
+
+describe('loadNotificationPrefs', () => {
+  it('maps a stored row to camelCase prefs', async () => {
+    const query = vi.fn().mockResolvedValue({
+      rows: [
+        {
+          email_enabled: false,
+          push_enabled: true,
+          sms_enabled: true,
+          application_updates: false,
+          pet_matches: true,
+          rescue_updates: true,
+          chat_messages: false,
+          quiet_hours_start: '22:00:00',
+          quiet_hours_end: '07:00:00',
+          timezone: 'Europe/London',
+        },
+      ],
+    });
+    const pool = { query } as unknown as Pool;
+
+    const result = await loadNotificationPrefs(pool, 'usr-1');
+
+    expect(result).toEqual({
+      emailEnabled: false,
+      pushEnabled: true,
+      smsEnabled: true,
+      applicationUpdates: false,
+      petMatches: true,
+      rescueUpdates: true,
+      chatMessages: false,
+      quietHoursStart: '22:00:00',
+      quietHoursEnd: '07:00:00',
+      timezone: 'Europe/London',
+    });
+  });
+
+  it('returns permissive defaults when the user has no prefs row', async () => {
+    const query = vi.fn().mockResolvedValue({ rows: [] });
+    const pool = { query } as unknown as Pool;
+
+    expect(await loadNotificationPrefs(pool, 'usr-new')).toEqual(DEFAULT_PREFS);
+  });
+});

--- a/services/notifications/src/preferences-gate.ts
+++ b/services/notifications/src/preferences-gate.ts
@@ -1,0 +1,180 @@
+// Preference gate for OUTBOUND delivery channels.
+//
+// The in-app notification row is the user's durable record and is always
+// written (createNotification). These preferences govern the INTERRUPTIVE
+// channels — push now, email once the email channel adapter lands — so a
+// user who disabled push, muted a category, or set quiet hours stops
+// getting those channels WITHOUT losing their in-app history. Stored prefs
+// (user_notification_prefs) were previously editable but never consulted
+// at dispatch; this is the consult point.
+
+import type { Pool } from 'pg';
+
+export type DeliveryChannel = 'in_app' | 'email' | 'push' | 'sms';
+
+export type NotificationPrefs = {
+  emailEnabled: boolean;
+  pushEnabled: boolean;
+  smsEnabled: boolean;
+  applicationUpdates: boolean;
+  petMatches: boolean;
+  rescueUpdates: boolean;
+  chatMessages: boolean;
+  quietHoursStart: string | null;
+  quietHoursEnd: string | null;
+  timezone: string;
+};
+
+// Permissive defaults — mirror the user_notification_prefs column defaults.
+// Used when a user has no prefs row yet (the row is created lazily by the
+// prefs RPCs, so a brand-new user has none).
+export const DEFAULT_PREFS: NotificationPrefs = {
+  emailEnabled: true,
+  pushEnabled: true,
+  smsEnabled: false,
+  applicationUpdates: true,
+  petMatches: true,
+  rescueUpdates: true,
+  chatMessages: true,
+  quietHoursStart: null,
+  quietHoursEnd: null,
+  timezone: 'UTC',
+};
+
+type PrefsRow = {
+  email_enabled: boolean;
+  push_enabled: boolean;
+  sms_enabled: boolean;
+  application_updates: boolean;
+  pet_matches: boolean;
+  rescue_updates: boolean;
+  chat_messages: boolean;
+  quiet_hours_start: string | null;
+  quiet_hours_end: string | null;
+  timezone: string;
+};
+
+export const loadNotificationPrefs = async (
+  pool: Pool,
+  userId: string
+): Promise<NotificationPrefs> => {
+  const res = await pool.query<PrefsRow>(
+    `SELECT email_enabled, push_enabled, sms_enabled,
+            application_updates, pet_matches, rescue_updates, chat_messages,
+            quiet_hours_start, quiet_hours_end, timezone
+     FROM notifications.user_notification_prefs
+     WHERE user_id = $1`,
+    [userId]
+  );
+  const row = res.rows[0];
+  if (!row) {
+    return DEFAULT_PREFS;
+  }
+  return {
+    emailEnabled: row.email_enabled,
+    pushEnabled: row.push_enabled,
+    smsEnabled: row.sms_enabled,
+    applicationUpdates: row.application_updates,
+    petMatches: row.pet_matches,
+    rescueUpdates: row.rescue_updates,
+    chatMessages: row.chat_messages,
+    quietHoursStart: row.quiet_hours_start,
+    quietHoursEnd: row.quiet_hours_end,
+    timezone: row.timezone,
+  };
+};
+
+// Map a notification type (the lowercase Postgres enum value) to the
+// category toggle that governs it. Types with no category (account
+// security, system announcements, reminders, marketing) are never
+// category-muted — account_security in particular must always reach the
+// user.
+const categoryEnabled = (prefs: NotificationPrefs, type: string): boolean => {
+  switch (type) {
+    case 'application_status':
+    case 'adoption_approved':
+    case 'adoption_rejected':
+    case 'home_visit_scheduled':
+    case 'interview_scheduled':
+    case 'reference_request':
+    case 'follow_up':
+      return prefs.applicationUpdates;
+    case 'pet_available':
+    case 'pet_update':
+      return prefs.petMatches;
+    case 'rescue_invitation':
+    case 'staff_assignment':
+      return prefs.rescueUpdates;
+    case 'message_received':
+      return prefs.chatMessages;
+    default:
+      return true;
+  }
+};
+
+const channelEnabled = (prefs: NotificationPrefs, channel: DeliveryChannel): boolean => {
+  switch (channel) {
+    case 'email':
+      return prefs.emailEnabled;
+    case 'push':
+      return prefs.pushEnabled;
+    case 'sms':
+      return prefs.smsEnabled;
+    case 'in_app':
+      return true;
+  }
+};
+
+const toMinutes = (hhmmss: string): number => {
+  const [h, m] = hhmmss.split(':');
+  return Number(h) * 60 + Number(m);
+};
+
+const minutesOfDayInTz = (now: Date, timezone: string): number => {
+  const parts = new Intl.DateTimeFormat('en-GB', {
+    timeZone: timezone,
+    hourCycle: 'h23',
+    hour: '2-digit',
+    minute: '2-digit',
+  }).formatToParts(now);
+  const hour = Number(parts.find(p => p.type === 'hour')?.value ?? '0');
+  const minute = Number(parts.find(p => p.type === 'minute')?.value ?? '0');
+  return hour * 60 + minute;
+};
+
+// Quiet hours apply only to interruptive channels (push). A window that
+// wraps midnight (start > end, e.g. 22:00 → 07:00) is handled.
+export const inQuietHours = (prefs: NotificationPrefs, now: Date): boolean => {
+  if (!prefs.quietHoursStart || !prefs.quietHoursEnd) {
+    return false;
+  }
+  const start = toMinutes(prefs.quietHoursStart);
+  const end = toMinutes(prefs.quietHoursEnd);
+  if (start === end) {
+    return false;
+  }
+  const current = minutesOfDayInTz(now, prefs.timezone || 'UTC');
+  return start < end ? current >= start && current < end : current >= start || current < end;
+};
+
+export type DeliveryDecision = { type: string; channel: DeliveryChannel; now: Date };
+
+// Whether to deliver a notification of `type` on `channel` to a user with
+// these prefs at `now`. in_app is always allowed (the durable record);
+// push/email/sms require the channel enabled AND the category un-muted, and
+// push additionally respects quiet hours.
+export const shouldDeliver = (prefs: NotificationPrefs, args: DeliveryDecision): boolean => {
+  if (args.channel === 'in_app') {
+    return true;
+  }
+  if (!channelEnabled(prefs, args.channel)) {
+    return false;
+  }
+  if (!categoryEnabled(prefs, args.type)) {
+    return false;
+  }
+  if (args.channel === 'push' && inQuietHours(prefs, args.now)) {
+    return false;
+  }
+  return true;
+};

--- a/services/notifications/src/push/worker.test.ts
+++ b/services/notifications/src/push/worker.test.ts
@@ -16,10 +16,13 @@ const flush = async (): Promise<void> => {
   }
 };
 
-const makePool = (claimRowCount: number) => {
+const makePool = (opts: { claimRowCount?: number; prefs?: Record<string, unknown> } = {}) => {
   const query = vi.fn(async (sql: string) => {
+    if (sql.includes('user_notification_prefs')) {
+      return { rows: opts.prefs ? [opts.prefs] : [] };
+    }
     if (sql.includes('processed_events')) {
-      return { rowCount: claimRowCount, rows: [] };
+      return { rowCount: opts.claimRowCount ?? 1, rows: [] };
     }
     if (sql.includes('device_tokens')) {
       return { rows: [{ token_id: 't1', device_token: 'tok-1', platform: 'ios' }] };
@@ -28,6 +31,9 @@ const makePool = (claimRowCount: number) => {
   });
   return { query, asPool: { query } as unknown as Pool };
 };
+
+const includesSql = (query: ReturnType<typeof vi.fn>, fragment: string): boolean =>
+  query.mock.calls.some(c => String(c[0]).includes(fragment));
 
 const makeProvider = () => {
   const send = vi.fn(async () => ({ success: true, messageId: 'm1' }));
@@ -92,33 +98,60 @@ const pushEvent = (overrides: Record<string, unknown> = {}) => ({
 
 describe('push worker dedup', () => {
   it('claims the event then fans out to device tokens on first delivery', async () => {
-    const { asPool, query } = makePool(1);
+    const { asPool, query } = makePool({ claimRowCount: 1 });
     const { provider, send } = makeProvider();
     const nats = makeNats([{ id: 'notifications.created.n-1', payload: pushEvent() }]);
 
     startPushWorker({ pool: asPool, nats, provider, logger });
     await flush();
 
-    expect(query.mock.calls[0][0]).toContain('processed_events');
+    expect(includesSql(query, 'processed_events')).toBe(true);
+    expect(includesSql(query, 'device_tokens')).toBe(true);
     expect(send).toHaveBeenCalledTimes(1);
   });
 
   it('does not fan out on a redelivery (claim loses the ON CONFLICT race)', async () => {
-    const { asPool, query } = makePool(0);
+    const { asPool, query } = makePool({ claimRowCount: 0 });
     const { provider, send } = makeProvider();
     const nats = makeNats([{ id: 'notifications.created.n-1', payload: pushEvent() }]);
 
     startPushWorker({ pool: asPool, nats, provider, logger });
     await flush();
 
-    expect(query.mock.calls[0][0]).toContain('processed_events');
+    expect(includesSql(query, 'processed_events')).toBe(true);
     // Claim failed → never reaches the device-token lookup or provider send.
-    expect(query.mock.calls.some(c => String(c[0]).includes('device_tokens'))).toBe(false);
+    expect(includesSql(query, 'device_tokens')).toBe(false);
     expect(send).not.toHaveBeenCalled();
   });
 
-  it('ignores non-push notifications without claiming the event', async () => {
-    const { asPool, query } = makePool(1);
+  it('suppresses the push (and does not claim) when push is disabled in prefs', async () => {
+    const { asPool, query } = makePool({
+      prefs: {
+        email_enabled: true,
+        push_enabled: false,
+        sms_enabled: false,
+        application_updates: true,
+        pet_matches: true,
+        rescue_updates: true,
+        chat_messages: true,
+        quiet_hours_start: null,
+        quiet_hours_end: null,
+        timezone: 'UTC',
+      },
+    });
+    const { provider, send } = makeProvider();
+    const nats = makeNats([{ id: 'notifications.created.n-1', payload: pushEvent() }]);
+
+    startPushWorker({ pool: asPool, nats, provider, logger });
+    await flush();
+
+    expect(includesSql(query, 'user_notification_prefs')).toBe(true);
+    expect(includesSql(query, 'processed_events')).toBe(false);
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it('ignores non-push notifications without loading prefs or claiming', async () => {
+    const { asPool, query } = makePool({ claimRowCount: 1 });
     const { provider, send } = makeProvider();
     const nats = makeNats([
       { id: 'notifications.created.n-2', payload: pushEvent({ channel: 'in_app' }) },

--- a/services/notifications/src/push/worker.ts
+++ b/services/notifications/src/push/worker.ts
@@ -14,6 +14,7 @@ import type { Logger } from 'winston';
 
 import { subscribe } from '@adopt-dont-shop/events';
 
+import { loadNotificationPrefs, shouldDeliver } from '../preferences-gate.js';
 import { claimEvent } from '../processed-events.js';
 
 import { listDeviceTokensForUser, markDeviceTokenInvalid } from './device-tokens.js';
@@ -100,6 +101,20 @@ export const startPushWorker = (opts: PushWorkerOptions): RunningPushWorker => {
         return;
       }
       if (!ev.userId) {
+        return;
+      }
+
+      // Preference gate — respect push_enabled, the category toggle, and
+      // quiet hours. A suppressed push leaves the in-app record intact;
+      // checked before the dedup claim so a redelivery re-evaluates to the
+      // same outcome rather than being silently swallowed.
+      const prefs = await loadNotificationPrefs(opts.pool, ev.userId);
+      if (!shouldDeliver(prefs, { type: ev.type, channel: 'push', now: new Date() })) {
+        opts.logger.info('push.worker.suppressed_by_prefs', {
+          userId: ev.userId,
+          notificationId: ev.notificationId,
+          type: ev.type,
+        });
         return;
       }
 

--- a/services/pets/src/grpc/handlers.test.ts
+++ b/services/pets/src/grpc/handlers.test.ts
@@ -12,6 +12,7 @@ import {
   getPet,
   getPetStats,
   HandlerError,
+  listFavoriters,
   listPets,
   updatePet,
   updatePetStatus,
@@ -623,6 +624,56 @@ describe('getPetStats', () => {
 
   it('rejects when caller has pets.read but no rescue scope and no :any', async () => {
     await expect(getPetStats(mocks.deps, ADOPTER, {})).rejects.toMatchObject({
+      code: 'PERMISSION_DENIED',
+    });
+  });
+});
+
+// --- listFavoriters --------------------------------------------------
+
+describe('listFavoriters', () => {
+  let mocks: ReturnType<typeof makeMocks>;
+  beforeEach(() => {
+    mocks = makeMocks();
+  });
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('returns the user_ids of every active favouriter for the pet', async () => {
+    mocks.poolMock.query.mockResolvedValueOnce({
+      rows: [{ user_id: 'usr-1' }, { user_id: 'usr-2' }],
+    });
+    const res = await listFavoriters(mocks.deps, ADOPTER, { petId: 'pet-1' });
+    expect(res.userIds).toEqual(['usr-1', 'usr-2']);
+
+    const [sql, params] = mocks.poolMock.query.mock.calls[0] as [string, unknown[]];
+    // Schema-qualified + filters out soft-deleted favourite rows.
+    expect(sql).toMatch(/pets\.user_favorites/);
+    expect(sql).toMatch(/pet_id = \$1/);
+    expect(sql).toMatch(/deleted_at IS NULL/);
+    expect(params).toEqual(['pet-1']);
+  });
+
+  it('returns an empty list when the pet has no favouriters', async () => {
+    mocks.poolMock.query.mockResolvedValueOnce({ rows: [] });
+    const res = await listFavoriters(mocks.deps, ADOPTER, { petId: 'pet-1' });
+    expect(res.userIds).toEqual([]);
+  });
+
+  it('INVALID_ARGUMENT when pet_id is missing', async () => {
+    await expect(listFavoriters(mocks.deps, ADOPTER, { petId: '' })).rejects.toMatchObject({
+      code: 'INVALID_ARGUMENT',
+    });
+  });
+
+  it('PERMISSION_DENIED for a principal without pets.read', async () => {
+    const noPerms: Principal = {
+      userId: 'usr-noperms' as UserId,
+      roles: ['adopter'],
+      permissions: [],
+    };
+    await expect(listFavoriters(mocks.deps, noPerms, { petId: 'pet-1' })).rejects.toMatchObject({
       code: 'PERMISSION_DENIED',
     });
   });

--- a/services/pets/src/grpc/handlers.ts
+++ b/services/pets/src/grpc/handlers.ts
@@ -34,6 +34,8 @@ import {
   type GetPetResponse,
   type GetPetStatsRequest,
   type GetPetStatsResponse,
+  type ListPetFavoritersRequest,
+  type ListPetFavoritersResponse,
   type ListPetsRequest,
   type ListPetsResponse,
   type Pet,
@@ -826,4 +828,31 @@ export async function getPetStats(
     monthlyAdoptions,
     averageDaysToAdoption,
   };
+}
+
+// --- ListFavoriters --------------------------------------------------
+
+// Recipient-discovery read for service.notifications: the user_ids of
+// every adopter with an ACTIVE favourite on the pet. Gated on plain
+// pets.read (same as Get / List) — no rescue scope, because favouriters
+// are cross-rescue and the caller is a trusted system principal fanning
+// out a pets.statusChanged event. A missing/soft-deleted pet just yields
+// an empty list (no NOT_FOUND): the caller only cares about recipients.
+export async function listFavoriters(
+  deps: HandlerDeps,
+  principal: Principal,
+  req: ListPetFavoritersRequest
+): Promise<ListPetFavoritersResponse> {
+  if (!req.petId) {
+    throw new HandlerError('INVALID_ARGUMENT', 'pet_id is required');
+  }
+  if (!hasPermission(principal, PETS_READ)) {
+    throw new HandlerError('PERMISSION_DENIED', `'${PETS_READ}' required`);
+  }
+
+  const result = await deps.pool.query<{ user_id: string }>(
+    `SELECT user_id FROM pets.user_favorites WHERE pet_id = $1 AND deleted_at IS NULL`,
+    [req.petId]
+  );
+  return { userIds: result.rows.map(row => row.user_id) };
 }

--- a/services/pets/src/grpc/server.test.ts
+++ b/services/pets/src/grpc/server.test.ts
@@ -30,7 +30,7 @@ const pool = {} as unknown as Pool;
 const nats = {} as unknown as NatsConnection;
 
 describe('createGrpcServer', () => {
-  it('registers all six PetService methods on the grpc.Server', () => {
+  it('registers all PetService methods on the grpc.Server', () => {
     const server = createGrpcServer({ config, pool, nats, logger: quietLogger });
     const handlers = (server as unknown as { handlers: Map<string, unknown> }).handlers;
 
@@ -40,6 +40,7 @@ describe('createGrpcServer', () => {
     expect(handlers.has('/adopt_dont_shop.pets.v1.PetService/Update')).toBe(true);
     expect(handlers.has('/adopt_dont_shop.pets.v1.PetService/UpdateStatus')).toBe(true);
     expect(handlers.has('/adopt_dont_shop.pets.v1.PetService/Delete')).toBe(true);
+    expect(handlers.has('/adopt_dont_shop.pets.v1.PetService/ListFavoriters')).toBe(true);
   });
 
   it('matches every path from the canonical PetServiceService Definition table', () => {

--- a/services/pets/src/grpc/server.ts
+++ b/services/pets/src/grpc/server.ts
@@ -22,6 +22,7 @@ import {
   deletePet,
   getPet,
   getPetStats,
+  listFavoriters,
   listPets,
   updatePet,
   updatePetStatus,
@@ -49,10 +50,20 @@ export const createGrpcServer = (opts: CreateGrpcServerOptions): Server => {
     updateStatus: adapt(updatePetStatus, { deps, logger }),
     delete: adapt(deletePet, { deps, logger }),
     getStats: adapt(getPetStats, { deps, logger }),
+    listFavoriters: adapt(listFavoriters, { deps, logger }),
   });
 
   logger.info('gRPC PetService registered', {
-    methods: ['create', 'get', 'list', 'update', 'updateStatus', 'delete', 'getStats'],
+    methods: [
+      'create',
+      'get',
+      'list',
+      'update',
+      'updateStatus',
+      'delete',
+      'getStats',
+      'listFavoriters',
+    ],
     grpcPort: config.grpcPort,
   });
 


### PR DESCRIPTION
## Land the rest of the notifications improvements on `main`

Follow-up to land the four improvements that **did not reach `main`**. The original five were a stack; only **P1 (#1047)** targeted `main`. The other four PRs (#1048–#1051) were each based on the PR below them, so merging them merged their changes **into the intermediate branches, not `main`**. This PR brings them home.

It is the top of that stack **rebased onto current `main`** (the original P1 commit dropped — it's already on `main` via #1047's squash), giving four clean commits:

1. `feat(notifications): enforce user notification preferences on push delivery` — **P3** (was #1048)
2. `feat(notifications): add email channel adapter for transactional emails` — **P2** (was #1049)
3. `feat(notifications): fan out pets/rescue events to real recipients` — **P4** (was #1050, incl. the new pets `ListFavoriters` RPC)
4. `refactor(notifications): declarative routing table for simple event subscribers` — **P5** (was #1051)

Per-commit history is preserved, so each change is still reviewable in isolation.

### What's included
- **P3** — preference gate (`shouldDeliver` + `loadNotificationPrefs`), wired into the push worker (respects `push_enabled`, category toggles, quiet hours).
- **P2** — email channel adapter on `notifications.created` (resolves the address via `AdminGetUser`, enqueues transactional emails; idempotency-key dedup).
- **P4** — cross-service fan-out: new pets `ListFavoriters` RPC + pets/rescue gRPC clients; `pets.statusChanged` → favouriters, `rescue.verified`/`rejected` → staff.
- **P5** — declarative `SIMPLE_EVENT_ROUTES` table for the simple single-recipient subscribers.

### Verification (rebased onto current `main`)
proto rebuilt; **notifications 258 tests pass**, type-check clean, lint 0 errors (only the pre-existing `beforeEach` warning); pets type-check clean.

> The pre-existing `Dependency Audit` failure (transitive `ws` via `apps/admin > socket.io-client`) is unrelated and also fails on `main`.

https://claude.ai/code/session_01LAJXPr3DARnLgzBdTTjYKr

---
_Generated by [Claude Code](https://claude.ai/code/session_01LAJXPr3DARnLgzBdTTjYKr)_