### PR TITLE
Shared backbone & infrastructure review: logger redaction, CI injection, events backoff, db schema guard

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -461,9 +461,15 @@ jobs:
       # characters. This runs on the Actions runner, not the deploy host.
       - name: Validate tag_overrides input
         if: ${{ github.event.inputs.tag_overrides != '' }}
+        # Pass the free-text input via the environment, never interpolated
+        # into the shell text — otherwise a value containing a single quote
+        # closes the assignment and executes arbitrary commands BEFORE the
+        # regex validation below ever runs.
+        env:
+          TAG_OVERRIDES: ${{ github.event.inputs.tag_overrides }}
         run: |
           set -euo pipefail
-          overrides='${{ github.event.inputs.tag_overrides }}'
+          overrides="$TAG_OVERRIDES"
           echo "$overrides" | tr ',' '\n' | while IFS= read -r pair; do
             pair="$(echo "$pair" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
             [ -z "$pair" ] && continue
@@ -497,13 +503,16 @@ jobs:
           SECRET_UPLOAD_SIGNING_SECRET: ${{ secrets.UPLOAD_SIGNING_SECRET }}
           SECRET_DB_PASSWORD: ${{ secrets.DB_PASSWORD }}
           SECRET_PRINCIPAL_SIGNING_KEY: ${{ secrets.PRINCIPAL_SIGNING_KEY }}
+          # Forwarded via `envs:` so the server script reads it as a shell
+          # variable — never interpolated into the script text (injection-safe).
+          TAG_OVERRIDES: ${{ github.event.inputs.tag_overrides }}
         uses: appleboy/ssh-action@0ff4204d59e8e51228ff73bce53f80d53301dee2  # v1.2.5
         with:
           host: ${{ secrets.HETZNER_HOST }}
           username: deploy
           key: ${{ secrets.HETZNER_SSH_KEY }}
           fingerprint: ${{ secrets.HETZNER_HOST_FINGERPRINT }}
-          envs: GHCR_TOKEN,SECRET_JWT_SECRET,SECRET_JWT_REFRESH_SECRET,SECRET_UPLOAD_SIGNING_SECRET,SECRET_DB_PASSWORD,SECRET_PRINCIPAL_SIGNING_KEY
+          envs: GHCR_TOKEN,SECRET_JWT_SECRET,SECRET_JWT_REFRESH_SECRET,SECRET_UPLOAD_SIGNING_SECRET,SECRET_DB_PASSWORD,SECRET_PRINCIPAL_SIGNING_KEY,TAG_OVERRIDES
           script: |
             set -euo pipefail
             ENV="${{ github.event.inputs.environment }}"
@@ -529,11 +538,12 @@ jobs:
             sed -i "s/^DEPLOY_SHA=.*/DEPLOY_SHA=$SHA/" .env || echo "DEPLOY_SHA=$SHA" >> .env
 
             # ADS-824: inject per-service tag overrides into .env.
-            # TAG_OVERRIDES is passed from the workflow input (comma- or
-            # newline-separated KEY=VALUE pairs). Validation is done in the
-            # runner step above; here we only write the already-validated pairs.
-            TAG_OVERRIDES='${{ github.event.inputs.tag_overrides }}'
-            if [ -n "$TAG_OVERRIDES" ]; then
+            # TAG_OVERRIDES is forwarded from the workflow input as a shell
+            # env var via the step's `envs:` list (comma- or newline-separated
+            # KEY=VALUE pairs) — NOT interpolated into this script text, so a
+            # quote in the value can't break out. Validation runs in the runner
+            # step above; here we re-validate and write the pairs.
+            if [ -n "${TAG_OVERRIDES:-}" ]; then
               # Normalise commas to newlines, strip blank lines
               echo "$TAG_OVERRIDES" | tr ',' '\n' | while IFS= read -r pair; do
                 pair="$(echo "$pair" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"

--- a/docs/backbone-infra-review.md
+++ b/docs/backbone-infra-review.md
@@ -1,0 +1,39 @@
+# Shared Backbone & Infrastructure Review
+
+Audit of the areas the earlier service/frontend reviews never covered: the
+shared backend packages every microservice depends on (`packages/events`,
+`authz`, `db`, `config-secrets`, `storage`, `observability`) and the
+infrastructure (`.github/workflows`, Docker, `scripts/`, `e2e/`).
+
+Each genuine finding was fixed in place with tests; items that are
+intentional design or need an ops/architecture decision are listed as
+recommendations rather than changed.
+
+## Fixed
+
+| Area | Fix | Severity |
+|---|---|---|
+| observability | The shared `createLogger` shipped every log line to console + Loki with **no redaction** (a documented TODO) — any service logging an object with a `password`/`token`/`secret`/`authorization`/`cookie`/`api-key`/`otp` field leaked it verbatim; the Sentry and audit redactors only cover those two paths. Added a recursive redactor (`packages/observability/src/redact.ts`) wired in as a logger-level Winston format so redaction runs ahead of every transport. | High |
+| CI (deploy.yml) | The free-text `tag_overrides` `workflow_dispatch` input was interpolated raw into single-quoted shell on both the runner and the prod host, so a `'` could break out and run arbitrary commands **before** the regex allowlist (in the same script) ran. Now passed via the environment (mirroring `rollback.yml`'s `ROLLBACK_SHA`), so the value is inert and validation actually guards it. | Medium |
+| events | A handler that consistently threw on a *parseable* message was `nak()`'d with no delay → immediate, indefinite redelivery (no `max_deliver`, no backoff) spinning the consumer hot. `nak()` now applies an exponential backoff keyed on the redelivery count (fast first retry, capped at 30s). | Medium |
+| db | The per-connection `SET search_path` ran fire-and-forget (`void`) — a failure silently served a wrong-schema connection (unqualified tables → `public`). Now surfaced via the pool's error channel (or stderr). Also validates `schema` as a plain SQL identifier at construction (fail-fast; closes the theoretical interpolation vector). | Low |
+
+## Verified sound (no change)
+
+- **authz** — the linchpin of all service authorization is correct: `hasPermission`/`requirePermission` **fail closed**, `super_admin` is the only bypass, and `rescueId`/`userId` scope uses plain branded-string equality. No fail-open/mis-scope path.
+- **config-secrets** — `requireSecret` rejects blank/whitespace (an empty secret can't pass as present), both-set is a hard error, `parsePort` rejects non-positive/NaN. No insecure defaults; no secret values logged.
+- **storage** — signed-URL generation/expiry is sound (S3 presigner TTL; gateway HMAC checks expiry before a constant-time signature compare). Path-traversal is guarded at the consumer (`safeResolve`, server-generated UUID filenames).
+- **Infra (rest)** — actions SHA-pinned; secrets flow via `envs:`/BuildKit `--secret`/file-mounted Docker secrets (never interpolated into `script:`); cosign keyless sign→verify→deploy; prod/staging pin `DEPLOY_SHA` (no `:latest`); containers run non-root with `cap_drop: ALL` + `no-new-privileges` + read-only rootfs; `.dockerignore` keeps `.env`/`.git` out of build context. The `ci-required` aggregator fails only on real failures (treats `skipped` as pass). The e2e harness has no hard waits and disposes role contexts per test.
+
+## Recommendations (intentional design / need a decision — not changed here)
+
+| Area | Item | Why deferred |
+|---|---|---|
+| service-bootstrap | When `PRINCIPAL_SIGNING_KEY` is unset, `extractPrincipal` falls back to trusting `x-user-*` headers (the **real** cross-service authz boundary). It is correctly fail-closed *when* a key is present, and the keyless mode is the intentional ADS-800 phased-rollout path — but consider failing closed (or at least a loud boot warning) when `NODE_ENV=production` and no key is set, so a misconfigured prod can't silently trust forged headers. Deployment-posture decision. |
+| events | No shared consumer-idempotency helper despite documented redelivery (broker `Nats-Msg-Id` dedup window is 2 min vs 7-day retention). Handlers are individually idempotent today; a shared "processed-events" helper would enforce it. Architectural. |
+| events | `nak()` backoff (added) slows hot-loops but there is still no `max_deliver` + dead-letter subject, so a permanently-poison message retries forever. Adding a DLQ drops/parks messages after N tries — needs a decision on the retry budget. |
+| events | A changed `deliver_policy`/`filter_subject` is silently ignored on an already-existing durable consumer (JetStream create-or-reuse). Operational footgun; worth a comment or explicit update path. |
+| storage | The provider methods (`getSignedUrl`/`deleteFile`/`getFileInfo`) trust callers for `..`-free path segments — safe today (guarded at the gateway, flat S3 keys) but would be more robust rejecting `..` internally. Defense-in-depth. |
+| infra | Dev-only notes: Grafana anonymous-Admin (bound to `127.0.0.1` in the observability profile — keep it out of any prod compose); `GRANT CREATE ON SCHEMA public TO PUBLIC` in `init-postgis.sql`; and `service-chat`/`service-cms` appear in prod/staging compose but not the base/dev compose while the e2e `.env` sets `CUTOVER_CHAT/CMS=true` (topology gap to confirm). |
+
+**Verification:** all changed packages green; `turbo build` for all packages (32 tasks) and `turbo test type-check` for all services (31 tasks) pass — the shared logger change is safe across the backend.

--- a/packages/db/src/client.test.ts
+++ b/packages/db/src/client.test.ts
@@ -49,6 +49,23 @@ describe('createDbClient', () => {
     });
   });
 
+  describe('schema validation', () => {
+    it('throws on a schema name that is not a plain SQL identifier', () => {
+      expect(() =>
+        createDbClient({ schema: 'bad"; DROP', connectionString: 'postgres://localhost/test' })
+      ).toThrow(/invalid schema name/);
+    });
+
+    it('accepts a normal schema name', () => {
+      const pool = createDbClient({
+        schema: 'auth',
+        connectionString: 'postgres://localhost/test',
+      });
+      expect(pool).toBeDefined();
+      void pool.end();
+    });
+  });
+
   describe('connection behaviour', () => {
     it('rejects within ~connectionTimeoutMillis when connecting to a non-routable address', async () => {
       const startMs = Date.now();

--- a/packages/db/src/client.ts
+++ b/packages/db/src/client.ts
@@ -18,12 +18,31 @@ const TIMEOUT_DEFAULTS = {
   query_timeout: 30_000,
 } satisfies PoolConfig;
 
+// `schema` is interpolated into SQL (the search_path SET). It's a
+// service-owned constant, not user input, but validate it as a plain SQL
+// identifier so a typo or a malformed value fails fast at construction
+// rather than producing a broken connection (or, in theory, injecting).
+const SAFE_SCHEMA = /^[A-Za-z_][A-Za-z0-9_]*$/;
+
 export function createDbClient(opts: DbClientOptions): Pool {
   const { schema, ...config } = opts;
+  if (!SAFE_SCHEMA.test(schema)) {
+    throw new Error(`createDbClient: invalid schema name "${schema}" (must match ${SAFE_SCHEMA})`);
+  }
   const pool = new Pool({ ...TIMEOUT_DEFAULTS, ...config });
 
   pool.on('connect', client => {
-    void client.query(`SET search_path TO "${schema}", public`);
+    // A connection that fails to set its search_path would silently resolve
+    // unqualified table refs to `public` (wrong rows / "relation does not
+    // exist") — surface the failure instead of swallowing it: via the pool's
+    // own error channel when a listener is attached, else stderr.
+    client.query(`SET search_path TO "${schema}", public`).catch((err: unknown) => {
+      if (pool.listenerCount('error') > 0) {
+        pool.emit('error', err as Error, client);
+      } else {
+        console.error(`db: failed to set search_path for schema "${schema}":`, err);
+      }
+    });
   });
 
   return pool;

--- a/packages/events/src/subscribe.test.ts
+++ b/packages/events/src/subscribe.test.ts
@@ -1,7 +1,7 @@
 import type { NatsConnection } from 'nats';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { subscribe } from './subscribe.js';
+import { nakBackoffMs, subscribe } from './subscribe.js';
 import { DOMAIN_STREAM } from './stream.js';
 
 // A minimal in-memory JetStream stand-in. It models the one property that
@@ -262,5 +262,21 @@ describe('subscribe (durable JetStream consumer)', () => {
     await flush();
 
     expect(calls.map(c => c.meta.id)).toEqual(['1', '2']);
+  });
+});
+
+describe('nakBackoffMs', () => {
+  it('is fast on the first redelivery, grows exponentially, and caps', () => {
+    expect(nakBackoffMs(1)).toBe(1_000);
+    expect(nakBackoffMs(2)).toBe(2_000);
+    expect(nakBackoffMs(3)).toBe(4_000);
+    expect(nakBackoffMs(5)).toBe(16_000);
+    // Capped at 30s no matter how many redeliveries.
+    expect(nakBackoffMs(6)).toBe(30_000);
+    expect(nakBackoffMs(100)).toBe(30_000);
+  });
+
+  it('never returns a negative delay for a degenerate attempt count', () => {
+    expect(nakBackoffMs(0)).toBe(1_000);
   });
 });

--- a/packages/events/src/subscribe.ts
+++ b/packages/events/src/subscribe.ts
@@ -141,7 +141,25 @@ async function dispatch<T>(
     // Handler failed — could be transient (DB blip) so nak() for redelivery.
     // Handlers are idempotent on the event id, so a redelivery of an event
     // that actually half-succeeded is a clean skip on the next attempt.
+    //
+    // Back off redelivery (exponential on the redelivery count, capped) so a
+    // persistently-failing but PARSEABLE message can't hot-loop the consumer
+    // — only JSON-parse failures term() immediately. The first retry is still
+    // fast (covers a transient blip); repeated failures slow down.
+    // (A hard max_deliver + dead-letter subject is a separate, deliberate
+    // decision — see the events review notes.)
     opts.onError?.(err, { subject: msg.subject, raw });
-    msg.nak();
+    const info = (msg as { info?: { redeliveryCount?: number } }).info;
+    const attempt = info?.redeliveryCount ?? (msg.redelivered ? 2 : 1);
+    msg.nak(nakBackoffMs(attempt));
   }
+}
+
+// Exponential redelivery backoff in milliseconds, keyed on the 1-based
+// redelivery attempt and capped. Exported for unit testing the curve.
+const NAK_BASE_DELAY_MS = 1_000;
+const NAK_MAX_DELAY_MS = 30_000;
+
+export function nakBackoffMs(attempt: number): number {
+  return Math.min(NAK_MAX_DELAY_MS, NAK_BASE_DELAY_MS * 2 ** Math.max(0, attempt - 1));
 }

--- a/packages/observability/src/index.ts
+++ b/packages/observability/src/index.ts
@@ -7,6 +7,8 @@ export type { SentryOptions } from './sentry.js';
 export { createLogger } from './logger.js';
 export type { LoggerOptions } from './logger.js';
 
+export { redactSecretFields, REDACTED, SECRET_KEY_PATTERN } from './redact.js';
+
 export {
   getMetricsRegistry,
   recordGrpcDuration,

--- a/packages/observability/src/logger.test.ts
+++ b/packages/observability/src/logger.test.ts
@@ -1,6 +1,11 @@
+import { Writable } from 'node:stream';
+
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import winston from 'winston';
 
 import { createLogger } from './logger.js';
+
+const flush = () => new Promise(resolve => setImmediate(resolve));
 
 const ENV_KEYS = ['LOG_LEVEL', 'LOKI_URL', 'NODE_ENV'] as const;
 
@@ -82,5 +87,40 @@ describe('createLogger', () => {
   it('actually emits log lines through the configured transport without throwing', () => {
     const logger = createLogger({ serviceName: 'svc' });
     expect(() => logger.info('hello', { context: 'smoke' })).not.toThrow();
+  });
+
+  it('redacts secret-shaped fields before they reach a transport', async () => {
+    const chunks: string[] = [];
+    const sink = new Writable({
+      write(chunk, _enc, cb) {
+        chunks.push(chunk.toString());
+        cb();
+      },
+    });
+    const logger = createLogger({ serviceName: 'svc' });
+    // Capture the redacted info as JSON (logger-level redaction runs before
+    // this transport's json format).
+    logger.add(new winston.transports.Stream({ stream: sink, format: winston.format.json() }));
+
+    logger.info('user login', {
+      userId: 'u1',
+      password: 'hunter2',
+      auth: { accessToken: 'jwt', nested: { 'x-api-key': 'k' } },
+      tokens: ['secret-a', 'secret-b'],
+    });
+    await flush();
+
+    const line = JSON.parse(chunks.join('')) as Record<string, unknown>;
+    // Non-secret fields survive.
+    expect(line.userId).toBe('u1');
+    expect(line.message).toBe('user login');
+    // Secret-shaped keys are redacted, recursively.
+    expect(line.password).toBe('[REDACTED]');
+    expect((line.auth as Record<string, unknown>).accessToken).toBe('[REDACTED]');
+    expect(
+      ((line.auth as Record<string, unknown>).nested as Record<string, unknown>)['x-api-key']
+    ).toBe('[REDACTED]');
+    // A key named `tokens` matches the `token` substring → value redacted wholesale.
+    expect(line.tokens).toBe('[REDACTED]');
   });
 });

--- a/packages/observability/src/logger.ts
+++ b/packages/observability/src/logger.ts
@@ -21,6 +21,8 @@
 import winston, { type Logger } from 'winston';
 import LokiTransport from 'winston-loki';
 
+import { redactSecretFields, REDACTED, SECRET_KEY_PATTERN } from './redact.js';
+
 const VALID_LOG_LEVELS = ['error', 'warn', 'info', 'http', 'debug', 'silly'] as const;
 type LogLevel = (typeof VALID_LOG_LEVELS)[number];
 
@@ -33,6 +35,20 @@ export type LoggerOptions = {
   // in development / `info` everywhere else.
   logLevel?: LogLevel;
 };
+
+// Redact secret/PII-shaped fields from every log line BEFORE it reaches
+// any transport (console + Loki). Runs as a logger-level format so it
+// applies ahead of the per-transport json/printf formats. Mutates the
+// info object's own string keys in place to preserve Winston's Symbol
+// properties (level/message), recursing into nested meta via
+// redactSecretFields.
+const redactingFormat = winston.format(info => {
+  const record = info as Record<string, unknown>;
+  for (const key of Object.keys(record)) {
+    record[key] = SECRET_KEY_PATTERN.test(key) ? REDACTED : redactSecretFields(record[key]);
+  }
+  return info;
+});
 
 const resolveLogLevel = (override?: LogLevel): LogLevel => {
   if (override) {
@@ -93,6 +109,8 @@ export const createLogger = (opts: LoggerOptions): Logger => {
   return winston.createLogger({
     level,
     defaultMeta: { service: opts.serviceName },
+    // Redaction runs first, then each transport's own format.
+    format: redactingFormat(),
     transports,
   });
 };

--- a/packages/observability/src/redact.test.ts
+++ b/packages/observability/src/redact.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+
+import { redactSecretFields, REDACTED } from './redact.js';
+
+describe('redactSecretFields', () => {
+  it('redacts secret-shaped top-level keys regardless of casing or affixes', () => {
+    const out = redactSecretFields({
+      password: 'hunter2',
+      passwordHash: 'abc',
+      ACCESS_TOKEN: 'jwt',
+      refreshToken: 'r',
+      'x-api-key': 'k',
+      authorization: 'Bearer x',
+      Cookie: 'session=1',
+      otp: '123456',
+      secretSauce: 's',
+    });
+    expect(out).toEqual({
+      password: REDACTED,
+      passwordHash: REDACTED,
+      ACCESS_TOKEN: REDACTED,
+      refreshToken: REDACTED,
+      'x-api-key': REDACTED,
+      authorization: REDACTED,
+      Cookie: REDACTED,
+      otp: REDACTED,
+      secretSauce: REDACTED,
+    });
+  });
+
+  it('leaves non-secret keys intact', () => {
+    const out = redactSecretFields({ userId: 'u1', email: 'a@b.com', count: 3 });
+    expect(out).toEqual({ userId: 'u1', email: 'a@b.com', count: 3 });
+  });
+
+  it('recurses through nested objects and arrays', () => {
+    const out = redactSecretFields({
+      user: { id: 'u1', credentials: { password: 'p' } },
+      events: [{ token: 't1' }, { ok: true }],
+    });
+    expect(out).toEqual({
+      user: { id: 'u1', credentials: { password: REDACTED } },
+      events: [{ token: REDACTED }, { ok: true }],
+    });
+  });
+
+  it('does not mutate the input', () => {
+    const input = { password: 'p', nested: { token: 't' } };
+    const out = redactSecretFields(input);
+    expect(input).toEqual({ password: 'p', nested: { token: 't' } });
+    expect(out).not.toBe(input);
+  });
+
+  it('passes primitives and null/undefined through unchanged', () => {
+    expect(redactSecretFields('plain')).toBe('plain');
+    expect(redactSecretFields(42)).toBe(42);
+    expect(redactSecretFields(null)).toBeNull();
+    expect(redactSecretFields(undefined)).toBeUndefined();
+  });
+});

--- a/packages/observability/src/redact.ts
+++ b/packages/observability/src/redact.ts
@@ -1,0 +1,38 @@
+// Recursive secret/PII redaction for log + telemetry payloads.
+//
+// Mirrors the audit-write redactor (packages/events/redact-audit-payload)
+// and the Sentry beforeSend redactor (sentry.ts), kept in THIS package so
+// the shared logger can redact without taking a dependency on
+// packages/events (a lower-level package must not depend on a higher one).
+//
+// A key is redacted when its name matches SECRET_KEY_PATTERN (case-
+// insensitive substring), so `passwordHash`, `ACCESS_TOKEN`, `x-api-key`,
+// `Set-Cookie` and `otp` all match. Values are walked recursively through
+// nested objects and arrays. The input is never mutated — a new structure
+// is returned.
+
+export const REDACTED = '[REDACTED]';
+
+// Broad on purpose (same strategy as the audit deny-list) so variants like
+// `passwordHash`, `bearer_token`, `x-api-key`, `Set-Cookie` are caught
+// without an exhaustive list.
+export const SECRET_KEY_PATTERN = /password|token|secret|otp|authorization|cookie|api[_-]?key/i;
+
+export const redactSecretFields = (value: unknown): unknown => {
+  if (value === null || value === undefined) {
+    return value;
+  }
+  if (Array.isArray(value)) {
+    return value.map(redactSecretFields);
+  }
+  if (typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>).map(([k, v]) =>
+        SECRET_KEY_PATTERN.test(k)
+          ? ([k, REDACTED] as const)
+          : ([k, redactSecretFields(v)] as const)
+      )
+    );
+  }
+  return value;
+};


### PR DESCRIPTION
Reviews the areas the earlier service/frontend passes never touched: the shared backend packages every microservice depends on, and the infrastructure (CI, Docker, scripts, e2e). Full writeup: `docs/backbone-infra-review.md`.

## Fixes

| Area | Fix | Severity |
|---|---|---|
| observability | The shared `createLogger` had **no secret/PII redaction** (a documented TODO) — any service logging a `password`/`token`/`secret`/`authorization`/`cookie`/`api-key`/`otp` field shipped it verbatim to console + Loki. Added a recursive redactor wired in as a logger-level Winston format (runs before every transport). | High |
| CI (`deploy.yml`) | The free-text `tag_overrides` input was interpolated raw into single-quoted shell on the runner **and** the prod host, so a `'` could break out and run arbitrary commands before the regex allowlist ran. Now passed via the environment (like `rollback.yml`'s `ROLLBACK_SHA`). | Medium |
| events | `nak()` on a persistently-failing but parseable message had no backoff/`max_deliver` → immediate, indefinite redelivery that hot-loops the consumer. Added exponential backoff (fast first retry, capped at 30s). | Medium |
| db | The per-connection `SET search_path` was fire-and-forget (`void`) — a failure silently served a wrong-schema connection. Now surfaced via the pool error channel; `schema` validated as a SQL identifier at construction. | Low |

## Verified sound (no change)
**authz** (fails closed; `super_admin`-only bypass; correct scope equality), **config-secrets** (no insecure defaults, blank secrets rejected), **storage** (sound signed-URL TTL/HMAC; traversal guarded at the consumer), and the rest of the infra (SHA-pinned actions, secrets via `envs:`/BuildKit/Docker secrets, cosign sign→verify→deploy, non-root hardened containers, `ci-required` aggregator correct).

## Recommendations (intentional design / need a decision — not changed)
- **service-bootstrap**: with no `PRINCIPAL_SIGNING_KEY`, `extractPrincipal` falls back to trusting `x-user-*` headers (the real cross-service authz boundary). Correct fail-closed *when* a key is set, and keyless is the intentional ADS-800 phased-rollout mode — but consider failing closed (or a loud boot warning) in production without a key.
- **events**: no shared consumer-idempotency helper; no `max_deliver`/dead-letter (poison messages still retry forever after the new backoff); `deliver_policy` change ignored on an existing durable.
- **storage**: internal `..` rejection as defense-in-depth.
- Dev-only infra notes (Grafana anon-admin bound to localhost; `init-postgis` GRANT; chat/cms compose topology gap).

## Verification
All changed packages green; `turbo build` for all packages (32) and `turbo test type-check` for all services (31) pass — the shared logger change is safe across the backend.

https://claude.ai/code/session_014EbfJyKja1PmRfjcZWokaH

---
_Generated by [Claude Code](https://claude.ai/code/session_014EbfJyKja1PmRfjcZWokaH)_