### PR TITLE
Deferred backlog fixes: auth session revocation, matching authz + re-swipe dedupe, email idempotency

### DIFF
--- a/docs/services-code-quality-review.md
+++ b/docs/services-code-quality-review.md
@@ -215,3 +215,18 @@ pending-invitation erasure, and moderation `reporter_id` nullability.
 | notifications | No reaper for orphaned `sending` email rows after a crash; provider-success-then-DB-failure can double-send | Needs a stale-claim timeout + a provider idempotency token |
 | matching | `getMatchProfile`/`upsertMatchProfile` have no permission gate (self-scoped, not IDOR) | Adding a gate changes access semantics |
 | moderation | `SYSTEM_USER_ID` string-interpolated into the `ON CONFLICT … WHERE` predicate | Safe today (hard-coded constant; index predicates can't be parameterised) — latent smell only |
+
+## Deferred backlog — resolved (follow-up PR, per product decision)
+
+After review of the deferred items, the following were actioned:
+
+| Service | Resolution | Decision |
+|---|---|---|
+| auth | The ADS-801 revocation-column split was already unified on `main` (refresh + ListSessions both honour `revoked_at` AND `is_revoked`). Added the remaining piece: **password reset and change now revoke all of the user's refresh tokens** inside the password-update transaction. Access tokens are short-lived JWTs that can't be refreshed once the session is gone. | Full fix |
+| matching | `getMatchProfile`/`upsertMatchProfile` now **gate on `pets.read`** (matching the sibling swipe handlers). | Gate on pets.read |
+| matching | Re-swipes are kept as an **append-only log, deduplicated at read time**: `getSessionStats` now collapses to the latest action per pet (DISTINCT ON), matching the user-level stats which already did so. No schema change. | Append-only log |
+| notifications | The stale-`sending` reaper was already on `main` (`claimDueEmails` reclaims orphaned rows). Added the second half: the Resend provider now sends a **stable `Idempotency-Key`** (row `idempotency_key`, falling back to the immutable `email_id`) so a retry after a post-send bookkeeping failure can't double-deliver. | Both |
+
+Login lockout and rescue invitation dedupe (also on the original deferred list)
+were independently resolved on `main` (login throttle + invitation pending
+unique index).

--- a/services/auth/src/grpc/account-handlers.test.ts
+++ b/services/auth/src/grpc/account-handlers.test.ts
@@ -285,6 +285,17 @@ describe('resetPassword', () => {
     expect(sql).toContain('locked_until = NULL');
     expect(sql).toContain('login_attempts = 0');
   });
+
+  it('revokes all of the user’s refresh tokens (sessions) on reset', async () => {
+    mocks.hasherMock.hash.mockResolvedValueOnce('hash');
+    mocks.clientScript([userRowFixture()]);
+    await resetPassword(mocks.deps, null, { resetToken: 'tok', newPassword: 'longenough' });
+    const revoke = realQueries(mocks.clientMock.query).find(
+      q => /auth\.refresh_tokens/.test(String(q[0])) && /is_revoked = true/.test(String(q[0]))
+    );
+    expect(revoke).toBeDefined();
+    expect(revoke?.[1]).toContain('usr-1');
+  });
 });
 
 describe('changePassword', () => {
@@ -321,6 +332,21 @@ describe('changePassword', () => {
     });
     expect(res.ok).toBe(true);
     expect(realQueries(mocks.clientMock.query)[0][1]).toContain('new-hash');
+  });
+
+  it('revokes all of the user’s refresh tokens (sessions) on change', async () => {
+    mocks.poolMock.query.mockResolvedValueOnce({ rows: [{ password: 'existing-hash' }] });
+    mocks.hasherMock.compare.mockResolvedValueOnce(true);
+    mocks.hasherMock.hash.mockResolvedValueOnce('new-hash');
+    await changePassword(mocks.deps, PRINCIPAL, {
+      currentPassword: 'right',
+      newPassword: 'longenough',
+    });
+    const revoke = realQueries(mocks.clientMock.query).find(
+      q => /auth\.refresh_tokens/.test(String(q[0])) && /is_revoked = true/.test(String(q[0]))
+    );
+    expect(revoke).toBeDefined();
+    expect(revoke?.[1]).toContain('usr-1');
   });
 });
 

--- a/services/auth/src/grpc/account-handlers.ts
+++ b/services/auth/src/grpc/account-handlers.ts
@@ -325,6 +325,17 @@ export async function resetPassword(
       throw new HandlerError('INVALID_ARGUMENT', 'invalid or expired reset token');
     }
     const user = res.rows[0];
+    // Revoke every existing session: a password reset is a security event
+    // (often a compromised-account recovery), so all refresh tokens must
+    // stop working. Sets both revocation columns so refresh AND ListSessions
+    // agree. Access tokens are short-lived JWTs that can no longer be
+    // refreshed once their session is gone.
+    await client.query(
+      `UPDATE auth.refresh_tokens
+          SET revoked_at = now(), is_revoked = true, updated_at = now()
+        WHERE user_id = $1 AND revoked_at IS NULL AND is_revoked = false`,
+      [user.user_id]
+    );
     publish({
       type: 'auth.passwordChanged',
       id: `auth.passwordChanged.${user.user_id}.reset.${Date.now()}`,
@@ -366,6 +377,14 @@ export async function changePassword(
     await client.query(
       `UPDATE auth.users SET password = $1, updated_at = now() WHERE user_id = $2`,
       [newHash, principal.userId]
+    );
+    // Changing the password ends all other sessions: revoke every refresh
+    // token for the user (both columns, so refresh + ListSessions agree).
+    await client.query(
+      `UPDATE auth.refresh_tokens
+          SET revoked_at = now(), is_revoked = true, updated_at = now()
+        WHERE user_id = $1 AND revoked_at IS NULL AND is_revoked = false`,
+      [principal.userId]
     );
     publish({
       type: 'auth.passwordChanged',

--- a/services/matching/src/grpc/profile-stats-handlers.test.ts
+++ b/services/matching/src/grpc/profile-stats-handlers.test.ts
@@ -16,7 +16,7 @@ function makePrincipal(
   return {
     userId: overrides.userId ?? 'usr-1',
     roles: overrides.roles ?? ['adopter'],
-    permissions: overrides.permissions ?? [],
+    permissions: overrides.permissions ?? ['pets.read'],
     rescueId: undefined,
   } as unknown as Parameters<typeof getMatchProfile>[1];
 }
@@ -74,6 +74,13 @@ describe('getMatchProfile', () => {
     expect(res.profile?.lifestyleJson).toBe('{}');
     expect(res.profile?.notifyNewMatches).toBe(true);
   });
+
+  it('denies a caller without pets.view', async () => {
+    const { deps } = makeDeps([]);
+    await expect(
+      getMatchProfile(deps, makePrincipal({ permissions: [] }), {})
+    ).rejects.toMatchObject({ code: 'PERMISSION_DENIED' });
+  });
 });
 
 // --- UpsertMatchProfile ----------------------------------------------
@@ -124,6 +131,17 @@ describe('upsertMatchProfile', () => {
         setPreferredSizes: true,
       })
     ).rejects.toMatchObject({ code: 'INVALID_ARGUMENT' });
+  });
+
+  it('denies a caller without pets.view', async () => {
+    const { deps } = makeDeps([]);
+    await expect(
+      upsertMatchProfile(deps, makePrincipal({ permissions: [] }), {
+        ...base,
+        preferredTypesJson: '["cat"]',
+        setPreferredTypes: true,
+      })
+    ).rejects.toMatchObject({ code: 'PERMISSION_DENIED' });
   });
 });
 
@@ -211,6 +229,15 @@ describe('getSessionStats', () => {
     const { deps } = makeDeps([{ rows: [{ user_id: 'usr-1' }] }, { rows: [statsRow] }]);
     const res = await getSessionStats(deps, makePrincipal(), { sessionId: 'sess-1' });
     expect(res.stats?.likes).toBe(6);
+  });
+
+  it('dedupes re-swipes within the session (latest action per pet wins)', async () => {
+    const { deps, query } = makeDeps([{ rows: [{ user_id: 'usr-1' }] }, { rows: [statsRow] }]);
+    await getSessionStats(deps, makePrincipal(), { sessionId: 'sess-1' });
+    // The stats query (2nd call) must collapse re-swipes via DISTINCT ON (pet_id).
+    const sql = query.mock.calls[1][0] as string;
+    expect(sql).toMatch(/DISTINCT ON \(pet_id\)/);
+    expect(sql).toMatch(/session_id =/);
   });
 
   it('allows anonymous (null-owner) sessions to be read', async () => {

--- a/services/matching/src/grpc/profile-stats-handlers.ts
+++ b/services/matching/src/grpc/profile-stats-handlers.ts
@@ -7,8 +7,8 @@
 // permission is held. Profile upsert is a single ON CONFLICT statement;
 // stats are aggregate COUNT queries over swipe_actions.
 
-import { hasPermission, type Principal } from '@adopt-dont-shop/authz';
-import type { Permission } from '@adopt-dont-shop/lib.types';
+import { hasPermission, requirePermission, type Principal } from '@adopt-dont-shop/authz';
+import { PETS_VIEW, type Permission } from '@adopt-dont-shop/lib.types';
 import type {
   GetMatchProfileRequest,
   GetMatchProfileResponse,
@@ -111,6 +111,12 @@ export async function getMatchProfile(
   _req: GetMatchProfileRequest
 ): Promise<GetMatchProfileResponse> {
   void _req;
+  // Self-scoped read, but still gate on the base swipe permission so the
+  // match-profile surface matches the sibling swipe/stats handlers
+  // (defence-in-depth — no ungated handler in this service).
+  if (!requirePermission(principal, PETS_VIEW)) {
+    throw new HandlerError('PERMISSION_DENIED', `'${PETS_VIEW}' required`);
+  }
   const res = await deps.pool.query<MatchProfileRow>(
     `SELECT ${PROFILE_SELECT} FROM matching.adopter_match_profiles WHERE user_id = $1 LIMIT 1`,
     [principal.userId]
@@ -138,6 +144,9 @@ export async function upsertMatchProfile(
   principal: Principal,
   req: UpsertMatchProfileRequest
 ): Promise<UpsertMatchProfileResponse> {
+  if (!requirePermission(principal, PETS_VIEW)) {
+    throw new HandlerError('PERMISSION_DENIED', `'${PETS_VIEW}' required`);
+  }
   // Build the column → value map from only the fields the caller marked
   // as set. COALESCE in the SQL keeps unset columns at their current
   // value (or default on insert).
@@ -240,12 +249,15 @@ const STATS_AGG = `
 // pet wins (a like→pass→like sequence counts as one like). DISTINCT ON
 // (pet_id) ordered by recency collapses to the most-recent row per pet;
 // the outer aggregate then counts those deduped rows.
-const userLatestPerPetStatsSql = (placeholder: string): string => `
+// `scope` is a fixed column name (never user input), so it is safe to
+// interpolate. Both the user-level and session-level stats dedupe the
+// same way; only the filter column differs.
+const latestPerPetStatsSql = (scope: 'user_id' | 'session_id', placeholder: string): string => `
   SELECT ${STATS_AGG}
   FROM (
     SELECT DISTINCT ON (pet_id) pet_id, action
     FROM matching.swipe_actions
-    WHERE user_id = ${placeholder}
+    WHERE ${scope} = ${placeholder}
     ORDER BY pet_id, timestamp DESC, swipe_action_id DESC
   ) AS latest
 `;
@@ -263,7 +275,7 @@ export async function getUserSwipeStats(
   if (target !== principal.userId && !hasPermission(principal, SWIPES_READ_ANY)) {
     throw new HandlerError('PERMISSION_DENIED', `'${SWIPES_READ_ANY}' required`);
   }
-  const res = await deps.pool.query<StatsRow>(userLatestPerPetStatsSql('$1'), [target]);
+  const res = await deps.pool.query<StatsRow>(latestPerPetStatsSql('user_id', '$1'), [target]);
   return { stats: statsRowToProto(res.rows[0]) };
 }
 
@@ -295,9 +307,10 @@ export async function getSessionStats(
     throw new HandlerError('PERMISSION_DENIED', 'not the session owner');
   }
 
-  const res = await deps.pool.query<StatsRow>(
-    `SELECT ${STATS_AGG} FROM matching.swipe_actions WHERE session_id = $1`,
-    [req.sessionId]
-  );
+  // Dedupe re-swipes within the session too (append-only swipe log): the
+  // latest action per pet wins, matching the user-level stats.
+  const res = await deps.pool.query<StatsRow>(latestPerPetStatsSql('session_id', '$1'), [
+    req.sessionId,
+  ]);
   return { stats: statsRowToProto(res.rows[0]) };
 }

--- a/services/notifications/src/email/providers/resend.test.ts
+++ b/services/notifications/src/email/providers/resend.test.ts
@@ -1,0 +1,79 @@
+import type { Resend } from 'resend';
+import { describe, expect, it, vi } from 'vitest';
+
+import type { QueuedEmail } from '../types.js';
+
+import { createResendProvider, type ResendProviderConfig } from './resend.js';
+
+const quietLogger = {
+  info: () => undefined,
+  warn: () => undefined,
+  error: () => undefined,
+  debug: () => undefined,
+} as unknown as Parameters<typeof createResendProvider>[0]['logger'];
+
+const config: ResendProviderConfig = {
+  apiKey: 'test-key',
+  fromEmail: 'noreply@example.com',
+  fromName: 'Adopt',
+};
+
+const queuedEmail = (overrides: Partial<QueuedEmail> = {}): QueuedEmail =>
+  ({
+    emailId: 'email-1',
+    fromEmail: 'noreply@example.com',
+    toEmail: 'adopter@example.com',
+    ccEmails: [],
+    bccEmails: [],
+    subject: 'Hello',
+    htmlContent: '<p>Hi</p>',
+    templateData: {},
+    attachments: [],
+    type: 'transactional',
+    priority: 'normal',
+    status: 'sending',
+    maxRetries: 3,
+    currentRetries: 0,
+    metadata: {},
+    tags: [],
+    idempotencyKey: null,
+    ...overrides,
+  }) as QueuedEmail;
+
+function makeClient(): {
+  client: Pick<Resend, 'emails'>;
+  send: ReturnType<typeof vi.fn>;
+} {
+  const send = vi.fn().mockResolvedValue({ data: { id: 'provider-msg-1' }, error: null });
+  return { client: { emails: { send } } as unknown as Pick<Resend, 'emails'>, send };
+}
+
+describe('resend provider — idempotency', () => {
+  it('passes a stable Idempotency-Key (the email_id) so a retry cannot double-send', async () => {
+    const { client, send } = makeClient();
+    const provider = createResendProvider({ config, logger: quietLogger, client });
+
+    await provider.send(queuedEmail({ emailId: 'email-42' }));
+
+    expect(send).toHaveBeenCalledTimes(1);
+    expect(send.mock.calls[0][1]).toEqual({ idempotencyKey: 'email-42' });
+  });
+
+  it('prefers the row idempotency_key when present', async () => {
+    const { client, send } = makeClient();
+    const provider = createResendProvider({ config, logger: quietLogger, client });
+
+    await provider.send(queuedEmail({ emailId: 'email-42', idempotencyKey: 'idem-99' }));
+
+    expect(send.mock.calls[0][1]).toEqual({ idempotencyKey: 'idem-99' });
+  });
+
+  it('returns the provider message id on success', async () => {
+    const { client } = makeClient();
+    const provider = createResendProvider({ config, logger: quietLogger, client });
+
+    const result = await provider.send(queuedEmail());
+
+    expect(result).toEqual({ success: true, messageId: 'provider-msg-1' });
+  });
+});

--- a/services/notifications/src/email/providers/resend.ts
+++ b/services/notifications/src/email/providers/resend.ts
@@ -57,8 +57,17 @@ export const createResendProvider = (deps: ResendProviderDeps): EmailProvider =>
         ...(deps.config.replyTo ? { replyTo: deps.config.replyTo } : {}),
       };
 
+      // Stable idempotency key so a retry after a post-send bookkeeping
+      // failure (provider succeeded, then markSent threw and the row was
+      // re-queued) does NOT deliver the email twice — Resend dedupes on the
+      // Idempotency-Key header. emailId is stable across retries of the row.
+      const idempotencyKey = email.idempotencyKey ?? email.emailId;
+
       try {
-        const result = await withTimeout(client.emails.send(payload), RESEND_SEND_TIMEOUT_MS);
+        const result = await withTimeout(
+          client.emails.send(payload, { idempotencyKey }),
+          RESEND_SEND_TIMEOUT_MS
+        );
         if (result.error !== null) {
           deps.logger.error('email.resend.send_failed', {
             to: sanitized.to,


### PR DESCRIPTION
Actions the deferred backlog from the services code-quality review, per product decisions captured for each item.

## Changes

| Service | Change | Decision |
|---|---|---|
| auth | **Password reset and change now revoke all of the user's refresh tokens** inside the password-update transaction (both revocation columns, so refresh + ListSessions agree). The ADS-801 column-split was already unified on `main`; this adds the session-revocation half. Access tokens are short-lived JWTs that can't be refreshed once the session is gone. | Full fix |
| matching | `getMatchProfile`/`upsertMatchProfile` now **gate on `pets.read`**, matching the sibling swipe handlers (no more ungated handler in the service). | Gate on pets.read |
| matching | Re-swipes stay an **append-only log, deduplicated at read time**: `getSessionStats` now collapses to the latest action per pet (`DISTINCT ON`), matching the user-level stats. No schema change. | Append-only log |
| notifications | Resend provider now sends a **stable `Idempotency-Key`** (row `idempotency_key`, falling back to the immutable `email_id`) so a retry after a post-send bookkeeping failure can't double-deliver. The stale-`sending` reaper was already on `main`. | Both (reaper + idempotency) |

## Not needed (already resolved on `main`)
Login lockout (login throttle) and rescue invitation dedupe (pending-unique index) from the original deferred list were independently fixed on `main`, as was the ADS-801 revocation-column unification.

## Verification
`turbo lint type-check test` for auth/matching/notifications — all green (0 errors), with tests added for each change.

https://claude.ai/code/session_014EbfJyKja1PmRfjcZWokaH

---
_Generated by [Claude Code](https://claude.ai/code/session_014EbfJyKja1PmRfjcZWokaH)_