### PR TITLE
Backbone/infra follow-ups: prod fail-closed principal auth, event DLQ, shared idempotency, storage traversal guard

### DIFF
--- a/docs/backbone-infra-review.md
+++ b/docs/backbone-infra-review.md
@@ -37,3 +37,18 @@ recommendations rather than changed.
 | infra | Dev-only notes: Grafana anonymous-Admin (bound to `127.0.0.1` in the observability profile — keep it out of any prod compose); `GRANT CREATE ON SCHEMA public TO PUBLIC` in `init-postgis.sql`; and `service-chat`/`service-cms` appear in prod/staging compose but not the base/dev compose while the e2e `.env` sets `CUTOVER_CHAT/CMS=true` (topology gap to confirm). |
 
 **Verification:** all changed packages green; `turbo build` for all packages (32 tasks) and `turbo test type-check` for all services (31 tasks) pass — the shared logger change is safe across the backend.
+
+## Follow-ups — resolved (per product decision)
+
+The recommendations above were actioned:
+
+| Area | Resolution | Decision |
+|---|---|---|
+| service-bootstrap | `assertPrincipalVerificationConfig()` now **fails closed at boot in production** when `PRINCIPAL_SIGNING_KEY` is unset (so a service can't silently trust forgeable `x-user-*` headers), unless `ALLOW_UNSIGNED_PRINCIPAL=true` is an explicit opt-in for the phased rollout. Wired into `startGrpcServer` (all gRPC services) and the gateway boot (the token signer). | Fail closed + escape hatch |
+| events | After the `nak()` backoff, consumers now set **`max_deliver=7`** and dead-letter exhausted messages to a new `DOMAIN_EVENTS_DLQ` stream (`dlq.<original-subject>`, 14-day retention) with triage headers, then `term()` — parked for inspection, not dropped or looped. | max_deliver + dead-letter |
+| events | `claimEvent` promoted to a **shared idempotency primitive** in `@adopt-dont-shop/events` (schema-agnostic via search_path). notifications re-exports it; new consumers adopt it via the `processed_events` migration. Naturally idempotent consumers (GDPR erase, ON CONFLICT inserts, deterministic completion ids) were intentionally left unchanged rather than gold-plated. | Build shared dedup helper |
+| events | Documented that a durable consumer's `deliver_policy`/`filter_subject` can't change on re-add (requires recreate). | — |
+| storage | Provider methods now reject any `filename`/`category` segment containing a path separator or `..` (guard runs before the catch so `getFileInfo` can't mask it). | — |
+| infra | The `service-chat`/`service-cms` "topology gap" was investigated and is a **non-issue**: `cutover.chat/cms` default to `false`, so the gateway doesn't route to those services unless explicitly enabled (prod/staging, where the containers exist); the dev/base omission is correct. The Grafana anon-admin and `init-postgis` GRANT remain documented dev-only notes. | — |
+
+**Verification:** `turbo build` (all packages) + `turbo test type-check lint` (all services + changed packages) — 57/57 tasks pass.

--- a/packages/events/src/idempotency.test.ts
+++ b/packages/events/src/idempotency.test.ts
@@ -1,0 +1,43 @@
+import type { Pool } from 'pg';
+import { describe, expect, it, vi } from 'vitest';
+
+import { claimEvent } from './idempotency.js';
+
+const makeConn = (rowCount: number) => {
+  const query = vi.fn().mockResolvedValue({ rowCount, rows: [] });
+  return { conn: { query } as unknown as Pool, query };
+};
+
+describe('claimEvent', () => {
+  it('returns true the first time an event is claimed (one row inserted)', async () => {
+    const { conn, query } = makeConn(1);
+
+    const claimed = await claimEvent(conn, 'applications.approved', 'app-1');
+
+    expect(claimed).toBe(true);
+    expect(query).toHaveBeenCalledWith(expect.stringContaining('processed_events'), [
+      'applications.approved',
+      'app-1',
+    ]);
+    // ON CONFLICT keeps a redelivery from inserting twice.
+    expect(query.mock.calls[0][0]).toMatch(/ON CONFLICT \(consumer, event_id\) DO NOTHING/);
+  });
+
+  it('returns false on a redelivery (ON CONFLICT inserts nothing)', async () => {
+    const { conn } = makeConn(0);
+
+    const claimed = await claimEvent(conn, 'applications.approved', 'app-1');
+
+    expect(claimed).toBe(false);
+  });
+
+  it('keys on (consumer, event_id) so the same id under different subjects both claim', async () => {
+    const { conn, query } = makeConn(1);
+
+    await claimEvent(conn, 'applications.approved', 'app-1');
+    await claimEvent(conn, 'applications.adopted', 'app-1');
+
+    expect(query.mock.calls[0][1]).toEqual(['applications.approved', 'app-1']);
+    expect(query.mock.calls[1][1]).toEqual(['applications.adopted', 'app-1']);
+  });
+});

--- a/packages/events/src/idempotency.ts
+++ b/packages/events/src/idempotency.ts
@@ -1,0 +1,48 @@
+// Inbound-event idempotency claim — the shared dedup primitive.
+//
+// `subscribe()` delivers at-least-once, so every subscriber that turns an
+// upstream event into a durable, NON-idempotent side-effect (a notification
+// row, a push fan-out, …) must dedupe on the event id. `claimEvent` is that
+// primitive: it inserts a (consumer, event_id) row into the service's
+// `processed_events` table and reports whether THIS call won the race. A
+// redelivery hits the ON CONFLICT and returns false, so the caller skips the
+// work it already did.
+//
+// The table is referenced UNQUALIFIED — it resolves to the calling service's
+// schema via the connection search_path (every service sets it through
+// @adopt-dont-shop/db `createDbClient`). Each adopting service adds a
+// migration creating:
+//
+//   processed_events (
+//     consumer     text        not null,
+//     event_id     text        not null,
+//     processed_at timestamptz not null default now(),
+//     primary key (consumer, event_id)
+//   )
+//
+// (see services/notifications migration 008 for the canonical shape). The key
+// is (consumer, event_id) — NOT event_id alone — so the same id consumed by
+// two different durables/subjects each claims independently.
+//
+// Pass a PoolClient to claim ATOMICALLY with the work (a rolled-back handler
+// also un-claims the event); pass a Pool for best-effort dedup where there is
+// no DB write to be atomic with (e.g. a fan-out worker — a missed side-effect
+// on a mid-flight crash is acceptable, a duplicate is the thing suppressed).
+
+import type { Pool, PoolClient } from 'pg';
+
+export type DedupConn = Pool | PoolClient;
+
+export const claimEvent = async (
+  conn: DedupConn,
+  consumer: string,
+  eventId: string
+): Promise<boolean> => {
+  const res = await conn.query(
+    `INSERT INTO processed_events (consumer, event_id)
+     VALUES ($1, $2)
+     ON CONFLICT (consumer, event_id) DO NOTHING`,
+    [consumer, eventId]
+  );
+  return res.rowCount === 1;
+};

--- a/packages/events/src/index.ts
+++ b/packages/events/src/index.ts
@@ -13,5 +13,7 @@ export {
 export { registerGdprSubscriber } from './gdpr-saga.js';
 export type { GdprEraseFn, RegisterGdprSubscriberOptions } from './gdpr-saga.js';
 export { redactAuditPayload } from './redact-audit-payload.js';
+export { claimEvent } from './idempotency.js';
+export type { DedupConn } from './idempotency.js';
 export { CONSUMER_REGISTRY } from './consumer-registry.js';
 export type { ConsumerEntry, RegistryEntry, ZeroConsumerEntry } from './consumer-registry.js';

--- a/packages/events/src/stream.test.ts
+++ b/packages/events/src/stream.test.ts
@@ -8,7 +8,13 @@
 import { describe, expect, it, vi } from 'vitest';
 import type { NatsConnection } from 'nats';
 
-import { DOMAIN_STREAM, DOMAIN_SUBJECTS, ensureStream } from './stream.js';
+import {
+  DLQ_STREAM,
+  DLQ_SUBJECT_PREFIX,
+  DOMAIN_STREAM,
+  DOMAIN_SUBJECTS,
+  ensureStream,
+} from './stream.js';
 
 // Token-aware matcher mirroring NATS semantics: `*` matches exactly one
 // token (including `$JS`), `>` matches one or more trailing tokens.
@@ -101,6 +107,16 @@ describe('ensureStream', () => {
     expect(update).toHaveBeenCalledWith(
       DOMAIN_STREAM,
       expect.objectContaining({ subjects: [...DOMAIN_SUBJECTS] })
+    );
+  });
+
+  it('also creates the dead-letter stream capturing dlq.>', async () => {
+    const { nc, add } = makeNc(async () => ({}));
+
+    await ensureStream(nc);
+
+    expect(add).toHaveBeenCalledWith(
+      expect.objectContaining({ name: DLQ_STREAM, subjects: [`${DLQ_SUBJECT_PREFIX}>`] })
     );
   });
 });

--- a/packages/events/src/stream.ts
+++ b/packages/events/src/stream.ts
@@ -21,10 +21,22 @@
 // coverage test in stream.test.ts). An unused prefix costs nothing; a
 // missing one means that domain's events have no durable stream.
 
-import { type NatsConnection, RetentionPolicy, StorageType } from 'nats';
+import {
+  type JetStreamManager,
+  type NatsConnection,
+  RetentionPolicy,
+  type StreamConfig,
+  StorageType,
+} from 'nats';
 
 // The one stream every service publishes to and consumes from.
 export const DOMAIN_STREAM = 'DOMAIN_EVENTS';
+
+// Dead-letter stream + subject prefix. A message that exhausts its consumer
+// redelivery budget (subscribe.ts MAX_DELIVER) is republished here on
+// `dlq.<original-subject>` for triage rather than being dropped or looped.
+export const DLQ_STREAM = 'DOMAIN_EVENTS_DLQ';
+export const DLQ_SUBJECT_PREFIX = 'dlq.';
 
 // One `<prefix>.>` filter per service domain (plus the cross-service gdpr
 // saga subjects). Explicit on purpose — see the header comment.
@@ -58,23 +70,39 @@ export type DomainSubject = (typeof DOMAIN_SUBJECTS)[number];
 // when the same event id is published twice within the window.
 export async function ensureStream(nc: NatsConnection): Promise<void> {
   const jsm = await nc.jetstreamManager();
-  const config = {
+
+  await addOrUpdateStream(jsm, {
     name: DOMAIN_STREAM,
     subjects: [...DOMAIN_SUBJECTS],
     retention: RetentionPolicy.Limits,
     storage: StorageType.File,
     max_age: 7 * 24 * 60 * 60 * 1_000_000_000, // 7 days in nanoseconds
     duplicate_window: 2 * 60 * 1_000_000_000, // 2 minutes in nanoseconds
-  };
+  });
 
+  // Dead-letter stream — messages that exhausted their redelivery budget land
+  // here on `dlq.<original-subject>`. Retained longer than the main stream so
+  // there's time to triage. Subjects don't overlap DOMAIN_SUBJECTS.
+  await addOrUpdateStream(jsm, {
+    name: DLQ_STREAM,
+    subjects: [`${DLQ_SUBJECT_PREFIX}>`],
+    retention: RetentionPolicy.Limits,
+    storage: StorageType.File,
+    max_age: 14 * 24 * 60 * 60 * 1_000_000_000, // 14 days in nanoseconds
+  });
+}
+
+// add-or-update a stream: `streams.add` throws when the stream already exists
+// (from a prior boot), so fall through to an update rather than crashing.
+async function addOrUpdateStream(
+  jsm: JetStreamManager,
+  config: Partial<StreamConfig> & { name: string }
+): Promise<void> {
   try {
     await jsm.streams.add(config);
   } catch (err) {
-    // Already exists — reconcile to the desired config. `streams.add`
-    // throws when the stream exists, so we fall through to an update
-    // rather than crashing the boot.
     if (isStreamAlreadyExists(err)) {
-      await jsm.streams.update(DOMAIN_STREAM, config);
+      await jsm.streams.update(config.name, config);
       return;
     }
     throw err;

--- a/packages/events/src/subscribe.test.ts
+++ b/packages/events/src/subscribe.test.ts
@@ -1,8 +1,8 @@
 import type { NatsConnection } from 'nats';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { nakBackoffMs, subscribe } from './subscribe.js';
-import { DOMAIN_STREAM } from './stream.js';
+import { deadLetter, handleFailure, MAX_DELIVER, nakBackoffMs, subscribe } from './subscribe.js';
+import { DLQ_SUBJECT_PREFIX, DOMAIN_STREAM } from './stream.js';
 
 // A minimal in-memory JetStream stand-in. It models the one property that
 // matters for this migration: messages live in the STREAM (not in a live
@@ -144,6 +144,17 @@ describe('subscribe (durable JetStream consumer)', () => {
     );
   });
 
+  it('caps redeliveries via max_deliver so poison messages eventually dead-letter', async () => {
+    const bus = makeBus();
+    subscribe(bus.nc, { subject: 'pets.created', durable: 'pets-workers' }, async () => undefined);
+    await flush();
+
+    expect(bus.jsmAdd).toHaveBeenCalledWith(
+      DOMAIN_STREAM,
+      expect.objectContaining({ max_deliver: MAX_DELIVER })
+    );
+  });
+
   it('delivers an event that was published WHILE the subscriber was down', async () => {
     const bus = makeBus();
     // Event fires first — no consumer exists yet (subscriber is "down").
@@ -278,5 +289,53 @@ describe('nakBackoffMs', () => {
 
   it('never returns a negative delay for a degenerate attempt count', () => {
     expect(nakBackoffMs(0)).toBe(1_000);
+  });
+});
+
+describe('handleFailure / deadLetter', () => {
+  function makeNc() {
+    const publish = vi.fn(async () => ({ seq: 1 }));
+    const nc = { jetstream: vi.fn(() => ({ publish })) } as unknown as NatsConnection;
+    return { nc, publish };
+  }
+
+  function fakeMsg(redeliveryCount: number) {
+    return {
+      subject: 'pets.created',
+      info: { redeliveryCount },
+      nak: vi.fn(),
+      term: vi.fn(),
+    };
+  }
+
+  it('backs off and redelivers while within the retry budget', async () => {
+    const { nc, publish } = makeNc();
+    const msg = fakeMsg(2);
+    await handleFailure(nc, msg, '{"id":"e1"}', new Error('blip'));
+    expect(msg.nak).toHaveBeenCalledWith(nakBackoffMs(2));
+    expect(msg.term).not.toHaveBeenCalled();
+    expect(publish).not.toHaveBeenCalled();
+  });
+
+  it('dead-letters and term()s once the retry budget is exhausted', async () => {
+    const { nc, publish } = makeNc();
+    const msg = fakeMsg(MAX_DELIVER);
+    await handleFailure(nc, msg, '{"id":"e1"}', new Error('still broken'));
+    expect(msg.nak).not.toHaveBeenCalled();
+    expect(msg.term).toHaveBeenCalledTimes(1);
+    expect(publish).toHaveBeenCalledTimes(1);
+    // Published to dlq.<original-subject>.
+    expect(publish.mock.calls[0][0]).toBe(`${DLQ_SUBJECT_PREFIX}pets.created`);
+  });
+
+  it('deadLetter preserves the raw payload and stamps triage headers', async () => {
+    const { nc, publish } = makeNc();
+    await deadLetter(nc, 'pets.created', '{"id":"e1"}', new Error('boom'));
+    const [subject, data, opts] = publish.mock.calls[0];
+    expect(subject).toBe('dlq.pets.created');
+    expect(new TextDecoder().decode(data as Uint8Array)).toBe('{"id":"e1"}');
+    const headers = (opts as { headers: { get: (k: string) => string } }).headers;
+    expect(headers.get('dlq-original-subject')).toBe('pets.created');
+    expect(headers.get('dlq-error')).toBe('boom');
   });
 });

--- a/packages/events/src/subscribe.ts
+++ b/packages/events/src/subscribe.ts
@@ -1,12 +1,13 @@
 import {
   AckPolicy,
   DeliverPolicy,
+  headers,
   type ConsumerMessages,
   type JsMsg,
   type NatsConnection,
 } from 'nats';
 
-import { DOMAIN_STREAM } from './stream.js';
+import { DLQ_SUBJECT_PREFIX, DOMAIN_STREAM } from './stream.js';
 
 export type SubscribeOptions = {
   // NATS subject pattern (e.g. `pets.unit.statusChanged`). Wildcards (`*`,
@@ -88,11 +89,21 @@ export function subscribe<T = unknown>(
     // already exists (from a previous boot) is reused with its saved
     // position, so the backlog accumulated while this subscriber was down is
     // delivered now.
+    //
+    // NOTE: JetStream does NOT apply a changed deliver_policy / filter_subject
+    // to an already-existing durable on re-add — those are fixed at creation.
+    // Changing them in code requires deleting and recreating the consumer (a
+    // deliberate ops step), so a flipped `deliverNew` won't take effect on an
+    // existing durable until it's recreated.
     await jsm.consumers.add(DOMAIN_STREAM, {
       durable_name: opts.durable,
       filter_subject: opts.subject,
       ack_policy: AckPolicy.Explicit,
       deliver_policy: opts.deliverNew ? DeliverPolicy.New : DeliverPolicy.All,
+      // Cap redeliveries — after MAX_DELIVER attempts handleFailure() dead-
+      // letters the message instead of retrying forever (backstop for the
+      // app-level term() in case a crash skips it).
+      max_deliver: MAX_DELIVER,
     });
 
     const js = nc.jetstream();
@@ -103,7 +114,7 @@ export function subscribe<T = unknown>(
     messages = await consumer.consume();
     const decoder = new TextDecoder();
     for await (const msg of messages) {
-      await dispatch<T>(msg, decoder, opts, handler);
+      await dispatch<T>(nc, msg, decoder, opts, handler);
     }
   })();
 
@@ -116,6 +127,7 @@ export function subscribe<T = unknown>(
 }
 
 async function dispatch<T>(
+  nc: NatsConnection,
   msg: JsMsg,
   decoder: TextDecoder,
   opts: SubscribeOptions,
@@ -138,20 +150,12 @@ async function dispatch<T>(
     await handler(envelope.payload, { subject: msg.subject, id: envelope.id, occurredAt });
     msg.ack();
   } catch (err) {
-    // Handler failed — could be transient (DB blip) so nak() for redelivery.
-    // Handlers are idempotent on the event id, so a redelivery of an event
-    // that actually half-succeeded is a clean skip on the next attempt.
-    //
-    // Back off redelivery (exponential on the redelivery count, capped) so a
-    // persistently-failing but PARSEABLE message can't hot-loop the consumer
-    // — only JSON-parse failures term() immediately. The first retry is still
-    // fast (covers a transient blip); repeated failures slow down.
-    // (A hard max_deliver + dead-letter subject is a separate, deliberate
-    // decision — see the events review notes.)
+    // Handler failed — could be transient (DB blip) so back off + redeliver;
+    // a persistently-failing message is dead-lettered once it exhausts the
+    // retry budget. Handlers are idempotent on the event id, so a redelivery
+    // of an event that half-succeeded is a clean skip on the next attempt.
     opts.onError?.(err, { subject: msg.subject, raw });
-    const info = (msg as { info?: { redeliveryCount?: number } }).info;
-    const attempt = info?.redeliveryCount ?? (msg.redelivered ? 2 : 1);
-    msg.nak(nakBackoffMs(attempt));
+    await handleFailure(nc, msg, raw, err);
   }
 }
 
@@ -162,4 +166,48 @@ const NAK_MAX_DELAY_MS = 30_000;
 
 export function nakBackoffMs(attempt: number): number {
   return Math.min(NAK_MAX_DELAY_MS, NAK_BASE_DELAY_MS * 2 ** Math.max(0, attempt - 1));
+}
+
+// After this many delivery attempts a persistently-failing (but parseable)
+// message is dead-lettered rather than retried forever.
+export const MAX_DELIVER = 7;
+
+// A handler failure either backs off for redelivery, or — once the retry
+// budget is exhausted — parks the message in the dead-letter stream and
+// term()s it so the consumer stops looping. Exported for unit testing.
+export async function handleFailure(
+  nc: NatsConnection,
+  msg: Pick<JsMsg, 'subject' | 'nak' | 'term'> & {
+    info?: { redeliveryCount?: number };
+    redelivered?: boolean;
+  },
+  raw: string,
+  err: unknown
+): Promise<void> {
+  const attempt = msg.info?.redeliveryCount ?? (msg.redelivered ? 2 : 1);
+  if (attempt >= MAX_DELIVER) {
+    await deadLetter(nc, msg.subject, raw, err);
+    msg.term();
+    return;
+  }
+  msg.nak(nakBackoffMs(attempt));
+}
+
+// Publish a failed message to the dead-letter stream on
+// `dlq.<original-subject>`, preserving the raw payload and stamping the
+// original subject + error message for triage. Exported for unit testing.
+export async function deadLetter(
+  nc: NatsConnection,
+  originalSubject: string,
+  raw: string,
+  err: unknown
+): Promise<void> {
+  const h = headers();
+  h.set('dlq-original-subject', originalSubject);
+  h.set('dlq-error', err instanceof Error ? err.message : String(err));
+  await nc
+    .jetstream()
+    .publish(`${DLQ_SUBJECT_PREFIX}${originalSubject}`, new TextEncoder().encode(raw), {
+      headers: h,
+    });
 }

--- a/packages/service-bootstrap/src/grpc-server.ts
+++ b/packages/service-bootstrap/src/grpc-server.ts
@@ -10,6 +10,9 @@ import { promisify } from 'node:util';
 import { Server, ServerCredentials } from '@grpc/grpc-js';
 import type { Logger } from 'winston';
 
+import { getDefaultPrincipalSigningKey } from './principal-token.js';
+import { assertPrincipalVerificationConfig } from './principal.js';
+
 export type GrpcServerConfig = {
   host: string;
   grpcPort: number;
@@ -26,6 +29,18 @@ export const startGrpcServer = async (
   config: GrpcServerConfig,
   logger: Logger
 ): Promise<RunningGrpcServer> => {
+  // Fail closed in production if signed-principal verification can't be
+  // enforced (no PRINCIPAL_SIGNING_KEY) — otherwise the service would trust
+  // forgeable x-user-* headers. Dev / escape-hatch logs the degraded mode.
+  assertPrincipalVerificationConfig();
+  if (getDefaultPrincipalSigningKey()) {
+    logger.info('principal verification: signed-token enforced');
+  } else {
+    logger.warn(
+      'principal verification DISABLED — trusting unsigned x-user-* headers (dev / phased rollout)'
+    );
+  }
+
   const bindAsync = promisify<string, ServerCredentials, number>(server.bindAsync.bind(server));
   const port = await bindAsync(
     `${config.host}:${config.grpcPort}`,

--- a/packages/service-bootstrap/src/index.ts
+++ b/packages/service-bootstrap/src/index.ts
@@ -48,7 +48,9 @@ export {
   extractPrincipal,
   extractPrincipalOptional,
   principalToMetadata,
+  assertPrincipalVerificationConfig,
   MissingPrincipalError,
+  InsecurePrincipalConfigError,
 } from './principal.js';
 export type { PrincipalVerification, PrincipalSigning } from './principal.js';
 

--- a/packages/service-bootstrap/src/principal.test.ts
+++ b/packages/service-bootstrap/src/principal.test.ts
@@ -1,15 +1,18 @@
 import { Metadata } from '@grpc/grpc-js';
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it } from 'vitest';
 
 import {
   PRINCIPAL_TOKEN_HEADER,
   PrincipalTokenError,
+  resetDefaultPrincipalSigningKeyForTests,
   signPrincipalToken,
   verifyPrincipalToken,
 } from './principal-token.js';
 import {
+  assertPrincipalVerificationConfig,
   extractPrincipal,
   extractPrincipalOptional,
+  InsecurePrincipalConfigError,
   MissingPrincipalError,
   principalToMetadata,
 } from './principal.js';
@@ -196,5 +199,54 @@ describe('extractPrincipalOptional', () => {
     );
     expect(p).not.toBeNull();
     expect(p?.userId).toBe('usr-2');
+  });
+});
+
+describe('assertPrincipalVerificationConfig', () => {
+  const origKey = process.env.PRINCIPAL_SIGNING_KEY;
+
+  afterEach(() => {
+    if (origKey === undefined) {
+      delete process.env.PRINCIPAL_SIGNING_KEY;
+    } else {
+      process.env.PRINCIPAL_SIGNING_KEY = origKey;
+    }
+    resetDefaultPrincipalSigningKeyForTests();
+  });
+
+  const withKey = (key: string | undefined): void => {
+    if (key === undefined) {
+      delete process.env.PRINCIPAL_SIGNING_KEY;
+    } else {
+      process.env.PRINCIPAL_SIGNING_KEY = key;
+    }
+    resetDefaultPrincipalSigningKeyForTests();
+  };
+
+  it('does not throw when a signing key is configured (even in production)', () => {
+    withKey('signing-key');
+    expect(() => assertPrincipalVerificationConfig({ NODE_ENV: 'production' })).not.toThrow();
+  });
+
+  it('throws in production when no key is set and no escape hatch', () => {
+    withKey(undefined);
+    expect(() => assertPrincipalVerificationConfig({ NODE_ENV: 'production' })).toThrow(
+      InsecurePrincipalConfigError
+    );
+  });
+
+  it('allows production header-trust only with the explicit ALLOW_UNSIGNED_PRINCIPAL opt-in', () => {
+    withKey(undefined);
+    expect(() =>
+      assertPrincipalVerificationConfig({
+        NODE_ENV: 'production',
+        ALLOW_UNSIGNED_PRINCIPAL: 'true',
+      })
+    ).not.toThrow();
+  });
+
+  it('does not throw outside production when no key is set (dev / phased rollout)', () => {
+    withKey(undefined);
+    expect(() => assertPrincipalVerificationConfig({ NODE_ENV: 'development' })).not.toThrow();
   });
 });

--- a/packages/service-bootstrap/src/principal.ts
+++ b/packages/service-bootstrap/src/principal.ts
@@ -17,6 +17,37 @@ export class MissingPrincipalError extends Error {
   }
 }
 
+// Thrown at boot when a service would run in production without the ability
+// to verify signed principals (and without an explicit opt-in).
+export class InsecurePrincipalConfigError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'InsecurePrincipalConfigError';
+  }
+}
+
+// Boot-time guard (ADS-800 hardening). Without PRINCIPAL_SIGNING_KEY,
+// extractPrincipal falls back to trusting unsigned x-user-* headers — fine
+// for dev and the phased-rollout window, but in production a missing key
+// would silently let anything that can reach the service forge identity (the
+// real cross-service authz boundary). Fail closed in production unless the
+// operator explicitly opts into header-trust via ALLOW_UNSIGNED_PRINCIPAL.
+export function assertPrincipalVerificationConfig(env: NodeJS.ProcessEnv = process.env): void {
+  if (getDefaultPrincipalSigningKey()) {
+    return; // signed-token verification enabled — the secure path.
+  }
+  const isProduction = env.NODE_ENV === 'production';
+  const allowUnsigned = env.ALLOW_UNSIGNED_PRINCIPAL === 'true';
+  if (isProduction && !allowUnsigned) {
+    throw new InsecurePrincipalConfigError(
+      'PRINCIPAL_SIGNING_KEY is required in production: without it the service trusts ' +
+        'unsigned x-user-* headers, which any client that can reach it could forge. ' +
+        'Set PRINCIPAL_SIGNING_KEY, or set ALLOW_UNSIGNED_PRINCIPAL=true to explicitly ' +
+        'accept header-trust (phased-rollout only).'
+    );
+  }
+}
+
 // Verification config (ADS-800). When a signing key is present the
 // service REQUIRES a valid x-principal-token and takes the principal
 // from the token payload — the x-user-* headers become informational,

--- a/packages/storage/src/base-provider.ts
+++ b/packages/storage/src/base-provider.ts
@@ -1,5 +1,16 @@
 export type StorageCategory = 'pets' | 'users' | 'documents';
 
+// Defence-in-depth path-segment guard. `filename`/`category` are normally
+// server-generated (UUID + a fixed category), but the provider methods are
+// public API — reject any segment that contains a path separator or `..` so a
+// caller can never escape the upload dir / bucket prefix even if the consumer
+// forgets to validate. A flat segment can't traverse.
+export function assertSafePathSegment(value: string, label: string): void {
+  if (value.length === 0 || value.includes('/') || value.includes('\\') || value.includes('..')) {
+    throw new Error(`storage: unsafe ${label} segment "${value}"`);
+  }
+}
+
 export type UploadResult = {
   url: string;
   filename: string;

--- a/packages/storage/src/local-storage-provider.test.ts
+++ b/packages/storage/src/local-storage-provider.test.ts
@@ -75,6 +75,12 @@ describe('LocalStorageProvider', () => {
     expect(info.exists).toBe(false);
   });
 
+  it('rejects path-traversal in filename or category instead of escaping the upload dir', async () => {
+    await expect(provider.deleteFile('../../etc/passwd', 'documents')).rejects.toThrow(/unsafe/);
+    await expect(provider.getFileInfo('ok.txt', '../secrets')).rejects.toThrow(/unsafe/);
+    await expect(provider.getFileInfo('a/b.txt', 'documents')).rejects.toThrow(/unsafe/);
+  });
+
   it('identifies itself and does not support signed urls', async () => {
     expect(provider.getName()).toBe('local');
     expect(provider.supportsSignedUrls()).toBe(false);

--- a/packages/storage/src/local-storage-provider.ts
+++ b/packages/storage/src/local-storage-provider.ts
@@ -2,7 +2,13 @@ import { randomUUID } from 'node:crypto';
 import path from 'node:path';
 import fs from 'fs-extra';
 import sharp from 'sharp';
-import type { FileInfo, StorageCategory, StorageProvider, UploadResult } from './base-provider.js';
+import {
+  assertSafePathSegment,
+  type FileInfo,
+  type StorageCategory,
+  type StorageProvider,
+  type UploadResult,
+} from './base-provider.js';
 import { type LocalStorageConfig, type StorageLogger, resolveLogger } from './config.js';
 
 // Cap decoded pixels so a small-on-disk image declaring extreme header
@@ -98,6 +104,9 @@ export class LocalStorageProvider implements StorageProvider {
   }
 
   async deleteFile(filename: string, category: string = 'documents'): Promise<void> {
+    // Guard BEFORE the try so traversal can't be masked by the catch.
+    assertSafePathSegment(category, 'category');
+    assertSafePathSegment(filename, 'filename');
     try {
       const filePath = path.join(this.uploadDir, category, filename);
       await fs.remove(filePath);
@@ -109,6 +118,10 @@ export class LocalStorageProvider implements StorageProvider {
   }
 
   async getFileInfo(filename: string, category: string = 'documents'): Promise<FileInfo> {
+    // Guard BEFORE the try — getFileInfo's catch maps errors to {exists:false},
+    // which would otherwise silently swallow a traversal attempt.
+    assertSafePathSegment(category, 'category');
+    assertSafePathSegment(filename, 'filename');
     try {
       const filePath = path.join(this.uploadDir, category, filename);
       const stats = await fs.stat(filePath);

--- a/packages/storage/src/s3-storage-provider.ts
+++ b/packages/storage/src/s3-storage-provider.ts
@@ -8,7 +8,13 @@ import {
   S3Client,
 } from '@aws-sdk/client-s3';
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
-import type { FileInfo, StorageCategory, StorageProvider, UploadResult } from './base-provider.js';
+import {
+  assertSafePathSegment,
+  type FileInfo,
+  type StorageCategory,
+  type StorageProvider,
+  type UploadResult,
+} from './base-provider.js';
 import { type S3StorageConfig, type StorageLogger, resolveLogger } from './config.js';
 
 type ValidatedS3Config = {
@@ -86,7 +92,7 @@ export class S3StorageProvider implements StorageProvider {
     const { bucket } = this.requireConfig();
     const ext = path.extname(originalName);
     const filename = `${randomUUID()}${ext}`;
-    const key = `${category}/${filename}`;
+    const key = this.objectKey(category, filename);
 
     // Non-image uploads land with Content-Disposition: attachment so a browser
     // never renders an HTML/PDF polyglot inline from the CDN origin. Images use
@@ -121,7 +127,7 @@ export class S3StorageProvider implements StorageProvider {
 
   async deleteFile(filename: string, category: string = 'documents'): Promise<void> {
     const { bucket } = this.requireConfig();
-    const key = `${category}/${filename}`;
+    const key = this.objectKey(category, filename);
     try {
       await this.client.send(
         new DeleteObjectCommand({
@@ -138,7 +144,7 @@ export class S3StorageProvider implements StorageProvider {
 
   async getFileInfo(filename: string, category: string = 'documents'): Promise<FileInfo> {
     const { bucket } = this.requireConfig();
-    const key = `${category}/${filename}`;
+    const key = this.objectKey(category, filename);
     try {
       const response = await this.client.send(
         new HeadObjectCommand({
@@ -161,6 +167,13 @@ export class S3StorageProvider implements StorageProvider {
       this.logger.error('S3 HeadObject failed:', error);
       throw error;
     }
+  }
+
+  // Build the S3 object key, rejecting any traversal in the segments.
+  private objectKey(category: string, filename: string): string {
+    assertSafePathSegment(category, 'category');
+    assertSafePathSegment(filename, 'filename');
+    return `${category}/${filename}`;
   }
 
   private static isNotFoundError(error: unknown): boolean {
@@ -199,7 +212,7 @@ export class S3StorageProvider implements StorageProvider {
     expiresInSeconds: number = DEFAULT_SIGNED_URL_TTL_SECONDS
   ): Promise<string> {
     const { bucket } = this.requireConfig();
-    const key = `${category}/${filename}`;
+    const key = this.objectKey(category, filename);
     const command = new GetObjectCommand({ Bucket: bucket, Key: key });
     return getSignedUrl(this.client, command, { expiresIn: expiresInSeconds });
   }

--- a/services/gateway/src/index.ts
+++ b/services/gateway/src/index.ts
@@ -2,6 +2,7 @@ import { connect, type NatsConnection } from 'nats';
 import type { Server as IOServer } from 'socket.io';
 
 import { createLogger } from '@adopt-dont-shop/observability';
+import { assertPrincipalVerificationConfig } from '@adopt-dont-shop/service-bootstrap';
 
 import { loadConfig } from './config.js';
 import { createApplicationsClient } from './grpc-clients/applications-client.js';
@@ -36,6 +37,11 @@ const main = async (): Promise<void> => {
 
   try {
     const config = loadConfig();
+
+    // Fail closed in production without PRINCIPAL_SIGNING_KEY: the gateway
+    // signs the principal tokens downstream services verify, so a prod
+    // gateway that can't sign would force every downstream into header-trust.
+    assertPrincipalVerificationConfig();
 
     // gRPC clients to extracted services come up before Fastify so the
     // route plugins / middleware can close over them. The channels are

--- a/services/notifications/src/processed-events.ts
+++ b/services/notifications/src/processed-events.ts
@@ -1,33 +1,8 @@
 // Inbound-event idempotency claim against `notifications.processed_events`.
 //
-// `subscribe()` delivers at-least-once, so every subscriber that turns an
-// upstream event into a durable side-effect (a notification row, a push
-// fan-out) must dedupe on the event id. `claimEvent` is that primitive:
-// it inserts a (consumer, event_id) row and reports whether THIS call won
-// the race. A redelivery hits the ON CONFLICT and returns false, so the
-// caller skips the work it already did.
-//
-// Pass a PoolClient when the claim must be atomic with the work (the
-// create handler claims inside the same transaction as the insert, so a
-// rolled-back handler also un-claims the event). Pass a Pool for
-// best-effort dedup where there is no DB write to be atomic with (the
-// push worker — a missed push on a mid-flight crash is acceptable, a
-// duplicate push is the thing we are suppressing).
+// The primitive now lives in @adopt-dont-shop/events (shared across services);
+// this module re-exports it so existing call sites keep their local import.
+// The table is resolved via the connection search_path (set to `notifications`
+// by @adopt-dont-shop/db createDbClient), and is created by migration 008.
 
-import type { Pool, PoolClient } from 'pg';
-
-export type DedupConn = Pool | PoolClient;
-
-export const claimEvent = async (
-  conn: DedupConn,
-  consumer: string,
-  eventId: string
-): Promise<boolean> => {
-  const res = await conn.query(
-    `INSERT INTO notifications.processed_events (consumer, event_id)
-     VALUES ($1, $2)
-     ON CONFLICT (consumer, event_id) DO NOTHING`,
-    [consumer, eventId]
-  );
-  return res.rowCount === 1;
-};
+export { claimEvent, type DedupConn } from '@adopt-dont-shop/events';


### PR DESCRIPTION
Actions the follow-up recommendations from the backbone/infra review (#1057), per the decisions captured for each.

## Changes

| Area | Change | Decision |
|---|---|---|
| service-bootstrap | `assertPrincipalVerificationConfig()` **fails closed at boot in production** when `PRINCIPAL_SIGNING_KEY` is unset — so a service can't silently trust forgeable `x-user-*` headers — unless `ALLOW_UNSIGNED_PRINCIPAL=true` is an explicit opt-in for the phased rollout. Wired into `startGrpcServer` (all gRPC services) and the gateway boot (the token signer). | Fail closed + escape hatch |
| events | Consumers now set **`max_deliver=7`** and dead-letter exhausted messages to a new `DOMAIN_EVENTS_DLQ` stream (`dlq.<original-subject>`, 14-day retention, triage headers), then `term()` — parked for inspection rather than dropped or looped. | max_deliver + dead-letter |
| events | `claimEvent` promoted to a **shared idempotency primitive** in `@adopt-dont-shop/events` (schema-agnostic via search_path); notifications re-exports it, new consumers adopt via the `processed_events` migration. Naturally idempotent consumers (GDPR erase, ON CONFLICT inserts, deterministic completion ids) left unchanged rather than gold-plated. | Build shared dedup helper |
| events | Documented the durable-consumer `deliver_policy`/`filter_subject` re-add limitation. | — |
| storage | Provider methods reject any `filename`/`category` segment with a path separator or `..` (guard runs before the catch so `getFileInfo` can't mask it). | — |

## Investigated, no change needed
The `service-chat`/`service-cms` compose "topology gap" is a non-issue: `cutover.chat/cms` default to `false`, so the gateway only routes to them when explicitly enabled (prod/staging, where the containers exist); the dev/base omission is correct. (The review agent's premise that e2e sets `CUTOVER_CHAT/CMS=true` was inaccurate — no such setting exists.)

## Verification
`turbo build` (all packages) + `turbo test type-check lint` (all services + changed packages) — **57/57 tasks pass**.

https://claude.ai/code/session_014EbfJyKja1PmRfjcZWokaH

---
_Generated by [Claude Code](https://claude.ai/code/session_014EbfJyKja1PmRfjcZWokaH)_