### PR TITLE
fix(auth): invalidate access tokens on revoke/reset + enforce signing-secret floors

### DIFF
--- a/packages/config-secrets/src/index.test.ts
+++ b/packages/config-secrets/src/index.test.ts
@@ -101,6 +101,19 @@ describe('requireSecret', () => {
     );
   });
 
+  it('throws when a present value is shorter than minBytes', () => {
+    expect(() =>
+      requireSecret('JWT_SECRET', { JWT_SECRET: 'short' }, undefined, { minBytes: 32 })
+    ).toThrow(/JWT_SECRET must be at least 32 bytes/);
+  });
+
+  it('accepts a value that meets minBytes', () => {
+    const value = 'a-signing-secret-that-is-at-least-32-bytes';
+    expect(requireSecret('JWT_SECRET', { JWT_SECRET: value }, undefined, { minBytes: 32 })).toBe(
+      value
+    );
+  });
+
   it('refuses to guess when both NAME and NAME_FILE are set (delegates to readSecret)', () => {
     const file = join(tmp, 'jwt');
     writeFileSync(file, 'file-value');

--- a/packages/config-secrets/src/index.ts
+++ b/packages/config-secrets/src/index.ts
@@ -58,16 +58,24 @@ export const readSecret = (
  * The optional `description` is appended to the error message to match the
  * per-service phrasing: `"${name} is required (${description})"`.
  * When omitted the message is `"${name} is required"`.
+ *
+ * Pass `opts.minBytes` to additionally reject a present-but-too-short secret
+ * — used for HMAC signing keys where a weak secret is offline-brute-forceable
+ * and would let an attacker forge tokens platform-wide.
  */
 export const requireSecret = (
   name: string,
   env: NodeJS.ProcessEnv = process.env,
-  description?: string
+  description?: string,
+  opts?: { minBytes?: number }
 ): string => {
   const value = readSecret(name, env)?.trim();
   if (!value) {
     const detail = description !== undefined ? ` (${description})` : '';
     throw new Error(`${name} is required${detail}`);
+  }
+  if (opts?.minBytes !== undefined && Buffer.byteLength(value, 'utf8') < opts.minBytes) {
+    throw new Error(`${name} must be at least ${opts.minBytes} bytes`);
   }
   return value;
 };

--- a/packages/service-bootstrap/src/principal-token.ts
+++ b/packages/service-bootstrap/src/principal-token.ts
@@ -150,6 +150,12 @@ function mac(encodedPayload: string, key: string): string {
 let cachedDefaultKey: string | undefined;
 let defaultKeyResolved = false;
 
+// HS256 signing key floor — a short key is offline-brute-forceable and would
+// let an attacker forge principal tokens trusted by every service. Enforced at
+// boot by assertPrincipalVerificationConfig (not here) so this stays a pure,
+// hot-path getter and explicit-key signing in tests is unaffected.
+export const MIN_SIGNING_KEY_BYTES = 32;
+
 export function getDefaultPrincipalSigningKey(): string | undefined {
   if (!defaultKeyResolved) {
     cachedDefaultKey = readSecret('PRINCIPAL_SIGNING_KEY')?.trim() || undefined;

--- a/packages/service-bootstrap/src/principal.test.ts
+++ b/packages/service-bootstrap/src/principal.test.ts
@@ -224,8 +224,15 @@ describe('assertPrincipalVerificationConfig', () => {
   };
 
   it('does not throw when a signing key is configured (even in production)', () => {
-    withKey('signing-key');
+    withKey('a-signing-key-that-is-at-least-32-bytes');
     expect(() => assertPrincipalVerificationConfig({ NODE_ENV: 'production' })).not.toThrow();
+  });
+
+  it('throws when the signing key is shorter than 32 bytes', () => {
+    withKey('too-short-key');
+    expect(() => assertPrincipalVerificationConfig({ NODE_ENV: 'production' })).toThrow(
+      InsecurePrincipalConfigError
+    );
   });
 
   it('throws in production when no key is set and no escape hatch', () => {

--- a/packages/service-bootstrap/src/principal.ts
+++ b/packages/service-bootstrap/src/principal.ts
@@ -2,6 +2,7 @@ import { Metadata } from '@grpc/grpc-js';
 
 import {
   getDefaultPrincipalSigningKey,
+  MIN_SIGNING_KEY_BYTES,
   PRINCIPAL_TOKEN_HEADER,
   signPrincipalToken,
   verifyPrincipalToken,
@@ -33,8 +34,17 @@ export class InsecurePrincipalConfigError extends Error {
 // real cross-service authz boundary). Fail closed in production unless the
 // operator explicitly opts into header-trust via ALLOW_UNSIGNED_PRINCIPAL.
 export function assertPrincipalVerificationConfig(env: NodeJS.ProcessEnv = process.env): void {
-  if (getDefaultPrincipalSigningKey()) {
-    return; // signed-token verification enabled — the secure path.
+  const key = getDefaultPrincipalSigningKey();
+  if (key) {
+    // Signed-token verification enabled — the secure path. Reject a weak key:
+    // a short HMAC secret is offline-brute-forceable and would let an attacker
+    // forge principal tokens trusted by every service.
+    if (Buffer.byteLength(key, 'utf8') < MIN_SIGNING_KEY_BYTES) {
+      throw new InsecurePrincipalConfigError(
+        `PRINCIPAL_SIGNING_KEY must be at least ${MIN_SIGNING_KEY_BYTES} bytes`
+      );
+    }
+    return;
   }
   const isProduction = env.NODE_ENV === 'production';
   const allowUnsigned = env.ALLOW_UNSIGNED_PRINCIPAL === 'true';

--- a/services/auth/src/config.test.ts
+++ b/services/auth/src/config.test.ts
@@ -2,10 +2,14 @@ import { describe, expect, it } from 'vitest';
 
 import { loadConfig } from './config.js';
 
+// Signing secrets must be >= 32 bytes (enforced at boot).
+const VALID_ACCESS_SECRET = 'access-signing-secret-at-least-32-bytes';
+const VALID_REFRESH_SECRET = 'refresh-signing-secret-at-least-32-bytes';
+
 const REQUIRED = {
   DATABASE_URL: 'postgres://test:test@localhost:5432/test',
-  JWT_SECRET: 'dev-access-secret',
-  JWT_REFRESH_SECRET: 'dev-refresh-secret',
+  JWT_SECRET: VALID_ACCESS_SECRET,
+  JWT_REFRESH_SECRET: VALID_REFRESH_SECRET,
 };
 
 describe('loadConfig', () => {
@@ -31,8 +35,8 @@ describe('loadConfig', () => {
       NODE_ENV: 'production',
       DATABASE_URL: 'postgres://prod:secret@db.example.com:5432/auth',
       NATS_URL: 'nats://nats.internal:4222',
-      JWT_SECRET: 'prod-access',
-      JWT_REFRESH_SECRET: 'prod-refresh',
+      JWT_SECRET: VALID_ACCESS_SECRET,
+      JWT_REFRESH_SECRET: VALID_REFRESH_SECRET,
     });
 
     expect(config.port).toBe(5500);
@@ -42,8 +46,8 @@ describe('loadConfig', () => {
     expect(config.schema).toBe('auth_test');
     expect(config.databaseUrl).toBe('postgres://prod:secret@db.example.com:5432/auth');
     expect(config.natsUrl).toBe('nats://nats.internal:4222');
-    expect(config.jwtSecret).toBe('prod-access');
-    expect(config.jwtRefreshSecret).toBe('prod-refresh');
+    expect(config.jwtSecret).toBe(VALID_ACCESS_SECRET);
+    expect(config.jwtRefreshSecret).toBe(VALID_REFRESH_SECRET);
   });
 
   it('rejects a non-numeric AUTH_PORT', () => {
@@ -80,9 +84,19 @@ describe('loadConfig', () => {
   });
 
   it('rejects an unset JWT_REFRESH_SECRET — refresh secret is distinct from access by design', () => {
-    expect(() => loadConfig({ DATABASE_URL: REQUIRED.DATABASE_URL, JWT_SECRET: 'x' })).toThrow(
-      /JWT_REFRESH_SECRET is required/
-    );
+    expect(() =>
+      loadConfig({ DATABASE_URL: REQUIRED.DATABASE_URL, JWT_SECRET: VALID_ACCESS_SECRET })
+    ).toThrow(/JWT_REFRESH_SECRET is required/);
+  });
+
+  it('rejects a too-short JWT_SECRET — a weak HMAC secret is brute-forceable', () => {
+    expect(() =>
+      loadConfig({
+        DATABASE_URL: REQUIRED.DATABASE_URL,
+        JWT_SECRET: 'too-short',
+        JWT_REFRESH_SECRET: VALID_REFRESH_SECRET,
+      })
+    ).toThrow(/JWT_SECRET must be at least 32 bytes/);
   });
 
   it('trims surrounding whitespace from string env values', () => {

--- a/services/auth/src/config.ts
+++ b/services/auth/src/config.ts
@@ -42,8 +42,17 @@ export const loadConfig = (env: NodeJS.ProcessEnv = process.env): AuthConfig => 
   const grpcPort = parsePort(env.AUTH_GRPC_PORT, DEFAULT_GRPC_PORT, 'AUTH_GRPC_PORT');
 
   const databaseUrl = requireSecret('DATABASE_URL', env, 'Postgres connection string');
-  const jwtSecret = requireSecret('JWT_SECRET', env, 'access-token signing secret');
-  const jwtRefreshSecret = requireSecret('JWT_REFRESH_SECRET', env, 'refresh-token signing secret');
+  // HS256 signing secrets — enforce a 32-byte floor so a weak secret can't be
+  // brute-forced offline to forge access/refresh tokens.
+  const jwtSecret = requireSecret('JWT_SECRET', env, 'access-token signing secret', {
+    minBytes: 32,
+  });
+  const jwtRefreshSecret = requireSecret(
+    'JWT_REFRESH_SECRET',
+    env,
+    'refresh-token signing secret',
+    { minBytes: 32 }
+  );
 
   return {
     port,

--- a/services/auth/src/grpc/account-handlers.test.ts
+++ b/services/auth/src/grpc/account-handlers.test.ts
@@ -284,6 +284,8 @@ describe('resetPassword', () => {
     const sql = realQueries(mocks.clientMock.query)[0][0] as string;
     expect(sql).toContain('locked_until = NULL');
     expect(sql).toContain('login_attempts = 0');
+    // Stamps the access-token revocation watermark.
+    expect(sql).toContain('tokens_valid_from = now()');
   });
 
   it('revokes all of the user’s refresh tokens (sessions) on reset', async () => {
@@ -332,6 +334,10 @@ describe('changePassword', () => {
     });
     expect(res.ok).toBe(true);
     expect(realQueries(mocks.clientMock.query)[0][1]).toContain('new-hash');
+    // Stamps the access-token revocation watermark.
+    expect(String(realQueries(mocks.clientMock.query)[0][0])).toContain(
+      'tokens_valid_from = now()'
+    );
   });
 
   it('revokes all of the user’s refresh tokens (sessions) on change', async () => {

--- a/services/auth/src/grpc/account-handlers.ts
+++ b/services/auth/src/grpc/account-handlers.ts
@@ -313,6 +313,7 @@ export async function resetPassword(
           reset_token_force_flag = false,
           locked_until = NULL,
           login_attempts = 0,
+          tokens_valid_from = now(),
           updated_at = now()
       WHERE reset_token = $2
         AND (reset_token_expiration IS NULL OR reset_token_expiration > now())
@@ -328,8 +329,9 @@ export async function resetPassword(
     // Revoke every existing session: a password reset is a security event
     // (often a compromised-account recovery), so all refresh tokens must
     // stop working. Sets both revocation columns so refresh AND ListSessions
-    // agree. Access tokens are short-lived JWTs that can no longer be
-    // refreshed once their session is gone.
+    // agree. Already-issued access tokens are invalidated immediately by the
+    // tokens_valid_from watermark stamped above (ValidateToken rejects any
+    // access token issued before it).
     await client.query(
       `UPDATE auth.refresh_tokens
           SET revoked_at = now(), is_revoked = true, updated_at = now()
@@ -375,7 +377,9 @@ export async function changePassword(
 
   await withTransaction(deps, async ({ client, publish }) => {
     await client.query(
-      `UPDATE auth.users SET password = $1, updated_at = now() WHERE user_id = $2`,
+      `UPDATE auth.users
+          SET password = $1, tokens_valid_from = now(), updated_at = now()
+        WHERE user_id = $2`,
       [newHash, principal.userId]
     );
     // Changing the password ends all other sessions: revoke every refresh

--- a/services/auth/src/grpc/handlers.test.ts
+++ b/services/auth/src/grpc/handlers.test.ts
@@ -644,6 +644,44 @@ describe('validateToken', () => {
       code: 'UNAUTHENTICATED',
     });
   });
+
+  it('UNAUTHENTICATED when the token predates the revocation watermark', async () => {
+    mocks.issuerMock.verifyAccess.mockResolvedValueOnce({
+      sub: 'usr-1',
+      jti: 'j',
+      iat: 1_000, // issued at second 1000
+      exp: 9_000_000_000,
+    });
+    mocks.poolMock.query
+      .mockResolvedValueOnce({ rows: [] }) // not denylisted
+      // watermark is AFTER the token's iat → token revoked
+      .mockResolvedValueOnce({
+        rows: [{ status: 'active', tokens_valid_from: new Date(2_000_000) }],
+      });
+    await expect(validateToken(mocks.deps, null, { accessToken: 'tok' })).rejects.toMatchObject({
+      code: 'UNAUTHENTICATED',
+    });
+  });
+
+  it('accepts a token issued at/after the revocation watermark', async () => {
+    mocks.issuerMock.verifyAccess.mockResolvedValueOnce({
+      sub: 'usr-1',
+      jti: 'j',
+      iat: 5_000, // issued at second 5000
+      exp: 9_000_000_000,
+    });
+    mocks.poolMock.query
+      .mockResolvedValueOnce({ rows: [] }) // not denylisted
+      // watermark (2000s) is before the token's iat (5000s) → still valid
+      .mockResolvedValueOnce({
+        rows: [{ status: 'active', tokens_valid_from: new Date(2_000_000) }],
+      })
+      .mockResolvedValueOnce({ rows: [{ user_type: 'adopter' }] }) // primary role
+      .mockResolvedValueOnce({ rows: [] }) // extra roles
+      .mockResolvedValueOnce({ rows: [] }); // permissions
+    const res = await validateToken(mocks.deps, null, { accessToken: 'tok' });
+    expect(res.principal.userId).toBe('usr-1');
+  });
 });
 
 // --- getMe -----------------------------------------------------------

--- a/services/auth/src/grpc/handlers.ts
+++ b/services/auth/src/grpc/handlers.ts
@@ -233,18 +233,37 @@ export async function loadPrincipal(
 // otherwise keep access — and could refresh indefinitely — until the
 // token's own expiry. ValidateToken (every gateway request) and
 // RefreshToken both gate on this. A single indexed point-read on the PK.
-async function assertActiveUser(deps: HandlerDeps, userId: string): Promise<void> {
-  const res = await deps.pool.query<{ status: UserStatusDb }>(
-    `SELECT status FROM auth.users WHERE user_id = $1 AND deleted_at IS NULL`,
+async function assertActiveUser(
+  deps: HandlerDeps,
+  userId: string,
+  // When provided (the access-token path), also enforce the per-user
+  // revocation watermark: an access token issued before `tokens_valid_from`
+  // is rejected. Omitted on the refresh path, which is gated by row-level
+  // refresh-token revocation instead.
+  accessIssuedAtSeconds?: number
+): Promise<void> {
+  const res = await deps.pool.query<{ status: UserStatusDb; tokens_valid_from: Date | null }>(
+    `SELECT status, tokens_valid_from FROM auth.users WHERE user_id = $1 AND deleted_at IS NULL`,
     [userId]
   );
-  const status = res.rows[0]?.status;
+  const row = res.rows[0];
   // Mirror Login's policy exactly: reject suspended/deactivated (and a
   // missing row = deleted). `inactive` / `pending_verification` are NOT
   // blocked here because Login lets them authenticate. We do NOT
   // distinguish cases in the error — the caller only needs "not allowed".
-  if (status === undefined || status === 'suspended' || status === 'deactivated') {
+  if (row === undefined || row.status === 'suspended' || row.status === 'deactivated') {
     throw new HandlerError('UNAUTHENTICATED', 'account is not active');
+  }
+  // Access-token revocation watermark. Compare at second granularity (the
+  // JWT `iat` is whole seconds) so a token minted in the same second as a
+  // revoke isn't spuriously rejected.
+  const validFrom = row.tokens_valid_from;
+  if (
+    accessIssuedAtSeconds !== undefined &&
+    validFrom instanceof Date &&
+    accessIssuedAtSeconds < Math.floor(validFrom.getTime() / 1000)
+  ) {
+    throw new HandlerError('UNAUTHENTICATED', 'access token revoked');
   }
 }
 
@@ -574,10 +593,11 @@ export async function validateToken(
   }
 
   // Reject the token if the user is no longer allowed to authenticate
-  // (suspended/deactivated/deleted) — a still-valid access token must not
-  // outlive an admin action. Checked BEFORE hydrating the principal so a
-  // blocked user never gets roles/permissions surfaced.
-  await assertActiveUser(deps, claims.sub);
+  // (suspended/deactivated/deleted) OR if it predates the user's revocation
+  // watermark (session revoke / password reset / change) — a still-valid
+  // access token must not outlive those actions. Checked BEFORE hydrating
+  // the principal so a blocked user never gets roles/permissions surfaced.
+  await assertActiveUser(deps, claims.sub, claims.iat);
 
   // Now (and only now) hydrate the principal. Single user_id read +
   // role/permission joins — same query loadPrincipal uses.

--- a/services/auth/src/grpc/session-handlers.test.ts
+++ b/services/auth/src/grpc/session-handlers.test.ts
@@ -131,7 +131,9 @@ describe('revokeSession', () => {
 
     const res = await revokeSession(mocks.deps, PRINCIPAL, { sessionId: 'tok-1' });
     expect(res.sessionId).toBe('tok-1');
-    expect(realQueries(mocks.clientMock.query)).toEqual(['UPDATE']);
+    // Two UPDATEs: the refresh-token family, plus the user's access-token
+    // revocation watermark.
+    expect(realQueries(mocks.clientMock.query)).toEqual(['UPDATE', 'UPDATE']);
     expect(mocks.natsMock.publish).toHaveBeenCalledTimes(1);
     expect(mocks.natsMock.publish.mock.calls[0][0]).toBe('auth.sessionRevoked');
     // UPDATE targets the family, not just the single token.
@@ -144,5 +146,12 @@ describe('revokeSession', () => {
     // revoked_at) also rejects a revoked session's tokens.
     expect(String(updateCall?.[0])).toMatch(/revoked_at = now\(\)/);
     expect(String(updateCall?.[0])).toMatch(/is_revoked = true/);
+    // Stamps the access-token watermark on the user.
+    const watermarkCall = mocks.clientMock.query.mock.calls.find(c => {
+      const sql = String(c[0]);
+      return sql.includes('UPDATE') && sql.includes('auth.users');
+    });
+    expect(watermarkCall?.[1]).toEqual(['usr-1']);
+    expect(String(watermarkCall?.[0])).toMatch(/tokens_valid_from = now\(\)/);
   });
 });

--- a/services/auth/src/grpc/session-handlers.ts
+++ b/services/auth/src/grpc/session-handlers.ts
@@ -129,6 +129,15 @@ export async function revokeSession(
       [family_id]
     );
 
+    // Stamp the access-token revocation watermark so the revoked session's
+    // already-issued access token stops working immediately (ValidateToken
+    // rejects tokens issued before this). Other live sessions transparently
+    // re-mint a newer access token on their next refresh.
+    await client.query(
+      `UPDATE auth.users SET tokens_valid_from = now(), updated_at = now() WHERE user_id = $1`,
+      [principal.userId]
+    );
+
     publish({
       type: 'auth.sessionRevoked',
       id: `auth.sessionRevoked.${req.sessionId}`,

--- a/services/auth/src/migrations/015_add_tokens_valid_from.ts
+++ b/services/auth/src/migrations/015_add_tokens_valid_from.ts
@@ -1,0 +1,23 @@
+import type { MigrationBuilder } from 'node-pg-migrate';
+
+// Access-token revocation watermark.
+//
+// Access tokens are short-lived JWTs that ValidateToken only denies on a
+// per-jti denylist + active-status check. Session revocation and password
+// reset/change revoke the REFRESH tokens but leave already-issued access
+// tokens usable until their natural expiry (up to the access TTL).
+//
+// tokens_valid_from is a per-user watermark: when set, ValidateToken rejects
+// any access token whose `iat` predates it. Revoke-session / reset / change
+// stamp it to now(), immediately invalidating outstanding access tokens.
+// NULL (the default) means "no watermark" — the common case — so the column
+// adds nothing to the hot path for users who've never revoked.
+export const up = async (pgm: MigrationBuilder): Promise<void> => {
+  pgm.addColumn('users', {
+    tokens_valid_from: { type: 'timestamptz' },
+  });
+};
+
+export const down = async (pgm: MigrationBuilder): Promise<void> => {
+  pgm.dropColumn('users', 'tokens_valid_from');
+};

--- a/services/auth/src/migrations/migrations.test.ts
+++ b/services/auth/src/migrations/migrations.test.ts
@@ -46,6 +46,7 @@ describe('auth migrations', () => {
     '005_create_user_roles.ts',
     '006_create_refresh_tokens.ts',
     '007_create_revoked_tokens.ts',
+    '015_add_tokens_valid_from.ts',
   ])('%s exports `up` and `down` functions', async filename => {
     const mod = (await import(`./${filename}`)) as {
       up: unknown;


### PR DESCRIPTION
## Summary

Fifth review pass — deep security sweep of the two not-yet-covered backend services (`auth`, `notifications`) plus the shared auth/identity spine (`packages/authz`, `packages/service-bootstrap`). This PR lands the **auth + spine** findings. (Notifications findings — per-category email opt-out + SendEmail recipient binding — are coming in a separate PR.)

The spine review came back **otherwise clean**: algorithm pinning, constant-time signature comparison, fail-closed `extractPrincipal`, `requirePermission` scope logic, the `adapt`/`adaptUnauth` gate, and header-overclaim protection were all verified solid.

## 1. Access tokens survived session-revoke and password reset/change (HIGH ×2)

`RevokeSession`, `resetPassword`, and `changePassword` revoked the **refresh** tokens but `ValidateToken` (the hot path every gateway request hits) only checked a per-jti denylist + active-status. So a **stolen access token kept full API access for up to the access TTL (~15 min)** after the victim revoked the session or reset their password — exactly the window that matters for compromised-account recovery.

**Fix (your choice: per-user watermark on all three):** new `tokens_valid_from` column (migration `015`). Revoke/reset/change stamp it to `now()`; `ValidateToken` rejects any access token whose `iat` predates it (compared at second granularity so a token minted in the same second isn't spuriously rejected). Other live sessions transparently re-mint a newer access token on their next refresh. `NULL` (the default) means "no watermark", so the hot path is unaffected for users who've never revoked.

## 2. HMAC signing-secret strength not enforced at boot (MED, auth + spine)

`JWT_SECRET`, `JWT_REFRESH_SECRET`, and `PRINCIPAL_SIGNING_KEY` were only checked for non-blank. HS256 is symmetric — a short/low-entropy secret is brute-forceable offline and lets an attacker forge platform-wide tokens. Added an optional `minBytes` to `requireSecret` (config-secrets), applied a **32-byte floor** to the auth JWT secrets, and enforced the same floor on `PRINCIPAL_SIGNING_KEY` in `assertPrincipalVerificationConfig` (the boot guard, so explicit-key signing in tests is unaffected).

## Tests
TDD throughout, all green locally: auth `214`, config-secrets `23`, service-bootstrap `78`; type-check + lint clean.

## Reported, not changed (needs your call)

- **Register user-enumeration (MED):** `register` returns `ALREADY_EXISTS` for an existing email — an account-existence oracle. The real fix removes auto-login-on-register (return a uniform "check your email" and gate token issuance behind verification), which is a **frontend-coupled UX/flow change**. Flagging before doing that — happy to, with the SPA contract updated, if you want it.

https://claude.ai/code/session_014EbfJyKja1PmRfjcZWokaH

---
_Generated by [Claude Code](https://claude.ai/code/session_014EbfJyKja1PmRfjcZWokaH)_