### PR TITLE
Backend data integrity & email security (ADS-842, ADS-785, ADS-808, ADS-815)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -44,6 +44,7 @@ Documentation for the adopt-don't-shop monorepo, organized by audience. The root
 
 - [ADR 0001 — entity detail pattern](./adr/0001-entity-detail-pattern.md) — canonical pattern for entity detail pages
 - [ADR 0002 — applications strangler cutover](./adr/0002-applications-strangler-cutover.md) — plan to move `/api/v1/applications/*` to the microservice
+- [ADR 0003 — idempotent event consumers](./adr/0003-idempotent-event-consumers.md) — at-least-once delivery + idempotent-consumer convention
 - [ADR — sticky sessions for Socket.IO](./architecture/adr-socket-sticky-sessions.md) — connection-cap mitigation for the WebSocket edge
 - [Frontend technical architecture](./frontend/technical-architecture.md) — app shells, routing, state, styling
 - [Backend implementation guide](./backend/implementation-guide.md) — gateway routes → gRPC handlers → services wiring

--- a/docs/README.md
+++ b/docs/README.md
@@ -45,6 +45,7 @@ Documentation for the adopt-don't-shop monorepo, organized by audience. The root
 - [ADR 0001 — entity detail pattern](./adr/0001-entity-detail-pattern.md) — canonical pattern for entity detail pages
 - [ADR 0002 — applications strangler cutover](./adr/0002-applications-strangler-cutover.md) — plan to move `/api/v1/applications/*` to the microservice
 - [ADR 0003 — idempotent event consumers](./adr/0003-idempotent-event-consumers.md) — at-least-once delivery + idempotent-consumer convention
+- [ADR 0004 — Postgres read-replica routing](./adr/0004-postgres-read-replica-routing.md) — optional read-replica pool in `@adopt-dont-shop/db`
 - [ADR — sticky sessions for Socket.IO](./architecture/adr-socket-sticky-sessions.md) — connection-cap mitigation for the WebSocket edge
 - [Frontend technical architecture](./frontend/technical-architecture.md) — app shells, routing, state, styling
 - [Backend implementation guide](./backend/implementation-guide.md) — gateway routes → gRPC handlers → services wiring

--- a/docs/adr/0003-idempotent-event-consumers.md
+++ b/docs/adr/0003-idempotent-event-consumers.md
@@ -1,0 +1,83 @@
+# ADR 0003 — At-least-once delivery and idempotent event consumers
+
+- Status: Accepted
+- Date: 2026-06-16
+- Scope: every NATS/JetStream subscriber across `services/*/src/nats/`,
+  `services/*/src/gdpr/`, the saga subscribers in
+  `packages/events/src/gdpr-saga.ts`, and the shared `claimEvent` primitive in
+  `packages/events/src/idempotency.ts`
+- Related: ADS-808, PR #1002 (JetStream migration)
+
+## Context
+
+PR #1002 moved the event bus to JetStream with durable consumers. Delivery is
+now **at-least-once**: a handler may observe the same event id more than once —
+broker redelivery after a transient failure, a consumer restart between doing
+the work and acking, or a `nak` on a partial failure. The ack strategy from
+that PR is correct (`ack` on success, `nak` on transient error, `term` on a
+poison message, per-message `try/catch` so one bad message never tears down the
+subscription loop), but ack discipline alone does not make a handler safe — the
+side-effect itself must be safe to apply twice.
+
+A duplicate that produces a duplicate side-effect (two notification rows, two
+emails, two auto-reports, a double-counted GDPR completion) is a correctness
+bug. We need a single, documented convention so the discipline doesn't bit-rot
+as new subscribers are added.
+
+## Decision
+
+**Every subscriber that turns an upstream event into a durable, non-idempotent
+side-effect MUST be idempotent on the event id.** A redelivery of the same event
+must produce exactly one effect. There are three sanctioned ways to achieve
+this; pick the one that fits the side-effect:
+
+1. **`claimEvent` against `processed_events`** (the shared primitive in
+   `packages/events/src/idempotency.ts`). It inserts a `(consumer, event_id)`
+   row `ON CONFLICT DO NOTHING` and reports whether THIS call won the race; a
+   redelivery returns `false` and the handler skips. Pass a `PoolClient` to
+   claim **atomically inside the same transaction as the side-effect** — a
+   rolled-back handler also un-claims the event, so there is never an
+   ack-without-effect or effect-without-claim. Pass a `Pool` for best-effort
+   dedup where there is no DB write to be atomic with (a pure fan-out worker,
+   where suppressing a duplicate matters and a missed effect on a mid-flight
+   crash is acceptable).
+
+2. **A natural unique constraint that makes the write itself the claim.** When
+   the side-effect already has a deterministic key, an `INSERT … ON CONFLICT`
+   (or a unique index that raises `23505`) makes the insert atomic with the
+   dedup — no separate `processed_events` row needed. Examples in-tree:
+   - `services/notifications/src/email/channel-adapter.ts` keys the email queue
+     row on `notif-email:<notificationId>`; a redelivery hits
+     `email_queue_idempotency_key_unique` and is swallowed as a no-op.
+   - `services/moderation/src/grpc/handlers.ts` `fileReport` upserts on the
+     partial unique index `(reported_entity_type, reported_entity_id) WHERE
+     reporter_id = SYSTEM` and only publishes its domain event when the row was
+     genuinely inserted (`xmax = 0`), so a redelivered auto-report neither
+     duplicates the report nor re-emits `moderation.reportFiled`.
+   - `services/audit/src/nats/gdpr-subscribers.ts` upserts the saga row
+     `ON CONFLICT (correlation_id)` and merges each completion into a JSONB blob
+     keyed by service name, so a redelivered completion is idempotent.
+
+3. **State-guarded transitions** — when the side-effect is a state change, make
+   the update conditional on the current state so re-applying it is a no-op
+   (e.g. `WHERE status = 'pending'`). A redelivery finds the row already in the
+   target state and changes nothing.
+
+**Treat the four CAD lesson-#4 cases as a clean skip, not an error** (so the
+broker isn't told to redeliver forever): unknown id, wrong/already-advanced
+state, parse/`22P02` failure, and a plain redelivery. These are `ack`-and-move-on,
+not `nak`.
+
+## Consequences
+
+- New subscribers have a checklist: identify the event id, choose mechanism
+  1/2/3, and add a "publish twice → one effect" test (the redelivery test).
+  Subscribers that rely on a unique constraint (mechanism 2) historically had no
+  such test; ADS-808 adds one for the moderation auto-report path as the
+  template.
+- `claimEvent`'s key is `(consumer, event_id)`, never `event_id` alone, so the
+  same id consumed by two different durables/subjects each claims independently.
+- This is a convention, not a framework: there is no enforced base class. The
+  guard against drift is code review plus the per-subscriber redelivery test.
+- Out of scope: exactly-once delivery (impossible across a network) and
+  read-after-write consistency.

--- a/docs/adr/0004-postgres-read-replica-routing.md
+++ b/docs/adr/0004-postgres-read-replica-routing.md
@@ -1,0 +1,80 @@
+# ADR 0004 — Postgres read-replica routing in `@adopt-dont-shop/db`
+
+- Status: Accepted
+- Date: 2026-06-16
+- Scope: `packages/db` (`createDbClient`), the per-service `READ_DATABASE_URL`
+  config convention, and the read-only call sites in read-heavy services
+  (`pets`, `rescue`, `cms`)
+- Related: ADS-815, ADS-1007 (file-mounted secret loader)
+
+## Context
+
+Postgres is a single instance today: every service connects to the same
+physical database (schema-per-service). That is fine at current scale, but
+read-heavy services (pet/rescue listings, CMS content) will eventually want to
+offload reads to a replica so a traffic spike doesn't starve the primary of
+write capacity. There is no replica yet and no routing layer that would know
+what to do with one — so the discipline has to exist in code *before* the
+replica is provisioned, or it never gets retrofitted cleanly.
+
+This ADR defines the routing convention. **Replica provisioning itself is out of
+scope** (managed replica in prod, logical replication self-hosted), as is
+read-after-write consistency (handled case-by-case if it ever bites).
+
+## Decision
+
+### `createDbClient` gains an optional `readUrl`
+
+`createDbClient` accepts an optional `readUrl` alongside the existing primary
+`connectionString`. It returns a `DbClient` — the primary `Pool` augmented with
+a `.read` pool:
+
+- **`readUrl` set** → a second, independent pool is opened against the replica,
+  with the same timeout defaults and schema `search_path` wiring as the primary.
+  `.read` is that pool.
+- **`readUrl` unset/empty** → `.read` aliases the primary pool.
+
+`.read` is therefore *always present*. Call sites use `pool.read` for reads
+unconditionally and fall back to the primary transparently in single-instance
+deploys — no `if (replica)` branching anywhere.
+
+### Config convention: `READ_DATABASE_URL` (+ `_FILE`)
+
+Each service resolves `READ_DATABASE_URL` through the shared secret loader
+(`@adopt-dont-shop/config-secrets`), which already supports the
+`READ_DATABASE_URL_FILE` file-mounted-secret path (ADS-1007). It is **optional**:
+absent → no replica → primary fallback. The service passes the resolved value as
+`readUrl` to `createDbClient`, mirroring how `DATABASE_URL` becomes
+`connectionString` today.
+
+### Which call sites use `.read` — the convention
+
+**Reads use `pool.read`; writes and every transaction use the primary `pool`.**
+Concretely:
+
+- Read-only RPC handlers / queries (the `List*`, `Get*`, `Search*` surface) read
+  through `pool.read`.
+- Any write, and anything inside `withTransaction` (`@adopt-dont-shop/events`),
+  stays on the primary `pool`. Routing a transaction's reads to a replica would
+  break read-your-writes within that transaction, so transactions are never
+  split across pools.
+
+We route explicitly at the call site (`pool` vs `pool.read`) rather than
+inferring from a handler-name prefix: it is greppable, it keeps the read/write
+decision next to the query, and it never silently mis-routes a handler whose
+name doesn't match a heuristic.
+
+## Consequences
+
+- Backward compatible: `DbClient` is a `Pool` with one extra property, so every
+  existing caller that treats the result as a `Pool` is unaffected; `.read` is
+  opt-in per query.
+- A real replica can be introduced later by setting `READ_DATABASE_URL` in
+  staging/prod compose — no code change at the call sites that already use
+  `.read`.
+- Graceful shutdown in a replica deployment must end both pools (`pool.end()`
+  and `pool.read.end()`); in the fallback case they are the same pool, so one
+  `end()` suffices. No service wires `readUrl` yet, so this is documented for
+  when the first one does.
+- Out of scope here: provisioning the replica, compose changes, and
+  read-after-write consistency policy.

--- a/packages/db/src/client.test.ts
+++ b/packages/db/src/client.test.ts
@@ -87,4 +87,62 @@ describe('createDbClient', () => {
       void pool.end();
     }, 3_000); // Test-level timeout: well above the pool timeout, below the default 5s
   });
+
+  describe('read-replica routing (ADS-815)', () => {
+    it('aliases .read to the primary when no readUrl is configured (single-instance fallback)', () => {
+      const pool = createDbClient({
+        schema: 'pets',
+        connectionString: 'postgres://localhost/primary',
+      });
+
+      // Read-only call sites use pool.read unconditionally; with no replica it
+      // is the very same primary pool.
+      expect(pool.read).toBe(pool);
+
+      void pool.end();
+    });
+
+    it('treats an empty readUrl as no replica', () => {
+      const pool = createDbClient({
+        schema: 'pets',
+        connectionString: 'postgres://localhost/primary',
+        readUrl: '',
+      });
+
+      expect(pool.read).toBe(pool);
+
+      void pool.end();
+    });
+
+    it('opens a distinct read pool against readUrl when configured', () => {
+      const pool = createDbClient({
+        schema: 'pets',
+        connectionString: 'postgres://localhost/primary',
+        readUrl: 'postgres://replica.example.com/pets',
+      });
+
+      // A separate pool is created for reads …
+      expect(pool.read).not.toBe(pool);
+      // … pointed at the replica, not the primary.
+      expect(pool.read.options.connectionString).toBe('postgres://replica.example.com/pets');
+      expect(pool.options.connectionString).toBe('postgres://localhost/primary');
+
+      void pool.read.end();
+      void pool.end();
+    });
+
+    it('applies the same timeout defaults to the read pool', () => {
+      const pool = createDbClient({
+        schema: 'pets',
+        connectionString: 'postgres://localhost/primary',
+        readUrl: 'postgres://replica.example.com/pets',
+      });
+
+      expect(pool.read.options.connectionTimeoutMillis).toBe(10_000);
+      expect(pool.read.options.statement_timeout).toBe(30_000);
+
+      void pool.read.end();
+      void pool.end();
+    });
+  });
 });

--- a/packages/db/src/client.ts
+++ b/packages/db/src/client.ts
@@ -7,7 +7,25 @@ export type DbClientOptions = PoolConfig & {
   // Docker image) remain resolvable. CAD lesson from PR #48 — without
   // `public` on the path, `geography(Point,4326)` and `<->` blow up.
   schema: string;
+
+  // Optional read-replica connection string (ADS-815). When set, a second,
+  // read-only pool is opened against it and exposed as `.read`; read-only
+  // queries can be routed there to take load off the primary. When unset,
+  // `.read` aliases the primary pool, so call sites use `.read` unconditionally
+  // and transparently fall back to the primary in single-instance deploys.
+  //
+  // Wire it from the per-service config convention READ_DATABASE_URL (and
+  // READ_DATABASE_URL_FILE for the file-mounted secret path). The convention
+  // for which call sites use `.read`: read-only RPCs / queries use `pool.read`;
+  // every write and every transaction (withTransaction) stays on `pool`
+  // (the primary). See docs/adr/0004-postgres-read-replica-routing.md.
+  readUrl?: string;
 };
+
+// A primary pool with a `read` pool for read-only routing. `read` is always
+// present — it aliases the primary when no replica is configured — so call
+// sites never branch on whether a replica exists.
+export type DbClient = Pool & { read: Pool };
 
 // Unresponsive Postgres must fail fast — these defaults apply unless the
 // caller explicitly overrides them.
@@ -24,11 +42,8 @@ const TIMEOUT_DEFAULTS = {
 // rather than producing a broken connection (or, in theory, injecting).
 const SAFE_SCHEMA = /^[A-Za-z_][A-Za-z0-9_]*$/;
 
-export function createDbClient(opts: DbClientOptions): Pool {
-  const { schema, ...config } = opts;
-  if (!SAFE_SCHEMA.test(schema)) {
-    throw new Error(`createDbClient: invalid schema name "${schema}" (must match ${SAFE_SCHEMA})`);
-  }
+// Build a single pool with the schema search_path wiring applied on connect.
+function buildPool(schema: string, config: PoolConfig): Pool {
   const pool = new Pool({ ...TIMEOUT_DEFAULTS, ...config });
 
   pool.on('connect', client => {
@@ -46,4 +61,25 @@ export function createDbClient(opts: DbClientOptions): Pool {
   });
 
   return pool;
+}
+
+export function createDbClient(opts: DbClientOptions): DbClient {
+  const { schema, readUrl, ...config } = opts;
+  if (!SAFE_SCHEMA.test(schema)) {
+    throw new Error(`createDbClient: invalid schema name "${schema}" (must match ${SAFE_SCHEMA})`);
+  }
+
+  const primary = buildPool(schema, config);
+
+  // No replica configured → `.read` falls back to the primary so read-only
+  // call sites work unchanged in single-instance deploys.
+  if (readUrl === undefined || readUrl === '') {
+    return Object.assign(primary, { read: primary });
+  }
+
+  // A replica IS configured: open a read-only pool against it. It inherits the
+  // same timeout defaults and search_path wiring, but only the connection
+  // string differs — credentials/host come from readUrl, never the primary's.
+  const read = buildPool(schema, { ...config, connectionString: readUrl });
+  return Object.assign(primary, { read });
 }

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -1,4 +1,4 @@
 export { createDbClient } from './client.js';
-export type { DbClientOptions } from './client.js';
+export type { DbClientOptions, DbClient } from './client.js';
 export { runMigrations } from './migrate.js';
 export type { MigrationOptions } from './migrate.js';

--- a/packages/events/src/gdpr.test.ts
+++ b/packages/events/src/gdpr.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+
+import { CONSUMER_REGISTRY } from './consumer-registry.js';
+import { EXPECTED_GDPR_SERVICES } from './gdpr.js';
+
+// EXPECTED_GDPR_SERVICES is the single source of truth for the saga's
+// completion-count (ADS-785). The CONSUMER_REGISTRY's gdpr.> entry is the
+// independently-maintained record of which services subscribe to the saga.
+// This assertion fails the build if the two drift apart — i.e. if a service
+// is added/removed from the saga without updating EXPECTED_GDPR_SERVICES.
+//
+// The registry lists every gdpr.> consumer; the saga PARTICIPANTS are the
+// services that erase their slice and publish a completion (those wired via
+// registerGdprSubscriber). The audit service is the aggregator, not a
+// participant — it consumes completions rather than emitting one — so it is
+// excluded from the expected set.
+describe('EXPECTED_GDPR_SERVICES drift guard', () => {
+  it('matches the gdpr.> saga participants declared in CONSUMER_REGISTRY', () => {
+    const gdpr = CONSUMER_REGISTRY.find(e => e.subject === 'gdpr.>');
+    if (gdpr === undefined || !('consumers' in gdpr)) {
+      throw new Error('CONSUMER_REGISTRY is missing a gdpr.> entry with consumers');
+    }
+
+    const participants = gdpr.consumers
+      .filter(c => c.description.includes('registerGdprSubscriber'))
+      .map(c => c.service.replace(/^service\./, ''))
+      .sort();
+
+    expect(participants).toEqual([...EXPECTED_GDPR_SERVICES].sort());
+  });
+
+  it('has no duplicate entries', () => {
+    expect(new Set(EXPECTED_GDPR_SERVICES).size).toBe(EXPECTED_GDPR_SERVICES.length);
+  });
+});

--- a/packages/events/src/gdpr.ts
+++ b/packages/events/src/gdpr.ts
@@ -17,6 +17,27 @@
 export const GDPR_ERASURE_REQUESTED = 'gdpr.erasureRequested';
 export const GDPR_ERASURE_COMPLETED = 'gdpr.erasureCompleted';
 
+// Single source of truth for the services that participate in the GDPR
+// erasure saga (ADS-785). Each one subscribes to gdpr.erasureRequested,
+// erases its slice, and publishes gdpr.erasureCompleted. service.audit's
+// completion detection flips a request to completed_at = now() only once
+// every service below has acked error-free, so this count must match the
+// fleet exactly — too few marks the saga complete early, too many means it
+// never completes. Centralised here (not hand-maintained in the audit
+// subscriber) so adding/removing a participant is a one-line change with a
+// drift assertion guarding it.
+export const EXPECTED_GDPR_SERVICES = [
+  'auth',
+  'notifications',
+  'pets',
+  'chat',
+  'applications',
+  'matching',
+  'moderation',
+  'cms',
+  'rescue',
+] as const;
+
 export type GdprErasureRequestedPayload = {
   // The user being erased — primary key in auth.users.
   userId: string;

--- a/packages/events/src/index.ts
+++ b/packages/events/src/index.ts
@@ -7,6 +7,7 @@ export type { DomainSubject } from './stream.js';
 export {
   GDPR_ERASURE_REQUESTED,
   GDPR_ERASURE_COMPLETED,
+  EXPECTED_GDPR_SERVICES,
   type GdprErasureRequestedPayload,
   type GdprErasureCompletedPayload,
 } from './gdpr.js';

--- a/services/audit/src/grpc/reports-handlers.test.ts
+++ b/services/audit/src/grpc/reports-handlers.test.ts
@@ -177,6 +177,40 @@ describe('createSavedReport', () => {
     expect(params[0]).toBe('usr-1'); // user_id
     expect(params[3]).toBe('My Report');
   });
+
+  it('rejects a non-existent template_id with INVALID_ARGUMENT (ADS-785)', async () => {
+    // Existence check returns no row → the template doesn't exist.
+    const q = vi.fn().mockResolvedValue({ rows: [], rowCount: 0 });
+    const { deps } = makeDeps(q);
+    await expect(
+      createSavedReport(deps, makePrincipal({ permissions: ['reports.create'] }), {
+        name: 'My Report',
+        configJson: '{"widgets":[]}',
+        templateId: 'missing-template',
+      })
+    ).rejects.toMatchObject({ code: 'INVALID_ARGUMENT' });
+    // The orphan check runs before the INSERT — no row was written.
+    const sqls = q.mock.calls.map(c => String(c[0]));
+    expect(sqls.some(s => s.includes('INSERT INTO saved_reports'))).toBe(false);
+  });
+
+  it('inserts when the referenced template exists', async () => {
+    const q = vi
+      .fn()
+      // Existence check finds the template …
+      .mockResolvedValueOnce({ rows: [{ template_id: 't-1' }], rowCount: 1 })
+      // … then the INSERT returns the new row.
+      .mockResolvedValueOnce({ rows: [makeRow({ template_id: 't-1' })], rowCount: 1 });
+    const { deps } = makeDeps(q);
+    const res = await createSavedReport(deps, makePrincipal({ permissions: ['reports.create'] }), {
+      name: 'My Report',
+      configJson: '{"widgets":[]}',
+      templateId: 't-1',
+    });
+    expect(res.report?.templateId).toBe('t-1');
+    const insertParams = q.mock.calls[1][1] as unknown[];
+    expect(insertParams[2]).toBe('t-1'); // template_id passed through
+  });
 });
 
 describe('updateSavedReport', () => {

--- a/services/audit/src/grpc/reports-handlers.ts
+++ b/services/audit/src/grpc/reports-handlers.ts
@@ -270,6 +270,23 @@ export async function createSavedReport(
   }
   const config = parseConfig(req.configJson);
 
+  // Reject a reference to a template that doesn't exist (or was soft-deleted)
+  // with a clear validation error, rather than relying solely on the FK to
+  // raise an opaque constraint violation (ADS-785). The FK still backstops
+  // a TOCTOU race where the template is deleted between this check and the
+  // INSERT — but the common case gets a readable message.
+  const templateId = req.templateId ?? null;
+  if (templateId !== null) {
+    const exists = await deps.pool.query<{ template_id: string }>(
+      `SELECT template_id FROM report_templates
+         WHERE template_id = $1 AND deleted_at IS NULL`,
+      [templateId]
+    );
+    if (exists.rows.length === 0) {
+      throw new HandlerError('INVALID_ARGUMENT', `template ${templateId} does not exist`);
+    }
+  }
+
   const result = await deps.pool.query<SavedReportRow>(
     `INSERT INTO saved_reports
        (user_id, rescue_id, template_id, name, description, config)
@@ -278,7 +295,7 @@ export async function createSavedReport(
     [
       principal.userId,
       req.rescueId ?? null,
-      req.templateId ?? null,
+      templateId,
       name,
       req.description ?? null,
       JSON.stringify(config),

--- a/services/audit/src/migrations/007_add_saved_reports_template_fk.ts
+++ b/services/audit/src/migrations/007_add_saved_reports_template_fk.ts
@@ -1,0 +1,38 @@
+import type { MigrationBuilder } from 'node-pg-migrate';
+
+// saved_reports.template_id was declared `uuid` with only an index — no FK
+// to report_templates (ADS-785). A row could silently reference a
+// non-existent or hard-deleted template, leaving the admin UI to guess.
+//
+// Add the FK with ON DELETE SET NULL so deleting a template detaches its
+// saved reports rather than orphaning them. Before adding the constraint we
+// NULL any rows that already point at a template that no longer exists,
+// otherwise the ALTER would fail validation against existing data.
+//
+// rescue_id and user_id are intentionally NOT FK'd: they reference rows in
+// other services' schemas (rescue.*, auth.*), and cross-schema/cross-service
+// FKs are deliberately avoided here — service.audit owns only its own tables.
+
+export const up = async (pgm: MigrationBuilder): Promise<void> => {
+  // Pre-migration cleanup: detach any orphaned references so the FK validates.
+  pgm.sql(`
+    UPDATE saved_reports sr
+    SET template_id = NULL
+    WHERE sr.template_id IS NOT NULL
+      AND NOT EXISTS (
+        SELECT 1 FROM report_templates rt WHERE rt.template_id = sr.template_id
+      )
+  `);
+
+  pgm.addConstraint('saved_reports', 'saved_reports_template_id_fk', {
+    foreignKeys: {
+      columns: 'template_id',
+      references: 'report_templates(template_id)',
+      onDelete: 'SET NULL',
+    },
+  });
+};
+
+export const down = async (pgm: MigrationBuilder): Promise<void> => {
+  pgm.dropConstraint('saved_reports', 'saved_reports_template_id_fk');
+};

--- a/services/audit/src/migrations/migrations.test.ts
+++ b/services/audit/src/migrations/migrations.test.ts
@@ -43,6 +43,7 @@ describe('audit migrations', () => {
     '004_add_gdpr_failed_at.ts',
     '005_add_gdpr_saga_deadline.ts',
     '006_add_aggregate_keyset_index.ts',
+    '007_add_saved_reports_template_fk.ts',
   ])('%s exports `up` and `down` functions', async filename => {
     const mod = (await import(`./${filename}`)) as {
       up: unknown;

--- a/services/audit/src/nats/gdpr-subscribers.ts
+++ b/services/audit/src/nats/gdpr-subscribers.ts
@@ -16,6 +16,7 @@ import type { Pool } from 'pg';
 import type { Logger } from 'winston';
 
 import {
+  EXPECTED_GDPR_SERVICES,
   GDPR_ERASURE_COMPLETED,
   GDPR_ERASURE_REQUESTED,
   subscribe,
@@ -26,21 +27,10 @@ import {
 
 // The set of services we expect to ack each request. Once every one of
 // these has an error-free completion entry, the request flips to
-// completed_at = now().
-// Keep this in sync with services/{auth,notifications,pets,chat,
-// applications,matching,moderation,cms,rescue}/src/index.ts subscriber
-// wiring.
-export const EXPECTED_SERVICES = [
-  'auth',
-  'notifications',
-  'pets',
-  'chat',
-  'applications',
-  'matching',
-  'moderation',
-  'cms',
-  'rescue',
-] as const;
+// completed_at = now(). Sourced from @adopt-dont-shop/events so it stays
+// in lockstep with the saga participant list (ADS-785) — a drift assertion
+// there guards against a service being added/removed without updating it.
+export const EXPECTED_SERVICES = EXPECTED_GDPR_SERVICES;
 
 // Durable consumer names — all audit replicas bind the same durables so the
 // saga-tracking work is load-shared. Distinct durables per subject keep each

--- a/services/moderation/src/nats/subscribers.test.ts
+++ b/services/moderation/src/nats/subscribers.test.ts
@@ -137,4 +137,44 @@ describe('registerSubscribers', () => {
 
     expect(fileReportMock).not.toHaveBeenCalled();
   });
+
+  // Redelivery (ADS-808): JetStream is at-least-once, so the same
+  // chat.messageCreated can arrive twice. The auto-report is made idempotent
+  // by FileReport's UNIQUE (reported_entity_type, reported_entity_id) WHERE
+  // reporter_id = SYSTEM index, which UPSERTs the existing row and only
+  // publishes for a genuinely new insert. Model that constraint here and
+  // assert that a redelivery produces a SINGLE stored effect — the subscriber
+  // forwards the same deterministic (entity_type, entity_id) both times, so
+  // the downstream UPSERT collapses them.
+  it('produces a single effect when the same event is delivered twice (idempotent on entity)', async () => {
+    const storedReports = new Set<string>();
+    let insertCount = 0;
+    fileReportMock.mockImplementation(async (...args: unknown[]) => {
+      const req = args[2] as FileReportRequest;
+      const key = `${req.reportedEntityType}:${req.reportedEntityId}`;
+      // The UNIQUE index: a second file for the same entity is a no-op insert.
+      if (!storedReports.has(key)) {
+        storedReports.add(key);
+        insertCount += 1;
+      }
+      return { report: undefined };
+    });
+
+    registerSubscribers({ nats, deps, logger });
+    const event = {
+      messageId: 'msg-dup',
+      chatId: 'chat-1',
+      senderId: 'usr-sender',
+      content: 'go kill yourself',
+    };
+
+    await handlerFor('chat.messageCreated')(event);
+    await handlerFor('chat.messageCreated')(event);
+
+    // Handler ran for both deliveries (no in-handler dedup) …
+    expect(fileReportMock).toHaveBeenCalledTimes(2);
+    // … but both targeted the same entity, so only one report is stored.
+    expect(insertCount).toBe(1);
+    expect(storedReports.size).toBe(1);
+  });
 });

--- a/services/notifications/src/email/channel-adapter.ts
+++ b/services/notifications/src/email/channel-adapter.ts
@@ -23,6 +23,7 @@ import { subscribe, type SubscriptionHandle } from '@adopt-dont-shop/events';
 
 import { loadNotificationPrefs, shouldDeliver } from '../preferences-gate.js';
 
+import { escapeHtml } from './escape-html.js';
 import { insertEmail } from './queue.js';
 
 const DURABLE = 'notifications-email-channel';
@@ -68,9 +69,6 @@ export type EmailChannelWorkerOptions = {
 };
 
 export type RunningEmailChannelWorker = { stop: () => Promise<void> };
-
-const escapeHtml = (s: string): string =>
-  s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
 
 const renderHtml = (title: string, message: string): string =>
   `<h1>${escapeHtml(title)}</h1><p>${escapeHtml(message)}</p>`;

--- a/services/notifications/src/email/escape-html.ts
+++ b/services/notifications/src/email/escape-html.ts
@@ -1,0 +1,14 @@
+// HTML-context escaping for values interpolated into email HTML bodies.
+//
+// Shared by the template renderer (ADS-842) and the channel adapter's
+// inline notification HTML. Escapes the five characters that can break out
+// of HTML text / attribute context so a user-controlled value can never
+// inject markup or script into a recipient's mail client.
+
+export const escapeHtml = (s: string): string =>
+  s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');

--- a/services/notifications/src/email/renderer.test.ts
+++ b/services/notifications/src/email/renderer.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it } from 'vitest';
+
+import { renderEmailTemplate, renderHtmlTemplate, renderTemplate } from './renderer.js';
+
+describe('renderTemplate (plain text)', () => {
+  it('substitutes {{var}} with the raw value, leaving text un-escaped', () => {
+    const out = renderTemplate('Hi {{name}}', { name: '<b>Ada</b> & co' });
+    // Text context: nothing to break out of, so no escaping.
+    expect(out).toBe('Hi <b>Ada</b> & co');
+  });
+
+  it('leaves unmatched placeholders intact so typos are visible', () => {
+    expect(renderTemplate('Hi {{missing}}', {})).toBe('Hi {{missing}}');
+  });
+
+  it('resolves dotted paths', () => {
+    expect(renderTemplate('{{user.firstName}}', { user: { firstName: 'Ada' } })).toBe('Ada');
+  });
+});
+
+describe('renderHtmlTemplate (HTML context)', () => {
+  it('HTML-escapes a script injection so it renders inert', () => {
+    const out = renderHtmlTemplate('<p>Hi {{name}}</p>', {
+      name: '<script>alert(1)</script>',
+    });
+    expect(out).toBe('<p>Hi &lt;script&gt;alert(1)&lt;/script&gt;</p>');
+    expect(out).not.toContain('<script>');
+  });
+
+  it('escapes quotes so a value cannot break out of an HTML attribute', () => {
+    const out = renderHtmlTemplate('<a title="{{name}}">x</a>', {
+      name: '" onmouseover="alert(1)',
+    });
+    expect(out).toBe('<a title="&quot; onmouseover=&quot;alert(1)">x</a>');
+    expect(out).not.toContain('onmouseover="alert');
+  });
+
+  it('escapes ampersands without double-encoding the surrounding template', () => {
+    const out = renderHtmlTemplate('<p>{{name}} &amp; friends</p>', { name: 'A & B' });
+    // The value's `&` is escaped; the template's own `&amp;` is untouched.
+    expect(out).toBe('<p>A &amp; B &amp; friends</p>');
+  });
+
+  it('passes {{{var}}} through raw for pre-sanitised HTML', () => {
+    const out = renderHtmlTemplate('<p>{{{link}}}</p>', {
+      link: '<a href="https://example.com">Reset</a>',
+    });
+    expect(out).toBe('<p><a href="https://example.com">Reset</a></p>');
+  });
+
+  it('escapes a {{var}} even when a {{{raw}}} placeholder is also present', () => {
+    const out = renderHtmlTemplate('{{{safe}}} {{unsafe}}', {
+      safe: '<b>ok</b>',
+      unsafe: '<b>bad</b>',
+    });
+    expect(out).toBe('<b>ok</b> &lt;b&gt;bad&lt;/b&gt;');
+  });
+
+  it('leaves unmatched placeholders intact', () => {
+    expect(renderHtmlTemplate('Hi {{missing}}', {})).toBe('Hi {{missing}}');
+    expect(renderHtmlTemplate('Hi {{{missing}}}', {})).toBe('Hi {{{missing}}}');
+  });
+});
+
+describe('renderEmailTemplate', () => {
+  it('escapes htmlContent and the subject, but keeps textContent literal', () => {
+    const rendered = renderEmailTemplate(
+      {
+        subject: 'Welcome {{name}}',
+        htmlContent: '<h1>Welcome {{name}}</h1>',
+        textContent: 'Welcome {{name}}',
+      },
+      { name: '<script>x</script>' }
+    );
+
+    expect(rendered.subject).toBe('Welcome &lt;script&gt;x&lt;/script&gt;');
+    expect(rendered.htmlContent).toBe('<h1>Welcome &lt;script&gt;x&lt;/script&gt;</h1>');
+    // Text body is not double-encoded.
+    expect(rendered.textContent).toBe('Welcome <script>x</script>');
+  });
+
+  it('renders a null textContent as null', () => {
+    const rendered = renderEmailTemplate(
+      { subject: 'Hi', htmlContent: '<p>Hi</p>', textContent: null },
+      {}
+    );
+    expect(rendered.textContent).toBeNull();
+  });
+
+  // Render-all-templates snapshot — guards against accidental
+  // double-escaping of HTML that legitimately belongs in a template body.
+  // The literal markup, entities, and {{{raw}}} passthrough must survive
+  // verbatim; only the {{var}} interpolations are escaped.
+  it('renders representative templates without corrupting intended HTML (snapshot)', () => {
+    const variables = {
+      firstName: 'Ada',
+      rescueName: 'Happy Tails',
+      petName: 'Rex',
+      reason: 'We found a closer match <see notes>',
+      resetLink: '<a href="https://example.com/reset?t=abc">Reset your password</a>',
+    };
+
+    const templates = [
+      {
+        name: 'application-approved',
+        subject: 'Your application for {{petName}} was approved',
+        htmlContent:
+          '<h1>Great news, {{firstName}}!</h1>' +
+          '<p>{{rescueName}} approved your application for <strong>{{petName}}</strong>.</p>' +
+          '<hr />',
+        textContent: 'Great news, {{firstName}}! {{rescueName}} approved {{petName}}.',
+      },
+      {
+        name: 'application-rejected',
+        subject: 'Update on your application',
+        htmlContent: '<p>Hi {{firstName}},</p><p>Reason: {{reason}}</p>',
+        textContent: 'Hi {{firstName}}, Reason: {{reason}}',
+      },
+      {
+        name: 'password-reset',
+        subject: 'Reset your password',
+        // {{{resetLink}}} is server-built and pre-sanitised — passes through raw.
+        htmlContent: '<p>Hello {{firstName}} &mdash; click below:</p><p>{{{resetLink}}}</p>',
+        textContent: 'Hello {{firstName}}, reset your password.',
+      },
+    ];
+
+    const rendered = templates.map(t => ({ name: t.name, ...renderEmailTemplate(t, variables) }));
+    expect(rendered).toMatchInlineSnapshot(`
+      [
+        {
+          "htmlContent": "<h1>Great news, Ada!</h1><p>Happy Tails approved your application for <strong>Rex</strong>.</p><hr />",
+          "name": "application-approved",
+          "subject": "Your application for Rex was approved",
+          "textContent": "Great news, Ada! Happy Tails approved Rex.",
+        },
+        {
+          "htmlContent": "<p>Hi Ada,</p><p>Reason: We found a closer match &lt;see notes&gt;</p>",
+          "name": "application-rejected",
+          "subject": "Update on your application",
+          "textContent": "Hi Ada, Reason: We found a closer match <see notes>",
+        },
+        {
+          "htmlContent": "<p>Hello Ada &mdash; click below:</p><p><a href="https://example.com/reset?t=abc">Reset your password</a></p>",
+          "name": "password-reset",
+          "subject": "Reset your password",
+          "textContent": "Hello Ada, reset your password.",
+        },
+      ]
+    `);
+  });
+});

--- a/services/notifications/src/email/renderer.ts
+++ b/services/notifications/src/email/renderer.ts
@@ -4,7 +4,24 @@
 // brace substitution. Unmatched placeholders are left intact so a typo
 // is visible in the rendered email rather than silently becoming an
 // empty string.
+//
+// Context-aware escaping (ADS-842): values interpolated into HTML are
+// HTML-escaped so a user-controlled variable can't inject markup/script
+// into a recipient's mail client. Two placeholder forms in HTML context:
+//   {{var}}   — escaped (the safe default for every variable)
+//   {{{var}}} — raw passthrough, for values a producer has ALREADY
+//               sanitised (server-built links, pre-sanitised HTML). Each
+//               raw site must be justified at the producer.
+// Plain-text bodies use the unescaped renderer (no markup to break out
+// of, and escaping would corrupt the text). Subjects are HTML-escaped too
+// — some mail clients render entities in the subject line, and a subject
+// is never intended to carry markup.
 
+import { escapeHtml } from './escape-html.js';
+
+// Triple-brace MUST be tried before double-brace, hence a separate regex
+// matched first; the double-brace regex then handles the rest.
+const RAW_PLACEHOLDER_RE = /\{\{\{\s*([a-zA-Z0-9_.]+)\s*\}\}\}/g;
 const PLACEHOLDER_RE = /\{\{\s*([a-zA-Z0-9_.]+)\s*\}\}/g;
 
 const dig = (obj: Record<string, unknown>, path: string): unknown => {
@@ -20,6 +37,7 @@ const dig = (obj: Record<string, unknown>, path: string): unknown => {
   return cur;
 };
 
+// Plain-text / non-HTML renderer: substitute {{var}} with the raw string.
 export const renderTemplate = (source: string, variables: Record<string, unknown>): string =>
   source.replace(PLACEHOLDER_RE, (match, name: string) => {
     const value = dig(variables, name);
@@ -28,6 +46,26 @@ export const renderTemplate = (source: string, variables: Record<string, unknown
     }
     return String(value);
   });
+
+// HTML-context renderer: {{{var}}} passes through raw (pre-sanitised),
+// {{var}} is HTML-escaped. Raw placeholders are resolved first so their
+// names aren't also matched by the double-brace pass.
+export const renderHtmlTemplate = (source: string, variables: Record<string, unknown>): string =>
+  source
+    .replace(RAW_PLACEHOLDER_RE, (match, name: string) => {
+      const value = dig(variables, name);
+      if (value === undefined || value === null) {
+        return match;
+      }
+      return String(value);
+    })
+    .replace(PLACEHOLDER_RE, (match, name: string) => {
+      const value = dig(variables, name);
+      if (value === undefined || value === null) {
+        return match;
+      }
+      return escapeHtml(String(value));
+    });
 
 export type RenderedTemplate = {
   subject: string;
@@ -39,7 +77,7 @@ export const renderEmailTemplate = (
   template: { subject: string; htmlContent: string; textContent: string | null },
   variables: Record<string, unknown>
 ): RenderedTemplate => ({
-  subject: renderTemplate(template.subject, variables),
-  htmlContent: renderTemplate(template.htmlContent, variables),
+  subject: renderHtmlTemplate(template.subject, variables),
+  htmlContent: renderHtmlTemplate(template.htmlContent, variables),
   textContent: template.textContent ? renderTemplate(template.textContent, variables) : null,
 });


### PR DESCRIPTION
Themed PR covering four backend data-integrity and email-security tickets. Each ticket is one focused commit; all changes are scoped to the notifications email pipeline, the audit service, `@adopt-dont-shop/events`, `@adopt-dont-shop/db`, the moderation subscriber test, and new ADRs.

## ADS-842 — Email template XSS (HTML escaping)

`renderTemplate` interpolated `{{var}}` values into the HTML body with bare `String(value)`, so any user-controlled field (names, rescue/pet names, rejection reasons) was stored XSS in the recipient's mail client.

- Added a context-aware HTML renderer: `{{var}}` interpolations are HTML-escaped; `{{{var}}}` is a raw passthrough for pre-sanitised HTML (each raw site must be justified at the producer).
- `htmlContent` and the subject are escaped (some clients render entities in subjects); `textContent` stays literal — no double-encoding.
- Extracted the channel-adapter's inline `escapeHtml` into a shared `services/notifications/src/email/escape-html.ts` helper rather than adding a dependency.
- Tests: script / quote / attribute injection becomes inert, plus a render-all-templates inline snapshot guarding against accidental double-escaping. `base.ts` `sanitizeEmail` untouched.

## ADS-785 — Audit service data integrity

**FK on `saved_reports.template_id`:** new migration `007_add_saved_reports_template_fk.ts` NULLs any orphaned `template_id` values, then adds an FK to `report_templates(template_id)` with `ON DELETE SET NULL` (up + down). `createSavedReport` now rejects a non-existent/soft-deleted `template_id` with a clear `INVALID_ARGUMENT` before INSERT; the FK backstops the TOCTOU race. (`rescue_id`/`user_id` are intentionally not FK'd — cross-schema.)

**Dynamic `EXPECTED_SERVICES`:** exported `EXPECTED_GDPR_SERVICES` from `@adopt-dont-shop/events` as the single source of truth; the audit GDPR subscriber derives `EXPECTED_SERVICES` from it and the hand-maintained list + "keep in sync" comment are gone. A vitest drift assertion in `@adopt-dont-shop/events` fails when the central list and the `gdpr.>` saga participants in `CONSUMER_REGISTRY` diverge.

## ADS-808 — NATS subscriber idempotency

- ADR 0003 documents the at-least-once + idempotent-consumer convention (claimEvent against `processed_events`, natural unique constraint, or state-guarded transition; the four CAD lesson-#4 cases are a clean skip, not a nak).
- Added an explicit redelivery test to the moderation subscribers: delivering the same `chat.messageCreated` twice files a single auto-report (collapsed by FileReport's UNIQUE entity index) — coverage the suite lacked.

## ADS-815 — Postgres read-replica routing in `@adopt-dont-shop/db`

- `createDbClient` accepts an optional `readUrl`; the returned `DbClient` is the primary `Pool` augmented with a `.read` pool. With a replica it opens a second read-only pool (same timeout + search_path wiring); without one, `.read` aliases the primary so read call sites need no branching.
- Documented the `READ_DATABASE_URL` (+ `_FILE`) config convention and the reads-use-`.read` / writes+transactions-use-primary rule. ADR 0004 captures the routing convention. Replica provisioning / compose changes are out of scope.
- Tests cover the replica pool, single-instance fallback, and timeout inheritance. Backward compatible — `DbClient` is assignable wherever `Pool` is.

## Verification

Scoped tests + type-checks pass for every affected package: `@adopt-dont-shop/events` (97), `@adopt-dont-shop/db` (15), `service.audit` (149), `service.notifications` (277), `service.moderation` (304). Pre-existing docs-index warnings for 4 unrelated review docs already present on `main` are untouched; both new ADRs are correctly linked.

https://claude.ai/code/session_01Cq35z47L2XmwwcjBtqeCX4

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cq35z47L2XmwwcjBtqeCX4)_