### PR TITLE
fix(gateway): MIME type + extension allowlist for document uploads (ADS-841)

### DIFF
--- a/services/gateway/src/routes/application-documents.test.ts
+++ b/services/gateway/src/routes/application-documents.test.ts
@@ -8,7 +8,10 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { ApplicationsClient } from '../grpc-clients/applications-client.js';
 
-import { registerApplicationDocumentsRoutes } from './application-documents.js';
+import {
+  ALLOWED_DOCUMENT_MIME,
+  registerApplicationDocumentsRoutes,
+} from './application-documents.js';
 
 function makeClient(): {
   client: ApplicationsClient;
@@ -74,13 +77,19 @@ describe('application document routes', () => {
     rmSync(tmp, { recursive: true, force: true });
   });
 
-  function multipartBody(boundary: string, file: Buffer, filename: string, type: string): Buffer {
+  function multipartBody(
+    boundary: string,
+    file: Buffer,
+    filename: string,
+    type: string,
+    mimeType = 'application/pdf'
+  ): Buffer {
     const enc = (s: string): Buffer => Buffer.from(s, 'utf8');
     return Buffer.concat([
       enc(
         `--${boundary}\r\nContent-Disposition: form-data; name="type"\r\n\r\n${type}\r\n` +
           `--${boundary}\r\nContent-Disposition: form-data; name="file"; filename="${filename}"\r\n` +
-          `Content-Type: application/pdf\r\n\r\n`
+          `Content-Type: ${mimeType}\r\n\r\n`
       ),
       file,
       enc(`\r\n--${boundary}--\r\n`),
@@ -208,5 +217,74 @@ describe('application document routes', () => {
       headers: ADOPTER,
     });
     expect(res.statusCode).toBe(403);
+  });
+
+  it('POST → 400 when the MIME type is outside the allowlist (text/html)', async () => {
+    const boundary = 'b-mime-reject';
+    const body = multipartBody(
+      boundary,
+      Buffer.from('<html><script>alert(1)</script></html>'),
+      'evil.html',
+      'id_verification',
+      'text/html'
+    );
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/v1/applications/app-1/documents',
+      headers: { ...ADOPTER, 'content-type': `multipart/form-data; boundary=${boundary}` },
+      payload: body,
+    });
+    expect(res.statusCode).toBe(400);
+    expect((res.json() as { error: string }).error).toMatch(/not allowed/);
+    expect(mocks.addDocument).not.toHaveBeenCalled();
+  });
+
+  it('POST → 400 when the MIME type is outside the allowlist (application/octet-stream)', async () => {
+    const boundary = 'b-exe-reject';
+    const body = multipartBody(
+      boundary,
+      Buffer.from('MZ\x90\x00'),
+      'malware.exe',
+      'id_verification',
+      'application/octet-stream'
+    );
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/v1/applications/app-1/documents',
+      headers: { ...ADOPTER, 'content-type': `multipart/form-data; boundary=${boundary}` },
+      payload: body,
+    });
+    expect(res.statusCode).toBe(400);
+    expect((res.json() as { error: string }).error).toMatch(/not allowed/);
+    expect(mocks.addDocument).not.toHaveBeenCalled();
+  });
+
+  it('POST → 400 when the extension is disallowed even if MIME claims application/pdf', async () => {
+    // Defence-in-depth: a lying Content-Type must not bypass the extension check.
+    const boundary = 'b-ext-reject';
+    const body = multipartBody(
+      boundary,
+      Buffer.from('MZ\x90\x00'),
+      'malware.exe',
+      'id_verification',
+      'application/pdf'
+    );
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/v1/applications/app-1/documents',
+      headers: { ...ADOPTER, 'content-type': `multipart/form-data; boundary=${boundary}` },
+      payload: body,
+    });
+    expect(res.statusCode).toBe(400);
+    expect((res.json() as { error: string }).error).toMatch(/not allowed/);
+    expect(mocks.addDocument).not.toHaveBeenCalled();
+  });
+
+  it('ALLOWED_DOCUMENT_MIME export includes pdf and common image types', () => {
+    expect(ALLOWED_DOCUMENT_MIME.has('application/pdf')).toBe(true);
+    expect(ALLOWED_DOCUMENT_MIME.has('image/jpeg')).toBe(true);
+    expect(ALLOWED_DOCUMENT_MIME.has('image/png')).toBe(true);
+    expect(ALLOWED_DOCUMENT_MIME.has('text/html')).toBe(false);
+    expect(ALLOWED_DOCUMENT_MIME.has('application/octet-stream')).toBe(false);
   });
 });

--- a/services/gateway/src/routes/application-documents.ts
+++ b/services/gateway/src/routes/application-documents.ts
@@ -11,9 +11,36 @@
 // storage provider. Wire an AV step in front of `uploadFile` when the
 // scanner is extracted.
 
+import { extname } from 'node:path';
+
 import type { FastifyInstance } from 'fastify';
 
 import { createStorageProvider, type StorageConfig } from '@adopt-dont-shop/storage';
+
+// Allowed MIME types for application documents. Narrower than image
+// uploads: PDF, common images (ID photos), and Word docs cover all
+// legitimate use cases without admitting executables, HTML (XSS risk),
+// archives, or polyglot files. Exported so any downstream serve route
+// can enforce the same allowlist on Content-Type rather than
+// re-specifying it.
+export const ALLOWED_DOCUMENT_MIME = new Set([
+  'application/pdf',
+  'image/jpeg',
+  'image/png',
+  'application/msword',
+  'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+]);
+
+// Extension → allowed MIME. Second check so a lying Content-Type can't
+// smuggle a disallowed file through the MIME check alone.
+const ALLOWED_EXTENSIONS = new Map([
+  ['.pdf', 'application/pdf'],
+  ['.jpg', 'image/jpeg'],
+  ['.jpeg', 'image/jpeg'],
+  ['.png', 'image/png'],
+  ['.doc', 'application/msword'],
+  ['.docx', 'application/vnd.openxmlformats-officedocument.wordprocessingml.document'],
+]);
 
 import type { ApplicationsClient } from '../grpc-clients/applications-client.js';
 
@@ -66,6 +93,15 @@ export const registerApplicationDocumentsRoutes = async (
     }
     if (docType === '') {
       return reply.code(400).send({ error: 'a `type` field is required' });
+    }
+
+    if (!ALLOWED_DOCUMENT_MIME.has(mimetype)) {
+      return reply.code(400).send({ error: `File type ${mimetype} is not allowed` });
+    }
+
+    const ext = extname(filename).toLowerCase();
+    if (!ALLOWED_EXTENSIONS.has(ext)) {
+      return reply.code(400).send({ error: `File extension ${ext || '(none)'} is not allowed` });
     }
 
     let upload;


### PR DESCRIPTION
## Summary

Fixes ADS-841: the `POST /api/v1/applications/:id/documents` route accepted any file type (including executables, HTML, Office macros) without MIME or extension validation, unlike the sibling image upload route which already enforced an allowlist.

- Adds `ALLOWED_DOCUMENT_MIME` (pdf, jpeg, png, doc, docx) — returns 400 immediately if the client-claimed MIME is outside this set
- Adds a second extension-based check (`ALLOWED_EXTENSIONS`) as defence-in-depth so a lying `Content-Type` header cannot smuggle a disallowed file through the MIME check
- Exports `ALLOWED_DOCUMENT_MIME` so any future serve/download route can enforce the same allowlist without re-specifying it

No new dependencies. Pattern mirrors `uploads.ts:44/114-116` which already does this for images.

## Test plan

- [x] `POST` with `text/html` MIME → 400 "not allowed"
- [x] `POST` with `application/octet-stream` MIME → 400 "not allowed"
- [x] `POST` with `.exe` extension (lying `Content-Type: application/pdf`) → 400 "not allowed" (extension check)
- [x] `POST` with valid `application/pdf` + `.pdf` → 201 (existing happy-path test still passes)
- [x] `ALLOWED_DOCUMENT_MIME` export contains expected types and excludes `text/html`
- [x] Full gateway test suite: 617/617 tests pass

## Linear

https://linear.app/ideasquared/issue/ADS-841

---
_Generated by [Claude Code](https://claude.ai/code/session_01NsmCQvc13pHTg2RKXAdMnN)_