### PR TITLE
fix(docker): repair dev WebSocket URL and give single-app stacks a backend

### DIFF
--- a/.claude/skills/new-app/SKILL.md
+++ b/.claude/skills/new-app/SKILL.md
@@ -130,7 +130,7 @@ app-<name>:
     NODE_ENV: ${NODE_ENV:-development}
     DOCKER_ENV: 'true'
     VITE_API_BASE_URL: ''    # Empty — requests go through Vite proxy
-    VITE_WS_BASE_URL: ws://localhost:5000
+    VITE_WS_BASE_URL: ws://localhost:4000
     CHOKIDAR_USEPOLLING: true
     CHOKIDAR_INTERVAL: 1000
     CHOKIDAR_AWAITWRITEFINISH: 2000

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ That's it. `pnpm setup` is the one-shot bootstrap and it will:
 
 Skip the Playwright step with `pnpm setup -- --skip-playwright` if you don't plan to run E2E tests locally; install them later with `pnpm test:e2e:install`.
 
-Pass `--no-start` to skip the stack-start prompt (default when stdin is not a TTY, e.g. CI sandboxes), or `--start` to force it without prompting. After setup, set `POSTGRES_PASSWORD` and any third-party API keys in `.env` — if you accepted the prompt, the stack is already running on the URLs printed above.
+Pass `--no-start` to skip the stack-start prompt (default when stdin is not a TTY, e.g. CI sandboxes), or `--start` to force it without prompting. All secrets — including `POSTGRES_PASSWORD` and `REDIS_PASSWORD` — are generated for you; you only need to add any third-party API keys you want in `.env`. If you accepted the prompt, the stack is already running on the URLs printed above.
 
 ### Run (Docker — recommended)
 

--- a/apps/admin/.env.example
+++ b/apps/admin/.env.example
@@ -1,8 +1,8 @@
 # Admin App - Specific Configuration
 # Copy this to .env and customize as needed
 
-VITE_API_BASE_URL=http://localhost:5000
-VITE_WS_BASE_URL=ws://localhost:5000
+VITE_API_BASE_URL=http://localhost:4000
+VITE_WS_BASE_URL=ws://localhost:4000
 
 VITE_APP_NAME=Adopt Don't Shop - Admin
 VITE_APP_VERSION=1.0.0

--- a/apps/client/.env.example
+++ b/apps/client/.env.example
@@ -1,8 +1,8 @@
 # Client App - Specific Configuration
 # Copy this to .env and customize as needed
 
-VITE_API_BASE_URL=http://localhost:5000
-VITE_WS_BASE_URL=ws://localhost:5000
+VITE_API_BASE_URL=http://localhost:4000
+VITE_WS_BASE_URL=ws://localhost:4000
 
 VITE_APP_NAME=Adopt Don't Shop - Client
 VITE_APP_VERSION=1.0.0

--- a/apps/rescue/.env.example
+++ b/apps/rescue/.env.example
@@ -1,8 +1,8 @@
 # Rescue App - Specific Configuration
 # Copy this to .env and customize as needed
 
-VITE_API_BASE_URL=http://localhost:5000
-VITE_WS_BASE_URL=ws://localhost:5000
+VITE_API_BASE_URL=http://localhost:4000
+VITE_WS_BASE_URL=ws://localhost:4000
 
 VITE_APP_NAME=Adopt Don't Shop - Rescue
 VITE_APP_VERSION=1.0.0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -147,7 +147,7 @@ services:
       NODE_ENV: ${NODE_ENV:-development}
       DOCKER_ENV: 'true'
       VITE_API_BASE_URL: ''
-      VITE_WS_BASE_URL: ws://localhost:5000
+      VITE_WS_BASE_URL: ws://localhost:4000
       # File-watcher polling — only set on macOS/Windows (see ADS-766).
       CHOKIDAR_USEPOLLING: ${CHOKIDAR_USEPOLLING:-}
       CHOKIDAR_INTERVAL: ${CHOKIDAR_INTERVAL:-}
@@ -182,7 +182,7 @@ services:
       NODE_ENV: ${NODE_ENV:-development}
       DOCKER_ENV: 'true'
       VITE_API_BASE_URL: ''
-      VITE_WS_BASE_URL: ws://localhost:5000
+      VITE_WS_BASE_URL: ws://localhost:4000
       # File-watcher polling — only set on macOS/Windows (see ADS-766).
       CHOKIDAR_USEPOLLING: ${CHOKIDAR_USEPOLLING:-}
       CHOKIDAR_INTERVAL: ${CHOKIDAR_INTERVAL:-}
@@ -217,7 +217,7 @@ services:
       NODE_ENV: ${NODE_ENV:-development}
       DOCKER_ENV: 'true'
       VITE_API_BASE_URL: ''
-      VITE_WS_BASE_URL: ws://localhost:5000
+      VITE_WS_BASE_URL: ws://localhost:4000
       # File-watcher polling — only set on macOS/Windows (see ADS-766).
       CHOKIDAR_USEPOLLING: ${CHOKIDAR_USEPOLLING:-}
       CHOKIDAR_INTERVAL: ${CHOKIDAR_INTERVAL:-}

--- a/docs/infrastructure/new-app-generator.md
+++ b/docs/infrastructure/new-app-generator.md
@@ -181,7 +181,7 @@ app.{name}:
   ports:
     - '300X:3000' # Choose available port
   environment:
-    - VITE_API_BASE_URL=http://api.localhost:5000
+    - VITE_API_BASE_URL=http://api.localhost
 ```
 
 ### 4. Update nginx Configuration

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "docker:reset": "docker compose -f docker-compose.yml -f docker-compose.dev.yml down -v",
     "docker:logs": "docker compose -f docker-compose.yml -f docker-compose.dev.yml logs -f",
     "docker:ps": "docker compose ps",
-    "docker:shell:db": "docker compose exec database psql -U $POSTGRES_USER -d $POSTGRES_DB",
+    "docker:shell:db": "docker compose exec database sh -c 'psql -U \"$POSTGRES_USER\" -d \"$POSTGRES_DB\"'",
     "db:seed": "node scripts/seed.mjs",
     "build": "turbo run build",
     "build:libs": "turbo run build --filter='@adopt-dont-shop/lib.*'",

--- a/scripts/docker-dev.mjs
+++ b/scripts/docker-dev.mjs
@@ -300,9 +300,20 @@ function buildDevImage() {
 }
 
 // --- bring the stack up ----------------------------------------------------
+// A single frontend profile (client/admin/rescue) must also enable the
+// `services` profile — otherwise the app boots without the gateway and every
+// /api call 502s through the Vite proxy. `full` already includes everything.
+function resolveProfiles(profile) {
+  return ['client', 'admin', 'rescue'].includes(profile)
+    ? [profile, 'services']
+    : [profile];
+}
+
 function up() {
-  step(`Starting stack (profile: ${PROFILE}${DETACH ? ', detached' : ''})`);
-  const parts = ['docker compose', ...COMPOSE, '--profile', PROFILE, 'up'];
+  const profiles = resolveProfiles(PROFILE);
+  step(`Starting stack (profile: ${profiles.join(', ')}${DETACH ? ', detached' : ''})`);
+  const profileArgs = profiles.flatMap(p => ['--profile', p]);
+  const parts = ['docker compose', ...COMPOSE, ...profileArgs, 'up'];
   if (DETACH) parts.push('-d');
   run(parts.join(' '));
 }

--- a/scripts/templates/lib/common/README.md
+++ b/scripts/templates/lib/common/README.md
@@ -52,7 +52,7 @@ const customResult = await customService.exampleMethod({ custom: 'data' });
 
 ```bash
 # API Configuration (Vite apps use VITE_ prefix)
-VITE_API_BASE_URL=http://localhost:5000
+VITE_API_BASE_URL=http://localhost:4000
 
 # Development
 NODE_ENV=development


### PR DESCRIPTION
## Summary

A review of the Docker local-dev flow ("one command → full suite with hot reloads"). The happy path is already solid — `pnpm setup` is a true one-shot bootstrap (generates **all** secrets incl. `POSTGRES_PASSWORD`/`REDIS_PASSWORD`, adds OS-aware HMR polling, installs, builds libs, validates, auto-starts and health-gates the stack), and `pnpm docker:dev` has thorough preflight, a GHCR-pull-then-local-build fallback, migration advisory-lock retry, and a clean anon-volume HMR strategy.

The review found **one real functional bug** and a broken convenience path, plus some drift that misleads developers. This PR fixes all of them.

## What was broken

### 🔴 WebSocket pointed at a dead port (functional bug)
All three apps set `VITE_WS_BASE_URL: ws://localhost:5000` in `docker-compose.yml`. Port 5000 was the **deleted monolith**; the gateway (the REST/WS edge) listens on **4000**. Because Vite gives the compose `environment:` block precedence over the root `.env` — the exact mechanism the repo relies on for `VITE_API_BASE_URL: ''` — the apps baked `ws://localhost:5000` into the browser bundle, so **Socket.IO / chat / realtime notifications could never connect in Docker dev**. Every other source of truth (`.env.example`, `README`, `docs/`, the nginx `upstream backend`) already says `4000`.

### 🟠 Single-app commands had no backend
`pnpm docker:dev:client|admin|rescue` passed only the single frontend profile. The gateway and all `service-*` are gated to `['services','full']`, so those commands started the frontend + infra but **no gateway** — every `/api` call 502'd through the Vite proxy.

## Changes

- **`docker-compose.yml`** — `VITE_WS_BASE_URL` → `ws://localhost:4000` for all three apps (the functional fix).
- **`scripts/docker-dev.mjs`** — new pure `resolveProfiles()`; single-app profiles now also enable `services` so the gateway + services come up. `full` is unchanged.
- **`package.json`** — `docker:shell:db` now expands `POSTGRES_USER`/`POSTGRES_DB` **inside** the container (`sh -c`), so it works on every host OS instead of relying on unexported host shell vars.
- **Consistency / stop the drift** — `apps/{client,admin,rescue}/.env.example` (5000→4000), `README` (drop the stale "set `POSTGRES_PASSWORD`" note — bootstrap already generates it), and the new-app generator examples (`.claude/skills/new-app/SKILL.md`, `scripts/templates/lib/common/README.md`, `docs/infrastructure/new-app-generator.md`) so freshly generated apps don't re-introduce the 5000 bug.

## Verification

⚠️ This was developed in a fresh container without `node_modules`, so prettier/lint and a live stack run were **not** executed here. Changes are config/docs only plus one syntax-checked `.mjs` (`node --check` passed; `package.json` validated as JSON). Recommended manual checks before merge:

1. `pnpm docker:dev:detach` → `pnpm docker:ps` shows the full stack healthy. Open `http://localhost:3000`; in DevTools → Network → WS, confirm the Socket.IO connection targets **`ws://localhost:4000`** and returns `101 Switching Protocols`; exercise chat/notifications.
2. `pnpm docker:down` then `pnpm docker:dev:admin --detach` → `pnpm docker:ps` now also lists `service-gateway` + `service-*`; hit an `/api/v1/*` route from `http://localhost:3001` and confirm 2xx (not 502).
3. `pnpm docker:shell:db` opens a `psql` prompt (no empty `-U`/`-d`).
4. Edit `apps/admin/src/**`, a `packages/lib.*/src/**` file, and `services/auth/src/**`; confirm HMR / `tsx watch` reload.

## Out of scope (flagged, not changed)
- `docker:dev:legacy` (base-only `Dockerfile.app.optimized` dev target) may be stale — it's an escape hatch, left as-is.

https://claude.ai/code/session_01CxgvotaGVDUnmdFtLPgbEH

---
_Generated by [Claude Code](https://claude.ai/code/session_01CxgvotaGVDUnmdFtLPgbEH)_