### PR TITLE
fix(services): reporter-safe moderation reads, foster pet-ownership, chat/gateway hardening

### DIFF
--- a/services/chat/src/grpc/handlers.test.ts
+++ b/services/chat/src/grpc/handlers.test.ts
@@ -856,6 +856,8 @@ describe('deleteMessage', () => {
     mocks.poolMock.query.mockResolvedValueOnce({
       rows: [messageRowFixture({ sender_id: 'usr-adopter' })],
     });
+    // ensureChatWritable → active chat
+    mocks.poolMock.query.mockResolvedValueOnce({ rows: [{ status: 'active', deleted_at: null }] });
     // Inside withTransaction: UPDATE returning, SELECT participants
     mocks.clientScript.push({ rows: [messageRowFixture({ deleted_at: new Date() })] });
     mocks.clientScript.push({
@@ -865,6 +867,41 @@ describe('deleteMessage', () => {
     mocks.poolMock.query.mockResolvedValueOnce({ rows: [] });
 
     const res = await deleteMessage(mocks.deps, ADOPTER_PRINCIPAL, { messageId: 'msg-1' });
+    expect(res.message?.deletedAt).toBeDefined();
+    expect(mocks.natsMock.publish.mock.calls[0][0]).toBe('chat.messageDeleted');
+  });
+
+  it('rejects a sender deleting their message in a closed (archived) chat', async () => {
+    mocks.poolMock.query.mockResolvedValueOnce({
+      rows: [messageRowFixture({ sender_id: 'usr-adopter' })],
+    });
+    // ensureChatWritable → archived chat
+    mocks.poolMock.query.mockResolvedValueOnce({
+      rows: [{ status: 'archived', deleted_at: null }],
+    });
+
+    await expect(
+      deleteMessage(mocks.deps, ADOPTER_PRINCIPAL, { messageId: 'msg-1' })
+    ).rejects.toMatchObject({ code: 'FAILED_PRECONDITION' });
+    expect(mocks.natsMock.publish).not.toHaveBeenCalled();
+  });
+
+  it('lets a delete:any moderator delete a message in a closed chat', async () => {
+    const moderator: Principal = {
+      userId: 'usr-mod' as UserId,
+      roles: ['moderator'],
+      permissions: ['chat.message.delete:any' as Permission],
+    };
+    // existing row → owned by someone else, not yet deleted
+    mocks.poolMock.query.mockResolvedValueOnce({
+      rows: [messageRowFixture({ sender_id: 'usr-adopter' })],
+    });
+    // No ensureChatWritable lookup happens for delete:any — straight to tx.
+    mocks.clientScript.push({ rows: [messageRowFixture({ deleted_at: new Date() })] });
+    mocks.clientScript.push({ rows: [{ participant_id: 'usr-adopter' }] });
+    mocks.poolMock.query.mockResolvedValueOnce({ rows: [] }); // reactions
+
+    const res = await deleteMessage(mocks.deps, moderator, { messageId: 'msg-1' });
     expect(res.message?.deletedAt).toBeDefined();
     expect(mocks.natsMock.publish.mock.calls[0][0]).toBe('chat.messageDeleted');
   });

--- a/services/chat/src/grpc/handlers.ts
+++ b/services/chat/src/grpc/handlers.ts
@@ -977,6 +977,14 @@ export async function deleteMessage(
     };
   }
 
+  // A plain sender can only delete within a writable (active) chat — a
+  // closed / locked / archived chat is immutable. Moderators with
+  // delete:any bypass this so they can still remove content from a
+  // closed chat.
+  if (!hasPermission(principal, CHAT_MESSAGE_DELETE_ANY)) {
+    await ensureChatWritable(deps, row.chat_id);
+  }
+
   let updated: MessageRow | undefined;
   await withTransaction(deps, async ({ client, publish }) => {
     const result = await client.query<MessageRow>(

--- a/services/gateway/src/routes/moderation-admin.test.ts
+++ b/services/gateway/src/routes/moderation-admin.test.ts
@@ -210,6 +210,20 @@ describe('moderation admin reports', () => {
     expect(res.statusCode).toBe(400);
   });
 
+  it('bulk-update with too many ids → 400', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/v1/admin/moderation/reports/bulk-update',
+      headers: ADMIN,
+      payload: {
+        reportIds: Array.from({ length: 101 }, (_, i) => `rpt-${i}`),
+        action: 'resolve',
+      },
+    });
+    expect(res.statusCode).toBe(400);
+    expect(res.json()).toMatchObject({ error: expect.stringContaining('maximum') });
+  });
+
   it('maps PERMISSION_DENIED → 403', async () => {
     mocks.listReports.mockRejectedValueOnce({
       code: grpcStatus.PERMISSION_DENIED,

--- a/services/gateway/src/routes/moderation-admin.ts
+++ b/services/gateway/src/routes/moderation-admin.ts
@@ -46,6 +46,10 @@ export type ModerationAdminRoutesOptions = {
 const RL_WRITE = { max: 30, timeWindow: '1 minute' } as const;
 const RL_READ = { max: 120, timeWindow: '1 minute' } as const;
 
+// Upper bound on a single bulk-update batch — each id is one sequential gRPC
+// call, so the array can't be unbounded.
+const MAX_BULK_REPORT_IDS = 100;
+
 export const registerModerationAdminRoutes = async (
   app: FastifyInstance,
   opts: ModerationAdminRoutesOptions
@@ -245,6 +249,13 @@ export const registerModerationAdminRoutes = async (
       const ids = Array.isArray(b.reportIds) ? b.reportIds : [];
       if (ids.length === 0) {
         return reply.code(400).send({ error: 'reportIds is required' });
+      }
+      // Bound the batch — each id is a sequential gRPC round trip, so an
+      // unbounded array would tie up a worker.
+      if (ids.length > MAX_BULK_REPORT_IDS) {
+        return reply
+          .code(400)
+          .send({ error: `reportIds exceeds the maximum of ${MAX_BULK_REPORT_IDS}` });
       }
       const meta = buildMetadata(req);
       const reports: ReturnType<typeof reportToView>[] = [];

--- a/services/gateway/src/routes/uploads.test.ts
+++ b/services/gateway/src/routes/uploads.test.ts
@@ -94,6 +94,22 @@ describe('POST /api/v1/uploads/images', () => {
     expect(res.json()).toMatchObject({ error: expect.stringContaining('image/svg+xml') });
   });
 
+  it('rejects a disallowed extension even when the MIME is allowed', async () => {
+    const boundary = 'b2e';
+    // A lying Content-Type (image/png) carrying an executable extension.
+    const body = multipartBody(boundary, Buffer.from('MZ'), 'payload.exe', 'image/png');
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/v1/uploads/images',
+      headers: { 'content-type': `multipart/form-data; boundary=${boundary}` },
+      payload: body,
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(res.json()).toMatchObject({ error: expect.stringContaining('.exe') });
+  });
+
   it('returns 400 when no file part is present', async () => {
     const boundary = 'b3';
     const body = Buffer.from(`--${boundary}--\r\n`, 'utf8');

--- a/services/gateway/src/routes/uploads.ts
+++ b/services/gateway/src/routes/uploads.ts
@@ -43,6 +43,11 @@ export type UploadsRoutesOptions = {
 // bypass have shipped before).
 const ALLOWED_IMAGE_MIME = new Set(['image/jpeg', 'image/png', 'image/gif', 'image/webp']);
 
+// Extension allowlist — second check so a lying Content-Type can't smuggle a
+// disallowed file past the MIME check alone (mirrors the document upload
+// route's defence-in-depth).
+const ALLOWED_IMAGE_EXTENSIONS = new Set(['.jpg', '.jpeg', '.png', '.gif', '.webp']);
+
 // MIME → extension lookup for streamed responses. Matches the monolith's
 // streamFile table.
 const MIME_BY_EXT: Record<string, string> = {
@@ -113,6 +118,11 @@ export const registerUploadsRoutes = async (
 
       if (!ALLOWED_IMAGE_MIME.has(mimetype)) {
         return reply.code(400).send({ error: `File type ${mimetype} is not allowed` });
+      }
+
+      const ext = path.extname(originalName).toLowerCase();
+      if (!ALLOWED_IMAGE_EXTENSIONS.has(ext)) {
+        return reply.code(400).send({ error: `File extension ${ext || '(none)'} is not allowed` });
       }
 
       let upload;

--- a/services/moderation/src/grpc/handlers.test.ts
+++ b/services/moderation/src/grpc/handlers.test.ts
@@ -214,6 +214,90 @@ describe('getReport', () => {
     expect(res.report.reportId).toBe('rpt-1');
   });
 
+  it('strips internal moderation fields from the reporter self-read', async () => {
+    const { deps } = makeDeps([
+      {
+        rows: [
+          reportRow({
+            reporter_id: 'usr-1',
+            assigned_moderator: 'mod-7',
+            assigned_at: new Date('2026-06-02T00:00:00.000Z'),
+            resolved_by: 'mod-7',
+            resolved_at: new Date('2026-06-03T00:00:00.000Z'),
+            resolution: 'action_taken',
+            resolution_notes: 'user suspended — internal',
+            escalated_to: 'mod-8',
+            escalated_at: new Date('2026-06-02T12:00:00.000Z'),
+            escalation_reason: 'needs senior review',
+          }),
+        ],
+      },
+    ]);
+    const res = await getReport(deps, makePrincipal({ userId: 'usr-1', permissions: [] }), {
+      reportId: 'rpt-1',
+    } as GetReportRequest);
+    // Internal workflow is hidden…
+    expect(res.report.assignedModerator).toBeUndefined();
+    expect(res.report.assignedAt).toBeUndefined();
+    expect(res.report.resolvedBy).toBeUndefined();
+    expect(res.report.resolutionNotes).toBeUndefined();
+    expect(res.report.escalatedTo).toBeUndefined();
+    expect(res.report.escalatedAt).toBeUndefined();
+    expect(res.report.escalationReason).toBeUndefined();
+    // …but the reporter still sees their report's status and outcome.
+    expect(res.report.status).toBeDefined();
+    expect(res.report.resolution).toBe('action_taken');
+    expect(res.report.resolvedAt).toBe('2026-06-03T00:00:00.000Z');
+  });
+
+  it('returns full internal fields to a moderator with reports-view', async () => {
+    const { deps } = makeDeps([
+      {
+        rows: [
+          reportRow({
+            reporter_id: 'someone-else',
+            assigned_moderator: 'mod-7',
+            resolution_notes: 'user suspended — internal',
+          }),
+        ],
+      },
+    ]);
+    const res = await getReport(
+      deps,
+      makePrincipal({ userId: 'mod-9', permissions: ['moderation.reports.view'] }),
+      { reportId: 'rpt-1' } as GetReportRequest
+    );
+    expect(res.report.assignedModerator).toBe('mod-7');
+    expect(res.report.resolutionNotes).toBe('user suspended — internal');
+  });
+
+  it('strips transition moderator identity and reason for a reporter', async () => {
+    const { deps } = makeDeps([
+      { rows: [reportRow({ reporter_id: 'usr-1' })] },
+      {
+        rows: [
+          {
+            transition_id: 't-1',
+            report_id: 'rpt-1',
+            from_status: 'pending',
+            to_status: 'resolved',
+            transitioned_at: new Date('2026-06-03T00:00:00.000Z'),
+            transitioned_by: 'mod-7',
+            reason: 'handled internally',
+          },
+        ],
+      },
+    ]);
+    const res = await getReport(deps, makePrincipal({ userId: 'usr-1', permissions: [] }), {
+      reportId: 'rpt-1',
+      includeTransitions: true,
+    });
+    expect(res.transitions).toHaveLength(1);
+    expect(res.transitions[0].toStatus).toBeDefined();
+    expect(res.transitions[0].transitionedBy).toBeUndefined();
+    expect(res.transitions[0].reason).toBeUndefined();
+  });
+
   it('throws NOT_FOUND when the report does not exist', async () => {
     const { deps } = makeDeps([{ rows: [] }]);
     await expect(
@@ -265,6 +349,27 @@ describe('listReports', () => {
     const params = query.mock.calls[0][1] as unknown[];
     expect(sql).toContain('reporter_id = $1');
     expect(params[0]).toBe('usr-1');
+  });
+
+  it('strips internal moderation fields from a reporter-scoped list', async () => {
+    const { deps } = makeDeps([
+      {
+        rows: [
+          reportRow({
+            reporter_id: 'usr-1',
+            assigned_moderator: 'mod-7',
+            resolution_notes: 'internal',
+            escalation_reason: 'why',
+          }),
+        ],
+      },
+    ]);
+    const res = await listReports(deps, makePrincipal({ userId: 'usr-1', permissions: [] }), {
+      limit: 10,
+    } as ListReportsRequest);
+    expect(res.reports[0].assignedModerator).toBeUndefined();
+    expect(res.reports[0].resolutionNotes).toBeUndefined();
+    expect(res.reports[0].escalationReason).toBeUndefined();
   });
 
   it('does NOT scope a moderator with moderation.reports.view to their own reports', async () => {

--- a/services/moderation/src/grpc/handlers.ts
+++ b/services/moderation/src/grpc/handlers.ts
@@ -188,14 +188,18 @@ export async function getReport(
   }
 
   // A reporter can always read their OWN report without a moderation
-  // permission; everyone else needs MODERATION_REPORTS_VIEW.
+  // permission; everyone else needs MODERATION_REPORTS_VIEW. A caller
+  // without that permission only ever reaches here on the self-report path,
+  // and gets the reporter-safe projection (no internal moderation workflow).
   const isReporter = rows[0].reporter_id === principal.userId;
-  if (!isReporter && !requirePermission(principal, MODERATION_REPORTS_VIEW)) {
+  const canViewInternal = requirePermission(principal, MODERATION_REPORTS_VIEW);
+  if (!isReporter && !canViewInternal) {
     throw new HandlerError('PERMISSION_DENIED', `'${MODERATION_REPORTS_VIEW}' required`);
   }
+  const forReporter = !canViewInternal;
 
   const response: GetReportResponse = {
-    report: reportRowToProto(rows[0]),
+    report: reportRowToProto(rows[0], forReporter),
     transitions: [],
   };
 
@@ -208,7 +212,7 @@ export async function getReport(
        ORDER BY transitioned_at ASC`,
       [req.reportId]
     );
-    response.transitions = transitions.rows.map(transitionRowToProto);
+    response.transitions = transitions.rows.map(t => transitionRowToProto(t, forReporter));
   }
 
   return response;
@@ -228,9 +232,11 @@ export async function listReports(
   let p = 1;
 
   // Callers without MODERATION_REPORTS_VIEW are strictly self-scoped:
-  // they only ever see reports they filed. Moderators with the
-  // permission see all reports.
-  if (!requirePermission(principal, MODERATION_REPORTS_VIEW)) {
+  // they only ever see reports they filed, and get the reporter-safe
+  // projection (no internal moderation workflow). Moderators with the
+  // permission see all reports in full.
+  const canViewInternal = requirePermission(principal, MODERATION_REPORTS_VIEW);
+  if (!canViewInternal) {
     where.push(`reporter_id = $${p++}`);
     params.push(principal.userId);
   }
@@ -289,7 +295,7 @@ export async function listReports(
 
   const hasMore = rows.length > limit;
   const pageRows = hasMore ? rows.slice(0, limit) : rows;
-  const reports = pageRows.map(reportRowToProto);
+  const reports = pageRows.map(row => reportRowToProto(row, !canViewInternal));
 
   const response: ListReportsResponse = { reports };
   if (hasMore && pageRows.length > 0) {

--- a/services/moderation/src/grpc/mapper.ts
+++ b/services/moderation/src/grpc/mapper.ts
@@ -48,7 +48,11 @@ export type ReportRow = {
   updated_at: Date;
 };
 
-export function reportRowToProto(row: ReportRow): Report {
+// `forReporter` returns the reporter-safe projection: a user reading their
+// OWN report (no MODERATION_REPORTS_VIEW) keeps the report content, its
+// status and final outcome, but must NOT see internal moderation workflow —
+// who is handling it, private resolution notes, or escalation reasoning.
+export function reportRowToProto(row: ReportRow, forReporter = false): Report {
   const report: Report = {
     reportId: row.report_id,
     reporterId: row.reporter_id,
@@ -64,9 +68,22 @@ export function reportRowToProto(row: ReportRow): Report {
     updatedAt: row.updated_at.toISOString(),
   };
 
+  // Reporter-visible optional fields — the report's subject and its outcome.
   if (row.reported_user_id !== null) {
     report.reportedUserId = row.reported_user_id;
   }
+  if (row.resolution !== null) {
+    report.resolution = row.resolution;
+  }
+  if (row.resolved_at !== null) {
+    report.resolvedAt = row.resolved_at.toISOString();
+  }
+
+  if (forReporter) {
+    return report;
+  }
+
+  // Internal moderation-workflow fields — moderators only.
   if (row.assigned_moderator !== null) {
     report.assignedModerator = row.assigned_moderator;
   }
@@ -75,12 +92,6 @@ export function reportRowToProto(row: ReportRow): Report {
   }
   if (row.resolved_by !== null) {
     report.resolvedBy = row.resolved_by;
-  }
-  if (row.resolved_at !== null) {
-    report.resolvedAt = row.resolved_at.toISOString();
-  }
-  if (row.resolution !== null) {
-    report.resolution = row.resolution;
   }
   if (row.resolution_notes !== null) {
     report.resolutionNotes = row.resolution_notes;
@@ -114,7 +125,12 @@ export type ReportStatusTransitionRow = {
   reason: string | null;
 };
 
-export function transitionRowToProto(row: ReportStatusTransitionRow): ReportStatusTransition {
+// `forReporter` omits the moderator identity (`transitionedBy`) and the
+// free-text `reason`, leaving the reporter only the status timeline.
+export function transitionRowToProto(
+  row: ReportStatusTransitionRow,
+  forReporter = false
+): ReportStatusTransition {
   const transition: ReportStatusTransition = {
     transitionId: row.transition_id,
     reportId: row.report_id,
@@ -125,6 +141,11 @@ export function transitionRowToProto(row: ReportStatusTransitionRow): ReportStat
   if (row.from_status !== null) {
     transition.fromStatus = reportStatusFromDb(row.from_status);
   }
+
+  if (forReporter) {
+    return transition;
+  }
+
   if (row.transitioned_by !== null) {
     transition.transitionedBy = row.transitioned_by;
   }

--- a/services/rescue/src/config.test.ts
+++ b/services/rescue/src/config.test.ts
@@ -16,6 +16,7 @@ describe('loadConfig', () => {
     expect(config.databaseUrl).toBe(REQUIRED.DATABASE_URL);
     expect(config.schema).toBe('rescue');
     expect(config.natsUrl).toBe('nats://nats:4222');
+    expect(config.petsGrpcUrl).toBe('service-pets:6003');
   });
 
   it('honours all env overrides when set', () => {
@@ -27,6 +28,7 @@ describe('loadConfig', () => {
       NODE_ENV: 'production',
       DATABASE_URL: 'postgres://prod:secret@db.example.com:5432/rescue',
       NATS_URL: 'nats://nats.internal:4222',
+      PETS_GRPC_URL: 'pets.internal:6003',
     });
 
     expect(config.port).toBe(5500);
@@ -36,6 +38,7 @@ describe('loadConfig', () => {
     expect(config.schema).toBe('rescue_test');
     expect(config.databaseUrl).toBe('postgres://prod:secret@db.example.com:5432/rescue');
     expect(config.natsUrl).toBe('nats://nats.internal:4222');
+    expect(config.petsGrpcUrl).toBe('pets.internal:6003');
   });
 
   it('rejects a non-numeric RESCUE_PORT', () => {

--- a/services/rescue/src/config.ts
+++ b/services/rescue/src/config.ts
@@ -25,6 +25,9 @@ export type RescueConfig = {
   // it can denormalise newly-registered users into staff_member rows
   // (CAD-style cross-service maintained read model).
   natsUrl: string;
+  // service.pets gRPC address. createFosterPlacement resolves pet → rescue
+  // here to reject a petId that doesn't belong to the placement's rescue.
+  petsGrpcUrl: string;
 };
 
 const DEFAULT_PORT = 5004;
@@ -32,6 +35,7 @@ const DEFAULT_GRPC_PORT = 6004;
 const DEFAULT_HOST = '0.0.0.0';
 const DEFAULT_SCHEMA = 'rescue';
 const DEFAULT_NATS_URL = 'nats://nats:4222';
+const DEFAULT_PETS_GRPC_URL = 'service-pets:6003';
 
 export const loadConfig = (env: NodeJS.ProcessEnv = process.env): RescueConfig => {
   const port = parsePort(env.RESCUE_PORT, DEFAULT_PORT, 'RESCUE_PORT');
@@ -47,5 +51,6 @@ export const loadConfig = (env: NodeJS.ProcessEnv = process.env): RescueConfig =
     databaseUrl,
     schema: env.RESCUE_SCHEMA?.trim() || DEFAULT_SCHEMA,
     natsUrl: env.NATS_URL?.trim() || DEFAULT_NATS_URL,
+    petsGrpcUrl: env.PETS_GRPC_URL?.trim() || DEFAULT_PETS_GRPC_URL,
   };
 };

--- a/services/rescue/src/grpc/pets-client.ts
+++ b/services/rescue/src/grpc/pets-client.ts
@@ -1,0 +1,98 @@
+// Service-to-service gRPC client for service.pets.
+//
+// createFosterPlacement is the only RescueService RPC that needs a cross-
+// vertical lookup: a placement references a pet by id, but pet → rescue
+// ownership lives in the pets vertical (a cross-schema FK we can't enforce
+// in the database). The handler resolves pet → rescue via PetService.Get and
+// rejects a petId that doesn't belong to the placement's rescue.
+//
+// Only the Get RPC is wrapped — that's all this vertical needs. The interface
+// is exported so the gRPC server boot can inject a real client and tests can
+// substitute a stub. Direct port of services/applications/src/grpc/pets-client.ts.
+
+import { credentials, status, type CallOptions, type Metadata } from '@grpc/grpc-js';
+
+import { PetsV1, type GetPetRequest, type GetPetResponse } from '@adopt-dont-shop/proto';
+
+export type PetsClient = {
+  getPet(req: GetPetRequest, metadata: Metadata): Promise<GetPetResponse>;
+  close(): void;
+};
+
+export type CreatePetsClientOptions = {
+  address: string;
+  // Per-call deadline in milliseconds. Without one, a hung downstream
+  // service would hang this request forever; 5s caps the blast radius
+  // and lets the caller fail fast with DEADLINE_EXCEEDED.
+  deadlineMs?: number;
+  // Maximum additional attempts after the first. Only UNAVAILABLE and
+  // DEADLINE_EXCEEDED trigger a retry (both are safe for idempotent
+  // reads). Defaults to 2 (i.e. up to 3 total attempts).
+  maxRetries?: number;
+};
+
+const DEFAULT_DEADLINE_MS = 5_000;
+const DEFAULT_MAX_RETRIES = 2;
+// Retry-eligible status codes for idempotent reads.
+const RETRYABLE_CODES = new Set([status.UNAVAILABLE, status.DEADLINE_EXCEEDED]);
+
+const isRetryableError = (err: unknown): boolean => {
+  if (err === null || typeof err !== 'object') {
+    return false;
+  }
+  const code = (err as { code?: unknown }).code;
+  return typeof code === 'number' && RETRYABLE_CODES.has(code);
+};
+
+const sleep = (ms: number): Promise<void> => new Promise(resolve => setTimeout(resolve, ms));
+
+const jitteredBackoff = (attempt: number, baseMs: number): number => {
+  // Exponential backoff with ±25% jitter: 100ms, 200ms (base defaults).
+  const base = baseMs * Math.pow(2, attempt - 1);
+  return base * (0.75 + Math.random() * 0.5);
+};
+
+export const createPetsClient = (opts: CreatePetsClientOptions): PetsClient => {
+  const stub = new PetsV1.PetServiceClient(opts.address, credentials.createInsecure());
+  const deadlineMs = opts.deadlineMs ?? DEFAULT_DEADLINE_MS;
+  const maxRetries = opts.maxRetries ?? DEFAULT_MAX_RETRIES;
+
+  const callWithRetry = <Req, Res>(
+    fn: (
+      req: Req,
+      metadata: Metadata,
+      options: Partial<CallOptions>,
+      cb: (err: unknown, res: Res) => void
+    ) => unknown,
+    req: Req,
+    metadata: Metadata
+  ): Promise<Res> => {
+    const attempt = (remaining: number): Promise<Res> =>
+      new Promise<Res>((resolve, reject) => {
+        const options: Partial<CallOptions> = {
+          deadline: new Date(Date.now() + deadlineMs),
+        };
+        fn.call(stub, req, metadata, options, (err: unknown, res: Res) => {
+          if (err) {
+            if (remaining > 0 && isRetryableError(err)) {
+              const retryIndex = maxRetries - remaining + 1;
+              sleep(jitteredBackoff(retryIndex, 100))
+                .then(() => attempt(remaining - 1))
+                .then(resolve, reject);
+            } else {
+              reject(err);
+            }
+            return;
+          }
+          resolve(res);
+        });
+      });
+
+    return attempt(maxRetries);
+  };
+
+  return {
+    getPet: (req, metadata) => callWithRetry(stub.get, req, metadata),
+    close: () => stub.close(),
+  };
+};

--- a/services/rescue/src/grpc/principal.ts
+++ b/services/rescue/src/grpc/principal.ts
@@ -3,5 +3,6 @@
 export {
   extractPrincipal,
   extractPrincipalOptional,
+  principalToMetadata,
   MissingPrincipalError,
 } from '@adopt-dont-shop/service-bootstrap';

--- a/services/rescue/src/grpc/server.test.ts
+++ b/services/rescue/src/grpc/server.test.ts
@@ -24,14 +24,18 @@ const config: RescueConfig = {
   databaseUrl: 'postgres://test',
   schema: 'rescue',
   natsUrl: 'nats://localhost:4222',
+  petsGrpcUrl: 'service-pets:6003',
 };
 
 const pool = {} as unknown as Pool;
 const nats = {} as unknown as NatsConnection;
+const petsClient = { getPet: async () => ({}), close: () => undefined } as unknown as Parameters<
+  typeof createGrpcServer
+>[0]['petsClient'];
 
 describe('createGrpcServer', () => {
   it('registers all six RescueService methods on the grpc.Server', () => {
-    const server = createGrpcServer({ config, pool, nats, logger: quietLogger });
+    const server = createGrpcServer({ config, pool, nats, logger: quietLogger, petsClient });
     const handlers = (server as unknown as { handlers: Map<string, unknown> }).handlers;
 
     expect(handlers.has('/adopt_dont_shop.rescue.v1.RescueService/Create')).toBe(true);
@@ -46,7 +50,7 @@ describe('createGrpcServer', () => {
     const definition = RescueV1.RescueServiceService;
     const expectedPaths = Object.values(definition).map(d => (d as { path: string }).path);
 
-    const server = createGrpcServer({ config, pool, nats, logger: quietLogger });
+    const server = createGrpcServer({ config, pool, nats, logger: quietLogger, petsClient });
     const handlers = (server as unknown as { handlers: Map<string, unknown> }).handlers;
 
     for (const p of expectedPaths) {

--- a/services/rescue/src/grpc/server.ts
+++ b/services/rescue/src/grpc/server.ts
@@ -26,20 +26,23 @@ import {
   verifyRescue,
 } from './handlers.js';
 import {
-  createFosterPlacement,
   endFosterPlacement,
   getFosterPlacement,
   getInvitationByToken,
   getMyStaffMembership,
   listFosterPlacements,
   listStaffMembers,
+  makeCreateFosterPlacement,
 } from './staff-foster-handlers.js';
+import { createPetsClient, type PetsClient } from './pets-client.js';
 
 export type CreateGrpcServerOptions = {
   config: RescueConfig;
   pool: Pool;
   nats: NatsConnection;
   logger: Logger;
+  // Injectable for tests; defaults to a real client at config.petsGrpcUrl.
+  petsClient?: PetsClient;
 };
 
 export type { RunningGrpcServer };
@@ -47,6 +50,7 @@ export type { RunningGrpcServer };
 export const createGrpcServer = (opts: CreateGrpcServerOptions): Server => {
   const { config, pool, nats, logger } = opts;
   const deps = { pool, nats };
+  const petsClient = opts.petsClient ?? createPetsClient({ address: config.petsGrpcUrl });
   const server = new Server();
 
   server.addService(RescueV1.RescueServiceService, {
@@ -58,7 +62,7 @@ export const createGrpcServer = (opts: CreateGrpcServerOptions): Server => {
     inviteStaff: adapt(inviteStaff, { deps, logger }),
     getMyStaffMembership: adapt(getMyStaffMembership, { deps, logger }),
     listStaffMembers: adapt(listStaffMembers, { deps, logger }),
-    createFosterPlacement: adapt(createFosterPlacement, { deps, logger }),
+    createFosterPlacement: adapt(makeCreateFosterPlacement(petsClient), { deps, logger }),
     listFosterPlacements: adapt(listFosterPlacements, { deps, logger }),
     getFosterPlacement: adapt(getFosterPlacement, { deps, logger }),
     endFosterPlacement: adapt(endFosterPlacement, { deps, logger }),
@@ -92,6 +96,26 @@ export const startGrpcServer = async (
   opts: CreateGrpcServerOptions
 ): Promise<RunningGrpcServer> => {
   const { config, logger } = opts;
-  const server = createGrpcServer(opts);
-  return startGrpcServerShared(server, config, logger);
+  // Build + own the pets client here so it's closed on shutdown.
+  const petsClient = opts.petsClient ?? createPetsClient({ address: config.petsGrpcUrl });
+  const server = createGrpcServer({ ...opts, petsClient });
+  const running = await startGrpcServerShared(server, config, logger);
+
+  return {
+    ...running,
+    shutdown: () =>
+      new Promise<void>(resolve => {
+        server.tryShutdown(err => {
+          if (err) {
+            logger.error('gRPC server shutdown error', { err });
+          }
+          try {
+            petsClient.close();
+          } catch (closeErr) {
+            logger.error('pets client close error', { err: closeErr });
+          }
+          resolve();
+        });
+      }),
+  };
 };

--- a/services/rescue/src/grpc/staff-foster-handlers.test.ts
+++ b/services/rescue/src/grpc/staff-foster-handlers.test.ts
@@ -7,14 +7,15 @@ import type { Permission, RescueId, UserId } from '@adopt-dont-shop/lib.types';
 import { RescueV1 } from '@adopt-dont-shop/proto';
 
 import type { HandlerDeps } from './handlers.js';
+import type { PetsClient } from './pets-client.js';
 import {
-  createFosterPlacement,
   endFosterPlacement,
   getFosterPlacement,
   getInvitationByToken,
   getMyStaffMembership,
   listFosterPlacements,
   listStaffMembers,
+  makeCreateFosterPlacement,
 } from './staff-foster-handlers.js';
 
 const RESCUE_ID = 'rsc-1';
@@ -174,8 +175,17 @@ describe('listStaffMembers', () => {
 
 describe('createFosterPlacement', () => {
   let mocks: ReturnType<typeof makeMocks>;
+  let petsStub: { getPet: ReturnType<typeof vi.fn>; close: ReturnType<typeof vi.fn> };
+  let createFosterPlacement: ReturnType<typeof makeCreateFosterPlacement>;
+
   beforeEach(() => {
     mocks = makeMocks();
+    // Default: the pet belongs to the placement's rescue.
+    petsStub = {
+      getPet: vi.fn(async () => ({ pet: { petId: 'pet-1', rescueId: RESCUE_ID } })),
+      close: vi.fn(),
+    };
+    createFosterPlacement = makeCreateFosterPlacement(petsStub as unknown as PetsClient);
   });
 
   const baseReq = {
@@ -195,11 +205,36 @@ describe('createFosterPlacement', () => {
     await expect(createFosterPlacement(mocks.deps, UNPRIVILEGED, baseReq)).rejects.toMatchObject({
       code: 'PERMISSION_DENIED',
     });
+    expect(petsStub.getPet).not.toHaveBeenCalled();
+  });
+
+  it('rejects a pet that belongs to another rescue', async () => {
+    petsStub.getPet.mockResolvedValueOnce({ pet: { petId: 'pet-1', rescueId: 'rsc-2' } });
+    await expect(createFosterPlacement(mocks.deps, STAFF, baseReq)).rejects.toMatchObject({
+      code: 'INVALID_ARGUMENT',
+    });
+    // No insert / publish on a rejected pet.
+    expect(mocks.natsMock.publish).not.toHaveBeenCalled();
+  });
+
+  it('rejects a pet the caller cannot read (pets NOT_FOUND)', async () => {
+    petsStub.getPet.mockRejectedValueOnce({ code: 5 });
+    await expect(createFosterPlacement(mocks.deps, STAFF, baseReq)).rejects.toMatchObject({
+      code: 'INVALID_ARGUMENT',
+    });
+  });
+
+  it('surfaces an unexpected pets error as INTERNAL', async () => {
+    petsStub.getPet.mockRejectedValueOnce({ code: 13 });
+    await expect(createFosterPlacement(mocks.deps, STAFF, baseReq)).rejects.toMatchObject({
+      code: 'INTERNAL',
+    });
   });
 
   it('inserts the placement + publishes rescue.fosterPlacementCreated', async () => {
     mocks.clientScript([fosterRow()]);
     const res = await createFosterPlacement(mocks.deps, STAFF, baseReq);
+    expect(petsStub.getPet).toHaveBeenCalledTimes(1);
     expect(res.placement?.placementId).toBe('fp-1');
     expect(res.placement?.status).toBe(
       RescueV1.FosterPlacementStatus.FOSTER_PLACEMENT_STATUS_ACTIVE

--- a/services/rescue/src/grpc/staff-foster-handlers.ts
+++ b/services/rescue/src/grpc/staff-foster-handlers.ts
@@ -37,6 +37,12 @@ import {
 } from '@adopt-dont-shop/proto';
 
 import { HandlerError, type HandlerDeps } from './handlers.js';
+import type { PetsClient } from './pets-client.js';
+import { principalToMetadata } from './principal.js';
+
+// grpc-js status codes service.pets can return on Get.
+const PETS_GRPC_NOT_FOUND = 5;
+const PETS_GRPC_PERMISSION_DENIED = 7;
 
 // --- Permissions -----------------------------------------------------
 
@@ -238,27 +244,71 @@ export async function listStaffMembers(
 
 export type FosterDeps = WithTransactionDeps;
 
-export async function createFosterPlacement(
+// createFosterPlacement is a factory closing over the PetsClient so the gRPC
+// server boot injects the real client and tests inject a stub. It resolves
+// pet → rescue via service.pets and rejects a petId that doesn't belong to
+// the placement's rescue (a cross-schema FK we can't enforce in the DB).
+export function makeCreateFosterPlacement(
+  petsClient: PetsClient
+): (
   deps: FosterDeps,
   principal: Principal,
   req: CreateFosterPlacementRequest
-): Promise<CreateFosterPlacementResponse> {
-  if (!req.rescueId) {
-    throw new HandlerError('INVALID_ARGUMENT', 'rescue_id is required');
-  }
-  if (!req.petId) {
-    throw new HandlerError('INVALID_ARGUMENT', 'pet_id is required');
-  }
-  if (!req.fosterUserId) {
-    throw new HandlerError('INVALID_ARGUMENT', 'foster_user_id is required');
-  }
-  if (!req.startDate) {
-    throw new HandlerError('INVALID_ARGUMENT', 'start_date is required');
-  }
-  if (!requirePermission(principal, FOSTER_CREATE, { rescueId: req.rescueId as RescueId })) {
-    throw new HandlerError('PERMISSION_DENIED', `'${FOSTER_CREATE}' required for this rescue`);
-  }
+) => Promise<CreateFosterPlacementResponse> {
+  return async (deps, principal, req) => {
+    if (!req.rescueId) {
+      throw new HandlerError('INVALID_ARGUMENT', 'rescue_id is required');
+    }
+    if (!req.petId) {
+      throw new HandlerError('INVALID_ARGUMENT', 'pet_id is required');
+    }
+    if (!req.fosterUserId) {
+      throw new HandlerError('INVALID_ARGUMENT', 'foster_user_id is required');
+    }
+    if (!req.startDate) {
+      throw new HandlerError('INVALID_ARGUMENT', 'start_date is required');
+    }
+    if (!requirePermission(principal, FOSTER_CREATE, { rescueId: req.rescueId as RescueId })) {
+      throw new HandlerError('PERMISSION_DENIED', `'${FOSTER_CREATE}' required for this rescue`);
+    }
 
+    // The pet must belong to the placement's rescue — otherwise a staffer
+    // could fabricate a placement over another rescue's animal.
+    await assertPetBelongsToRescue(petsClient, principal, req.petId, req.rescueId);
+
+    return insertFosterPlacement(deps, req);
+  };
+}
+
+// Resolve the pet via service.pets (forwarding the caller's identity so pets
+// runs its own read gate) and confirm it belongs to `rescueId`. A pet the
+// caller can't read (NOT_FOUND / PERMISSION_DENIED) or one owned by a
+// different rescue is rejected as a bad pet_id.
+async function assertPetBelongsToRescue(
+  petsClient: PetsClient,
+  principal: Principal,
+  petId: string,
+  rescueId: string
+): Promise<void> {
+  let res;
+  try {
+    res = await petsClient.getPet({ petId }, principalToMetadata(principal));
+  } catch (err) {
+    const code = (err as { code?: number }).code;
+    if (code === PETS_GRPC_NOT_FOUND || code === PETS_GRPC_PERMISSION_DENIED) {
+      throw new HandlerError('INVALID_ARGUMENT', `pet ${petId} is not in rescue ${rescueId}`);
+    }
+    throw new HandlerError('INTERNAL', 'failed to resolve pet rescue');
+  }
+  if (res.pet?.rescueId !== rescueId) {
+    throw new HandlerError('INVALID_ARGUMENT', `pet ${petId} is not in rescue ${rescueId}`);
+  }
+}
+
+async function insertFosterPlacement(
+  deps: FosterDeps,
+  req: CreateFosterPlacementRequest
+): Promise<CreateFosterPlacementResponse> {
   const placementId = randomUUID();
   let inserted: FosterPlacementRow | undefined;
 

--- a/services/rescue/src/server.test.ts
+++ b/services/rescue/src/server.test.ts
@@ -20,6 +20,7 @@ const baseConfig: RescueConfig = {
   databaseUrl: 'postgres://test',
   schema: 'rescue',
   natsUrl: 'nats://localhost:4222',
+  petsGrpcUrl: 'service-pets:6003',
 };
 
 describe('createServer — health endpoint', () => {


### PR DESCRIPTION
## Summary

Fourth review pass across the not-yet-swept services (`gateway`, `chat`, `moderation`, `rescue`, `matching`). This PR lands the verified findings plus the follow-ups you approved. `matching` came back clean.

## Verified findings (fixed)

### 1. `moderation` — internal report fields leaked to reporters (HIGH)
`getReport`/`listReports` mapped the **full** row on the reporter self-read path (no moderation permission required), leaking assigned/resolving/escalated **moderator IDs**, private `resolution_notes`, `escalation_reason`, and the transition history (`transitionedBy` + `reason`) to the reporting user. Added a reporter-safe projection (selected whenever the caller lacks `MODERATION_REPORTS_VIEW`) that keeps content/status/outcome but omits internal workflow; moderators still get the full payload.

### 2. `gateway` — input hardening (LOW)
- Image upload now enforces the same **extension allowlist** the document route already had (a lying Content-Type can't smuggle a disallowed file).
- `/admin/moderation/reports/bulk-update` array is now **bounded to 100 ids** (was one unbounded sequential gRPC call per id).

## Approved follow-ups (your decisions)

### 3. `chat deleteMessage` closed-chat guard (you chose: add the guard)
A sender could soft-delete their own message in a locked/archived chat. Now `ensureChatWritable` runs on the non-privileged sender path (after the idempotent short-circuit); `delete:any` moderators still bypass it.

### 4. `rescue createFosterPlacement` pet-ownership (you chose: add the check)
Gated correctly on the rescue but inserted `petId` verbatim, so a staffer could fabricate a placement over another rescue's animal. Now resolves pet → rescue via a new `service.pets` gRPC client (forwarding the caller's identity) and rejects a pet the caller can't read or that belongs to a different rescue. Mirrors the applications→pets client pattern; client owned by the gRPC boot and closed on shutdown.

### 5. Gateway fail-open auth (you chose: investigate first) — **no change, by design**
Investigated whether anonymous requests passing the gateway create a fail-open data path. **They don't.** The shared gRPC `adapt` wrapper rejects every principal-less call with `UNAUTHENTICATED` before any handler runs; only 11 intentionally-public `adaptUnauth` endpoints (auth credential-minting, cms public content, rescue invitation-by-token) are reachable anonymously. A gateway-side 401 would add only thin defence-in-depth **and** is risky: the current `PUBLIC_PATH_PREFIXES` is incomplete as an allowlist and would break genuinely-public routes (`/api/v1/cms/public/*`, `/api/v1/legal/*`, `/api/v1/config`, `/api/v1/analytics`, `/api/v1/invitations/details/:token`). **Recommendation: leave as-is.** (The stale comments in `authenticate.ts` citing the now-deleted monolith could be tidied separately — happy to if you want.)

## Tests
TDD throughout; all green locally: moderation `303`, gateway `619`, chat `90`, rescue `121`; type-check + lint clean for each.

https://claude.ai/code/session_014EbfJyKja1PmRfjcZWokaH