### PR TITLE
fix(auth): make Register enumeration-safe and verification-first

### DIFF
--- a/services/auth/src/grpc/account-handlers.test.ts
+++ b/services/auth/src/grpc/account-handlers.test.ts
@@ -14,7 +14,7 @@ import {
   updateAccount,
   verifyEmail,
 } from './account-handlers.js';
-import { HandlerError, type HandlerDeps, type MintedTokens } from './handlers.js';
+import { HandlerError, type HandlerDeps } from './handlers.js';
 
 function userRowFixture(overrides: Record<string, unknown> = {}) {
   return {
@@ -40,21 +40,6 @@ function userRowFixture(overrides: Record<string, unknown> = {}) {
     created_at: new Date('2026-01-01T00:00:00Z'),
     updated_at: new Date('2026-01-01T00:00:00Z'),
     ...overrides,
-  };
-}
-
-function mintedFixture(): MintedTokens {
-  return {
-    pair: {
-      accessToken: 'access',
-      refreshToken: 'refresh',
-      accessExpiresAt: '2026-06-05T17:30:00Z',
-      refreshExpiresAt: '2026-07-05T17:00:00Z',
-    },
-    accessJti: 'a-jti',
-    accessExpiresAt: new Date('2026-06-05T17:30:00Z'),
-    refreshJti: 'r-jti',
-    refreshExpiresAt: new Date('2026-07-05T17:00:00Z'),
   };
 }
 
@@ -98,6 +83,7 @@ function makeMocks() {
     clientScript: c.script,
     hasherMock: passwordHasher,
     issuerMock: tokenIssuer,
+    natsMock: nats,
   };
 }
 
@@ -155,33 +141,53 @@ describe('register', () => {
     ).rejects.toMatchObject({ code: 'INVALID_ARGUMENT' });
   });
 
-  it('rejects ALREADY_EXISTS when email is taken', async () => {
+  it('does NOT leak that an email is already registered (enumeration-safe)', async () => {
+    // Existing-email pre-check returns a row.
     mocks.poolMock.query.mockResolvedValueOnce({ rows: [{ '?column?': 1 }] });
-    await expect(register(mocks.deps, null, REGISTER_REQ)).rejects.toMatchObject({
-      code: 'ALREADY_EXISTS',
-    });
+
+    const res = await register(mocks.deps, null, REGISTER_REQ);
+
+    // Uniform response — no error, no tokens, no user. Identical to a fresh
+    // signup, so the caller can't tell the email exists.
+    expect(res).toEqual({ permissions: [] });
+    // Still hashes (uniform timing) but never inserts or mints tokens.
+    expect(mocks.hasherMock.hash).toHaveBeenCalled();
+    expect(realQueries(mocks.clientMock.query)).toEqual([]);
+    expect(mocks.issuerMock.mint).not.toHaveBeenCalled();
+    expect(mocks.natsMock.publish).not.toHaveBeenCalled();
   });
 
-  it('hashes the password, inserts the user, mints tokens, publishes', async () => {
-    mocks.poolMock.query.mockResolvedValueOnce({ rows: [] }); // uniqueness check
+  it('creates a pending-verification user, publishes, and issues NO tokens', async () => {
+    mocks.poolMock.query.mockResolvedValueOnce({ rows: [] }); // uniqueness check — free
     mocks.hasherMock.hash.mockResolvedValueOnce('$2b$12$new-hash');
     const created = userRowFixture({ user_id: 'usr-new', email: 'new@example.com' });
     mocks.clientScript([created]); // INSERT
-    mocks.issuerMock.mint.mockResolvedValueOnce(mintedFixture());
-    // After commit: refresh-token insert + loadPrincipal queries
-    // (user_type, extra roles, permissions, optional rescue lookup).
-    mocks.poolMock.query.mockResolvedValueOnce({ rows: [] }); // refresh-token insert
-    mocks.poolMock.query.mockResolvedValueOnce({ rows: [{ user_type: 'adopter' }] }); // primary role
-    mocks.poolMock.query.mockResolvedValue({ rows: [] }); // remaining loadPrincipal queries
 
     const res = await register(mocks.deps, null, REGISTER_REQ);
+
+    // Verification-first: uniform response, no tokens, no auto-login.
+    expect(res).toEqual({ permissions: [] });
+    expect(mocks.issuerMock.mint).not.toHaveBeenCalled();
 
     expect(mocks.hasherMock.hash).toHaveBeenCalledWith('hunter22');
     const insertCall = realQueries(mocks.clientMock.query)[0];
     expect(insertCall[0]).toContain('INSERT INTO auth.users');
+    expect(insertCall[0]).toContain("'pending_verification'");
     expect(insertCall[1]).toContain('$2b$12$new-hash');
-    expect(res.user.userId).toBe('usr-new');
-    expect(res.tokens.accessToken).toBe('access');
+    // Publishes the verification event so the email is sent.
+    expect(mocks.natsMock.publish).toHaveBeenCalled();
+  });
+
+  it('returns the uniform response on a unique-violation race (no leak)', async () => {
+    mocks.poolMock.query.mockResolvedValueOnce({ rows: [] }); // pre-check: free
+    // INSERT races a concurrent register → Postgres unique violation.
+    mocks.clientMock.query.mockImplementation(async (sql: string) => {
+      if (sql === 'BEGIN' || sql === 'COMMIT' || sql === 'ROLLBACK') return { rows: [] };
+      throw Object.assign(new Error('duplicate key'), { code: '23505' });
+    });
+
+    const res = await register(mocks.deps, null, REGISTER_REQ);
+    expect(res).toEqual({ permissions: [] });
   });
 });
 

--- a/services/auth/src/grpc/account-handlers.ts
+++ b/services/auth/src/grpc/account-handlers.ts
@@ -38,13 +38,7 @@ import type {
 } from '@adopt-dont-shop/proto';
 
 import { roleToDb } from './enum-map.js';
-import {
-  HandlerError,
-  loadPrincipal,
-  rowToProtoUser,
-  type HandlerDeps,
-  type UserRow,
-} from './handlers.js';
+import { HandlerError, rowToProtoUser, type HandlerDeps, type UserRow } from './handlers.js';
 
 const VERIFICATION_TOKEN_TTL_MS = 24 * 60 * 60 * 1000; // 24h
 const RESET_TOKEN_TTL_MS = 60 * 60 * 1000; // 1h
@@ -88,85 +82,93 @@ export async function register(
     throw new HandlerError('INVALID_ARGUMENT', 'terms and privacy policy must be accepted');
   }
 
-  // Uniqueness pre-check (citext makes the comparison case-insensitive).
+  // Hash up front so the response takes the same time whether or not the email
+  // is already taken — no fast path that would leak account existence via
+  // response timing.
+  const password = await deps.passwordHasher.hash(req.password);
+
+  // Enumeration-safe: never reveal whether the email is already registered.
+  // An existing email returns the SAME uniform response as a fresh signup —
+  // no error, no tokens. (A duplicate INSERT racing this check is caught
+  // below and handled identically.)
   const existing = await deps.pool.query(
     `SELECT 1 FROM auth.users WHERE email = $1 AND deleted_at IS NULL LIMIT 1`,
     [req.email]
   );
   if (existing.rows.length > 0) {
-    throw new HandlerError('ALREADY_EXISTS', 'email already registered');
+    return REGISTERED_RESPONSE;
   }
 
-  const password = await deps.passwordHasher.hash(req.password);
   const verificationToken = mintToken();
   const verificationExpires = new Date(Date.now() + VERIFICATION_TOKEN_TTL_MS);
   // Adopters self-register; everything else is invitation-based.
   const userType = 'adopter' as const;
   void roleToDb; // satisfy import — the proto user_type is ignored on Register
 
-  const inserted = await withTransaction(deps, async ({ client, publish }) => {
-    const insertRes = await client.query<UserRow>(
-      `
-      INSERT INTO auth.users (
-        user_id, email, password, first_name, last_name, phone_number,
-        verification_token, verification_token_expires_at,
-        status, user_type, email_verified, phone_verified,
-        two_factor_enabled, terms_accepted_at, privacy_policy_accepted_at,
-        login_attempts, created_at, updated_at
-      )
-      VALUES (
-        gen_random_uuid(), $1, $2, $3, $4, $5,
-        $6, $7,
-        'pending_verification', $8, false, false,
-        false, now(), now(),
-        0, now(), now()
-      )
-      RETURNING *
-      `,
-      [
-        req.email,
-        password,
-        req.firstName,
-        req.lastName,
-        req.phoneNumber ?? null,
-        verificationToken,
-        verificationExpires,
-        userType,
-      ]
-    );
-    const user = insertRes.rows[0];
+  try {
+    await withTransaction(deps, async ({ client, publish }) => {
+      const insertRes = await client.query<UserRow>(
+        `
+        INSERT INTO auth.users (
+          user_id, email, password, first_name, last_name, phone_number,
+          verification_token, verification_token_expires_at,
+          status, user_type, email_verified, phone_verified,
+          two_factor_enabled, terms_accepted_at, privacy_policy_accepted_at,
+          login_attempts, created_at, updated_at
+        )
+        VALUES (
+          gen_random_uuid(), $1, $2, $3, $4, $5,
+          $6, $7,
+          'pending_verification', $8, false, false,
+          false, now(), now(),
+          0, now(), now()
+        )
+        RETURNING *
+        `,
+        [
+          req.email,
+          password,
+          req.firstName,
+          req.lastName,
+          req.phoneNumber ?? null,
+          verificationToken,
+          verificationExpires,
+          userType,
+        ]
+      );
+      const user = insertRes.rows[0];
 
-    publish({
-      type: 'auth.userRegistered',
-      id: `auth.userRegistered.${user.user_id}`,
-      payload: {
-        userId: user.user_id,
-        email: user.email,
-        firstName: user.first_name,
-        verificationToken,
-        verificationExpiresAt: verificationExpires.toISOString(),
-      },
+      publish({
+        type: 'auth.userRegistered',
+        id: `auth.userRegistered.${user.user_id}`,
+        payload: {
+          userId: user.user_id,
+          email: user.email,
+          firstName: user.first_name,
+          verificationToken,
+          verificationExpiresAt: verificationExpires.toISOString(),
+        },
+      });
     });
+  } catch (err) {
+    // Unique-violation race: a concurrent register created the row between
+    // the pre-check and the INSERT. Treat it exactly like the existing-email
+    // case — same uniform response, no leak.
+    if ((err as { code?: string }).code === '23505') {
+      return REGISTERED_RESPONSE;
+    }
+    throw err;
+  }
 
-    return user;
-  });
-
-  const tokens = await deps.tokenIssuer.mint(inserted.user_id);
-  await deps.pool.query(
-    `
-    INSERT INTO auth.refresh_tokens (token, user_id, expires_at, revoked_at, created_at, updated_at)
-    VALUES ($1, $2, $3, NULL, now(), now())
-    `,
-    [tokens.pair.refreshToken, inserted.user_id, tokens.refreshExpiresAt]
-  );
-  const principal = await loadPrincipal(deps, inserted.user_id);
-
-  return {
-    user: rowToProtoUser(inserted),
-    tokens: tokens.pair,
-    permissions: principal.permissions,
-  };
+  // Verification-first: NO tokens are issued here. The user verifies their
+  // email (which flips status → active), then signs in via Login.
+  return REGISTERED_RESPONSE;
 }
+
+// Uniform Register response — identical for a fresh signup and an
+// already-registered email, so the response can't probe account existence.
+// `permissions` is the only required proto field; user/tokens are omitted.
+const REGISTERED_RESPONSE: RegisterResponse = { permissions: [] };
 
 // --- VerifyEmail -----------------------------------------------------
 


### PR DESCRIPTION
## Summary

Closes the register user-enumeration item flagged in #1063. Turned out to be **backend-only**: the frontend was already migrated to the no-token, verify-email contract (ADS-538) — it ignores the register response body and routes to `/check-your-email`. The auth handler, however, still leaked existence and minted unused tokens.

## The fix

`register` previously:
- threw `ALREADY_EXISTS` for a taken email — a direct account-existence oracle;
- minted an access/refresh pair to auto-log-in (which the SPA no longer uses).

Now:
- **Enumeration-safe:** an existing email returns the **same uniform response** as a fresh signup (`{ permissions: [] }`) — no error, no tokens. A unique-violation race on the INSERT is caught and handled identically.
- **No timing oracle:** the password is hashed *before* the existence check, so an existing email doesn't return faster than a new one.
- **Verification-first:** no tokens are issued. The user verifies their email (status → `active`), then signs in via `Login`. (`auth.userRegistered` is still published so the verification email is sent.)

## Why no proto / frontend / gateway changes
- The `RegisterResponse` proto fields (`user`, `tokens`, `permissions`) are left intact and returned empty — the frontend already ignores them, and regenerating proto isn't reliably reproducible in this environment (the committed ts-proto output differs in style from the local toolchain; `check:fresh` does a raw `diff`). Returning a uniform empty response needs no schema change.
- Frontend: already done (lib.auth `register` stores no tokens, `AuthContext` doesn't `setUser`, `RegisterForm` → `/check-your-email`).
- Gateway: unchanged — it forwards `RegisterResponse.toJSON`, now `{ permissions: [] }`; its route test already mocks that shape.

## Tests
TDD; auth `215` green (rewrote the two register tests: existing email is non-enumerating + issues no tokens; new email creates a `pending_verification` user, publishes, no tokens; + a unique-violation-race case). Gateway register route test still green. type-check + lint clean.

## Minor follow-up (not done)
A stale MSW success handler at `apps/client/src/__tests__/authentication.behavior.test.tsx` still mocks the old `{ data: { user, token } }` shape — it's dead (only the 400 branch is asserted) and won't break anything, but could be tidied to the new contract separately.

https://claude.ai/code/session_014EbfJyKja1PmRfjcZWokaH

---
_Generated by [Claude Code](https://claude.ai/code/session_014EbfJyKja1PmRfjcZWokaH)_