### PR TITLE
fix(notifications): enforce per-type email opt-outs + require userId for marketing

### DIFF
--- a/services/notifications/src/email/preferences.ts
+++ b/services/notifications/src/email/preferences.ts
@@ -8,6 +8,7 @@
 import { randomUUID } from 'node:crypto';
 
 import type { DbConn } from './queue.js';
+import type { EmailType } from './types.js';
 
 export type EmailPreferencesRow = {
   preference_id: string;
@@ -126,16 +127,33 @@ export const updatePreferences = async (
 //   - blacklisted (hard suppression — bounce / abuse)
 //   - global unsubscribe (user clicked unsubscribe-all)
 //   - email channel disabled
-// Per-type opt-outs in `preferences[]` are checked by the caller when
-// it knows the email's type — the worker doesn't.
-export const isEmailChannelOpen = async (conn: DbConn, userId: string): Promise<boolean> => {
+//   - the user has opted out of this specific email `type` (when provided)
+//
+// Per-type opt-outs live in the `preferences[]` JSONB array as entries of the
+// shape `{ type: EmailType, optedOut: true }`. Malformed/unknown entries are
+// ignored (fail-open to "allowed") so a bad row can't silently suppress
+// transactional mail.
+export const isEmailTypeOptedOut = (
+  preferences: Array<Record<string, unknown>>,
+  type: EmailType
+): boolean =>
+  preferences.some(
+    e => e !== null && typeof e === 'object' && e.type === type && e.optedOut === true
+  );
+
+export const isEmailChannelOpen = async (
+  conn: DbConn,
+  userId: string,
+  type?: EmailType
+): Promise<boolean> => {
   const res = await conn.query<{
     is_email_enabled: boolean;
     global_unsubscribe: boolean;
     is_blacklisted: boolean;
+    preferences: Array<Record<string, unknown>>;
   }>(
     `
-    SELECT is_email_enabled, global_unsubscribe, is_blacklisted
+    SELECT is_email_enabled, global_unsubscribe, is_blacklisted, preferences
     FROM email_preferences
     WHERE user_id = $1
     LIMIT 1
@@ -147,5 +165,11 @@ export const isEmailChannelOpen = async (conn: DbConn, userId: string): Promise<
   if (!row) {
     return true;
   }
-  return row.is_email_enabled && !row.global_unsubscribe && !row.is_blacklisted;
+  if (!row.is_email_enabled || row.global_unsubscribe || row.is_blacklisted) {
+    return false;
+  }
+  if (type !== undefined && isEmailTypeOptedOut(row.preferences ?? [], type)) {
+    return false;
+  }
+  return true;
 };

--- a/services/notifications/src/email/worker.test.ts
+++ b/services/notifications/src/email/worker.test.ts
@@ -167,6 +167,72 @@ describe('email worker', () => {
       await worker.stop();
     }
   });
+
+  it('suppresses a marketing email when the user opted out of that type', async () => {
+    const claimed = [queuedFixture({ emailId: 'em-M', userId: 'usr-1', type: 'marketing' })];
+    const { pool, queries } = makePool([
+      { rows: claimed.map(toRow) }, // claimDueEmails
+      // Channel toggles are all open, but preferences[] opts out of marketing.
+      {
+        rows: [
+          {
+            is_email_enabled: true,
+            global_unsubscribe: false,
+            is_blacklisted: false,
+            preferences: [{ type: 'marketing', optedOut: true }],
+          },
+        ],
+      },
+      { rows: [] }, // UPDATE → unsubscribed
+    ]);
+    const provider = makeProvider({ success: true });
+    const worker = startEmailWorker({
+      pool,
+      nats: {} as never,
+      provider,
+      logger: quietLogger(),
+      pollIntervalMs: 60_000,
+    });
+    try {
+      await worker.tick();
+      expect(provider.send).not.toHaveBeenCalled();
+      expect(queries[2].sql).toContain("SET status = 'unsubscribed'");
+    } finally {
+      await worker.stop();
+    }
+  });
+
+  it('still sends a transactional email when only marketing is opted out', async () => {
+    const claimed = [queuedFixture({ emailId: 'em-T', userId: 'usr-1', type: 'transactional' })];
+    const { pool } = makePool([
+      { rows: claimed.map(toRow) }, // claimDueEmails
+      {
+        rows: [
+          {
+            is_email_enabled: true,
+            global_unsubscribe: false,
+            is_blacklisted: false,
+            preferences: [{ type: 'marketing', optedOut: true }],
+          },
+        ],
+      },
+      { rows: [] }, // markSent
+    ]);
+    const provider = makeProvider({ success: true, messageId: 'm' });
+    const worker = startEmailWorker({
+      pool,
+      nats: {} as never,
+      provider,
+      logger: quietLogger(),
+      pollIntervalMs: 60_000,
+    });
+    try {
+      await worker.tick();
+      expect(provider.send).toHaveBeenCalledTimes(1);
+    } finally {
+      await worker.stop();
+    }
+  });
 });
 
 // Map QueuedEmail back to a flat row matching what claimDueEmails returns.

--- a/services/notifications/src/email/worker.ts
+++ b/services/notifications/src/email/worker.ts
@@ -54,9 +54,10 @@ const dispatchOne = async (
   email: QueuedEmail,
   logger: Logger
 ): Promise<void> => {
-  // Preference check (when tied to a user).
+  // Preference check (when tied to a user). Honours the channel toggles AND
+  // the per-type opt-out for this email's type.
   if (email.userId) {
-    const open = await isEmailChannelOpen(pool, email.userId);
+    const open = await isEmailChannelOpen(pool, email.userId, email.type);
     if (!open) {
       // Re-using `markFailed` with retriable=false would terminate as
       // 'failed' which mis-categorises an opt-out. The DB transition

--- a/services/notifications/src/grpc/email-handlers.test.ts
+++ b/services/notifications/src/grpc/email-handlers.test.ts
@@ -174,6 +174,27 @@ describe('sendEmail', () => {
     ).rejects.toMatchObject({ code: 'INVALID_ARGUMENT' });
   });
 
+  it("rejects a 'marketing' email with no user_id (opt-outs would be bypassed)", async () => {
+    await expect(
+      sendEmail(mocks.deps, SYSTEM_PRINCIPAL, {
+        ...BASE_SEND_REQ,
+        type: NotificationsV1.EmailType.EMAIL_TYPE_MARKETING,
+        userId: '',
+      })
+    ).rejects.toMatchObject({ code: 'INVALID_ARGUMENT' });
+  });
+
+  it("accepts a 'marketing' email when user_id is supplied", async () => {
+    mocks.clientScript.push({ rows: [{ email_id: 'queued-mkt' }] }); // INSERT
+    const res = await sendEmail(mocks.deps, SYSTEM_PRINCIPAL, {
+      ...BASE_SEND_REQ,
+      type: NotificationsV1.EmailType.EMAIL_TYPE_MARKETING,
+      userId: 'usr-adopter',
+    });
+    expect(res.emailId).toBeTruthy();
+    expect(res.alreadyQueued).toBe(false);
+  });
+
   it('rejects when template_data_json is not a JSON object', async () => {
     await expect(
       sendEmail(mocks.deps, SYSTEM_PRINCIPAL, {

--- a/services/notifications/src/grpc/email-handlers.ts
+++ b/services/notifications/src/grpc/email-handlers.ts
@@ -186,6 +186,16 @@ export async function sendEmail(
   const type = protoTypeToDb[req.type] ?? 'system';
   const priority = protoPriorityToDb[req.priority] ?? 'normal';
 
+  // Marketing mail must carry a userId so the worker can honour the
+  // recipient's opt-out before sending — email_preferences is user-keyed, so
+  // a userId-less marketing send would bypass suppression entirely.
+  if (type === 'marketing' && !req.userId) {
+    throw new HandlerError(
+      'INVALID_ARGUMENT',
+      "user_id is required for 'marketing' email so recipient opt-outs are honoured"
+    );
+  }
+
   // Resolve subject / html / text — template wins when present.
   let subject: string;
   let htmlContent: string;


### PR DESCRIPTION
## Summary

Follow-ups to the notifications findings from the fifth review pass (the auth/spine half shipped in #1063). Two safe, contained fixes — neither breaks legitimate system email.

## 1. Per-type email opt-outs were write-only (HIGH)

`email_preferences.preferences[]` could hold per-category opt-outs, but **no send path ever read them** — `isEmailChannelOpen` only checked the channel toggles (`is_email_enabled`, `global_unsubscribe`, `is_blacklisted`). So a user who opted out of a category still got emailed; the opt-out was write-only.

**Fix:** define the `preferences[]` entry shape — `{ type: EmailType, optedOut: true }` — and have `isEmailChannelOpen` honour it for the email's `type`. The worker now passes `email.type` into the gate. Malformed/unknown entries are ignored (fail-open to "allowed") so a bad row can't silently suppress transactional mail. No migration or proto change — `UpdateEmailPreferences` already persists `preferences[]`.

## 2. `SendEmail` userId-less suppression bypass for marketing (MED)

`email_preferences` is **user-keyed** (no email column), so a marketing send with no `userId` couldn't be preference-checked and bypassed suppression entirely. `SendEmail` now **requires a `userId` for `marketing`-type email**. Transactional/system mail (legitimately user-less) is unaffected.

### Why not the originally-discussed shapes
- A hard `toEmail`→principal binding (the literal "constrain SendEmail") was rejected: `notifications.email.send` is a **system/service permission** (not granted to any end-user role), so binding would break the legitimate system-send use case. Requiring `userId` for marketing closes the real gap without that regression.
- "Suppress by recipient address" isn't possible against `email_preferences` (it has no email column); requiring `userId` is the correct equivalent.

## Tests
TDD: notifications `265` pass (new — marketing opt-out suppresses dispatch, transactional still sends when only marketing is opted out, SendEmail rejects userId-less marketing, accepts it with userId); type-check + lint clean.

https://claude.ai/code/session_014EbfJyKja1PmRfjcZWokaH

---
_Generated by [Claude Code](https://claude.ai/code/session_014EbfJyKja1PmRfjcZWokaH)_