### PR TITLE
fix(services): close cross-tenant authz gaps in applications writes and pets listing

### DIFF
--- a/services/applications/src/grpc/command-runner.ts
+++ b/services/applications/src/grpc/command-runner.ts
@@ -8,7 +8,9 @@
 // withTransaction. DomainError + ConcurrencyError translate to
 // HandlerError codes here so individual handlers stay declarative.
 
+import { requirePermission, type Principal } from '@adopt-dont-shop/authz';
 import { withTransaction } from '@adopt-dont-shop/events';
+import type { Permission, RescueId, UserId } from '@adopt-dont-shop/lib.types';
 
 import {
   apply as applyEvent,
@@ -23,6 +25,41 @@ import { HandlerError, type HandlerDeps } from './adapter.js';
 import { appendEvents, ConcurrencyError, loadAggregate, projectReadModel } from './event-store.js';
 
 export type PublishEnvelope = { type: string; id: string; payload: unknown };
+
+// A command-authorization hook: runs against the loaded aggregate state
+// (after the empty/NOT_FOUND check) so a write can be denied based on the
+// target's owning rescue / adopter — not just the bare permission. Throws
+// HandlerError('PERMISSION_DENIED') to reject.
+export type Authorize = (state: ApplicationState) => void;
+
+// Rescue-staff write: the principal must hold `permission` AND be scoped to
+// the application's owning rescue. Mirrors the read side's rescue branch in
+// read-handlers.ts. super_admin bypasses the scope inside requirePermission.
+export function requireRescueScope(
+  principal: Principal,
+  permission: Permission,
+  state: ApplicationState
+): void {
+  if (!requirePermission(principal, permission, { rescueId: state.rescueId as RescueId })) {
+    throw new HandlerError('PERMISSION_DENIED', `'${permission}' required`);
+  }
+}
+
+// Adopter-or-staff write: allowed when the principal is the owning adopter
+// OR holds the permission scoped to the owning rescue. Same OR-scope the
+// read side (getApplication / listDocuments) uses.
+export function requireOwnerOrRescueScope(
+  principal: Principal,
+  permission: Permission,
+  state: ApplicationState
+): void {
+  const ok =
+    requirePermission(principal, permission, { userId: state.adopterId as UserId }) ||
+    requirePermission(principal, permission, { rescueId: state.rescueId as RescueId });
+  if (!ok) {
+    throw new HandlerError('PERMISSION_DENIED', `'${permission}' required`);
+  }
+}
 
 // Translate the pure domain's DomainError codes into HandlerError
 // codes. ILLEGAL_TRANSITION / INVALID_INPUT → INVALID_ARGUMENT;
@@ -51,10 +88,19 @@ export async function runCommand(
   aggregateId: string,
   command: ApplicationCommand,
   actorUserId: string,
-  publishFor: (state: ApplicationState) => PublishEnvelope | null
+  publishFor: (state: ApplicationState) => PublishEnvelope | null,
+  authorize?: Authorize
 ): Promise<ApplicationState> {
   return withTransaction(deps, async ({ client, publish }) => {
     const state = await loadAggregate(client, aggregateId);
+
+    // Tenant/ownership scope check on the loaded aggregate. Only meaningful
+    // once the aggregate exists (version > 0); a missing aggregate is
+    // INITIAL_STATE and falls through to handle(), which raises NOT_FOUND —
+    // so we never leak "exists" via PERMISSION_DENIED for unknown ids.
+    if (authorize !== undefined && state.version > 0) {
+      authorize(state);
+    }
 
     let events;
     try {

--- a/services/applications/src/grpc/document-handlers.test.ts
+++ b/services/applications/src/grpc/document-handlers.test.ts
@@ -25,6 +25,12 @@ function makeDeps(): { deps: HandlerDeps; query: ReturnType<typeof vi.fn> } {
   return { deps: { pool, nats: {} } as unknown as HandlerDeps, query };
 }
 
+// The owner-row lookup every document handler runs first to scope the call
+// to the application's adopter / rescue.
+function ownerRow(overrides: Partial<{ user_id: string; rescue_id: string }> = {}) {
+  return { user_id: overrides.user_id ?? 'usr-1', rescue_id: overrides.rescue_id ?? 'rsc-1' };
+}
+
 const documentRow = {
   document_id: 'doc-1',
   application_id: 'app-1',
@@ -38,7 +44,8 @@ const documentRow = {
 
 describe('addDocument', () => {
   it('throws PERMISSION_DENIED without applications.update', async () => {
-    const { deps } = makeDeps();
+    const { deps, query } = makeDeps();
+    query.mockResolvedValueOnce({ rows: [ownerRow({ user_id: 'usr-1' })] });
     await expect(
       addDocument(deps, makePrincipal({ permissions: ['applications.read'] }), {
         applicationId: 'app-1',
@@ -50,7 +57,7 @@ describe('addDocument', () => {
   });
 
   it('throws INVALID_ARGUMENT when application_id is empty', async () => {
-    const { deps } = makeDeps();
+    const { deps, query } = makeDeps();
     await expect(
       addDocument(deps, makePrincipal(), {
         applicationId: '',
@@ -59,11 +66,61 @@ describe('addDocument', () => {
         url: 'https://files/ref.pdf',
       })
     ).rejects.toBeInstanceOf(HandlerError);
+    expect(query).not.toHaveBeenCalled();
+  });
+
+  it('throws NOT_FOUND when the application does not exist', async () => {
+    const { deps, query } = makeDeps();
+    query.mockResolvedValueOnce({ rows: [] });
+    await expect(
+      addDocument(deps, makePrincipal(), {
+        applicationId: 'missing',
+        type: 'reference',
+        filename: 'ref.pdf',
+        url: 'https://files/ref.pdf',
+      })
+    ).rejects.toMatchObject({ code: 'NOT_FOUND' });
+    // Never reaches the INSERT.
+    expect(query).toHaveBeenCalledTimes(1);
+  });
+
+  it('denies an adopter who is not the application owner', async () => {
+    const { deps, query } = makeDeps();
+    query.mockResolvedValueOnce({ rows: [ownerRow({ user_id: 'someone-else' })] });
+    await expect(
+      addDocument(deps, makePrincipal({ userId: 'usr-1' }), {
+        applicationId: 'app-1',
+        type: 'reference',
+        filename: 'ref.pdf',
+        url: 'https://files/ref.pdf',
+      })
+    ).rejects.toMatchObject({ code: 'PERMISSION_DENIED' });
+    expect(query).toHaveBeenCalledTimes(1);
+  });
+
+  it('denies rescue staff of a different rescue', async () => {
+    const { deps, query } = makeDeps();
+    query.mockResolvedValueOnce({ rows: [ownerRow({ user_id: 'other', rescue_id: 'rsc-9' })] });
+    await expect(
+      addDocument(
+        deps,
+        makePrincipal({ userId: 'staff-1', roles: ['rescue_staff'], rescueId: 'rsc-1' }),
+        {
+          applicationId: 'app-1',
+          type: 'reference',
+          filename: 'ref.pdf',
+          url: 'https://files/ref.pdf',
+        }
+      )
+    ).rejects.toMatchObject({ code: 'PERMISSION_DENIED' });
+    expect(query).toHaveBeenCalledTimes(1);
   });
 
   it('inserts the metadata row and returns the mapped Document', async () => {
     const { deps, query } = makeDeps();
-    query.mockResolvedValueOnce({ rows: [documentRow] });
+    query
+      .mockResolvedValueOnce({ rows: [ownerRow({ user_id: 'usr-9' })] })
+      .mockResolvedValueOnce({ rows: [documentRow] });
 
     const res = await addDocument(deps, makePrincipal({ userId: 'usr-9' }), {
       applicationId: 'app-1',
@@ -74,7 +131,7 @@ describe('addDocument', () => {
       mimeType: 'application/pdf',
     });
 
-    const params = query.mock.calls[0][1] as unknown[];
+    const params = query.mock.calls[1][1] as unknown[];
     // application_id, type, filename, url, size, mime_type, uploaded_by
     expect(params.slice(1)).toEqual([
       'app-1',
@@ -97,11 +154,31 @@ describe('addDocument', () => {
     });
   });
 
+  it('lets rescue staff of the application rescue add a document', async () => {
+    const { deps, query } = makeDeps();
+    query
+      .mockResolvedValueOnce({ rows: [ownerRow({ user_id: 'other', rescue_id: 'rsc-9' })] })
+      .mockResolvedValueOnce({ rows: [documentRow] });
+
+    const res = await addDocument(
+      deps,
+      makePrincipal({ userId: 'staff-1', roles: ['rescue_staff'], rescueId: 'rsc-9' }),
+      {
+        applicationId: 'app-1',
+        type: 'reference',
+        filename: 'ref.pdf',
+        url: 'https://files/ref.pdf',
+      }
+    );
+
+    expect(res.document?.documentId).toBe('doc-1');
+  });
+
   it('persists null for omitted size / mime_type', async () => {
     const { deps, query } = makeDeps();
-    query.mockResolvedValueOnce({
-      rows: [{ ...documentRow, size: null, mime_type: null }],
-    });
+    query
+      .mockResolvedValueOnce({ rows: [ownerRow({ user_id: 'usr-1' })] })
+      .mockResolvedValueOnce({ rows: [{ ...documentRow, size: null, mime_type: null }] });
 
     const res = await addDocument(deps, makePrincipal(), {
       applicationId: 'app-1',
@@ -110,7 +187,7 @@ describe('addDocument', () => {
       url: 'https://files/ref.pdf',
     });
 
-    const params = query.mock.calls[0][1] as unknown[];
+    const params = query.mock.calls[1][1] as unknown[];
     expect(params[5]).toBeNull();
     expect(params[6]).toBeNull();
     expect(res.document?.size).toBeUndefined();
@@ -130,7 +207,7 @@ describe('listDocuments', () => {
 
   it('denies an adopter who is not the application owner', async () => {
     const { deps, query } = makeDeps();
-    query.mockResolvedValueOnce({ rows: [{ user_id: 'someone-else', rescue_id: 'rsc-1' }] });
+    query.mockResolvedValueOnce({ rows: [ownerRow({ user_id: 'someone-else' })] });
 
     await expect(
       listDocuments(deps, makePrincipal({ userId: 'usr-1' }), { applicationId: 'app-1' })
@@ -140,7 +217,7 @@ describe('listDocuments', () => {
   it('lets the owning adopter list their documents', async () => {
     const { deps, query } = makeDeps();
     query
-      .mockResolvedValueOnce({ rows: [{ user_id: 'usr-1', rescue_id: 'rsc-1' }] })
+      .mockResolvedValueOnce({ rows: [ownerRow({ user_id: 'usr-1' })] })
       .mockResolvedValueOnce({ rows: [documentRow] });
 
     const res = await listDocuments(deps, makePrincipal({ userId: 'usr-1' }), {
@@ -154,7 +231,7 @@ describe('listDocuments', () => {
   it('lets rescue staff of the application rescue list documents', async () => {
     const { deps, query } = makeDeps();
     query
-      .mockResolvedValueOnce({ rows: [{ user_id: 'other', rescue_id: 'rsc-9' }] })
+      .mockResolvedValueOnce({ rows: [ownerRow({ user_id: 'other', rescue_id: 'rsc-9' })] })
       .mockResolvedValueOnce({ rows: [] });
 
     const res = await listDocuments(
@@ -169,7 +246,8 @@ describe('listDocuments', () => {
 
 describe('removeDocument', () => {
   it('throws PERMISSION_DENIED without applications.update', async () => {
-    const { deps } = makeDeps();
+    const { deps, query } = makeDeps();
+    query.mockResolvedValueOnce({ rows: [ownerRow({ user_id: 'usr-1' })] });
     await expect(
       removeDocument(deps, makePrincipal({ permissions: ['applications.read'] }), {
         applicationId: 'app-1',
@@ -186,23 +264,40 @@ describe('removeDocument', () => {
     expect(query).not.toHaveBeenCalled();
   });
 
+  it('denies rescue staff of a different rescue', async () => {
+    const { deps, query } = makeDeps();
+    query.mockResolvedValueOnce({ rows: [ownerRow({ user_id: 'other', rescue_id: 'rsc-9' })] });
+    await expect(
+      removeDocument(
+        deps,
+        makePrincipal({ userId: 'staff-1', roles: ['rescue_staff'], rescueId: 'rsc-1' }),
+        { applicationId: 'app-1', documentId: 'doc-1' }
+      )
+    ).rejects.toMatchObject({ code: 'PERMISSION_DENIED' });
+    expect(query).toHaveBeenCalledTimes(1);
+  });
+
   it('soft-deletes the document and returns an empty response', async () => {
     const { deps, query } = makeDeps();
-    query.mockResolvedValueOnce({ rowCount: 1 });
+    query
+      .mockResolvedValueOnce({ rows: [ownerRow({ user_id: 'usr-1' })] })
+      .mockResolvedValueOnce({ rowCount: 1 });
 
     const res = await removeDocument(deps, makePrincipal(), {
       applicationId: 'app-1',
       documentId: 'doc-1',
     });
 
-    const params = query.mock.calls[0][1] as unknown[];
+    const params = query.mock.calls[1][1] as unknown[];
     expect(params).toEqual(['doc-1', 'app-1']);
     expect(res).toEqual({});
   });
 
   it('throws NOT_FOUND when no live document matches', async () => {
     const { deps, query } = makeDeps();
-    query.mockResolvedValueOnce({ rowCount: 0 });
+    query
+      .mockResolvedValueOnce({ rows: [ownerRow({ user_id: 'usr-1' })] })
+      .mockResolvedValueOnce({ rowCount: 0 });
 
     await expect(
       removeDocument(deps, makePrincipal(), { applicationId: 'app-1', documentId: 'gone' })

--- a/services/applications/src/grpc/document-handlers.ts
+++ b/services/applications/src/grpc/document-handlers.ts
@@ -9,12 +9,14 @@
 // single INSERT / SELECT / UPDATE each.
 //
 // Authz:
-//   - addDocument / removeDocument: gate APPLICATIONS_UPDATE (same plain
-//     gate the write handlers use; the rescue owns the application).
+//   - addDocument / removeDocument: APPLICATIONS_UPDATE scoped to the
+//     application's owner / rescue — read the application's user_id /
+//     rescue_id from the read model first (404 if it doesn't exist), then
+//     adopter-owns OR rescue-staff-of-this-rescue OR admin. A bare
+//     permission check would let any rescue attach to / delete another
+//     rescue's application documents.
 //   - listDocuments: gate APPLICATIONS_VIEW with the SAME owner / rescue /
-//     admin scoping as getApplication — read the application's user_id /
-//     rescue_id from the read model, then adopter-owns OR rescue-staff-of-
-//     this-rescue OR admin.
+//     admin scoping as getApplication.
 
 import { randomUUID } from 'node:crypto';
 
@@ -22,6 +24,7 @@ import { requirePermission, type Principal } from '@adopt-dont-shop/authz';
 import {
   APPLICATIONS_UPDATE,
   APPLICATIONS_VIEW,
+  type Permission,
   type RescueId,
   type UserId,
 } from '@adopt-dont-shop/lib.types';
@@ -74,6 +77,31 @@ function rowToProto(row: DocumentRow): Document {
   return doc;
 }
 
+// Load the application's owner / rescue, 404 if it doesn't exist. Shared by
+// every document handler so a write can't target an application that isn't
+// there (and can't skip the scope check below).
+async function loadOwnerOrThrow(deps: HandlerDeps, applicationId: string): Promise<OwnerRow> {
+  const { rows } = await deps.pool.query<OwnerRow>(
+    `SELECT user_id, rescue_id FROM applications WHERE application_id = $1 AND deleted_at IS NULL`,
+    [applicationId]
+  );
+  if (rows.length === 0) {
+    throw new HandlerError('NOT_FOUND', 'application not found');
+  }
+  return rows[0];
+}
+
+// adopter-owns OR rescue-staff-of-this-rescue OR admin — the same OR-scope
+// getApplication uses, applied to a document read/write.
+function assertOwnerOrRescue(principal: Principal, owner: OwnerRow, permission: Permission): void {
+  const ok =
+    requirePermission(principal, permission, { userId: owner.user_id as UserId }) ||
+    requirePermission(principal, permission, { rescueId: owner.rescue_id as RescueId });
+  if (!ok) {
+    throw new HandlerError('PERMISSION_DENIED', `'${permission}' required`);
+  }
+}
+
 // --- AddDocument -----------------------------------------------------
 
 export async function addDocument(
@@ -81,12 +109,11 @@ export async function addDocument(
   principal: Principal,
   req: AddDocumentRequest
 ): Promise<AddDocumentResponse> {
-  if (!requirePermission(principal, APPLICATIONS_UPDATE)) {
-    throw new HandlerError('PERMISSION_DENIED', `'${APPLICATIONS_UPDATE}' required`);
-  }
   if (req.applicationId === '') {
     throw new HandlerError('INVALID_ARGUMENT', 'application_id is required');
   }
+  const owner = await loadOwnerOrThrow(deps, req.applicationId);
+  assertOwnerOrRescue(principal, owner, APPLICATIONS_UPDATE);
 
   const sql = `
     INSERT INTO application_documents
@@ -122,21 +149,8 @@ export async function listDocuments(
   }
 
   // Scope from the application's owner / rescue — the read model row.
-  const owner = await deps.pool.query<OwnerRow>(
-    `SELECT user_id, rescue_id FROM applications WHERE application_id = $1 AND deleted_at IS NULL`,
-    [req.applicationId]
-  );
-  if (owner.rows.length === 0) {
-    throw new HandlerError('NOT_FOUND', 'application not found');
-  }
-
-  const { user_id, rescue_id } = owner.rows[0];
-  const canRead =
-    requirePermission(principal, APPLICATIONS_VIEW, { userId: user_id as UserId }) ||
-    requirePermission(principal, APPLICATIONS_VIEW, { rescueId: rescue_id as RescueId });
-  if (!canRead) {
-    throw new HandlerError('PERMISSION_DENIED', `'${APPLICATIONS_VIEW}' required`);
-  }
+  const owner = await loadOwnerOrThrow(deps, req.applicationId);
+  assertOwnerOrRescue(principal, owner, APPLICATIONS_VIEW);
 
   const { rows } = await deps.pool.query<DocumentRow>(
     `SELECT document_id, application_id, type, filename, url, size, mime_type, created_at
@@ -156,15 +170,14 @@ export async function removeDocument(
   principal: Principal,
   req: RemoveDocumentRequest
 ): Promise<RemoveDocumentResponse> {
-  if (!requirePermission(principal, APPLICATIONS_UPDATE)) {
-    throw new HandlerError('PERMISSION_DENIED', `'${APPLICATIONS_UPDATE}' required`);
-  }
   if (req.applicationId === '') {
     throw new HandlerError('INVALID_ARGUMENT', 'application_id is required');
   }
   if (req.documentId === '') {
     throw new HandlerError('INVALID_ARGUMENT', 'document_id is required');
   }
+  const owner = await loadOwnerOrThrow(deps, req.applicationId);
+  assertOwnerOrRescue(principal, owner, APPLICATIONS_UPDATE);
 
   const { rowCount } = await deps.pool.query(
     `UPDATE application_documents

--- a/services/applications/src/grpc/handlers.test.ts
+++ b/services/applications/src/grpc/handlers.test.ts
@@ -153,6 +153,19 @@ describe('saveDraftAnswers', () => {
     const refs = JSON.parse(res.application.referencesJson) as Array<Record<string, string>>;
     expect(refs[0]).toMatchObject({ name: 'Jane', email: 'j@e.com', relationship: 'friend' });
   });
+
+  it('denies a different adopter editing another user’s draft', async () => {
+    // Draft is owned by usr-1; usr-2 holds applications.update but is not
+    // the owner and belongs to no rescue.
+    const { deps } = makeDeps([draftCreatedRow('app-1', 'usr-1')]);
+    await expect(
+      saveDraftAnswers(deps, makePrincipal({ userId: 'usr-2' }), {
+        applicationId: 'app-1',
+        expectedVersion: 1,
+        answersPatchJson: '{"hasYard":true}',
+      } as SaveDraftAnswersRequest)
+    ).rejects.toMatchObject({ code: 'PERMISSION_DENIED' });
+  });
 });
 
 describe('makeStartDraft', () => {
@@ -252,6 +265,16 @@ describe('submitDraft', () => {
       type: 'applications.submitted',
       id: 'app-1:2',
     });
+  });
+
+  it('denies a different adopter submitting another user’s draft', async () => {
+    const { deps } = makeDeps([draftCreatedRow('app-1', 'usr-1')]);
+    await expect(
+      submitDraft(deps, makePrincipal({ userId: 'usr-2' }), {
+        applicationId: 'app-1',
+        expectedVersion: 1,
+      } as SubmitDraftRequest)
+    ).rejects.toMatchObject({ code: 'PERMISSION_DENIED' });
   });
 
   it('surfaces a domain ILLEGAL_TRANSITION as INVALID_ARGUMENT (double submit)', async () => {

--- a/services/applications/src/grpc/handlers.ts
+++ b/services/applications/src/grpc/handlers.ts
@@ -37,7 +37,7 @@ import type {
 import type { ApplicationCommand, Reference } from '../domain/index.js';
 
 import { HandlerError, type HandlerDeps } from './adapter.js';
-import { runCommand, runCreateCommand } from './command-runner.js';
+import { requireOwnerOrRescueScope, runCommand, runCreateCommand } from './command-runner.js';
 import type { PetsClient } from './pets-client.js';
 import { principalToMetadata } from './principal.js';
 import { stateToProto } from './state-mapper.js';
@@ -157,11 +157,18 @@ export async function saveDraftAnswers(
     at: new Date().toISOString(),
   };
 
-  const state = await runCommand(deps, req.applicationId, command, principal.userId, () => ({
-    type: 'applications.draftUpdated',
-    id: req.applicationId,
-    payload: { applicationId: req.applicationId },
-  }));
+  const state = await runCommand(
+    deps,
+    req.applicationId,
+    command,
+    principal.userId,
+    () => ({
+      type: 'applications.draftUpdated',
+      id: req.applicationId,
+      payload: { applicationId: req.applicationId },
+    }),
+    s => requireOwnerOrRescueScope(principal, APPLICATIONS_UPDATE, s)
+  );
 
   return { application: stateToProto(state) };
 }
@@ -186,17 +193,24 @@ export async function submitDraft(
     at: new Date().toISOString(),
   };
 
-  const state = await runCommand(deps, req.applicationId, command, principal.userId, s => ({
-    type: 'applications.submitted',
-    id: req.applicationId,
-    payload: {
-      applicationId: req.applicationId,
-      adopterId: s.adopterId,
-      petId: s.petId,
-      rescueId: s.rescueId,
-      submittedAt: s.submittedAt,
-    },
-  }));
+  const state = await runCommand(
+    deps,
+    req.applicationId,
+    command,
+    principal.userId,
+    s => ({
+      type: 'applications.submitted',
+      id: req.applicationId,
+      payload: {
+        applicationId: req.applicationId,
+        adopterId: s.adopterId,
+        petId: s.petId,
+        rescueId: s.rescueId,
+        submittedAt: s.submittedAt,
+      },
+    }),
+    s => requireOwnerOrRescueScope(principal, APPLICATIONS_UPDATE, s)
+  );
 
   return { application: stateToProto(state) };
 }

--- a/services/applications/src/grpc/review-handlers.test.ts
+++ b/services/applications/src/grpc/review-handlers.test.ts
@@ -254,6 +254,81 @@ describe('withdraw', () => {
   });
 });
 
+// The application stream is owned by rescue rsc-1 / adopter usr-1. A
+// principal that holds the permission but belongs to a DIFFERENT rescue
+// must not be able to drive another rescue's application lifecycle.
+describe('cross-rescue authorization', () => {
+  it('denies startReview from a staffer of another rescue', async () => {
+    const foreign = {
+      userId: 'staff-9',
+      roles: ['rescue_staff'],
+      permissions: [
+        'applications.review',
+        'applications.approve',
+        'applications.reject',
+        'applications.update',
+      ],
+      rescueId: 'rsc-2',
+    } as unknown as Parameters<typeof startReview>[1];
+    const { deps } = makeDeps(submittedStream());
+    await expect(startReview(deps, foreign, { applicationId: 'app-1' })).rejects.toMatchObject({
+      code: 'PERMISSION_DENIED',
+    });
+  });
+
+  it('denies approve / reject / markAdopted from a foreign rescue', async () => {
+    const foreign = {
+      userId: 'staff-9',
+      roles: ['rescue_staff'],
+      permissions: [
+        'applications.review',
+        'applications.approve',
+        'applications.reject',
+        'applications.update',
+      ],
+      rescueId: 'rsc-2',
+    } as unknown as Parameters<typeof approve>[1];
+
+    const a = makeDeps(decidableStream());
+    await expect(approve(a.deps, foreign, { applicationId: 'app-1' })).rejects.toMatchObject({
+      code: 'PERMISSION_DENIED',
+    });
+
+    const r = makeDeps(decidableStream());
+    await expect(
+      reject(r.deps, foreign, { applicationId: 'app-1', reason: 'no' })
+    ).rejects.toMatchObject({ code: 'PERMISSION_DENIED' });
+
+    const m = makeDeps([
+      ...decidableStream(),
+      ev('approved', 6, { actorUserId: 'staff-1', notes: null }),
+    ]);
+    await expect(markAdopted(m.deps, foreign, { applicationId: 'app-1' })).rejects.toMatchObject({
+      code: 'PERMISSION_DENIED',
+    });
+  });
+
+  it('lets the owning adopter withdraw but denies an unrelated user', async () => {
+    const owner = {
+      userId: 'usr-1',
+      roles: ['adopter'],
+      permissions: ['applications.update'],
+    } as unknown as Parameters<typeof withdraw>[1];
+    const ok = makeDeps(submittedStream());
+    await expect(withdraw(ok.deps, owner, { applicationId: 'app-1' })).resolves.toBeDefined();
+
+    const stranger = {
+      userId: 'usr-2',
+      roles: ['adopter'],
+      permissions: ['applications.update'],
+    } as unknown as Parameters<typeof withdraw>[1];
+    const no = makeDeps(submittedStream());
+    await expect(withdraw(no.deps, stranger, { applicationId: 'app-1' })).rejects.toMatchObject({
+      code: 'PERMISSION_DENIED',
+    });
+  });
+});
+
 describe('markAdopted', () => {
   it('throws PERMISSION_DENIED without applications.approve', async () => {
     const { deps } = makeDeps([

--- a/services/applications/src/grpc/review-handlers.ts
+++ b/services/applications/src/grpc/review-handlers.ts
@@ -52,7 +52,7 @@ import {
 import type { ApplicationCommand, HomeVisitOutcome } from '../domain/index.js';
 
 import { HandlerError, type HandlerDeps } from './adapter.js';
-import { runCommand } from './command-runner.js';
+import { requireOwnerOrRescueScope, requireRescueScope, runCommand } from './command-runner.js';
 import { homeVisitOutcomeToDb } from './enum-map.js';
 import { stateToProto } from './state-mapper.js';
 
@@ -86,11 +86,18 @@ export async function startReview(
     at: new Date().toISOString(),
   };
 
-  const state = await runCommand(deps, id, command, principal.userId, s => ({
-    type: 'applications.reviewStarted',
+  const state = await runCommand(
+    deps,
     id,
-    payload: { applicationId: id, reviewerId: principal.userId, rescueId: s.rescueId },
-  }));
+    command,
+    principal.userId,
+    s => ({
+      type: 'applications.reviewStarted',
+      id,
+      payload: { applicationId: id, reviewerId: principal.userId, rescueId: s.rescueId },
+    }),
+    s => requireRescueScope(principal, APPLICATIONS_PROCESS, s)
+  );
 
   return { application: stateToProto(state) };
 }
@@ -116,16 +123,23 @@ export async function scheduleHomeVisit(
     at: new Date().toISOString(),
   };
 
-  const state = await runCommand(deps, id, command, principal.userId, s => ({
-    type: 'applications.homeVisitScheduled',
+  const state = await runCommand(
+    deps,
     id,
-    payload: {
-      applicationId: id,
-      adopterId: s.adopterId,
-      rescueId: s.rescueId,
-      scheduledAt: req.scheduledAt,
-    },
-  }));
+    command,
+    principal.userId,
+    s => ({
+      type: 'applications.homeVisitScheduled',
+      id,
+      payload: {
+        applicationId: id,
+        adopterId: s.adopterId,
+        rescueId: s.rescueId,
+        scheduledAt: req.scheduledAt,
+      },
+    }),
+    s => requireRescueScope(principal, APPLICATIONS_PROCESS, s)
+  );
 
   return { application: stateToProto(state) };
 }
@@ -156,11 +170,18 @@ export async function completeHomeVisit(
     at: new Date().toISOString(),
   };
 
-  const state = await runCommand(deps, id, command, principal.userId, s => ({
-    type: 'applications.homeVisitCompleted',
+  const state = await runCommand(
+    deps,
     id,
-    payload: { applicationId: id, adopterId: s.adopterId, rescueId: s.rescueId, outcome },
-  }));
+    command,
+    principal.userId,
+    s => ({
+      type: 'applications.homeVisitCompleted',
+      id,
+      payload: { applicationId: id, adopterId: s.adopterId, rescueId: s.rescueId, outcome },
+    }),
+    s => requireRescueScope(principal, APPLICATIONS_PROCESS, s)
+  );
 
   return { application: stateToProto(state) };
 }
@@ -182,17 +203,24 @@ export async function approve(
     at: new Date().toISOString(),
   };
 
-  const state = await runCommand(deps, id, command, principal.userId, s => ({
-    type: 'applications.approved',
+  const state = await runCommand(
+    deps,
     id,
-    payload: {
-      applicationId: id,
-      adopterId: s.adopterId,
-      petId: s.petId,
-      rescueId: s.rescueId,
-      approvedBy: principal.userId,
-    },
-  }));
+    command,
+    principal.userId,
+    s => ({
+      type: 'applications.approved',
+      id,
+      payload: {
+        applicationId: id,
+        adopterId: s.adopterId,
+        petId: s.petId,
+        rescueId: s.rescueId,
+        approvedBy: principal.userId,
+      },
+    }),
+    s => requireRescueScope(principal, APPLICATIONS_APPROVE, s)
+  );
 
   return { application: stateToProto(state) };
 }
@@ -217,18 +245,25 @@ export async function reject(
     at: new Date().toISOString(),
   };
 
-  const state = await runCommand(deps, id, command, principal.userId, s => ({
-    type: 'applications.rejected',
+  const state = await runCommand(
+    deps,
     id,
-    payload: {
-      applicationId: id,
-      adopterId: s.adopterId,
-      petId: s.petId,
-      rescueId: s.rescueId,
-      rejectedBy: principal.userId,
-      reason: req.reason,
-    },
-  }));
+    command,
+    principal.userId,
+    s => ({
+      type: 'applications.rejected',
+      id,
+      payload: {
+        applicationId: id,
+        adopterId: s.adopterId,
+        petId: s.petId,
+        rescueId: s.rescueId,
+        rejectedBy: principal.userId,
+        reason: req.reason,
+      },
+    }),
+    s => requireRescueScope(principal, APPLICATIONS_REJECT, s)
+  );
 
   return { application: stateToProto(state) };
 }
@@ -241,9 +276,10 @@ export async function withdraw(
   req: WithdrawRequest
 ): Promise<WithdrawResponse> {
   // Adopter-or-staff. An adopter withdraws their own application; staff
-  // can withdraw on their behalf. The basic APPLICATIONS_UPDATE gate
-  // covers both; ownership is enforced by the domain only knowing the
-  // adopter (the gateway scopes adopter requests to their own id).
+  // can withdraw on their behalf. The base APPLICATIONS_UPDATE gate is the
+  // cheap upfront check; the runCommand authorize hook then enforces that
+  // the principal is the owning adopter OR scoped to the owning rescue
+  // (the loaded aggregate carries both).
   ensure(principal, APPLICATIONS_UPDATE);
   const id = requireApplicationId(req.applicationId);
 
@@ -254,16 +290,23 @@ export async function withdraw(
     at: new Date().toISOString(),
   };
 
-  const state = await runCommand(deps, id, command, principal.userId, s => ({
-    type: 'applications.withdrawn',
+  const state = await runCommand(
+    deps,
     id,
-    payload: {
-      applicationId: id,
-      adopterId: s.adopterId,
-      rescueId: s.rescueId,
-      withdrawnBy: principal.userId,
-    },
-  }));
+    command,
+    principal.userId,
+    s => ({
+      type: 'applications.withdrawn',
+      id,
+      payload: {
+        applicationId: id,
+        adopterId: s.adopterId,
+        rescueId: s.rescueId,
+        withdrawnBy: principal.userId,
+      },
+    }),
+    s => requireOwnerOrRescueScope(principal, APPLICATIONS_UPDATE, s)
+  );
 
   return { application: stateToProto(state) };
 }
@@ -283,11 +326,18 @@ export async function markAdopted(
     at: new Date().toISOString(),
   };
 
-  const state = await runCommand(deps, id, command, principal.userId, s => ({
-    type: 'applications.adopted',
+  const state = await runCommand(
+    deps,
     id,
-    payload: { applicationId: id, adopterId: s.adopterId, petId: s.petId, rescueId: s.rescueId },
-  }));
+    command,
+    principal.userId,
+    s => ({
+      type: 'applications.adopted',
+      id,
+      payload: { applicationId: id, adopterId: s.adopterId, petId: s.petId, rescueId: s.rescueId },
+    }),
+    s => requireRescueScope(principal, APPLICATIONS_APPROVE, s)
+  );
 
   return { application: stateToProto(state) };
 }

--- a/services/pets/src/grpc/handlers.test.ts
+++ b/services/pets/src/grpc/handlers.test.ts
@@ -257,6 +257,48 @@ describe('listPets', () => {
     expect(params).toContain('available');
     expect(params).toContain(RESCUE_ID);
   });
+
+  it('pins rescue staff to their own rescue, ignoring a foreign rescueIdFilter', async () => {
+    mocks.poolMock.query.mockResolvedValueOnce({ rows: [] });
+    // STAFF is scoped to rsc-1 but asks for rsc-2's pets.
+    await listPets(mocks.deps, STAFF, { limit: 0, rescueIdFilter: 'rsc-2' } as never);
+    const sql = mocks.poolMock.query.mock.calls[0][0] as string;
+    const params = mocks.poolMock.query.mock.calls[0][1] as unknown[];
+    expect(sql).toMatch(/rescue_id = \$1/);
+    // Scoped to their own rescue — the foreign filter is not honoured.
+    expect(params).toContain(RESCUE_ID);
+    expect(params).not.toContain('rsc-2');
+  });
+
+  it('scopes rescue staff to their own rescue even with no filter', async () => {
+    mocks.poolMock.query.mockResolvedValueOnce({ rows: [] });
+    await listPets(mocks.deps, STAFF, { limit: 0 } as never);
+    const sql = mocks.poolMock.query.mock.calls[0][0] as string;
+    const params = mocks.poolMock.query.mock.calls[0][1] as unknown[];
+    expect(sql).toMatch(/rescue_id = \$1/);
+    expect(params).toContain(RESCUE_ID);
+  });
+
+  it('lets a pets.read:any admin target any rescue', async () => {
+    const adminAny: Principal = {
+      userId: 'usr-admin' as UserId,
+      roles: ['admin'],
+      permissions: ['pets.read' as Permission, 'pets.read:any' as Permission],
+      rescueId: RESCUE_ID as RescueId,
+    };
+    mocks.poolMock.query.mockResolvedValueOnce({ rows: [] });
+    await listPets(mocks.deps, adminAny, { limit: 0, rescueIdFilter: 'rsc-2' } as never);
+    const params = mocks.poolMock.query.mock.calls[0][1] as unknown[];
+    expect(params).toContain('rsc-2');
+  });
+
+  it('lets an adopter browse the catalogue across rescues (no rescue filter)', async () => {
+    mocks.poolMock.query.mockResolvedValueOnce({ rows: [] });
+    await listPets(mocks.deps, ADOPTER, { limit: 0 } as never);
+    const sql = mocks.poolMock.query.mock.calls[0][0] as string;
+    // No rescue_id predicate is forced on a public browse.
+    expect(sql).not.toMatch(/rescue_id =/);
+  });
 });
 
 // --- updatePet -------------------------------------------------------

--- a/services/pets/src/grpc/handlers.ts
+++ b/services/pets/src/grpc/handlers.ts
@@ -314,6 +314,18 @@ export async function listPets(
     throw new HandlerError('PERMISSION_DENIED', `'${PETS_READ}' required`);
   }
 
+  // Resolve rescue scope, mirroring getPetStats. Rescue-bound staff are
+  // pinned to their own rescue and CANNOT read another rescue's pets by
+  // passing rescueIdFilter. pets.read:any (admin) may target any rescue or
+  // all. Public / adopter callers (no rescueId, no :any) browse the
+  // catalogue and may optionally narrow to a single rescue.
+  let rescueScope: string | undefined;
+  if (!hasPermission(principal, PETS_READ_ANY) && principal.rescueId) {
+    rescueScope = principal.rescueId;
+  } else {
+    rescueScope = req.rescueIdFilter ? req.rescueIdFilter : undefined;
+  }
+
   const limit = clampLimit(req.limit);
   const cursor = req.cursor ? parseCursor(req.cursor) : undefined;
 
@@ -339,9 +351,9 @@ export async function listPets(
     params.push(sizeToDb(req.sizeFilter));
     n++;
   }
-  if (req.rescueIdFilter) {
+  if (rescueScope) {
     where.push(`rescue_id = $${n}`);
-    params.push(req.rescueIdFilter);
+    params.push(rescueScope);
     n++;
   }
   if (cursor) {


### PR DESCRIPTION
## Summary

A fresh code-quality/security pass over the **least-reviewed services** (`applications`, `pets`, `cms`, `audit`) surfaced two **high-severity cross-tenant authorization holes** where a write/read handler checked a bare permission but never scoped to the target's owning rescue/user. Both are fixed here by mirroring the *already-correct* scoping patterns elsewhere in the same files.

`audit` and `cms` came back essentially clean (see "Reported, not changed" below for the remaining policy-dependent items).

## 1. `applications` — write path had no tenant/owner scope (HIGH)

The read path (`getApplication`, `listApplications`, `listDocuments`) correctly scopes via `requirePermission(principal, perm, { rescueId | userId })`. The **write path did not** — it gated on a bare permission, so:

- Any rescue staffer with `APPLICATIONS_PROCESS`/`APPROVE`/`REJECT` could drive **another rescue's** application lifecycle (start review, schedule/complete home visit, approve, reject, mark adopted) by passing its `applicationId`.
- Any adopter with `APPLICATIONS_UPDATE` could **edit/submit/withdraw another user's** application.
- `addDocument`/`removeDocument` attached or soft-deleted document metadata on **any** application — and `addDocument` never even verified the application existed (a comment claimed "the gateway scopes adopter requests to their own id"; it does not).

**Fix:** added a post-load `authorize` hook to `runCommand` (runs once the aggregate's owning rescue/adopter are known, before the write) and scoped every write to the owning rescue (review/decision) or owner-or-rescue (draft edits, withdraw). The document handlers now load the owner row first, 404 if absent, then apply the same owner-or-rescue scope as `listDocuments`. Missing aggregates still surface as `NOT_FOUND` (no existence leak beyond what the read side already does).

## 2. `pets` — `listPets` cross-rescue read leak (HIGH)

`listPets` applied `req.rescueIdFilter` verbatim behind a bare `pets.read` check, so a rescue staffer scoped to one rescue could list **another rescue's entire inventory** (including non-available / medical-hold / internal-note pets). `getPetStats` in the same file already resolves scope correctly.

**Fix:** mirror `getPetStats` — rescue-bound staff (lacking `pets.read:any`) are pinned to their own rescue; `pets.read:any` admins may target any rescue; public/adopter browse (no `rescueId`) may still optionally narrow to one rescue.

## Tests

TDD throughout — added cross-tenant denial tests alongside the existing happy-path ones:
- applications: `231 passed` (new wrong-rescue / wrong-adopter denial cases for review, draft, and document handlers)
- pets: `123 passed` (staff pinned to own rescue, admin may target any, adopter browses across rescues)
- type-check + lint green for both.

## Reported, not changed (policy-dependent — want a decision before touching)

These are real exposure concerns but changing them could alter intended UI/product behaviour, so they are **not** in this PR:

- **pets**: default `listPets`/`getPet` return pets in **every** status (adopted/deceased/medical-hold/archived) to the public browse path, and `medical_notes`/`behavioral_notes` are surfaced to non-staff readers (no field-mask on the pets read route).
- **cms**: public content responses ship the full `versions` edit-history blob plus `author_id`/`last_modified_by` to anonymous visitors.
- **audit**: redaction is key-name-based, so PII-by-content under generic keys (e.g. `note`, `value`) isn't caught; producer-supplied `actorUserId`/`occurredAt`/`event_id` are trusted verbatim (architectural trust-boundary, mitigated by server-stamped `recorded_at`); `getByTarget` sort isn't index-backed.

Happy to follow up on any of these in a separate PR.

https://claude.ai/code/session_014EbfJyKja1PmRfjcZWokaH

---
_Generated by [Claude Code](https://claude.ai/code/session_014EbfJyKja1PmRfjcZWokaH)_