### PR TITLE
Frontend & shared-libraries code-quality review

### DIFF
--- a/apps/admin/src/components/modals/UserActionsMenu.test.tsx
+++ b/apps/admin/src/components/modals/UserActionsMenu.test.tsx
@@ -252,6 +252,26 @@ describe('UserActionsMenu', () => {
     });
   });
 
+  describe('action failure handling', () => {
+    it('keeps the modal open and surfaces an error when the action rejects', async () => {
+      const handlers = {
+        ...defaultHandlers,
+        onDelete: vi.fn().mockRejectedValue(new Error('Server unavailable')),
+      };
+      renderWithProviders(<UserActionsMenu user={activeUser} {...handlers} />);
+      const user = await openMenu();
+
+      await user.click(screen.getByRole('menuitem', { name: /delete user/i }));
+      await user.click(screen.getByRole('button', { name: /delete user/i }));
+
+      // The failure is surfaced in an alert and the dialog stays open.
+      await waitFor(() => {
+        expect(screen.getByRole('alert')).toHaveTextContent('Server unavailable');
+      });
+      expect(screen.getByText(/are you sure you want to delete this user/i)).toBeInTheDocument();
+    });
+  });
+
   describe('cancel actions', () => {
     it('does not call the action handler when cancel is clicked', async () => {
       renderWithProviders(<UserActionsMenu user={activeUser} {...defaultHandlers} />);

--- a/apps/admin/src/components/modals/UserActionsMenu.tsx
+++ b/apps/admin/src/components/modals/UserActionsMenu.tsx
@@ -39,13 +39,20 @@ export const ConfirmationModal: React.FC<ConfirmationModalProps> = ({
 }) => {
   const [reason, setReason] = useState('');
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
 
   const handleConfirm = async () => {
     setIsSubmitting(true);
+    setError(null);
     try {
       await onConfirm(requiresReason ? reason : undefined);
       setReason('');
       onClose();
+    } catch (err) {
+      // Keep the modal open and surface the failure — otherwise a rejected
+      // destructive action leaves the admin with no feedback (and an
+      // unhandled promise rejection), likely to retry blindly.
+      setError(err instanceof Error ? err.message : 'Something went wrong. Please try again.');
     } finally {
       setIsSubmitting(false);
     }
@@ -54,6 +61,7 @@ export const ConfirmationModal: React.FC<ConfirmationModalProps> = ({
   const handleClose = () => {
     if (!isSubmitting) {
       setReason('');
+      setError(null);
       onClose();
     }
   };
@@ -92,6 +100,12 @@ export const ConfirmationModal: React.FC<ConfirmationModalProps> = ({
               placeholder='Provide a reason for this action...'
               disabled={isSubmitting}
             />
+          </div>
+        )}
+
+        {error && (
+          <div className={styles.dangerBox} role='alert'>
+            {error}
           </div>
         )}
 

--- a/apps/admin/src/hooks/useAnalytics.ts
+++ b/apps/admin/src/hooks/useAnalytics.ts
@@ -15,8 +15,14 @@ export const usePlatformMetrics = () => {
 
 export const useDashboardAnalytics = (options?: DashboardAnalyticsOptions) => {
   return useQuery({
+    // Key lives in the `analytics` namespace so useAnalyticsInvalidator's
+    // `invalidateQueries({ queryKey: ['analytics', cat] })` can match it —
+    // the previous `['dashboard-analytics', …]` key was a sibling namespace
+    // the invalidator could never reach (ADS-647). Real-time refresh still
+    // requires the backend to emit a `dashboard` category.
     queryKey: [
-      'dashboard-analytics',
+      'analytics',
+      'dashboard',
       options?.startDate?.toISOString(),
       options?.endDate?.toISOString(),
     ],

--- a/apps/client/src/components/profile/ProfileEditForm.tsx
+++ b/apps/client/src/components/profile/ProfileEditForm.tsx
@@ -105,8 +105,13 @@ export const ProfileEditForm: React.FC<ProfileEditFormProps> = ({
       newErrors.phone = 'Please enter a valid phone number';
     }
 
-    if (formData.location.zipCode && !/^\d{5}(-\d{4})?$/.test(formData.location.zipCode)) {
-      newErrors['location.zipCode'] = 'Please enter a valid ZIP code';
+    // UK postcode (this is a UK product) — the previous US ZIP pattern
+    // rejected every valid UK postcode, blocking UK adopters from saving.
+    if (
+      formData.location.zipCode &&
+      !/^[A-Z]{1,2}[0-9][A-Z0-9]?\s?[0-9][A-Z]{2}$/i.test(formData.location.zipCode)
+    ) {
+      newErrors['location.zipCode'] = 'Please enter a valid UK postcode';
     }
 
     if (formData.bio && formData.bio.length > 500) {

--- a/apps/client/src/pages/ApplicationDashboard.tsx
+++ b/apps/client/src/pages/ApplicationDashboard.tsx
@@ -155,7 +155,7 @@ export const ApplicationDashboard: React.FC = () => {
         <div className={styles.emptyState}>
           <h2>No applications yet</h2>
           <p>Start your adoption journey by browsing available pets.</p>
-          <Link to='/pets'>
+          <Link to='/search'>
             <Button>Browse Pets</Button>
           </Link>
         </div>

--- a/apps/client/src/pages/ApplicationDetailsPage.tsx
+++ b/apps/client/src/pages/ApplicationDetailsPage.tsx
@@ -260,7 +260,7 @@ export const ApplicationDetailsPage: React.FC = () => {
           </Button>
         )}
         {application.status === 'withdrawn' && (
-          <Button variant='primary' onClick={() => navigate('/pets')}>
+          <Button variant='primary' onClick={() => navigate('/search')}>
             Browse Available Pets
           </Button>
         )}

--- a/docs/frontend-libs-quality-review.md
+++ b/docs/frontend-libs-quality-review.md
@@ -1,0 +1,45 @@
+# Frontend & Shared-Libraries Code-Quality Review
+
+A pass over the areas the two backend `services/*` reviews did not touch: the
+three React apps (`app.admin`, `app.client`, `app.rescue`) and the shared
+`packages/lib.*` libraries. Each area was audited independently for security,
+correctness, data, accessibility and type-safety. Genuine defects were fixed
+in place with tests; defense-in-depth / policy / pre-existing-dead-code items
+are catalogued below rather than changed.
+
+## Fixed
+
+| Package | Fix | Severity |
+|---|---|---|
+| lib.auth | Logout/updateProfile read the literal `'accessToken'`/`'authToken'` localStorage keys, but the setters write under `STORAGE_KEYS.ACCESS_TOKEN`/`AUTH_TOKEN` (`__dev_*`) — so dev-token cleanup never ran and the updateProfile dev short-circuit was dead. Use the constants. (dev-only) | Med |
+| lib.validation | `PhoneNumberSchema` stripped separators then only checked length, so a non-numeric 10–20 char string passed despite the "digits" message. Added a digit charset regex. | Med |
+| lib.components | `Toast`/`ToastContainer` had no `role`/`aria-live`, so screen-reader users got no announcement on success/error feedback (used on live admin pages). Added `status`/`polite` (info/success) and `alert`/`assertive` (error/warning). | High (a11y) |
+| lib.components | `MetricCard` currency format hardcoded USD/runtime locale in a UK GBP app → `en-GB`/`GBP`. (latent — no live caller yet) | Med |
+| lib.components | `SelectInput` label `htmlFor` pointed at an id no element carried; added the id to `Select.Trigger` so the label focuses the control. | Low (a11y) |
+| app.admin | `UserActionsMenu` confirm handler had a `try/finally` with no `catch`, so a rejected destructive action (delete/suspend/reset) left the modal open with no feedback and an unhandled rejection. Now catches, surfaces the error in an `alert`, and stays open. | High |
+| app.admin | `useDashboardAnalytics` query key `['dashboard-analytics', …]` sat in a sibling namespace the realtime `useAnalyticsInvalidator` (`['analytics', cat]`) could never match, so the dashboard never refreshed on `analytics:invalidate`. Moved into the `['analytics', 'dashboard', …]` namespace. | Med |
+| app.client | `ProfileEditForm` validated the postcode with a US ZIP regex (`\d{5}(-\d{4})?`), rejecting every valid UK postcode and blocking UK adopters from saving their profile. Switched to the UK postcode pattern. | High |
+| app.client | "Browse Pets" CTAs linked to `/pets`, which is not a route (only `/pets/:id`) — both landed on the 404 page. Pointed at `/search`. | Med |
+
+## Verified sound (no change needed)
+
+- **Auth/token security (lib.api/lib.auth):** access/refresh tokens are in httpOnly cookies (not localStorage), `getBaseUrl()` is `''` in-browser so requests stay same-origin (no cross-origin Bearer leak), CSRF tokens are single-flight cached, and the 401 refresh-and-retry uses a correct single-flight promise with no refresh loop.
+- **UI authorization gating (lib.auth / lib.permissions / lib.feature-flags):** `PermissionGate`, `PermissionsContext`, `usePlan`/`PlanGate`, and the Statsig flag hooks all **fail closed** — they deny / default-off while permissions or flags are loading or errored. No flash-of-privileged-UI.
+- **rescueId scoping (app.rescue / app.admin):** read endpoints are server-scoped (no client-chosen rescueId); staff-write path params derive from the user's own staff record. No cross-rescue access vector found.
+- **React Query keys / forms (app.admin):** reviewed hooks include all queryFn params and invalidate correctly; modals guard double-submit; Broadcast carries a per-send idempotency key.
+- **lib.components primitives:** `Modal` (focus trap/restore/escape/scroll-lock), `Table`/`DataTable`/`Pagination` (sort + clamping, no off-by-one), and Radix-backed dropdowns/selects/tooltips are correct.
+
+## Deferred (defense-in-depth / policy / pre-existing — not changed)
+
+| Area | Item | Why deferred |
+|---|---|---|
+| app.rescue | `PlanGate` has zero production usage — plan-restricted features (Analytics/Reports `growth`+, custom questions `professional`-only) render ungated | Backend enforces plan limits; wrapping routes is an entitlement-UX policy decision spanning several pages |
+| app.rescue | `PetManagement` renders create/edit/delete controls without a `useHasPermission` gate (other pages gate theirs) | Defense-in-depth only — backend enforces; UI-gating policy |
+| app.rescue | `/reports` reachable by direct URL despite nav-hiding; `as` casts in pet submit | Backend-enforced; low impact |
+| app.admin | `SendEmailModal` can POST `{ templateId: undefined }` on a template lookup miss | Latent — `selectedTemplate` is constrained to known ids today |
+| app.admin | Realtime refresh of dashboard analytics also needs the backend to emit a `dashboard` category | Backend change, out of app scope |
+| lib.validation | Local `EmailSchema` in `rescue.ts`/`application.ts` bypasses the canonical NFKC/single-script normalization; over-permissive UK postcode regex + stale "mirrors backend" comment | Low impact (homograph defense-in-depth); regex tightening risks false-rejects |
+| lib.api / lib.components | Dead code: unused `cache` field + `clearCache()` in api-service; unexported `en-US` `utils/date.ts` & `utils/currency.ts`; unrendered `EditUserModal` | Pre-existing dead code — flagged, not deleted (per repo convention) |
+| app.client | `useApplicationDraft` shows "Failed to save draft" on a load failure; module-singleton chat/search caches not cleared on logout (no cross-user leak — keys are id-scoped) | Low / cosmetic |
+
+**Verification:** `turbo lint type-check test` for the touched packages (lib.auth, lib.validation, lib.components, app.admin, app.client) — all green.

--- a/packages/lib.auth/src/contexts/AuthContext.test.tsx
+++ b/packages/lib.auth/src/contexts/AuthContext.test.tsx
@@ -2,7 +2,7 @@ import { act, render, waitFor } from '@testing-library/react';
 import React from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import type { AuthResponse, LoginRequest, User } from '../types';
+import { STORAGE_KEYS, type AuthResponse, type LoginRequest, type User } from '../types';
 
 // Module-level mock state lets each test stub out auth-service behaviour
 // before mounting AuthProvider. Using vi.hoisted because vi.mock factories
@@ -320,6 +320,38 @@ describe('AuthProvider onLogout callback', () => {
     });
 
     expect(mockedApiService.clearCsrfToken).toHaveBeenCalled();
+  });
+
+  it('clears the dev mock tokens (stored under the __dev_* keys) on logout', async () => {
+    vi.stubEnv('DEV', true);
+    const devUser = { userId: 'dev-1', email: 'dev@example.com' };
+    window.localStorage.setItem('dev_user', JSON.stringify(devUser));
+    // The setters write the mock token under STORAGE_KEYS.* — cleanup must
+    // read/remove the SAME keys, not the bare 'accessToken'/'authToken'.
+    window.localStorage.setItem(STORAGE_KEYS.ACCESS_TOKEN, 'dev-token-dev-1-123');
+    window.localStorage.setItem(STORAGE_KEYS.AUTH_TOKEN, 'dev-token-dev-1-123');
+
+    let triggerLogout: (() => Promise<void>) | undefined;
+    render(
+      <AuthProvider allowedUserTypes={ALLOWED_ADOPTER} appType="client">
+        <LogoutTrigger
+          onReady={(fn) => {
+            triggerLogout = fn;
+          }}
+        />
+      </AuthProvider>
+    );
+
+    await waitFor(() => {
+      expect(triggerLogout).toBeDefined();
+    });
+
+    await act(async () => {
+      await triggerLogout?.();
+    });
+
+    expect(window.localStorage.getItem(STORAGE_KEYS.ACCESS_TOKEN)).toBeNull();
+    expect(window.localStorage.getItem(STORAGE_KEYS.AUTH_TOKEN)).toBeNull();
   });
 
   it('invokes onLogout even when the backend logout call fails', async () => {

--- a/packages/lib.auth/src/contexts/AuthContext.tsx
+++ b/packages/lib.auth/src/contexts/AuthContext.tsx
@@ -336,10 +336,10 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({
       if (import.meta.env?.DEV) {
         localStorage.removeItem('dev_user');
         // Clear mock tokens for dev users
-        const token = localStorage.getItem('accessToken');
+        const token = localStorage.getItem(STORAGE_KEYS.ACCESS_TOKEN);
         if (token?.startsWith('dev-token-')) {
-          localStorage.removeItem('accessToken');
-          localStorage.removeItem('authToken');
+          localStorage.removeItem(STORAGE_KEYS.ACCESS_TOKEN);
+          localStorage.removeItem(STORAGE_KEYS.AUTH_TOKEN);
         }
       }
     } catch (error) {
@@ -359,10 +359,10 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({
       if (import.meta.env?.DEV) {
         localStorage.removeItem('dev_user');
         // Clear mock tokens for dev users
-        const token = localStorage.getItem('accessToken');
+        const token = localStorage.getItem(STORAGE_KEYS.ACCESS_TOKEN);
         if (token?.startsWith('dev-token-')) {
-          localStorage.removeItem('accessToken');
-          localStorage.removeItem('authToken');
+          localStorage.removeItem(STORAGE_KEYS.ACCESS_TOKEN);
+          localStorage.removeItem(STORAGE_KEYS.AUTH_TOKEN);
         }
       }
     } finally {
@@ -392,7 +392,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({
 
     // In development mode, handle dev users differently
     if (import.meta.env?.DEV) {
-      const token = localStorage.getItem('accessToken');
+      const token = localStorage.getItem(STORAGE_KEYS.ACCESS_TOKEN);
       if (token?.startsWith('dev-token-')) {
         const updatedUser = { ...user, ...profileData };
         setUser(updatedUser);

--- a/packages/lib.components/src/components/charts/MetricCard.tsx
+++ b/packages/lib.components/src/components/charts/MetricCard.tsx
@@ -21,9 +21,9 @@ const formatValue = (value: number | string, format: MetricCardFormat | undefine
     return `${(value * 100).toFixed(1)}%`;
   }
   if (format === 'currency') {
-    return new Intl.NumberFormat(undefined, {
+    return new Intl.NumberFormat('en-GB', {
       style: 'currency',
-      currency: 'USD',
+      currency: 'GBP',
       maximumFractionDigits: 0,
     }).format(value);
   }

--- a/packages/lib.components/src/components/form/SelectInput/SelectInput.tsx
+++ b/packages/lib.components/src/components/form/SelectInput/SelectInput.tsx
@@ -226,6 +226,7 @@ export const SelectInput = ({
         >
           <Select.Trigger
             ref={ref}
+            id={dataTestId}
             className={trigger({ size, state: actualState, disabled, fullWidth })}
             aria-label={label}
             aria-required={required ? true : undefined}

--- a/packages/lib.components/src/components/ui/Toast/Toast.test.tsx
+++ b/packages/lib.components/src/components/ui/Toast/Toast.test.tsx
@@ -43,6 +43,21 @@ describe('Toast', () => {
     expect(screen.getByText('Test notification')).toBeInTheDocument();
   });
 
+  it('announces success/info as a polite status region', () => {
+    renderWithTheme(<Toast {...mockToast} type='info' />);
+    const region = screen.getByRole('status');
+    expect(region).toHaveAttribute('aria-live', 'polite');
+    expect(region).toHaveTextContent('Test notification');
+  });
+
+  it('announces errors/warnings as an assertive alert region', () => {
+    const { rerender } = renderWithTheme(<Toast {...mockToast} type='error' />);
+    expect(screen.getByRole('alert')).toHaveAttribute('aria-live', 'assertive');
+
+    rerender(<Toast {...mockToast} type='warning' />);
+    expect(screen.getByRole('alert')).toHaveAttribute('aria-live', 'assertive');
+  });
+
   it('calls onClose when close button is clicked', () => {
     const handleClose = vi.fn();
     renderWithTheme(<Toast {...mockToast} onClose={handleClose} />);

--- a/packages/lib.components/src/components/ui/Toast/Toast.tsx
+++ b/packages/lib.components/src/components/ui/Toast/Toast.tsx
@@ -125,8 +125,17 @@ export const Toast: React.FC<ToastProps> = ({
     exitTimerRef.current = setTimeout(() => onClose?.(id), 200);
   };
 
+  // Announce to assistive tech: errors/warnings interrupt (assertive),
+  // success/info wait their turn (polite). Without this, screen-reader
+  // users get no feedback when an action succeeds or fails.
+  const isUrgent = type === 'error' || type === 'warning';
+
   return (
-    <div className={styles.toastWrapper({ type, position, exiting: isExiting })}>
+    <div
+      className={styles.toastWrapper({ type, position, exiting: isExiting })}
+      role={isUrgent ? 'alert' : 'status'}
+      aria-live={isUrgent ? 'assertive' : 'polite'}
+    >
       <div className={styles.toastIcon}>{typeIcons[type]}</div>
       <div className={styles.toastContent}>{message}</div>
       <button

--- a/packages/lib.validation/src/schemas/user.phone.test.ts
+++ b/packages/lib.validation/src/schemas/user.phone.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+
+import { PhoneNumberSchema } from './user';
+
+describe('PhoneNumberSchema', () => {
+  it('accepts a plain UK number after stripping separators', () => {
+    const result = PhoneNumberSchema.safeParse('020 7946 0958');
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data).toBe('02079460958');
+    }
+  });
+
+  it('accepts an international number with a leading +', () => {
+    const result = PhoneNumberSchema.safeParse('+44 7911 123456');
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data).toBe('+447911123456');
+    }
+  });
+
+  it('rejects non-digit input even when the length is in range', () => {
+    // Regression: the schema previously only checked length, so a 10–20
+    // character non-numeric string passed despite the "digits" message.
+    expect(PhoneNumberSchema.safeParse('abcdefghij').success).toBe(false);
+    expect(PhoneNumberSchema.safeParse('not-a-number!').success).toBe(false);
+  });
+
+  it('rejects too-short and too-long numbers', () => {
+    expect(PhoneNumberSchema.safeParse('12345').success).toBe(false);
+    expect(PhoneNumberSchema.safeParse('1'.repeat(21)).success).toBe(false);
+  });
+});

--- a/packages/lib.validation/src/schemas/user.ts
+++ b/packages/lib.validation/src/schemas/user.ts
@@ -78,6 +78,7 @@ export const PhoneNumberSchema = z
   .pipe(
     z
       .string()
+      .regex(/^\+?\d+$/, 'Phone number must contain only digits (optionally prefixed with +)')
       .min(10, 'Phone number must be at least 10 digits')
       .max(20, 'Phone number must be at most 20 digits')
   );


### PR DESCRIPTION
A code-quality pass over the areas the two `services/*` reviews didn't touch: the three React apps (`app.admin`, `app.client`, `app.rescue`) and the shared `packages/lib.*` libraries. Each area was audited independently for security, correctness, data, accessibility and type-safety. Full writeup: `docs/frontend-libs-quality-review.md`.

## Fixes

| Package | Fix | Severity |
|---|---|---|
| lib.auth | Logout/updateProfile read literal `'accessToken'`/`'authToken'` keys, but setters write `STORAGE_KEYS.*` (`__dev_*`) — dev-token cleanup was a dead no-op. (dev-only) | Med |
| lib.validation | `PhoneNumberSchema` only checked length, so non-numeric strings passed despite the "digits" message. Added a digit charset regex. | Med |
| lib.components | `Toast`/`ToastContainer` had no `role`/`aria-live` — screen-reader users got no success/error announcement (used on live admin pages). Added polite/assertive live regions. | High (a11y) |
| lib.components | `MetricCard` currency hardcoded USD in a GBP app → `en-GB`/`GBP` (latent). | Med |
| lib.components | `SelectInput` label `htmlFor` targeted a non-existent id; added the id to the trigger. | Low (a11y) |
| app.admin | `UserActionsMenu` confirm handler had no `catch`, so a rejected delete/suspend/reset left the modal open with no feedback + an unhandled rejection. Now surfaces the error and stays open. | High |
| app.admin | `useDashboardAnalytics` key sat in a namespace the realtime invalidator could never match → dashboard never refreshed. Moved into `['analytics', 'dashboard', …]`. | Med |
| app.client | `ProfileEditForm` validated the postcode with a US ZIP regex, blocking UK adopters from saving their profile. Switched to the UK pattern. | High |
| app.client | "Browse Pets" CTAs linked to `/pets` (not a route) → 404. Pointed at `/search`. | Med |

## Verified sound (no change)
- Token security (httpOnly cookies, same-origin, single-flight 401 refresh), UI authz gating (fails closed), rescueId scoping (server-side), React Query keys, and the lib.components primitives (Modal/Table/Pagination) all check out.

## Deferred (defense-in-depth / policy / pre-existing dead code)
Catalogued in the report rather than changed — e.g. `PlanGate` having zero production usage, `PetManagement` UI gating, the local `EmailSchema` homograph gap, and several unused dead-code spots. These are backend-enforced or need a policy decision.

## Verification
`turbo lint type-check test` for the touched packages (lib.auth, lib.validation, lib.components, app.admin, app.client) — all green.

https://claude.ai/code/session_014EbfJyKja1PmRfjcZWokaH

---
_Generated by [Claude Code](https://claude.ai/code/session_014EbfJyKja1PmRfjcZWokaH)_