### PR TITLE
fix(services): harden public reads (pets/cms) and audit PII redaction + index

### DIFF
--- a/packages/events/src/redact-audit-payload.test.ts
+++ b/packages/events/src/redact-audit-payload.test.ts
@@ -73,15 +73,52 @@ describe('redactAuditPayload', () => {
   it('preserves non-sensitive keys alongside sensitive ones', () => {
     const result = redactAuditPayload({
       userId: 'u-1',
-      email: 'x@example.com',
-      password: 'secret!',
       action: 'login',
+      password: 'secret!',
     }) as Record<string, unknown>;
 
     expect(result['userId']).toBe('u-1');
-    expect(result['email']).toBe('x@example.com');
     expect(result['action']).toBe('login');
     expect(result['password']).toBe('[REDACTED]');
+  });
+
+  // --- PII deny-list coverage ---
+
+  it.each([
+    ['email', 'x@example.com'],
+    ['userEmail', 'x@example.com'],
+    ['emailAddress', 'x@example.com'],
+    ['phone', '07700900000'],
+    ['phoneNumber', '07700900000'],
+    ['address', '1 High St'],
+    ['homeAddress', '1 High St'],
+    ['postcode', 'SW1A 1AA'],
+    ['postalCode', '90210'],
+    ['nationalInsurance', 'QQ123456C'],
+    ['passport', '123456789'],
+    ['dateOfBirth', '1990-01-01'],
+    ['creditCard', '4111111111111111'],
+    ['cardNumber', '4111111111111111'],
+    ['sortCode', '00-00-00'],
+    ['bankAccount', '12345678'],
+    ['iban', 'GB33BUKB20201555555555'],
+    ['ssn', '123-45-6789'],
+  ])('redacts PII key "%s"', (key, value) => {
+    const result = redactAuditPayload({ [key]: value }) as Record<string, unknown>;
+    expect(result[key]).toBe('[REDACTED]');
+  });
+
+  it('redacts PII nested inside objects and arrays', () => {
+    const result = redactAuditPayload({
+      applicant: { name: 'alice', email: 'a@e.com', phone: '07700900000' },
+      references: [{ name: 'bob', email: 'b@e.com' }],
+    }) as { applicant: Record<string, unknown>; references: Array<Record<string, unknown>> };
+
+    expect(result.applicant['name']).toBe('alice');
+    expect(result.applicant['email']).toBe('[REDACTED]');
+    expect(result.applicant['phone']).toBe('[REDACTED]');
+    expect(result.references[0]['email']).toBe('[REDACTED]');
+    expect(result.references[0]['name']).toBe('bob');
   });
 
   // --- recursive nesting ---
@@ -185,7 +222,7 @@ describe('redactAuditPayload', () => {
 
     expect(result.source).toBe('web');
     expect(result.ip).toBe('1.2.3.4');
-    expect(result.loginAttempt['email']).toBe('user@example.com');
+    expect(result.loginAttempt['email']).toBe('[REDACTED]');
     expect(result.loginAttempt['password']).toBe('[REDACTED]');
     expect(result.loginAttempt['otp']).toBe('[REDACTED]');
     expect((result.loginAttempt['deviceInfo'] as Record<string, unknown>)['browser']).toBe(

--- a/packages/events/src/redact-audit-payload.ts
+++ b/packages/events/src/redact-audit-payload.ts
@@ -16,9 +16,18 @@
 //   - null / undefined / primitives pass through unchanged.
 //   - Arrays are walked element-by-element.
 //
-// Covered keys (must cover at least the keys listed in ADS-772):
-//   password, token, accessToken, refreshToken, otp, secret,
-//   authorization, cookie, apiKey
+// Covered keys fall into two families:
+//
+//   Secrets (credential-shaped):
+//     password, token, accessToken, refreshToken, otp, secret,
+//     authorization, cookie, apiKey
+//
+//   PII (personal data — redacted because `payload` is durable, admin-
+//   readable storage and the actor's own email is already captured in the
+//   `actor_email_snapshot` column, so it never needs to live in the blob):
+//     email, phone, address, postcode/postalCode, ssn, nationalInsurance,
+//     passport, dateOfBirth, creditCard/cardNumber, sortCode, bankAccount,
+//     iban
 //
 // The `token` substring covers accessToken and refreshToken, but they are
 // also listed explicitly for clarity. `apiKey` / `api_key` / `api-key`
@@ -32,6 +41,13 @@ const REDACTED = '[REDACTED]';
 // without needing an exhaustive list.
 const SECRET_KEY_PATTERN = /password|token|secret|otp|authorization|cookie|api[_\-]?key/i;
 
+// Known PII key names. Substring matching, so `emailAddress`, `userPhone`,
+// `homeAddress`, `dateOfBirth` all match. Kept to high-confidence PII keys
+// (multi-character, unlikely to false-match a forensic field) so the audit
+// trail keeps its "who did what" value while shedding personal data.
+const PII_KEY_PATTERN =
+  /email|phone|address|postcode|postalcode|nationalinsurance|passport|dateofbirth|creditcard|cardnumber|sortcode|bankaccount|iban|ssn/i;
+
 const redactValue = (value: unknown): unknown => {
   if (value === null || value === undefined) {
     return value;
@@ -41,7 +57,7 @@ const redactValue = (value: unknown): unknown => {
   }
   if (typeof value === 'object') {
     const entries = Object.entries(value as Record<string, unknown>).map(([k, v]) => {
-      if (SECRET_KEY_PATTERN.test(k)) {
+      if (SECRET_KEY_PATTERN.test(k) || PII_KEY_PATTERN.test(k)) {
         return [k, REDACTED] as const;
       }
       return [k, redactValue(v)] as const;

--- a/services/audit/src/migrations/006_add_aggregate_keyset_index.ts
+++ b/services/audit/src/migrations/006_add_aggregate_keyset_index.ts
@@ -1,0 +1,19 @@
+import type { MigrationBuilder } from 'node-pg-migrate';
+
+// getByTarget filters on (aggregate_type, aggregate_id) and paginates with a
+// keyset cursor ordered by (occurred_at DESC, event_id DESC). The existing
+// audit_events_aggregate_idx covers only the filter, so for a hot aggregate
+// Postgres filters then sorts every page. This composite index covers both
+// the equality filter AND the keyset order, so the cursor predicate is served
+// straight from the index with no per-page sort.
+
+export const up = async (pgm: MigrationBuilder): Promise<void> => {
+  pgm.sql(`
+    CREATE INDEX audit_events_aggregate_keyset_idx
+    ON audit_events (aggregate_type, aggregate_id, occurred_at DESC, event_id DESC)
+  `);
+};
+
+export const down = async (pgm: MigrationBuilder): Promise<void> => {
+  pgm.sql('DROP INDEX IF EXISTS audit_events_aggregate_keyset_idx');
+};

--- a/services/audit/src/migrations/migrations.test.ts
+++ b/services/audit/src/migrations/migrations.test.ts
@@ -42,6 +42,7 @@ describe('audit migrations', () => {
     '001_create_audit_events.ts',
     '004_add_gdpr_failed_at.ts',
     '005_add_gdpr_saga_deadline.ts',
+    '006_add_aggregate_keyset_index.ts',
   ])('%s exports `up` and `down` functions', async filename => {
     const mod = (await import(`./${filename}`)) as {
       up: unknown;

--- a/services/cms/src/grpc/handlers.test.ts
+++ b/services/cms/src/grpc/handlers.test.ts
@@ -178,6 +178,60 @@ describe('public reads', () => {
     expect(res.content?.slug).toBe('hello');
   });
 
+  it('getPublicContentBySlug: strips edit history, author IDs and scheduling', async () => {
+    mocks.poolScript.push({
+      rows: [
+        contentRow({
+          status: 'published',
+          versions: [
+            {
+              version: 1,
+              title: 'old',
+              content: 'x',
+              changedBy: 'usr-admin',
+              createdAt: '2026-06-01T00:00:00Z',
+            },
+          ],
+          author_id: 'usr-admin',
+          last_modified_by: 'usr-editor',
+          scheduled_publish_at: new Date('2026-07-01T00:00:00Z'),
+          scheduled_unpublish_at: new Date('2026-08-01T00:00:00Z'),
+        }),
+      ],
+    });
+    const res = await getPublicContentBySlug(mocks.deps, null, { slug: 'hello' });
+    expect(res.content?.versionsJson).toBe('[]');
+    expect(res.content?.authorId).toBe('');
+    expect(res.content?.lastModifiedBy).toBeUndefined();
+    expect(res.content?.scheduledPublishAt).toBeUndefined();
+    expect(res.content?.scheduledUnpublishAt).toBeUndefined();
+  });
+
+  it('listPublicContent: strips edit history and author IDs from each item', async () => {
+    mocks.poolScript.push({ rows: [{ count: '1' }] });
+    mocks.poolScript.push({
+      rows: [
+        contentRow({
+          status: 'published',
+          versions: [
+            {
+              version: 1,
+              title: 't',
+              content: 'c',
+              changedBy: 'usr-admin',
+              createdAt: '2026-06-01T00:00:00Z',
+            },
+          ],
+          last_modified_by: 'usr-editor',
+        }),
+      ],
+    });
+    const res = await listPublicContent(mocks.deps, null, { contentType: 0, page: 1, limit: 10 });
+    expect(res.items[0].versionsJson).toBe('[]');
+    expect(res.items[0].authorId).toBe('');
+    expect(res.items[0].lastModifiedBy).toBeUndefined();
+  });
+
   it('getPublicContentBySlug: rejects empty slug with INVALID_ARGUMENT', async () => {
     await expect(getPublicContentBySlug(mocks.deps, null, { slug: '' })).rejects.toMatchObject({
       code: 'INVALID_ARGUMENT',

--- a/services/cms/src/grpc/handlers.ts
+++ b/services/cms/src/grpc/handlers.ts
@@ -229,6 +229,21 @@ function rowToContent(row: ContentRow): CmsContentProto {
   };
 }
 
+// Public projection of a content row. Anonymous visitors only need the
+// published content itself, so we drop the full edit history (versions),
+// the internal author / last-editor IDs, and the scheduling timestamps that
+// would otherwise leak when/how the page is managed.
+function rowToPublicContent(row: ContentRow): CmsContentProto {
+  return {
+    ...rowToContent(row),
+    versionsJson: '[]',
+    authorId: '',
+    lastModifiedBy: undefined,
+    scheduledPublishAt: undefined,
+    scheduledUnpublishAt: undefined,
+  };
+}
+
 function rowToMenu(row: MenuRow): CmsMenuProto {
   return {
     menuId: row.menu_id,
@@ -295,7 +310,7 @@ export async function listPublicContent(
     [...params, limit, offset]
   );
   return {
-    items: result.rows.map(rowToContent),
+    items: result.rows.map(rowToPublicContent),
     total,
     page,
     totalPages: Math.max(1, Math.ceil(total / limit)),
@@ -320,7 +335,7 @@ export async function getPublicContentBySlug(
   if (!row) {
     throw new HandlerError('NOT_FOUND', `content "${slug}" not found`);
   }
-  return { content: rowToContent(row) };
+  return { content: rowToPublicContent(row) };
 }
 
 // --- Admin content reads --------------------------------------------

--- a/services/pets/src/grpc/handlers.test.ts
+++ b/services/pets/src/grpc/handlers.test.ts
@@ -208,6 +208,54 @@ describe('getPet', () => {
       code: 'NOT_FOUND',
     });
   });
+
+  it('strips internal notes for a non-staff reader', async () => {
+    mocks.poolMock.query.mockResolvedValueOnce({
+      rows: [petRow({ medical_notes: 'allergic to chicken', behavioral_notes: 'shy' })],
+    });
+    const res = await getPet(mocks.deps, ADOPTER, { petId: 'pet-1' });
+    const extra = JSON.parse(res.pet.extraJson) as Record<string, unknown>;
+    expect(extra.medicalNotes).toBeUndefined();
+    expect(extra.behavioralNotes).toBeUndefined();
+  });
+
+  it('keeps internal notes for rescue staff of the pet rescue', async () => {
+    mocks.poolMock.query.mockResolvedValueOnce({
+      rows: [petRow({ medical_notes: 'allergic to chicken', behavioral_notes: 'shy' })],
+    });
+    const res = await getPet(mocks.deps, STAFF, { petId: 'pet-1' });
+    const extra = JSON.parse(res.pet.extraJson) as Record<string, unknown>;
+    expect(extra.medicalNotes).toBe('allergic to chicken');
+    expect(extra.behavioralNotes).toBe('shy');
+  });
+
+  it('NOT_FOUND for a non-staff reader on a terminal-status pet', async () => {
+    mocks.poolMock.query.mockResolvedValueOnce({ rows: [petRow({ status: 'adopted' })] });
+    await expect(getPet(mocks.deps, ADOPTER, { petId: 'pet-1' })).rejects.toMatchObject({
+      code: 'NOT_FOUND',
+    });
+  });
+
+  it('NOT_FOUND for a non-staff reader on an archived pet', async () => {
+    mocks.poolMock.query.mockResolvedValueOnce({ rows: [petRow({ archived: true })] });
+    await expect(getPet(mocks.deps, ADOPTER, { petId: 'pet-1' })).rejects.toMatchObject({
+      code: 'NOT_FOUND',
+    });
+  });
+
+  it('lets rescue staff of the pet rescue view a terminal-status pet', async () => {
+    mocks.poolMock.query.mockResolvedValueOnce({ rows: [petRow({ status: 'adopted' })] });
+    const res = await getPet(mocks.deps, STAFF, { petId: 'pet-1' });
+    expect(res.pet.status).toBe(PetsV1.PetStatus.PET_STATUS_ADOPTED);
+  });
+
+  it('hides another rescue staff’s terminal pet (treats them as non-privileged)', async () => {
+    mocks.poolMock.query.mockResolvedValueOnce({ rows: [petRow({ status: 'adopted' })] });
+    // OTHER_STAFF is scoped to rsc-2; the pet belongs to rsc-1.
+    await expect(getPet(mocks.deps, OTHER_STAFF, { petId: 'pet-1' })).rejects.toMatchObject({
+      code: 'NOT_FOUND',
+    });
+  });
 });
 
 // --- listPets --------------------------------------------------------
@@ -298,6 +346,34 @@ describe('listPets', () => {
     const sql = mocks.poolMock.query.mock.calls[0][0] as string;
     // No rescue_id predicate is forced on a public browse.
     expect(sql).not.toMatch(/rescue_id =/);
+  });
+
+  it('hides terminal + archived pets from a public browse', async () => {
+    mocks.poolMock.query.mockResolvedValueOnce({ rows: [] });
+    await listPets(mocks.deps, ADOPTER, { limit: 0 } as never);
+    const sql = mocks.poolMock.query.mock.calls[0][0] as string;
+    const params = mocks.poolMock.query.mock.calls[0][1] as unknown[];
+    expect(sql).toMatch(/status NOT IN/);
+    expect(sql).toMatch(/archived = false/);
+    expect(params).toEqual(expect.arrayContaining(['adopted', 'deceased', 'not_available']));
+  });
+
+  it('does not hide statuses from rescue staff (own-rescue view)', async () => {
+    mocks.poolMock.query.mockResolvedValueOnce({ rows: [] });
+    await listPets(mocks.deps, STAFF, { limit: 0 } as never);
+    const sql = mocks.poolMock.query.mock.calls[0][0] as string;
+    expect(sql).not.toMatch(/status NOT IN/);
+    expect(sql).not.toMatch(/archived = false/);
+  });
+
+  it('strips internal notes from public browse results', async () => {
+    mocks.poolMock.query.mockResolvedValueOnce({
+      rows: [petRow({ medical_notes: 'sensitive', behavioral_notes: 'sensitive' })],
+    });
+    const res = await listPets(mocks.deps, ADOPTER, { limit: 2 } as never);
+    const extra = JSON.parse(res.pets[0].extraJson) as Record<string, unknown>;
+    expect(extra.medicalNotes).toBeUndefined();
+    expect(extra.behavioralNotes).toBeUndefined();
   });
 });
 

--- a/services/pets/src/grpc/handlers.ts
+++ b/services/pets/src/grpc/handlers.ts
@@ -131,15 +131,18 @@ type PetRow = {
   version: number;
 };
 
-function rowToProto(row: PetRow): Pet {
+function rowToProto(row: PetRow, includeInternalNotes = true): Pet {
   const extra = {
     color: row.color,
     goodWithChildren: row.good_with_children,
     goodWithDogs: row.good_with_dogs,
     goodWithCats: row.good_with_cats,
     goodWithSmallAnimals: row.good_with_small_animals,
-    medicalNotes: row.medical_notes,
-    behavioralNotes: row.behavioral_notes,
+    // Internal staff-only fields — omitted for public / adopter readers so
+    // a rescue's medical / behavioural notes never reach the browse path.
+    ...(includeInternalNotes
+      ? { medicalNotes: row.medical_notes, behavioralNotes: row.behavioral_notes }
+      : {}),
   };
   return {
     petId: row.pet_id,
@@ -192,6 +195,20 @@ const PETS_CREATE: Permission = 'pets.create' as Permission;
 const PETS_READ: Permission = 'pets.read' as Permission;
 const PETS_UPDATE: Permission = 'pets.update' as Permission;
 const PETS_DELETE: Permission = 'pets.delete' as Permission;
+
+// Statuses a pet can hold that a public / adopter browse must NOT surface.
+// Terminal or off-market states — archived pets are hidden separately.
+const PUBLIC_HIDDEN_STATUSES = ['adopted', 'deceased', 'not_available'];
+
+// A reader is "privileged" for a pet when they may see its internal notes
+// and non-public statuses: platform admins (pets.read:any) and rescue staff
+// viewing their OWN rescue's pet. Everyone else gets the public projection.
+function isPrivilegedReader(principal: Principal, rescueId: string | null): boolean {
+  if (hasPermission(principal, PETS_READ_ANY)) {
+    return true;
+  }
+  return rescueId !== null && principal.rescueId === rescueId;
+}
 
 // --- Create ----------------------------------------------------------
 
@@ -295,7 +312,15 @@ export async function getPet(
   if (!row) {
     throw new HandlerError('NOT_FOUND', `pet ${req.petId} not found`);
   }
-  return { pet: rowToProto(row) };
+
+  // Non-privileged readers (public / adopter, or staff of another rescue)
+  // can't see a pet in a hidden status or one that's archived — treat it as
+  // not found rather than leaking its existence, and strip internal notes.
+  const privileged = isPrivilegedReader(principal, row.rescue_id);
+  if (!privileged && (PUBLIC_HIDDEN_STATUSES.includes(row.status) || row.archived)) {
+    throw new HandlerError('NOT_FOUND', `pet ${req.petId} not found`);
+  }
+  return { pet: rowToProto(row, privileged) };
 }
 
 // --- List ------------------------------------------------------------
@@ -325,6 +350,11 @@ export async function listPets(
   } else {
     rescueScope = req.rescueIdFilter ? req.rescueIdFilter : undefined;
   }
+
+  // Privileged readers (admins / rescue staff, pinned above to their own
+  // rescue) see every status; public / adopter browse hides terminal and
+  // archived pets and never receives internal notes.
+  const privileged = hasPermission(principal, PETS_READ_ANY) || principal.rescueId !== undefined;
 
   const limit = clampLimit(req.limit);
   const cursor = req.cursor ? parseCursor(req.cursor) : undefined;
@@ -356,6 +386,12 @@ export async function listPets(
     params.push(rescueScope);
     n++;
   }
+  if (!privileged) {
+    const placeholders = PUBLIC_HIDDEN_STATUSES.map(() => `$${n++}`).join(', ');
+    where.push(`status NOT IN (${placeholders})`);
+    params.push(...PUBLIC_HIDDEN_STATUSES);
+    where.push('archived = false');
+  }
   if (cursor) {
     where.push(`(created_at, pet_id) < ($${n}, $${n + 1})`);
     params.push(new Date(cursor.createdAt));
@@ -381,7 +417,7 @@ export async function listPets(
       ? encodeCursor({ createdAt: last.created_at.toISOString(), petId: last.pet_id })
       : undefined;
 
-  return { pets: page.map(rowToProto), nextCursor };
+  return { pets: page.map(row => rowToProto(row, privileged)), nextCursor };
 }
 
 // --- Update ----------------------------------------------------------


### PR DESCRIPTION
## Summary

Follow-up to #1060 — implements the four **policy-dependent** items that were reported-but-not-changed in the last review pass, with the product decisions you made:

| Area | Decision | Change |
|------|----------|--------|
| **pets** public reads | Hide terminal/archived only | Non-staff `listPets`/`getPet` exclude adopted/deceased/not_available + archived |
| **pets** internal notes | Strip for non-staff | `medical_notes`/`behavioral_notes` omitted for non-privileged readers |
| **cms** public payload | Trim public projection | `versions`, author/editor IDs, scheduling stripped from unauth reads |
| **audit** | Both | composite keyset index + PII redaction |

All changes mirror existing correct patterns (the `getPetStats`/admin-projection scoping) and are gated so **rescue staff (own rescue) and admins are unaffected**.

## 1. `pets` — public read hardening
- **Status visibility:** non-privileged readers (no `pets.read:any`, and not staff of the pet's rescue) get a catalogue that excludes terminal (`adopted`/`deceased`/`not_available`) and archived pets. `getPet` returns `NOT_FOUND` for a hidden pet rather than leaking it. Pending + medical/behavioural holds remain visible per your choice.
- **Internal notes:** `medical_notes`/`behavioral_notes` are stripped from the proto for non-privileged readers (fixed at the source so the gateway can't leak them).
- Rescue staff (pinned to their own rescue by #1060) and `pets.read:any` admins see everything, unchanged.

## 2. `cms` — public projection
- New `rowToPublicContent` drops the `versions` edit-history blob (per-revision `changedBy` + prior bodies), `author_id`/`last_modified_by`, and the scheduling timestamps for `getPublicContentBySlug` + `listPublicContent`. Admin reads keep the full payload.

## 3. `audit` — index + PII redaction
- **Index (migration 006):** `audit_events_aggregate_keyset_idx (aggregate_type, aggregate_id, occurred_at DESC, event_id DESC)` so `getByTarget`'s keyset pagination is index-served instead of filter-then-sort per page. Pure performance, no behaviour change.
- **PII redaction:** `redactAuditPayload` now also redacts known PII key names (email, phone, address, postcode, nationalInsurance, passport, dateOfBirth, card/bank fields, iban, ssn) on top of the existing credential deny-list. The actor's email is still kept in the dedicated `actor_email_snapshot` column, so the trail keeps its "who did what" value while shedding personal data from the durable blob.
  - **Interpretation note:** I implemented this as **key-name** redaction (extending the deny-list), not value-content scanning of every string, to avoid over-redacting legitimate forensic content. This updates two existing tests that asserted `email` was preserved. If you'd prefer value-content scanning (regex every string for email/phone patterns) instead/as well, say the word.

## Tests
TDD throughout, all green locally:
- pets `132`, cms `64`, audit `146`, events redaction suite — all passing; type-check + lint clean for each.

https://claude.ai/code/session_014EbfJyKja1PmRfjcZWokaH

---
_Generated by [Claude Code](https://claude.ai/code/session_014EbfJyKja1PmRfjcZWokaH)_