### PR TITLE
docs: API versioning, SLOs/alerting, backup/runbooks, per-service READMEs

### DIFF
--- a/.github/workflows/backup.yml
+++ b/.github/workflows/backup.yml
@@ -1,0 +1,83 @@
+name: Backup
+
+# Nightly Postgres snapshot (ADS-811). Ships scripts/snapshot-postgres.sh to the
+# production host and runs it there — pg_dump | gzip -> S3.
+# See docs/db-backup-runbook.md.
+#
+# Schedule: 02:00 UTC daily, matching the documented backup window. Also
+# workflow_dispatch so an operator can take an ad-hoc / pre-migration snapshot.
+#
+# The script is copied from the repo at run time (rather than assumed present on
+# the host) so the workflow always runs the committed version. POSTGRES_USER /
+# POSTGRES_DB are read from the host .env (same pattern as deploy/rollback);
+# BACKUP_BUCKET / AWS_REGION come from repo variables; the host's own AWS
+# credentials authorise the S3 upload (no AWS keys flow through this workflow).
+on:
+  schedule:
+    - cron: '0 2 * * *'
+  workflow_dispatch: {}
+
+concurrency:
+  group: backup-production
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  snapshot-postgres:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    environment: production
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # NOTE: pin to a commit SHA before merge, matching the ssh-action pin
+      # convention below (see rollback.yml). Tag used here for readability.
+      - name: Copy snapshot script to server
+        uses: appleboy/scp-action@v0.1.7
+        with:
+          host: ${{ secrets.HETZNER_HOST }}
+          username: deploy
+          key: ${{ secrets.HETZNER_SSH_KEY }}
+          fingerprint: ${{ secrets.HETZNER_HOST_FINGERPRINT }}
+          source: scripts/snapshot-postgres.sh
+          target: /opt/ads/production
+          overwrite: true
+
+      - name: Run snapshot on server
+        env:
+          BACKUP_BUCKET: ${{ vars.BACKUP_BUCKET }}
+          AWS_REGION: ${{ vars.AWS_REGION }}
+        uses: appleboy/ssh-action@0ff4204d59e8e51228ff73bce53f80d53301dee2 # v1.2.5
+        with:
+          host: ${{ secrets.HETZNER_HOST }}
+          username: deploy
+          key: ${{ secrets.HETZNER_SSH_KEY }}
+          fingerprint: ${{ secrets.HETZNER_HOST_FINGERPRINT }}
+          envs: BACKUP_BUCKET,AWS_REGION
+          script: |
+            set -euo pipefail
+
+            : "${BACKUP_BUCKET:?BACKUP_BUCKET not configured (repo variable)}"
+            : "${AWS_REGION:?AWS_REGION not configured (repo variable)}"
+
+            cd /opt/ads/production
+
+            # Read a key from the host .env, quotes stripped; fail if absent.
+            read_env() {
+              local v
+              v="$(grep -E "^$1=" .env | head -n1 | cut -d= -f2-)" || true
+              v="${v%\"}"; v="${v#\"}"; v="${v%\'}"; v="${v#\'}"
+              [ -n "$v" ] || { echo "ERROR: $1 missing from .env" >&2; exit 1; }
+              printf '%s' "$v"
+            }
+            POSTGRES_USER="$(read_env POSTGRES_USER)"
+            POSTGRES_DB="$(read_env POSTGRES_DB)"
+
+            export BACKUP_BUCKET AWS_REGION POSTGRES_USER POSTGRES_DB
+            export COMPOSE_FILE=/opt/ads/production/docker-compose.prod.yml
+
+            chmod +x scripts/snapshot-postgres.sh
+            ./scripts/snapshot-postgres.sh

--- a/docs/README.md
+++ b/docs/README.md
@@ -166,6 +166,8 @@ Documentation for the adopt-don't-shop monorepo, organized by audience. The root
 - [Applications cutover runbook](./runbooks/applications-cutover.md) — route applications traffic to the microservice
 - [DB pool exhaustion runbook](./runbooks/db-pool-exhaustion.md) — recover from connection saturation
 - [Deploy rollback runbook](./runbooks/deploy-rollback.md) — roll back a bad release
+- [GDPR erasure incident runbook](./runbooks/gdpr-erasure-incident.md) — recover a failed / timed-out erasure saga
+- [JetStream backlog runbook](./runbooks/jetstream-backlog.md) — drain a stalled durable consumer / DLQ
 - [Maintenance mode runbook](./runbooks/maintenance-mode.md) — engage / disengage maintenance mode
 - [Migration failure runbook](./runbooks/migration-failure.md) — recover from a failed DB migration
 - [Redis outage runbook](./runbooks/redis-outage.md) — degrade gracefully when Redis is down

--- a/docs/README.md
+++ b/docs/README.md
@@ -159,7 +159,8 @@ Documentation for the adopt-don't-shop monorepo, organized by audience. The root
 - [Per-service rollback](./deploy/per-service-rollback.md) — hotfix and rollback a single service
 - [Distributed tracing](./observability/tracing.md) — OpenTelemetry setup and conventions
 - [DB backup runbook](./db-backup-runbook.md) — taking and restoring backups
-- [Observability and alerting](./observability-alerting.md) — metrics, logs, alert routing
+- [Service level objectives & alerting](./slo.md) — per-service SLOs, error budgets, and the Prometheus rules under `infra/prometheus/rules/`
+- [Observability and alerting](./observability-alerting.md) — metrics, logs, alert routing (legacy — superseded by `slo.md`)
 - [Runbooks index](./runbooks/README.md) — runbook catalogue
 - [5xx spike runbook](./runbooks/5xx-spike.md) — diagnose elevated server errors
 - [Applications cutover runbook](./runbooks/applications-cutover.md) — route applications traffic to the microservice

--- a/docs/README.md
+++ b/docs/README.md
@@ -74,6 +74,7 @@ Documentation for the adopt-don't-shop monorepo, organized by audience. The root
 ## Backend development
 
 - [API endpoints](./backend/api-endpoints.md) — REST endpoints reference
+- [API versioning & deprecation](./api-versioning.md) — `/api/v<N>/` scheme, breaking-change definition, deprecation lifecycle
 - [Database schema](./backend/database-schema.md) — service-owned schemas and relationships
 - [Implementation guide](./backend/implementation-guide.md) — patterns for gateway routes, gRPC handlers, services
 - [Testing](./backend/testing.md) — backend test strategy and Vitest setup

--- a/docs/api-versioning.md
+++ b/docs/api-versioning.md
@@ -1,0 +1,162 @@
+# API Versioning & Deprecation (ADS-820)
+
+How the Adopt Don't Shop REST API is versioned, what counts as a breaking
+change, and the lifecycle a route follows from deprecation to sunset. The
+contract this document governs is the gateway's public REST surface — the
+single `/api/v1/*` edge served by `services/gateway`, described by
+[`docs/backend/openapi.yaml`](./backend/openapi.yaml).
+
+> Scope: the public REST API only. The internal gRPC contracts between the
+> gateway and the extracted services are versioned separately by the proto
+> package (`adopt_dont_shop.<domain>.v1`) and are not a public surface.
+
+## Versioning scheme
+
+- The API is versioned **in the URL path**: `/api/v<N>/`.
+- **Every route is currently on `v1`** (`/api/v1/...`). There is no `v2` yet.
+- The version is a single integer that increments only when a backwards-
+  incompatible change cannot be avoided. It is **not** tied to the package
+  `version` (`1.0.0`) in `openapi.yaml` — the OpenAPI `info.version` tracks
+  spec revisions; the path version tracks the wire contract.
+- A new major version is introduced **side-by-side**: `/api/v2/*` routes are
+  added while `/api/v1/*` continues to serve until its sunset date. We do not
+  reuse a version number after it is retired.
+
+## What counts as a breaking change
+
+Aligned with the OpenAPI document — a change is **breaking** if an existing
+client written against the current spec could stop working. Concretely:
+
+- Removing a route, or removing a supported method on a route.
+- Removing a response field, or changing its type / format / nullability.
+- Removing or renaming an enum value a response can return.
+- Adding a **required** request field, or making an existing optional field
+  required.
+- Removing a previously-accepted request field or query parameter.
+- Tightening validation (narrower length / range / pattern) on an existing
+  field.
+- Changing the success status code, or the error-body shape, for an existing
+  outcome.
+- Changing authentication / authorization requirements for an existing route
+  (e.g. a route that was public now requires a token).
+
+**Non-breaking** (additive — ship in the current version):
+
+- Adding a new route or a new method on a route.
+- Adding an **optional** request field or query parameter.
+- Adding a new response field (clients must ignore unknown fields).
+- Adding a new enum value to a request field the server already tolerates, or
+  to a response field where clients are documented to tolerate unknowns.
+- Relaxing validation (wider range, looser pattern).
+
+When in doubt, treat it as breaking. The cost of a needless version bump is
+lower than the cost of silently breaking a client.
+
+## Deprecation lifecycle
+
+A route or field moves through four states. The default deprecation window is
+**6 months** between "deprecated" and "sunset" — long enough for first-party
+apps (`app.client`, `app.rescue`, `app.admin`) and any external integrator to
+migrate. Shorten it only with sign-off, and only when no external client is
+affected; lengthen it for widely-used routes.
+
+| State | Meaning | Client impact |
+| --- | --- | --- |
+| **Active** | Supported, no replacement planned. | None. |
+| **Deprecated** | Still works; a replacement exists; removal scheduled. | `Deprecation` + `Sunset` headers on every response; `deprecated: true` in OpenAPI. |
+| **Sunset** | Past the sunset date; may be removed at any time. | Route is removed; calls return `404`. |
+| **Removed** | Gone. | `404`. |
+
+### `Deprecation` and `Sunset` response headers (RFC 8594)
+
+Once a route is deprecated, the gateway attaches two headers to every response
+from it, per [RFC 8594](https://www.rfc-editor.org/rfc/rfc8594):
+
+```http
+Deprecation: Sat, 01 Aug 2026 00:00:00 GMT
+Sunset: Mon, 01 Feb 2027 00:00:00 GMT
+Link: </docs/api-versioning.md>; rel="deprecation"; type="text/markdown"
+```
+
+- `Deprecation` — an HTTP-date for when the route became deprecated (RFC 8594
+  also permits the bare token `true`; we prefer the dated form so clients can
+  reason about age).
+- `Sunset` — an HTTP-date for the earliest removal, per
+  [RFC 8594 §3](https://www.rfc-editor.org/rfc/rfc8594). With a 6-month
+  window, `Sunset = Deprecation + 6 months`.
+- `Link … rel="deprecation"` — points clients at this document for the
+  migration path.
+
+Clients should monitor for these headers in CI / runtime logs and surface them
+to engineers (e.g. log a warning on any response carrying a `Sunset` header).
+
+### OpenAPI annotation
+
+A deprecated route or field is marked in the OpenAPI document so the change is
+visible in generated docs and SDKs:
+
+```yaml
+paths:
+  /api/v1/old-thing:
+    get:
+      deprecated: true
+      description: |
+        Deprecated 2026-08-01, sunset 2027-02-01. Use `/api/v1/new-thing`.
+        See docs/api-versioning.md.
+```
+
+`deprecated: true` is the canonical machine-readable signal; the headers above
+are its runtime counterpart. Keep the two in sync.
+
+## The deprecation process
+
+1. **Decide.** Confirm the change is breaking (see the definition above). If
+   it is additive, just ship it — no version bump, no deprecation.
+2. **Land the replacement first.** The new route/field must be live and
+   documented before the old one is deprecated, so clients have somewhere to
+   go.
+3. **Record the decision in an ADR.** Add an entry under
+   [`docs/adr/`](./adr/) following the existing format (see
+   [ADR 0002](./adr/0002-applications-strangler-cutover.md)). The ADR states
+   what is being deprecated, the replacement, the timeline (deprecation date +
+   sunset date), and the migration steps. Link it from this document and from
+   the OpenAPI `description`.
+4. **Mark it deprecated.** Set `deprecated: true` in `openapi.yaml`, wire the
+   `Deprecation` / `Sunset` / `Link` headers on the route in the gateway, and
+   add the dates to the route's `description`.
+5. **Announce.** Note the deprecation in the commit using a conventional
+   commit `BREAKING CHANGE:` footer so it surfaces in the changelog:
+
+   ```
+   feat(api): add /api/v1/new-thing replacing /api/v1/old-thing
+
+   BREAKING CHANGE: /api/v1/old-thing is deprecated (sunset 2027-02-01).
+   Migrate to /api/v1/new-thing. See docs/api-versioning.md.
+   ```
+
+   The footer documents intent and timeline; the route itself keeps working
+   until its sunset date — deprecation is not removal.
+6. **Wait out the window.** Keep the deprecated route serving for the full
+   6-month (default) window. Watch its request volume; do not remove it while
+   it still has meaningful traffic from clients you cannot reach.
+7. **Sunset.** After the sunset date, and once traffic has fallen to zero (or
+   only reaches clients you've explicitly written off), remove the route. The
+   removal commit references the ADR.
+
+### When the whole version turns over
+
+A new path version (`/api/v2/`) is reserved for the rare case where breaking
+changes are too pervasive to deprecate route-by-route. The same process
+applies at the version level: stand up `/api/v2/*` alongside `/api/v1/*`,
+deprecate `v1` with `Deprecation` / `Sunset` headers and an ADR, run the
+6-month window, then retire `v1`.
+
+## Quick checklist
+
+- [ ] Change confirmed breaking (else: ship additively, stop here).
+- [ ] Replacement route/field live and documented.
+- [ ] ADR written under `docs/adr/` with deprecation + sunset dates.
+- [ ] `deprecated: true` set in `openapi.yaml`; dates in the `description`.
+- [ ] `Deprecation` + `Sunset` + `Link` headers wired in the gateway.
+- [ ] Conventional commit carries a `BREAKING CHANGE:` footer.
+- [ ] Calendar reminder set for the sunset date.

--- a/docs/db-backup-runbook.md
+++ b/docs/db-backup-runbook.md
@@ -1,14 +1,22 @@
-# Database Backup & Restore Runbook (ADS-443)
+# Database Backup & Restore Runbook (ADS-443, ADS-811)
 
 This runbook covers how the Adopt Don't Shop production PostgreSQL database is
 backed up, how to restore it, and the drill cadence required to keep that
 restore path trustworthy.
 
-The two scripts that implement this runbook live alongside the backend:
+The two scripts that implement this runbook live under `scripts/`:
 
-- `service.backend/scripts/db-backup.sh` — date-stamped, gzipped `pg_dump`.
-- `service.backend/scripts/db-restore.sh` — interactive `pg_restore` with a
-  destructive-action confirmation gate.
+- [`scripts/snapshot-postgres.sh`](../scripts/snapshot-postgres.sh) —
+  date-stamped `pg_dump` piped through `gzip -9`, uploaded to S3.
+- [`scripts/restore-postgres.sh`](../scripts/restore-postgres.sh) — pulls a
+  snapshot from S3 (or a local file) and replays it with `psql`, gated by a
+  destructive-action confirmation.
+
+> The old `service.backend/scripts/db-backup.sh` / `db-restore.sh` referenced
+> by earlier revisions of this runbook **no longer exist** — that backend was
+> deleted in the microservices migration. The live scripts above replace them.
+> Note the format difference: the snapshot is a **plain-SQL** dump
+> (`dump.sql.gz`), so restore uses `psql`, **not** `pg_restore`.
 
 ## Why this exists
 
@@ -17,135 +25,188 @@ later migrations are similarly forward-only. Without a known-good backup +
 rehearsed restore, every prod schema change is a one-way door. This runbook
 closes that gap.
 
+## Recovery objectives (RTO / RPO)
+
+| Target | Value | Basis |
+| --- | --- | --- |
+| **RPO** (max data loss) | **24 hours** | Daily 02:00 UTC snapshot; anything written since the last snapshot is lost on a full restore. |
+| **RTO** (time to restore) | **≤ 2 hours** | Download dump from S3 + `psql` replay into a scratch DB + verify + repoint. Dominated by `psql` replay time, which scales with DB size. |
+
+These are the targets for a logical-dump strategy. Tighter RPO (minutes) needs
+streaming replication / PITR — out of scope here, tracked under ADS-443.
+
 ## What gets backed up
 
-- **In scope**: the application database (schema + data) referenced by
-  `DATABASE_URL` / `PROD_DB_NAME`.
-- **Out of scope (handled separately)**: object storage (uploads), Redis
-  (transient queues + caches), application secrets (managed in the secrets
-  store, not the DB).
+- **In scope**: the application database (schema + data) — the `database`
+  service in `docker-compose.prod.yml`, named by `POSTGRES_DB`.
+- **Out of scope (handled separately)**: object storage / uploads (see
+  [`scripts/snapshot-uploads.sh`](../scripts/snapshot-uploads.sh) and the
+  [snapshot policy](./operations/snapshot-policy.md)), Redis (transient
+  queues + caches), application secrets (file-mounted Docker secrets, not in
+  the DB), and `letsencrypt` TLS state (regenerable).
 
 ## Schedule
 
-| Job                      | Cadence       | Retention         |
-| ------------------------ | ------------- | ----------------- |
-| Nightly automated dump   | Daily 02:00 UTC | 14 days local + 30 days off-site |
+| Job | Cadence | Retention |
+| --- | --- | --- |
+| Nightly automated dump | Daily 02:00 UTC | 30 days off-site (S3 lifecycle) |
 | Pre-migration manual dump | Before every prod migration | 30 days off-site |
-| Restore drill            | Quarterly     | Drill log retained 1 year |
+| Restore drill | Quarterly (staging) | Drill log retained 1 year |
 
-Nightly dumps are produced by running `db-backup.sh` from a scheduled job
-(cron / Kubernetes CronJob). The default local retention is 14 days; the
-off-site copy in object storage uses a longer lifecycle policy.
+Nightly dumps run via the [`backup.yml`](../.github/workflows/backup.yml)
+scheduled workflow (cron `0 2 * * *`), which SSHes to the prod host and runs
+`snapshot-postgres.sh`. The S3 bucket's lifecycle rule sets the 30-day off-site
+retention — **not** the script. A host cron entry is documented as an
+alternative in the [snapshot policy](./operations/snapshot-policy.md).
 
-## Required environment variables
+## S3 layout
 
-Both scripts authenticate using either:
+`snapshot-postgres.sh` writes to:
 
-- `DATABASE_URL=postgresql://user:pass@host:5432/dbname`, **or**
-- The standard libpq vars: `PGHOST`, `PGPORT`, `PGUSER`, `PGPASSWORD`,
-  `PGDATABASE`.
+```
+s3://${BACKUP_BUCKET}/postgres/$(date -u +%Y/%m/%d/%H%M%S)/dump.sql.gz
+```
 
-Backup-only:
+tagged `Class=tier1,Retention=30d`. To find the latest:
 
-- `BACKUP_DIR` — output directory (default `./backups`).
-- `BACKUP_RETENTION_DAYS` — local prune horizon (default `14`).
+```bash
+aws s3 ls "s3://${BACKUP_BUCKET}/postgres/" --recursive --region "$AWS_REGION" \
+  | sort | tail -n1
+```
 
-Restore-only:
+## Required environment
 
-- `CONFIRM_RESTORE=I_UNDERSTAND` — skips the interactive prompt for drills.
-- `RESTORE_JOBS` — parallel `pg_restore` workers (default `2`).
+Both scripts run `docker compose exec database …` against the prod stack, so
+they need docker access to the production host.
+
+Backup (`snapshot-postgres.sh`):
+
+- `BACKUP_BUCKET` — S3 bucket (no `s3://` prefix).
+- `AWS_REGION` — bucket region.
+- `POSTGRES_USER`, `POSTGRES_DB` — superuser + database name (from `.env`).
+- `COMPOSE_FILE` — optional, defaults to
+  `/opt/adopt-dont-shop/docker-compose.prod.yml`.
+
+Restore (`restore-postgres.sh`):
+
+- `POSTGRES_USER` — superuser for `psql`.
+- `TARGET_DB` — database to restore **into** (must already exist).
+- Source — exactly one of `S3_KEY` (with `BACKUP_BUCKET` + `AWS_REGION`) or
+  `DUMP_FILE` (a local `*.sql.gz`).
+- `CONFIRM_RESTORE=I_UNDERSTAND` — required only if `TARGET_DB` equals the live
+  `POSTGRES_DB` (the script refuses otherwise).
 
 ## Running a backup
 
 ```bash
-# Local
-DATABASE_URL=postgresql://app:pw@db.internal:5432/adopt_prod \
-BACKUP_DIR=/var/backups/adopt-dont-shop \
-./service.backend/scripts/db-backup.sh
+# On the prod host
+BACKUP_BUCKET=adopt-dont-shop-prod-backups \
+AWS_REGION=eu-west-2 \
+POSTGRES_USER=app POSTGRES_DB=adopt_prod \
+./scripts/snapshot-postgres.sh
 ```
 
 Successful output looks like:
 
 ```
-[db-backup] starting dump -> /var/backups/adopt-dont-shop/adopt-dont-shop-20260508T020000Z.dump.gz
-[db-backup] wrote /var/backups/adopt-dont-shop/adopt-dont-shop-20260508T020000Z.dump.gz (84231244 bytes)
-[db-backup] done
+[snapshot-postgres] dumping adopt_prod -> /tmp/pg-dump-XXXXXX.sql.gz
+[snapshot-postgres] uploading 84231244 bytes -> s3://adopt-dont-shop-prod-backups/postgres/2026/06/16/020000/dump.sql.gz
+[snapshot-postgres] done
 ```
 
-After every successful local dump, copy the file to the off-site bucket
-(e.g. `aws s3 cp ... s3://adopt-dont-shop-backups/`). Object storage retention
-is set by the bucket's lifecycle rule, **not** by this script.
+The script aborts if the dump is under 1 KiB (a cheap guard against an empty /
+failed dump being uploaded).
 
 ## Pre-migration backup checklist
 
 Before running any production migration:
 
-1. Verify last nightly backup completed (check job logs / monitoring).
-2. Run an ad-hoc backup with the migration tag in the filename:
+1. Verify the last nightly backup completed (check the `backup.yml` run / S3).
+2. Run an ad-hoc backup:
    ```bash
-   BACKUP_DIR=/var/backups/adopt-dont-shop ./db-backup.sh
+   ./scripts/snapshot-postgres.sh
    ```
-3. Confirm the new file exists and is non-zero in size.
-4. Copy the file off-site.
-5. Note the backup filename in the migration change ticket.
-6. Only then run `pnpm db:migrate`.
+3. Confirm the new object exists and is non-trivial in size (`aws s3 ls`).
+4. Note the S3 key in the migration change ticket.
+5. Only then trigger the migration (each service migrates its own schema on
+   container start).
 
 If the migration fails or produces unexpected results, restore from the
 ad-hoc backup using the procedure below before any further writes occur.
 
 ## Restoring
 
-`db-restore.sh` is **destructive**: it drops and recreates objects in the
-target database. Restore into a scratch DB first, verify, then repoint the
-application.
+Restore into a **scratch DB** first, verify, then repoint the application.
 
 ```bash
-# 1. Provision a scratch DB
-createdb adopt_restore_check
+# 1. Provision a scratch DB inside the prod stack's Postgres
+docker compose -f /opt/adopt-dont-shop/docker-compose.prod.yml exec -T database \
+  createdb -U "$POSTGRES_USER" adopt_restore_check
 
-# 2. Restore into it
-DATABASE_URL=postgresql://app:pw@db.internal:5432/adopt_restore_check \
-./service.backend/scripts/db-restore.sh /var/backups/adopt-dont-shop/adopt-dont-shop-20260508T020000Z.dump.gz
+# 2. Restore the chosen snapshot into it
+POSTGRES_USER=app \
+TARGET_DB=adopt_restore_check \
+BACKUP_BUCKET=adopt-dont-shop-prod-backups \
+AWS_REGION=eu-west-2 \
+S3_KEY=postgres/2026/06/16/020000/dump.sql.gz \
+./scripts/restore-postgres.sh
 
-# Type 'restore' at the prompt, or set CONFIRM_RESTORE=I_UNDERSTAND for
-# unattended drills.
+# 3. Verify row counts on critical tables (schemas are per-service)
+docker compose -f /opt/adopt-dont-shop/docker-compose.prod.yml exec -T database \
+  psql -U "$POSTGRES_USER" -d adopt_restore_check -c \
+  'select count(*) from auth.users; select count(*) from rescue.rescues; select count(*) from pets.pets;'
 
-# 3. Verify row counts on critical tables
-psql "$DATABASE_URL" -c 'select count(*) from users; select count(*) from rescues;'
-
-# 4. Repoint the application by updating its DATABASE_URL secret and
-#    restarting, only after verification passes.
+# 4. Repoint the app only after verification passes: update the
+#    database_url secret / POSTGRES_DB and restart, or promote the scratch DB.
 ```
 
-For an in-place restore (after a migration disaster), make sure the app is
-stopped first; otherwise concurrent writes will collide with the restore.
+For an in-place restore after a migration disaster, **stop the writing
+services first** (otherwise concurrent writes collide with the restore), then
+run with `TARGET_DB=$POSTGRES_DB CONFIRM_RESTORE=I_UNDERSTAND`.
 
-## Quarterly restore drill
+## Quarterly restore drill (staging)
 
-Pick a date each quarter to exercise the full path end-to-end:
+A backup you have never restored is a backup you do not have. We **cannot**
+prove the path against production live — instead we rehearse it in **staging**
+each quarter:
 
-1. Pick a backup at random from the last 30 days.
-2. Provision a scratch DB.
-3. Run `db-restore.sh` with `CONFIRM_RESTORE=I_UNDERSTAND`.
-4. Run a smoke-test query set (row counts on `users`, `rescues`, `pets`,
-   `applications`, `audit_logs`).
+1. Pick a snapshot at random from the last 30 days of production backups.
+2. On the **staging** host, provision a scratch DB in the staging Postgres:
+   ```bash
+   docker compose -f /opt/adopt-dont-shop/docker-compose.staging.yml exec -T database \
+     createdb -U "$POSTGRES_USER" adopt_drill_$(date +%Y%m%d)
+   ```
+3. Restore the production snapshot into it with `restore-postgres.sh`
+   (`COMPOSE_FILE=…docker-compose.staging.yml`, `S3_KEY=<the chosen key>`,
+   `TARGET_DB=adopt_drill_…`). No `CONFIRM_RESTORE` needed — the target is a
+   scratch DB.
+4. Run the smoke-test query set (row counts on `auth.users`,
+   `rescue.rescues`, `pets.pets`, `applications.applications`,
+   `audit.audit_events`).
 5. Record:
-   - Backup file used.
-   - Restore wall-clock time.
+   - Snapshot S3 key used.
+   - Restore wall-clock time (this is your measured RTO — compare to the 2h
+     target above).
    - Any errors encountered + remediation.
-6. File the drill log in the ops channel; archive it for at least one year.
+6. File the drill log in the ops channel; archive it for at least one year
+   (e.g. `docs/operations/restore-drills.md`).
 
 A drill that fails to complete cleanly is itself the highest-priority finding
 — fix the failure before the next scheduled migration.
 
+> "Restore tested against the live production environment" is intentionally out
+> of scope: there is no spare production environment to restore into safely.
+> The staging drill above is the substitute and must run quarterly.
+
 ## Troubleshooting
 
-- **`pg_dump: error: connection to server`** — check `DATABASE_URL` /
-  `PGHOST` etc. The script does not retry; cron should.
-- **`pg_restore: error: could not execute query`** — almost always a role /
-  extension mismatch. The scripts pass `--no-owner --no-acl` to minimise
-  this; if it still fires, ensure the target DB has the same extensions
-  (`pg_trgm`, `citext`, `postgis`) installed.
-- **Backup file is suspiciously small** — verify the source DSN points at
-  the right database. The script reports the byte count on stdout; alert
-  if it drops below the expected floor for two consecutive nights.
+- **`pg_dump: error: connection to server`** — the prod stack isn't up, or the
+  `database` container name / compose file is wrong. Check
+  `docker compose -f $COMPOSE_FILE ps database`.
+- **`psql: … ON_ERROR_STOP`** — the restore hit a failing statement and
+  stopped (by design). Almost always a role / extension mismatch: ensure the
+  target DB has the same extensions (`pg_trgm`, `citext`, `postgis`) and that
+  the per-service schemas exist. A scratch DB created fresh in the same
+  Postgres instance inherits the cluster's extensions.
+- **Dump is suspiciously small** — both scripts abort below 1 KiB. Verify the
+  source `POSTGRES_DB` is correct and the dump actually contains data.

--- a/docs/runbooks/gdpr-erasure-incident.md
+++ b/docs/runbooks/gdpr-erasure-incident.md
@@ -1,0 +1,153 @@
+# GDPR Erasure Saga Incident
+
+**Page severity:** `critical` — `GdprSagaFailed` or `GdprSagaTimedOut` (see
+[`infra/prometheus/rules/gdpr-saga.yml`](../../infra/prometheus/rules/gdpr-saga.yml)).
+An unfulfilled erasure request is a legal obligation, not a best-effort job.
+
+## Background
+
+A user erasure ("right to be forgotten") is a **distributed saga** coordinated
+by `services/audit`:
+
+1. The gateway publishes `gdpr.erasureRequested` (correlationId, userId,
+   reason) when a user requests erasure
+   (`/api/v1/users/me/erasure-request`).
+2. Every domain service binds a durable consumer `gdpr-<service>` and erases
+   that user's rows **in a transaction**, then publishes
+   `gdpr.erasureCompleted` (service, recordsErased, optional error) after
+   commit.
+3. `services/audit` tracks the saga in `audit.gdpr_erasure_requests`
+   (one row per `correlation_id`), merging each completion into a `completions`
+   JSONB blob. It stamps `completed_at` only once **every** service in
+   `EXPECTED_SERVICES` acks without error; an errored ack stamps `failed_at`.
+   See
+   [`services/audit/src/nats/gdpr-subscribers.ts`](../../services/audit/src/nats/gdpr-subscribers.ts).
+4. A sweep scheduler
+   ([`gdpr-sweep.ts`](../../services/audit/src/nats/gdpr-sweep.ts)) runs
+   periodically and:
+   - **Times out** sagas older than `GDPR_SAGA_DEADLINE_MS` (default **30 min**)
+     that still have services which never acked → stamps `timed_out_at`, logs
+     the missing services at error level.
+   - **Retries** sagas with `failed_at` set and `retry_count < GDPR_SAGA_MAX_RETRIES`
+     (default **3**) by re-publishing `gdpr.erasureRequested` with the same
+     `correlationId` but a distinct msgID. Erasure handlers are idempotent, so a
+     re-run is a clean no-op for already-erased rows.
+
+The `gdpr_sagas{state=…}` gauge
+([`gdpr-metrics.ts`](../../services/audit/src/nats/gdpr-metrics.ts)) exposes
+the count in each state (`in_progress` / `completed` / `failed` / `timed_out`)
+and is what the alerts watch.
+
+The expected services (must all ack):
+
+```
+auth, notifications, pets, chat, applications, matching, moderation, cms, rescue
+```
+
+## Symptoms
+
+- `GdprSagaFailed` — `gdpr_sagas{state="failed"} > 0`: a service acked with an
+  error.
+- `GdprSagaTimedOut` — `gdpr_sagas{state="timed_out"} > 0`: a service never
+  acked within 30 min.
+- `GdprErasureRequestedNotCompleted` — a saga sat `in_progress` past the
+  deadline + sweep margin.
+
+## Triage in 60 seconds
+
+Find the stuck saga(s) and which service(s) are at fault:
+
+```bash
+# Failed or timed-out sagas, with the per-service completion blob.
+docker compose -f docker-compose.prod.yml exec -T database psql -U "$POSTGRES_USER" "$POSTGRES_DB" -c "
+  select correlation_id, user_id, requested_at, failed_at, timed_out_at,
+         retry_count, jsonb_pretty(completions) as completions
+  from audit.gdpr_erasure_requests
+  where completed_at is null
+    and (failed_at is not null or timed_out_at is not null)
+  order by requested_at;"
+```
+
+- A service **present in `completions` with an `error`** → that service's
+  erasure handler threw. (failed)
+- A service **absent from `completions`** → that service never acked. (timed
+  out — the sweep logs the missing list)
+
+Then read the culprit service's log:
+
+```bash
+docker compose -f docker-compose.prod.yml logs --tail=200 --no-color service-<name> \
+  | grep -i "gdpr\|erasure\|<correlation_id>"
+```
+
+## Diagnosis
+
+- **Service down / consumer not bound** → the `gdpr-<service>` durable isn't
+  consuming. The event is safe in `DOMAIN_EVENTS` (7-day retention); the saga
+  just can't complete until the service is back. See
+  [`jetstream-backlog.md`](./jetstream-backlog.md).
+- **Handler error (failed)** → the erasure transaction threw (FK constraint,
+  DB error, a bug). The `completions[service].error` string and the service log
+  have the detail.
+- **Retries exhausted** → `retry_count >= 3` and still `failed_at`: the sweep
+  has stopped auto-retrying and is waiting for you.
+
+## Mitigation
+
+1. **Fix the culprit service** — restart if it was down, roll back if a bad
+   deploy broke the erasure handler:
+   ```bash
+   docker compose -f docker-compose.prod.yml restart service-<name>
+   ```
+   Once healthy, the durable consumer reprocesses the redelivered request (or
+   the sweep re-publishes on its next tick), and the service acks. The saga
+   advances on its own.
+
+2. **Force a re-run** if you've fixed the cause but don't want to wait for the
+   sweep — re-publish `gdpr.erasureRequested` with the same correlationId and a
+   fresh msgID. Idempotent handlers make this safe:
+   ```bash
+   nats pub gdpr.erasureRequested \
+     '{"correlationId":"<id>","userId":"<uid>","reason":"manual re-run","requestedAt":"'"$(date -u +%FT%TZ)"'"}' \
+     -H Nats-Msg-Id:"<id>:manual:$(date +%s)"
+   ```
+
+3. **If a service genuinely has nothing to erase** but errored on a transient
+   issue, the re-run will record a clean completion (0 rows) and unblock the
+   saga.
+
+4. **Never** mark a saga complete by hand-editing `audit.gdpr_erasure_requests`
+   to satisfy an alert. The row is the legal record — only let it flip to
+   `completed` because every service actually acked.
+
+## Verify
+
+```bash
+docker compose -f docker-compose.prod.yml exec -T database psql -U "$POSTGRES_USER" "$POSTGRES_DB" -c "
+  select correlation_id, completed_at, failed_at, timed_out_at
+  from audit.gdpr_erasure_requests where correlation_id = '<id>';"
+```
+
+- `completed_at` is stamped (all 9 expected services acked without error).
+- `gdpr_sagas{state="failed"}` and `{state="timed_out"}` return to 0; the
+  alerts resolve.
+
+## Capture
+
+```bash
+docker compose -f docker-compose.prod.yml exec -T database psql -U "$POSTGRES_USER" "$POSTGRES_DB" -c "
+  select * from audit.gdpr_erasure_requests where correlation_id = '<id>';" \
+  > /tmp/gdpr-incident-$(date +%s).txt
+```
+
+File the Linear follow-up. Because this is a compliance event, record the
+resolution date and confirm the erasure actually completed for the data
+subject. If a handler bug caused it, add a test reproducing the failing erasure
+before closing.
+
+## Related
+
+- [`docs/slo.md`](../slo.md) — GDPR saga correctness SLO.
+- [`docs/GDPR-ROPA.md`](../GDPR-ROPA.md) — record of processing activities.
+- [`jetstream-backlog.md`](./jetstream-backlog.md) — when the cause is a stalled
+  consumer rather than a handler error.

--- a/docs/runbooks/jetstream-backlog.md
+++ b/docs/runbooks/jetstream-backlog.md
@@ -1,0 +1,134 @@
+# JetStream Consumer Backlog
+
+**Page severity:** `warning` (a durable consumer's pending count climbs and
+does not drain) escalating to `critical` if user-visible (notifications stop,
+the GDPR saga stalls, the read-model projections lag).
+
+## Background
+
+All domain events flow through a **single** JetStream stream, `DOMAIN_EVENTS`
+(file storage, 7-day `max_age`, 2-minute duplicate window), defined in
+[`packages/events/src/stream.ts`](../../packages/events/src/stream.ts).
+Subjects are `<service>.>` per domain plus `gdpr.>`. Each subscriber binds a
+**durable, explicit-ack** consumer that filters the stream to its own subject
+(see [`packages/events/src/subscribe.ts`](../../packages/events/src/subscribe.ts)).
+
+Key behaviours that shape this runbook:
+
+- **Explicit ack.** A handler that throws `nak()`s the message with backoff
+  (`nakBackoffMs`) so JetStream redelivers it.
+- **Redelivery cap.** After `MAX_DELIVER = 7` attempts the message is `term()`'d
+  and republished to the dead-letter stream `DOMAIN_EVENTS_DLQ` on
+  `dlq.<original-subject>` (14-day retention). It is **not** dropped or looped.
+- **Durable = catch-up.** A consumer offline for < 7 days gets every missed
+  message when it reconnects. Offline > 7 days and the oldest messages have
+  aged out of `DOMAIN_EVENTS` — permanent loss for that consumer.
+
+## Symptoms
+
+- A consumer's `num_pending` (un-delivered) or `num_ack_pending`
+  (delivered-not-acked) grows and does not fall.
+- Downstream effects: in-app/push notifications stop arriving, chat real-time
+  fan-out lags, the audit GDPR saga doesn't progress, read models go stale.
+- `DOMAIN_EVENTS_DLQ` message count is rising (poison messages exhausting
+  redelivery).
+
+## Triage in 60 seconds
+
+```bash
+# Stream + consumer state (run from the prod host; `nats` CLI against the
+# server, or via the NATS box container if present).
+nats stream info DOMAIN_EVENTS
+nats consumer ls DOMAIN_EVENTS
+
+# Per-consumer detail — look at num_pending, num_ack_pending, num_redelivered.
+nats consumer info DOMAIN_EVENTS <durable-name>
+
+# Dead-letter stream — is it growing?
+nats stream info DOMAIN_EVENTS_DLQ
+```
+
+Durable names follow `gdpr-<service>` for the erasure saga and the
+service-specific names registered in
+[`packages/events/src/consumer-registry.ts`](../../packages/events/src/consumer-registry.ts).
+If you don't have the `nats` CLI, the same numbers are visible on the NATS
+monitoring port (`/jsz?consumers=true`).
+
+## Diagnosis
+
+Match the shape of the backlog:
+
+- **`num_ack_pending` high, `num_redelivered` climbing** → the handler is
+  failing and `nak()`-ing. The consuming service is broken (bad deploy, DB
+  down, downstream gRPC call failing). Check that service's logs:
+  ```bash
+  docker compose -f docker-compose.prod.yml logs --tail=200 --no-color service-<name>
+  ```
+- **`num_pending` high, consumer has no recent delivery** → the consumer isn't
+  running. The service is down or didn't re-bind its durable on restart. Check
+  the service is up and its `registerSubscribers` ran (look for the subscribe
+  log line at boot).
+- **`DOMAIN_EVENTS_DLQ` growing** → poison messages exhausted `MAX_DELIVER`.
+  The payload will never process. Triage the DLQ (below).
+- **Stream near `max_age` / a consumer offline for days** → catch-up risk.
+  Prioritise getting the consumer back before the 7-day window drops messages.
+
+## Mitigation
+
+1. **Fix the consuming service first.** The backlog is a symptom; the stream is
+   doing its job (retaining + redelivering). Restart / roll back the service:
+   ```bash
+   docker compose -f docker-compose.prod.yml restart service-<name>
+   # or, if it's a bad deploy, see deploy-rollback.md
+   ```
+   Once healthy, the durable consumer replays the backlog automatically. Watch
+   `num_pending` fall.
+
+2. **If a single poison message blocks a consumer** (same message redelivering,
+   blocking the rest), let it exhaust `MAX_DELIVER` (it will move to the DLQ on
+   its own) or, if it's urgent, `term` it manually so the consumer advances:
+   ```bash
+   nats consumer next DOMAIN_EVENTS <durable-name> --count 1   # inspect it
+   ```
+   Capture the payload before terminating — the DLQ keeps it for 14 days but
+   copy it into the incident notes.
+
+3. **Triage the DLQ** once the bleeding stops:
+   ```bash
+   nats stream view DOMAIN_EVENTS_DLQ            # inspect dead-lettered msgs
+   ```
+   For each class of dead-lettered message: fix the handler bug, then replay by
+   re-publishing the original subject (the events are idempotent by design —
+   erasure/notification handlers no-op on replay). Do **not** mass-replay
+   blindly.
+
+4. **If a consumer was offline > 7 days**, the oldest messages have aged out of
+   `DOMAIN_EVENTS`. That data is gone from the bus — reconstruct from the
+   source service's own DB (the event store / read model) rather than the
+   stream. Note the gap in the incident review.
+
+## Verify
+
+- `num_pending` and `num_ack_pending` for the consumer trend to ~0.
+- `num_redelivered` stops climbing.
+- `DOMAIN_EVENTS_DLQ` stops growing.
+- Downstream effects resume (notifications arrive, saga progresses).
+
+## Capture
+
+```bash
+nats consumer info DOMAIN_EVENTS <durable-name> > /tmp/jetstream-incident-$(date +%s).txt
+docker compose -f docker-compose.prod.yml logs --since 1h --no-color \
+  service-<name> >> /tmp/jetstream-incident-$(date +%s).txt
+```
+
+File the Linear follow-up. If the backlog was caused by a handler bug, add a
+test that reproduces the failing payload before closing.
+
+## Related
+
+- [`docs/slo.md`](../slo.md) — saga / consumer SLOs.
+- [`gdpr-erasure-incident.md`](./gdpr-erasure-incident.md) — when the stalled
+  consumer is the GDPR saga.
+- [`deploy-rollback.md`](./deploy-rollback.md) — when a bad deploy broke the
+  consumer.

--- a/docs/slo.md
+++ b/docs/slo.md
@@ -1,0 +1,139 @@
+# Service Level Objectives & Alerting (ADS-806)
+
+Per-service SLOs, error-budget windows, and the Prometheus alerting rules
+that watch them. The rules are committed as loadable rule files under
+[`infra/prometheus/rules/`](../infra/prometheus/rules/) — see that
+directory's [README](../infra/prometheus/rules/README.md) for how to wire
+them into a Prometheus server.
+
+> **This supersedes [`docs/observability-alerting.md`](./observability-alerting.md).**
+> That document targets the deleted monolith
+> (`service="adopt-dont-shop-backend"`, `http_requests_total`,
+> `METRICS_AUTH_TOKEN`) — none of which exist in the current microservices
+> stack. It is kept for history; treat this file and the rule files as
+> canonical.
+
+## What metrics actually exist today
+
+Every service mounts the shared registry from
+[`packages/observability/src/metrics.ts`](../packages/observability/src/metrics.ts)
+on an unauthenticated `/metrics` endpoint. The series available **right now**
+are:
+
+| Metric | Type | Labels | Source |
+| --- | --- | --- | --- |
+| `http_request_duration_seconds` | histogram | `method`, `route`, `status_code` | shared — Fastify `onResponse` hook |
+| `grpc_handler_duration_seconds` | histogram | `service`, `method`, `code`, `direction` | shared — gRPC adapter wrappers |
+| `gdpr_sagas` | gauge | `state` (`in_progress`/`completed`/`failed`/`timed_out`) | `services/audit` only |
+| `gateway_rate_limit_hits_total` | counter | `route` | `services/gateway` only |
+| `grpc_circuit_state` | gauge | `service` (`0`=closed, `1`=half-open, `2`=open) | `services/gateway` only |
+| `nodejs_*`, `process_*` | gauge/counter | — | `collectDefaultMetrics()` |
+
+Notes that shape every rule below:
+
+- **There is no `http_requests_total` counter.** Request rate and error rate
+  are derived from the histogram's `_count` series
+  (`http_request_duration_seconds_count`). The legacy doc's
+  `http_requests_total` does not exist.
+- **There is no `service` / app label on the HTTP histogram.** A request's
+  owning service is identified by the Prometheus **`job`** label set at scrape
+  time. The rule files assume one scrape job per service, named for the
+  service (`service-auth`, `service-gateway`, …). Adjust the `job` values to
+  match your scrape config.
+- `grpc_handler_duration_seconds` carries its own `service` label (the gRPC
+  service name, e.g. `auth.v1.AuthService`) plus `direction` (`in` on the
+  server side, `out` on the gateway's clients).
+- `up` and (optional) `probe_success` are synthesised by Prometheus itself
+  from scrape success / blackbox probes — they are not exported by the apps.
+
+### Future metrics (ADS-803)
+
+ADS-803 will add **domain** metrics (business counters/histograms on hot
+paths — applications submitted, pets listed, notifications sent, etc.). The
+comment block at the top of `metrics.ts` reserves that space ("Services
+annotate their own hot paths in a follow-up PR"). When those land, add
+per-domain SLOs to the table below and per-domain rules in a new
+`infra/prometheus/rules/domain-*.yml` file. Until then the SLOs are limited to
+the transport-level signals that genuinely exist.
+
+## SLO targets
+
+SLOs are expressed over a **rolling 30-day window**. The error budget is
+`(1 - target)` of that window — the amount of bad time/requests the service may
+spend before the SLO is breached.
+
+### Availability & latency — request-serving services
+
+These services serve HTTP and/or gRPC and own a user-facing latency budget.
+
+| Service | Job label | Availability SLO (non-5xx) | Latency SLO | 30-day error budget |
+| --- | --- | --- | --- | --- |
+| gateway | `service-gateway` | 99.9% | p95 HTTP < 500 ms | 43m 12s / 0.1% req |
+| auth | `service-auth` | 99.9% | p95 gRPC < 300 ms | 43m 12s |
+| pets | `service-pets` | 99.5% | p95 gRPC < 400 ms | 3h 36m |
+| rescue | `service-rescue` | 99.5% | p95 gRPC < 400 ms | 3h 36m |
+| applications | `service-applications` | 99.5% | p95 gRPC < 500 ms | 3h 36m |
+| chat | `service-chat` | 99.5% | p95 gRPC < 400 ms | 3h 36m |
+| matching | `service-matching` | 99.0% | p95 gRPC < 800 ms | 7h 18m |
+| moderation | `service-moderation` | 99.5% | p95 gRPC < 400 ms | 3h 36m |
+| notifications | `service-notifications` | 99.5% | p95 gRPC < 500 ms | 3h 36m |
+| cms | `service-cms` | 99.9% | p95 HTTP < 300 ms | 43m 12s |
+
+Rationale: the **gateway** and **auth** sit on every request path, so they
+carry the tightest budgets. **matching** runs a heavier recommender (and reads
+pets on-demand), so it gets the loosest latency/availability target.
+
+### Background correctness — audit GDPR saga
+
+The audit service has no user-facing latency SLO, but it owns a **correctness**
+objective on the GDPR erasure saga (a legal obligation):
+
+| Objective | Target | Measured by |
+| --- | --- | --- |
+| No saga stuck `failed` | `gdpr_sagas{state="failed"} == 0` | gauge |
+| No saga stuck `timed_out` | `gdpr_sagas{state="timed_out"} == 0` | gauge |
+| Erasure requests complete | each `erasureRequested` reaches `completed` within the saga deadline | gauge + sweep scheduler |
+
+A single `failed`/`timed_out` saga is a budget breach — there is no tolerable
+rate of unfulfilled erasure requests.
+
+## Alerting rules → SLO mapping
+
+The committed rules implement the objectives above. Each rule annotates the
+runbook to open on fire.
+
+| Rule (file) | Watches | SLO it protects |
+| --- | --- | --- |
+| `ServiceDown` (`service-down.yml`) | `up == 0` per job | Availability — service is unreachable |
+| `HighErrorRate` (`high-error-rate.yml`) | 5xx fraction of `http_request_duration_seconds_count` | Availability (HTTP) |
+| `HighGrpcErrorRate` (`high-error-rate.yml`) | non-OK fraction of `grpc_handler_duration_seconds_count` | Availability (gRPC) |
+| `HttpP95LatencyHigh` (`p95-latency.yml`) | `histogram_quantile(0.95, …http_request_duration_seconds_bucket…)` | Latency (HTTP) |
+| `GrpcP95LatencyHigh` (`p95-latency.yml`) | `histogram_quantile(0.95, …grpc_handler_duration_seconds_bucket…)` | Latency (gRPC) |
+| `GdprSagaFailed` (`gdpr-saga.yml`) | `gdpr_sagas{state="failed"} > 0` | GDPR saga correctness |
+| `GdprSagaTimedOut` (`gdpr-saga.yml`) | `gdpr_sagas{state="timed_out"} > 0` | GDPR saga correctness |
+| `GdprErasureRequestedNotCompleted` (`gdpr-saga.yml`) | `in_progress` backlog persisting beyond the saga deadline | GDPR saga correctness |
+| `GatewayCircuitOpen` (`gateway-resilience.yml`) | `grpc_circuit_state == 2` | Availability — downstream dependency unhealthy |
+| `GatewayRateLimitSpike` (`gateway-resilience.yml`) | surge in `gateway_rate_limit_hits_total` | Abuse / capacity signal |
+
+## Severity & on-call
+
+The rules label severity but **deliberately do not configure Alertmanager
+routing or receivers** — that needs a real destination (PagerDuty key / Slack
+webhook) which does not exist in this repo yet. Wire routing when a destination
+is provisioned. Until then the convention is:
+
+| Severity | Intended routing (TODO: wire) | Response |
+| --- | --- | --- |
+| `critical` | page | ack within 5 min |
+| `warning` | chat channel | review within 30 min |
+
+Each `critical`/`warning` rule annotates a `runbook` — open it from the alert.
+Runbook index: [`docs/runbooks/README.md`](./runbooks/README.md).
+
+## Reviewing & evolving SLOs
+
+- Revisit targets quarterly against actual 30-day burn. A budget never spent is
+  too loose; a budget chronically exhausted is too tight (or the service needs
+  work).
+- When ADS-803 domain metrics land, extend the SLO table and add
+  `domain-*.yml` rules rather than overloading the transport rules.

--- a/infra/prometheus/rules/README.md
+++ b/infra/prometheus/rules/README.md
@@ -1,0 +1,72 @@
+# Prometheus alerting rules (ADS-806)
+
+Loadable Prometheus rule files implementing the SLOs in
+[`docs/slo.md`](../../../docs/slo.md). Every rule is written against a metric
+that **actually exists** in the current stack (see the metrics table in
+`docs/slo.md`); none reference the deleted monolith's `http_requests_total` /
+`METRICS_AUTH_TOKEN`.
+
+## Files
+
+| File | Rules |
+| --- | --- |
+| `service-down.yml` | `ServiceDown` — scrape `up == 0` per service |
+| `high-error-rate.yml` | `HighErrorRate` (HTTP 5xx), `HighGrpcErrorRate` (gRPC non-OK) |
+| `p95-latency.yml` | `HttpP95LatencyHigh`, `GrpcP95LatencyHigh` |
+| `gdpr-saga.yml` | `GdprSagaFailed`, `GdprSagaTimedOut`, `GdprErasureRequestedNotCompleted` |
+| `gateway-resilience.yml` | `GatewayCircuitOpen`, `GatewayRateLimitSpike` |
+
+## Assumptions
+
+- **One scrape job per service**, named `service-<name>` (e.g. `service-auth`,
+  `service-gateway`). The HTTP histogram carries no service label, so service
+  identity for HTTP/`up` rules comes from the `job` label. Adjust the `job`
+  matchers if your scrape config names targets differently.
+- The `/metrics` endpoint on each service is unauthenticated (current
+  behaviour). If you add scrape auth, configure it in `prometheus.yml`, not
+  here.
+- `gdpr_sagas` is exported only by `service-audit`; `grpc_circuit_state` and
+  `gateway_rate_limit_hits_total` only by `service-gateway`.
+
+## Wiring into Prometheus
+
+Reference the files from your `prometheus.yml` and reload:
+
+```yaml
+# prometheus.yml
+rule_files:
+  - /etc/prometheus/rules/*.yml
+
+scrape_configs:
+  - job_name: service-gateway
+    metrics_path: /metrics
+    static_configs:
+      - targets: ['service-gateway:4000']
+  - job_name: service-auth
+    metrics_path: /metrics
+    static_configs:
+      - targets: ['service-auth:5002']
+  # … one job per service, named service-<name>, on its HTTP port.
+```
+
+Mount this directory at `/etc/prometheus/rules` (or copy the files there) and
+reload Prometheus (`SIGHUP` or `POST /-/reload`).
+
+## Validating
+
+Check syntax with `promtool` before shipping:
+
+```bash
+promtool check rules infra/prometheus/rules/*.yml
+```
+
+(YAML structure is also CI-checkable with any YAML loader; promtool
+additionally validates the PromQL expressions.)
+
+## Out of scope
+
+**Alertmanager routing & receivers are not configured here.** Routing needs a
+real destination (PagerDuty integration key / Slack webhook) that this repo
+does not yet have. The rules set a `severity` label and a `runbook` annotation;
+wire `severity`-based routes in Alertmanager once a destination exists. See
+`docs/slo.md` for the intended severity → routing convention.

--- a/infra/prometheus/rules/gateway-resilience.yml
+++ b/infra/prometheus/rules/gateway-resilience.yml
@@ -1,0 +1,40 @@
+# Gateway resilience rules (ADS-806).
+#
+# Two gateway-only metrics:
+#   grpc_circuit_state{service}  gauge — 0=closed, 1=half-open, 2=open
+#     (services/gateway/src/grpc-clients/resilience.ts)
+#   gateway_rate_limit_hits_total{route}  counter — incremented on every 429
+#     (services/gateway/src/server.ts)
+groups:
+  - name: ads-gateway-resilience
+    interval: 30s
+    rules:
+      # A downstream circuit is open — the gateway is rejecting calls to that
+      # service fast. Indicates the dependency is unhealthy.
+      - alert: GatewayCircuitOpen
+        expr: grpc_circuit_state == 2
+        for: 1m
+        labels:
+          severity: critical
+        annotations:
+          summary: 'Gateway circuit OPEN for {{ $labels.service }}'
+          description: >-
+            The gateway's circuit breaker for downstream {{ $labels.service }} is
+            open (2): calls are being rejected fast. The downstream is failing or
+            unreachable. Check that service's health and error rate.
+          runbook: docs/runbooks/5xx-spike.md
+
+      # Sustained rate-limiting on a route — abuse or under-provisioning.
+      - alert: GatewayRateLimitSpike
+        expr: |
+          sum by (route) (rate(gateway_rate_limit_hits_total[5m])) > 1
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: 'Sustained 429s on {{ $labels.route }} (5m rate >1/s)'
+          description: >-
+            The gateway has been rate-limiting {{ $labels.route }} at more than
+            one rejection per second for 10 minutes. Either a client is abusing
+            the route or the limit is too tight for legitimate load.
+          runbook: docs/runbooks/maintenance-mode.md

--- a/infra/prometheus/rules/gdpr-saga.yml
+++ b/infra/prometheus/rules/gdpr-saga.yml
@@ -1,0 +1,57 @@
+# GDPR erasure saga rules (ADS-806).
+#
+# The audit service exports a single gauge tracking saga state:
+#   gdpr_sagas{state="in_progress"|"completed"|"failed"|"timed_out"}
+# (services/audit/src/nats/gdpr-metrics.ts). The sweep scheduler flips a saga
+# that misses its deadline (GDPR_SAGA_DEADLINE_MS, default 30 min) to
+# "timed_out". A single stuck saga is a legal/correctness breach — there is no
+# tolerable rate (see docs/slo.md).
+groups:
+  - name: ads-gdpr-saga
+    interval: 30s
+    rules:
+      # A service acked an erasure with an error; failed_at is stamped and the
+      # saga will not complete until an operator resolves + re-runs it.
+      - alert: GdprSagaFailed
+        expr: gdpr_sagas{state="failed"} > 0
+        for: 1m
+        labels:
+          severity: critical
+        annotations:
+          summary: '{{ $value }} GDPR erasure saga(s) in failed state'
+          description: >-
+            At least one service acked a GDPR erasure with an error. The saga is
+            stuck; the erasure obligation is unmet until resolved.
+          runbook: docs/runbooks/gdpr-erasure-incident.md
+
+      # A saga passed its deadline with services that never acked. The sweep
+      # has already error-logged the missing services.
+      - alert: GdprSagaTimedOut
+        expr: gdpr_sagas{state="timed_out"} > 0
+        for: 1m
+        labels:
+          severity: critical
+        annotations:
+          summary: '{{ $value }} GDPR erasure saga(s) timed out'
+          description: >-
+            One or more erasure sagas passed the saga deadline without every
+            expected service acking. The audit sweep logged the missing services.
+          runbook: docs/runbooks/gdpr-erasure-incident.md
+
+      # Early-warning: erasureRequested that has not reached completed. The
+      # gauge is a snapshot, so we alert when the in_progress backlog persists
+      # longer than the saga deadline + sweep margin (40m > the 30m deadline),
+      # i.e. requests that should have completed or timed-out but haven't.
+      - alert: GdprErasureRequestedNotCompleted
+        expr: gdpr_sagas{state="in_progress"} > 0
+        for: 40m
+        labels:
+          severity: warning
+        annotations:
+          summary: 'GDPR erasure saga in_progress beyond the 30m deadline'
+          description: >-
+            {{ $value }} erasure saga(s) have been in_progress for over 40
+            minutes — past the 30-minute saga deadline plus sweep margin. They
+            should have flipped to completed or timed_out; investigate the sweep
+            scheduler and per-service erasure subscribers.
+          runbook: docs/runbooks/gdpr-erasure-incident.md

--- a/infra/prometheus/rules/high-error-rate.yml
+++ b/infra/prometheus/rules/high-error-rate.yml
@@ -1,0 +1,59 @@
+# Error-rate rules (ADS-806).
+#
+# There is NO http_requests_total counter in this stack. Request and error
+# rates are derived from the histogram COUNT series:
+#   http_request_duration_seconds_count{method,route,status_code}
+#   grpc_handler_duration_seconds_count{service,method,code,direction}
+#
+# Service identity for HTTP comes from the scrape `job` label (the HTTP
+# histogram carries no service label). gRPC errors use grpc-js numeric status
+# codes as strings: code="0" is OK; anything else is an error.
+groups:
+  - name: ads-error-rate
+    interval: 30s
+    rules:
+      # HTTP 5xx fraction per service (job). 1% over 5m -> warning.
+      - alert: HighErrorRate
+        expr: |
+          (
+            sum by (job) (
+              rate(http_request_duration_seconds_count{status_code=~"5.."}[5m])
+            )
+            /
+            sum by (job) (
+              rate(http_request_duration_seconds_count[5m])
+            )
+          ) > 0.01
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: '{{ $labels.job }} HTTP 5xx rate >1% (5m)'
+          description: >-
+            More than 1% of HTTP responses from {{ $labels.job }} were 5xx over
+            the last 5 minutes. Eating into the availability error budget
+            (see docs/slo.md).
+          runbook: docs/runbooks/5xx-spike.md
+
+      # gRPC server-side non-OK fraction per gRPC service. direction="in" is
+      # the inbound (server) side; "out" is the gateway's outbound clients.
+      - alert: HighGrpcErrorRate
+        expr: |
+          (
+            sum by (service) (
+              rate(grpc_handler_duration_seconds_count{direction="in", code!="0"}[5m])
+            )
+            /
+            sum by (service) (
+              rate(grpc_handler_duration_seconds_count{direction="in"}[5m])
+            )
+          ) > 0.02
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: '{{ $labels.service }} gRPC error rate >2% (5m)'
+          description: >-
+            More than 2% of inbound gRPC handler calls to {{ $labels.service }}
+            returned a non-OK status over the last 5 minutes.
+          runbook: docs/runbooks/5xx-spike.md

--- a/infra/prometheus/rules/p95-latency.yml
+++ b/infra/prometheus/rules/p95-latency.yml
@@ -1,0 +1,48 @@
+# p95 latency rules (ADS-806).
+#
+# histogram_quantile() over the _bucket series of the two shared histograms.
+# Bucket boundaries (le) are defined in packages/observability/src/metrics.ts:
+#   HTTP : 0.005 .. 10 s
+#   gRPC : 0.005 .. 5 s
+# HTTP latency is grouped by the scrape `job` (no service label on the metric);
+# gRPC latency is grouped by the metric's own `service` label.
+groups:
+  - name: ads-latency
+    interval: 30s
+    rules:
+      - alert: HttpP95LatencyHigh
+        expr: |
+          histogram_quantile(
+            0.95,
+            sum by (job, le) (
+              rate(http_request_duration_seconds_bucket[5m])
+            )
+          ) > 0.5
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: '{{ $labels.job }} HTTP p95 latency >500ms (10m)'
+          description: >-
+            95th-percentile HTTP latency for {{ $labels.job }} has exceeded the
+            500ms SLO for 10 minutes (see docs/slo.md). Per-service targets vary;
+            this is the default edge threshold.
+          runbook: docs/runbooks/db-pool-exhaustion.md
+
+      - alert: GrpcP95LatencyHigh
+        expr: |
+          histogram_quantile(
+            0.95,
+            sum by (service, le) (
+              rate(grpc_handler_duration_seconds_bucket{direction="in"}[5m])
+            )
+          ) > 0.5
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: '{{ $labels.service }} gRPC p95 latency >500ms (10m)'
+          description: >-
+            95th-percentile inbound gRPC handler latency for
+            {{ $labels.service }} has exceeded 500ms for 10 minutes.
+          runbook: docs/runbooks/db-pool-exhaustion.md

--- a/infra/prometheus/rules/service-down.yml
+++ b/infra/prometheus/rules/service-down.yml
@@ -1,0 +1,22 @@
+# Service availability — scrape-up rule (ADS-806).
+#
+# `up` is synthesised by Prometheus from scrape success; it is not exported by
+# the apps. One series per scrape target, keyed by the `job` label. The job
+# names below match the convention in docs/slo.md (service-<name>); adjust to
+# your scrape config if different.
+groups:
+  - name: ads-availability
+    interval: 30s
+    rules:
+      - alert: ServiceDown
+        expr: up{job=~"service-.+"} == 0
+        for: 2m
+        labels:
+          severity: critical
+        annotations:
+          summary: '{{ $labels.job }} is down (scrape failing for 2m)'
+          description: >-
+            Prometheus cannot scrape {{ $labels.job }} ({{ $labels.instance }}).
+            The /metrics endpoint is unreachable — the service is likely crashed,
+            unscheduled, or networkpartitioned.
+          runbook: docs/runbooks/5xx-spike.md

--- a/packages/README.md
+++ b/packages/README.md
@@ -1,0 +1,64 @@
+# Packages
+
+All shared workspace packages, scoped under `@adopt-dont-shop/`. Three groups:
+
+- **Frontend-shared libraries** (`lib.*`) — consumed by the React apps
+  (`app.client`, `app.admin`, `app.rescue`). Most are HTTP service clients +
+  React Query hooks + types.
+- **Service-only shared packages** — backend substrate consumed by the gateway
+  and the gRPC services.
+- **ESLint configs** — shared lint presets.
+
+Each package has its own `README.md` with the canonical, code-verified detail;
+this is just the map. The `lib.*` references are also indexed from
+[`docs/libraries/README.md`](../docs/libraries/README.md).
+
+## Frontend-shared libraries (`lib.*`)
+
+| Package | Purpose |
+| --- | --- |
+| [lib.analytics](./lib.analytics/README.md) | Event-tracking client — batched engagement events, metrics, A/B results. |
+| [lib.api](./lib.api/README.md) | HTTP transport: typed `ApiService`, interceptors, auth-token injection, CSRF, PostGIS transforms. |
+| [lib.applications](./lib.applications/README.md) | Adoption-application lifecycle client — submit, update, transition, documents. |
+| [lib.audit-logs](./lib.audit-logs/README.md) | Audit-log data access — filtering, pagination, date ranges. |
+| [lib.auth](./lib.auth/README.md) | Auth flows (login, registration, sessions, 2FA), `AuthProvider` / `useAuth`. |
+| [lib.chat](./lib.chat/README.md) | Real-time chat / messaging on Socket.IO. |
+| [lib.components](./lib.components/README.md) | Shared React component library / design system (vanilla-extract). |
+| [lib.dev-tools](./lib.dev-tools/README.md) | Dev-only utilities — seeded-user login, Ethereal mail preview, env guards (tree-shaken in prod). |
+| [lib.discovery](./lib.discovery/README.md) | Swipe-based pet-discovery — queue, swipes, sessions. |
+| [lib.feature-flags](./lib.feature-flags/README.md) | Statsig hooks + typed gate constants for flags / A-B tests. |
+| [lib.invitations](./lib.invitations/README.md) | Staff / volunteer invitation client — send, list, cancel, accept. |
+| [lib.legal](./lib.legal/README.md) | Re-acceptance modal, cookie banner, consent service (TOS / privacy / cookies). |
+| [lib.matching](./lib.matching/README.md) | Types-only package for pet-adopter matching shapes (zero runtime). |
+| [lib.moderation](./lib.moderation/README.md) | Content moderation / user reporting client. |
+| [lib.notifications](./lib.notifications/README.md) | Multi-channel notification client — email / push / in-app / SMS. |
+| [lib.observability](./lib.observability/README.md) | Frontend observability — Sentry init, Web Vitals, analytics-consent gate. |
+| [lib.permissions](./lib.permissions/README.md) | Frontend RBAC + field-level permission services. |
+| [lib.pets](./lib.pets/README.md) | Pet data — search, favourites, rescue-side CRUD + media. |
+| [lib.rescue](./lib.rescue/README.md) | Rescue-org client — profiles, listings, policies, search. |
+| [lib.search](./lib.search/README.md) | Cross-domain search client — pets, messages, facets, suggestions. |
+| [lib.support-tickets](./lib.support-tickets/README.md) | Support-ticket schemas, client, React Query hooks. |
+| [lib.types](./lib.types/README.md) | Shared types, permission constants, default configs (zero-dep; backend + frontend safe). |
+| [lib.utils](./lib.utils/README.md) | Shared utility functions / helpers. |
+| [lib.validation](./lib.validation/README.md) | Canonical Zod schemas (User, Pet, Rescue, Application) — one source of truth. |
+
+## Service-only shared packages
+
+| Package | Purpose |
+| --- | --- |
+| [proto](./proto/README.md) | Protobuf schemas + generated TypeScript for gRPC and NATS contracts (hermetic codegen, committed output). |
+| [events](./events/README.md) | NATS publish-after-commit, durable idempotent subscribers, the `DOMAIN_EVENTS` JetStream topology + DLQ, and GDPR saga helpers. |
+| [authz](./authz/README.md) | Backend authorization — `hasPermission` / `requirePermission` / scope checks over the permission-string model. |
+| [db](./db/README.md) | Postgres client + node-pg-migrate runner with PostGIS support. |
+| [observability](./observability/README.md) | Backend observability bootstrap — OpenTelemetry (OTLP/HTTP), Sentry, Winston (+ optional Loki), shared Prometheus `/metrics` registry. |
+| [storage](./storage/README.md) | File-storage abstraction (local FS + S3 providers) behind one `StorageProvider` contract. |
+| `config-secrets` | Boot-time secret loader — reads Docker-mounted secrets or env vars. |
+| `service-bootstrap` | Shared service boot — Fastify health server, gRPC bind / shutdown, adapters, principal extractor, `HandlerError`. |
+
+## ESLint configs
+
+| Package | Purpose |
+| --- | --- |
+| `eslint-config-base` | Base ESLint config for TypeScript packages. |
+| `eslint-config-node` | ESLint config for Node.js backend services. |
+| `eslint-config-react` | ESLint config for React apps. |

--- a/scripts/restore-postgres.sh
+++ b/scripts/restore-postgres.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# Restore a Postgres snapshot produced by scripts/snapshot-postgres.sh [ADS-811].
+# Pulls a gzipped plain-SQL dump from S3 (or reads a local file) and replays it
+# into the target database via `psql`. The snapshot is a plain `pg_dump | gzip`
+# dump (dump.sql.gz), so the restore is `gunzip | psql` — NOT pg_restore.
+#
+# DESTRUCTIVE: replaying a dump into a database that already has objects will
+# error or duplicate. Restore into a SCRATCH database first, verify, then
+# repoint the app (see docs/db-backup-runbook.md). The script refuses to run
+# against the live POSTGRES_DB unless CONFIRM_RESTORE=I_UNDERSTAND is set.
+#
+# Required env:
+#   POSTGRES_USER   superuser for psql
+#   TARGET_DB       database to restore INTO (must already exist; create it first)
+# Source — exactly one of:
+#   S3_KEY          object key under the bucket, e.g. postgres/2026/06/16/120000/dump.sql.gz
+#                   (requires BACKUP_BUCKET + AWS_REGION)
+#   DUMP_FILE       path to a local *.sql.gz dump
+# Required with S3_KEY:
+#   BACKUP_BUCKET   S3 bucket holding snapshots (no s3:// prefix)
+#   AWS_REGION      AWS region of the bucket
+# Optional:
+#   COMPOSE_FILE    defaults to /opt/adopt-dont-shop/docker-compose.prod.yml
+#   POSTGRES_DB     the LIVE database; restoring into it requires CONFIRM_RESTORE
+#   CONFIRM_RESTORE set to I_UNDERSTAND to allow restoring into POSTGRES_DB
+
+set -euo pipefail
+
+: "${POSTGRES_USER:?POSTGRES_USER required}"
+: "${TARGET_DB:?TARGET_DB required (restore into a scratch DB, not the live one)}"
+
+COMPOSE_FILE="${COMPOSE_FILE:-/opt/adopt-dont-shop/docker-compose.prod.yml}"
+
+# Guard: refuse to overwrite the live DB without explicit confirmation.
+if [[ -n "${POSTGRES_DB:-}" && "$TARGET_DB" == "$POSTGRES_DB" ]]; then
+  if [[ "${CONFIRM_RESTORE:-}" != "I_UNDERSTAND" ]]; then
+    echo "[restore-postgres] REFUSING: TARGET_DB equals the live POSTGRES_DB ($POSTGRES_DB)." >&2
+    echo "[restore-postgres] Restore into a scratch DB, or set CONFIRM_RESTORE=I_UNDERSTAND." >&2
+    exit 1
+  fi
+  echo "[restore-postgres] WARNING: restoring into the LIVE database $POSTGRES_DB (confirmed)."
+fi
+
+# Resolve the dump to a local temp file.
+TMPFILE=""
+cleanup() {
+  [[ -n "$TMPFILE" ]] && rm -f "$TMPFILE"
+}
+trap cleanup EXIT
+
+if [[ -n "${DUMP_FILE:-}" ]]; then
+  [[ -f "$DUMP_FILE" ]] || { echo "[restore-postgres] ERROR: $DUMP_FILE not found" >&2; exit 1; }
+  SRC="$DUMP_FILE"
+  echo "[restore-postgres] using local dump $SRC"
+elif [[ -n "${S3_KEY:-}" ]]; then
+  : "${BACKUP_BUCKET:?BACKUP_BUCKET required when using S3_KEY}"
+  : "${AWS_REGION:?AWS_REGION required when using S3_KEY}"
+  TMPFILE="$(mktemp -t pg-restore-XXXXXX.sql.gz)"
+  SRC="$TMPFILE"
+  echo "[restore-postgres] downloading s3://${BACKUP_BUCKET}/${S3_KEY} -> ${SRC}"
+  aws s3 cp "s3://${BACKUP_BUCKET}/${S3_KEY}" "$SRC" --region "$AWS_REGION"
+else
+  echo "[restore-postgres] ERROR: set DUMP_FILE or S3_KEY" >&2
+  exit 1
+fi
+
+DUMP_BYTES="$(stat -c%s "$SRC")"
+if [[ "$DUMP_BYTES" -lt 1024 ]]; then
+  echo "[restore-postgres] ERROR: dump is suspiciously small (${DUMP_BYTES} bytes)" >&2
+  exit 1
+fi
+
+echo "[restore-postgres] restoring ${DUMP_BYTES} bytes into ${TARGET_DB}"
+# ON_ERROR_STOP makes psql exit non-zero on the first failed statement so a
+# partial/corrupt restore is caught instead of silently continuing.
+gunzip -c "$SRC" \
+  | docker compose -f "$COMPOSE_FILE" exec -T database \
+      psql --set ON_ERROR_STOP=on -U "$POSTGRES_USER" -d "$TARGET_DB"
+
+echo "[restore-postgres] done — verify row counts before repointing the app"

--- a/services/README.md
+++ b/services/README.md
@@ -1,0 +1,50 @@
+# Services
+
+The backend is a Fastify **gateway** (the single REST/WS edge) fronting ten
+gRPC microservices, all communicating over gRPC (request/response) and a NATS
+JetStream bus (domain events). Each service owns its own Postgres **schema**
+within the shared database and migrates it on container start.
+
+See each service's own `README.md` for the full contract (schema, gRPC RPCs +
+required permissions, NATS subjects, dependencies, testing).
+
+## Index
+
+| Service | npm name | HTTP | gRPC | Schema | Purpose | Key deps |
+| --- | --- | --- | --- | --- | --- | --- |
+| [gateway](./gateway/README.md) | `service.gateway` | 4000 | — | — | REST/WS edge: authenticate middleware, REST→gRPC fan-out to all services, rate limiting, circuit breaking, WebSocket fan-out, GDPR erasure kickoff | all service clients, `events`, `storage`, `observability` |
+| [auth](./auth/README.md) | `service.auth` | 5002 | 6002 | `auth` | Identity & access: login/JWT, refresh rotation + revocation, roles/permissions, sessions, privacy prefs, field-permission overrides, admin user mgmt | `authz`, `db`, `events`, `proto` |
+| [notifications](./notifications/README.md) | `service.notifications` | 5001 | 6001 | `notifications` | In-app / email / push notifications, preferences, email templates, device tokens, event-driven fan-out, broadcast | `events`, `db`, `proto`; calls auth/pets/rescue gRPC |
+| [pets](./pets/README.md) | `service.pets` | 5003 | 6003 | `pets` | Pet listing catalogue: CRUD, event-sourced status state machine, favourites/ratings, rescue stats | `authz`, `db`, `events`, `proto` |
+| [rescue](./rescue/README.md) | `service.rescue` | 5004 | 6004 | `rescue` | Rescue orgs: CRUD, verification workflow, staff invitations + membership, foster placements | `authz`, `db`, `events`, `proto`; calls pets gRPC |
+| [applications](./applications/README.md) | `service.applications` | 5005 | 6005 | `applications` | Event-sourced adoption application lifecycle: drafts → submit → review → home visit → approve/reject/withdraw/adopt, documents | `authz`, `db`, `events`, `proto`; calls pets gRPC |
+| [chat](./chat/README.md) | `service.chat` | 5006 | 6006 | `chat` | Application-scoped messaging: chats, messages, reactions, read receipts, search; real-time via NATS→gateway WS | `authz`, `db`, `events`, `proto` |
+| [moderation](./moderation/README.md) | `service.moderation` | 5007 | 6007 | `moderation` | Reports, moderator actions + evidence, user sanctions + appeals, support tickets; auto-scans content from other services | `authz`, `db`, `events`, `proto` |
+| [matching](./matching/README.md) | `service.matching` | 5008 | 6008 | `matching` | Swipe-based discovery / recommender: sessions, swipe log, match profiles, ranked recommendations | `authz`, `db`, `events`, `proto`; calls pets gRPC |
+| [audit](./audit/README.md) | `service.audit` | 5009 | 6009 | `audit` | Forensic audit log (consumer of `*.actionTaken`), saved reports, and the GDPR erasure saga coordinator | `db`, `events`, `proto` |
+| [cms](./cms/README.md) | `service.cms` | 5010 | 6010 | `cms` | Content management: public pages / help articles / blog posts with version history, navigation menus | `authz`, `db`, `events`, `proto` |
+
+Ports are the per-service defaults from each `src/config.ts` and can be
+overridden by env. The gateway addresses services at `service-<name>:<grpcPort>`
+(see `services/gateway/src/config.ts`).
+
+## Shared substrate
+
+Every service is built on the same packages (see [`packages/README.md`](../packages/README.md)):
+
+- `@adopt-dont-shop/service-bootstrap` — Fastify health server, gRPC bind /
+  graceful shutdown, adapters, principal extraction, `HandlerError`.
+- `@adopt-dont-shop/proto` — generated gRPC stubs + NATS payload types.
+- `@adopt-dont-shop/events` — NATS publish-after-commit, durable subscribers,
+  the `DOMAIN_EVENTS` JetStream topology, and the GDPR saga helpers.
+- `@adopt-dont-shop/db` — Postgres client + node-pg-migrate runner.
+- `@adopt-dont-shop/authz` — `requirePermission` / scope checks.
+- `@adopt-dont-shop/observability` — OpenTelemetry, Winston logger, the shared
+  Prometheus `/metrics` registry (`http_request_duration_seconds`,
+  `grpc_handler_duration_seconds`).
+
+## Testing
+
+Every service uses **Vitest** (`pnpm test` runs `vitest run`). Handlers are
+written as pure functions tested directly; the gRPC adapter / NATS transport is
+thin. See each README's "Testing strategy" section.

--- a/services/applications/README.md
+++ b/services/applications/README.md
@@ -101,3 +101,77 @@ pnpm dev
 pnpm build
 pnpm start
 ```
+
+---
+
+## Canonical reference (ADS-817)
+
+### Responsibility
+
+Owns the event-sourced adoption-application lifecycle: draft → submit → review
+→ home visit → approve / reject / withdraw / mark-adopted, plus document
+attachments. Each application is an aggregate in a Postgres event store with a
+denormalised read-model projection; every state change publishes an
+`applications.*` event. Schema: `applications`.
+
+### Schema (`applications`)
+
+| Table | Purpose |
+| --- | --- |
+| `application_events` | Append-only event store (the source of truth). |
+| `applications` | Denormalised read-model projection. |
+| `application_status_transitions` | Status-change audit trail. |
+| `home_visits` | Home-visit scheduling + outcome. |
+| `home_visit_status_transitions` | Home-visit status audit. |
+| `application_drafts` | In-progress draft persistence. |
+| `application_documents` | Metadata for files attached to an application. |
+
+Migrations: `services/applications/src/migrations/001`–`008` (006 installs a
+status-propagation trigger).
+
+### gRPC RPCs
+
+`ApplicationService`. Scope is owner (adopter) or `rescue_id`; `super_admin`
+bypasses.
+
+| RPC | Permission |
+| --- | --- |
+| `StartDraft` | `applications.create` (resolves pet → rescue via pets gRPC) |
+| `SaveDraftAnswers` | `applications.update` (owner/rescue scope) |
+| `SubmitDraft` | `applications.update` (owner/rescue scope) |
+| `StartReview` | `applications.process` (rescue scope) |
+| `ScheduleHomeVisit` | `applications.process` (rescue scope) |
+| `CompleteHomeVisit` | `applications.process` (rescue scope) |
+| `Approve` | `applications.approve` (rescue scope) |
+| `Reject` | `applications.reject` (rescue scope) |
+| `Withdraw` | `applications.update` (owner/rescue scope) |
+| `MarkAdopted` | `applications.approve` (rescue scope) |
+| `Get` | `applications.view` (owner/rescue scope) |
+| `List` | `applications.view` (scope-pinned) |
+| `GetStats` | `applications.view` |
+| `AddDocument` | `applications.update` (rescue scope) |
+| `ListDocuments` | `applications.view` (owner/rescue scope) |
+| `RemoveDocument` | `applications.update` (rescue scope) |
+
+### NATS subjects
+
+**Emits** (publish-after-commit): `applications.draftCreated`,
+`applications.draftUpdated`, `applications.submitted`,
+`applications.reviewStarted`, `applications.homeVisitScheduled`,
+`applications.homeVisitCompleted`, `applications.approved`,
+`applications.rejected`, `applications.withdrawn`, `applications.adopted`. Plus
+`gdpr.erasureCompleted` as a saga participant.
+
+**Consumes:** `gdpr.erasureRequested` (durable `gdpr-applications`).
+
+### Dependencies
+
+`@adopt-dont-shop/{authz, config-secrets, db, events, lib.types, observability,
+proto, service-bootstrap}`. Cross-service gRPC: calls **service.pets**
+(`PETS_GRPC_URL`) in `StartDraft` to resolve a pet's owning rescue.
+
+### Testing strategy
+
+Vitest. Pure handlers over the event store + projection — assert each lifecycle
+transition (valid + invalid), permission/scope enforcement, the event-store →
+read-model projection, document add/remove, and publish-after-commit ordering.

--- a/services/audit/README.md
+++ b/services/audit/README.md
@@ -57,3 +57,82 @@ pattern). Owns the `audit.*` schema. Replaces the monolith's
 | `DATABASE_URL`    | —                  | ✅       | Postgres connection string.     |
 | `NATS_URL`        | `nats://nats:4222` |          | NATS bus URL.                   |
 | `NODE_ENV`        | `development`      |          | Surfaces in health + logs.      |
+
+---
+
+## Canonical reference (ADS-817)
+
+### Responsibility
+
+The forensic audit log + GDPR saga coordinator. Consumes state-changing domain
+events (`*.actionTaken`) from every service and persists them to an append-only,
+tamper-resistant store (a DB trigger blocks UPDATE/DELETE). Exposes read-only
+gRPC queries for admins, manages saved report templates, and **coordinates the
+GDPR erasure saga** — tracking each request until every expected service acks,
+timing out / retrying stuck sagas, and exporting saga-state metrics. Schema:
+`audit`.
+
+### Schema (`audit`)
+
+| Table | Purpose |
+| --- | --- |
+| `audit_events` | Append-only audit log (PK on `event_id` for idempotency). |
+| `gdpr_erasure_requests` | GDPR saga state per `correlation_id` (completions JSONB, `completed_at` / `failed_at` / `timed_out_at`, `retry_count`). |
+| `saved_reports` | User-created custom audit-report definitions. |
+| `report_templates` | Seed/migration-owned report template library. |
+
+Migrations: `services/audit/src/migrations/001`–`006`.
+
+### gRPC RPCs
+
+`AuditService` — **read-only** (no write RPCs; writes happen via NATS
+consumers). `super_admin` bypasses.
+
+| RPC | Permission |
+| --- | --- |
+| `Query` | `admin.audit_logs` |
+| `GetByTarget` | `admin.audit_logs` |
+| `ListSavedReports` | `reports.read` (`reports.read` scoping for own) |
+| `GetSavedReport` | `reports.read` |
+| `CreateSavedReport` | `reports.create` |
+| `UpdateSavedReport` | `reports.update` |
+| `DeleteSavedReport` | `reports.delete` |
+| `ListReportTemplates` | read-only (template library) |
+| `GetGdprErasureRequest` | `admin.gdpr.read` (or the subject reading their own saga) |
+
+### NATS subjects
+
+**Consumes:**
+
+| Subject | Effect |
+| --- | --- |
+| `*.actionTaken` | Persist an immutable audit event (idempotent on `event_id`). |
+| `gdpr.erasureRequested` | INSERT/UPSERT the saga row (durable `audit-workers-gdpr-request`). |
+| `gdpr.erasureCompleted` | Merge each service's completion; stamp `completed_at` once all 9 expected services ack, `failed_at` on an errored ack (durable `audit-workers-gdpr-completion`). |
+
+**Emits:** `gdpr.erasureRequested` — **re-published by the saga sweep** to retry
+a failed saga (same `correlationId`, distinct msgID; up to `GDPR_SAGA_MAX_RETRIES`).
+Audit publishes no other domain events.
+
+**Metrics:** exports the `gdpr_sagas{state}` gauge
+(`in_progress`/`completed`/`failed`/`timed_out`) — see
+[`docs/slo.md`](../../docs/slo.md) and the
+[GDPR erasure runbook](../../docs/runbooks/gdpr-erasure-incident.md).
+
+### Dependencies
+
+`@adopt-dont-shop/{authz, config-secrets, db, events, lib.types, observability,
+proto, service-bootstrap}`. No cross-service gRPC calls.
+
+### Configuration extras
+
+Beyond the standard vars: `GDPR_SAGA_DEADLINE_MS` (default 30 min — timeout
+horizon) and `GDPR_SAGA_MAX_RETRIES` (default 3) tune the sweep scheduler.
+
+### Testing strategy
+
+Vitest. The query handlers, the GDPR subscribers (request/completion UPSERT
+SQL), and the sweep scheduler (timeout + retry passes) are tested directly with
+an injected pool + NATS — assert idempotent event persistence, the saga
+completion/failure/timeout state machine, retry re-publish behaviour, and the
+`gdpr_sagas` gauge values.

--- a/services/auth/README.md
+++ b/services/auth/README.md
@@ -180,3 +180,84 @@ pnpm dev
 pnpm build
 pnpm start
 ```
+
+---
+
+## Canonical reference (ADS-817)
+
+### Responsibility
+
+Owns identity and access control: account lifecycle (register, verify, password
+reset/change, account update), JWT auth with refresh-token rotation +
+revocation, roles + permissions, sessions (per-device refresh chains), privacy
+preferences, field-permission overrides, and admin user management. Maintains
+the denormalised Principal (user + roles + permissions + optional rescue) that
+the gateway validates on every request. Schema: `auth`.
+
+### Schema (`auth`)
+
+| Table | Purpose |
+| --- | --- |
+| `users` | Core user row — email, password hash, status, type, profile, login throttling. |
+| `roles` / `permissions` | Reference data. |
+| `role_permissions` / `user_roles` | Role↔permission and user↔role junctions. |
+| `refresh_tokens` | Per-device refresh tokens (rotation chains). |
+| `revoked_tokens` | JTI denylist for access + old refresh tokens. |
+| `user_privacy_prefs` | Per-user privacy preferences. |
+| `field_permissions` | Overrides to the default field-level access matrix. |
+
+Migrations: `services/auth/src/migrations/001`–`015`.
+
+### gRPC RPCs
+
+`AuthService`. `super_admin` bypasses permission checks.
+
+**Public (no principal):** `Login`, `RefreshToken`, `ValidateToken`,
+`Register`, `VerifyEmail`, `ResendVerification`, `ForgotPassword`,
+`ResetPassword`.
+
+**Authenticated (self):** `Logout`, `GetMe`, `ChangePassword`, `UpdateAccount`,
+`ListSessions`, `RevokeSession`, `GetPrivacyPreferences` /
+`UpdatePrivacyPreferences` / `ResetPrivacyPreferences` (self; `privacy-prefs:*:any`
+for others).
+
+**Admin-gated:**
+
+| RPC | Permission |
+| --- | --- |
+| `AssignRole` | `admin.security.manage` |
+| `SearchUsers` | `admin.users.search` |
+| `AdminGetUser` / `GetUserStatistics` / `GetUserPermissions` | `admin.users.read` |
+| `AdminUpdateUser` | `admin.users.update` |
+| `DeactivateUser` | `admin.users.deactivate` |
+| `ReactivateUser` | `admin.users.reactivate` |
+| `BulkUpdateUsers` | `admin.users.bulk_update` |
+| `ListUserIdsByCohort` | `admin.users.broadcast` |
+| `GetFieldPermissionDefaults` / `GetFieldPermissionDefaultsForRole` / `ListFieldPermissionOverrides` / `ListFieldPermissionOverridesForRole` | `admin.field_permissions.read` |
+| `UpsertFieldPermission` / `BulkUpsertFieldPermissions` | `admin.field_permissions.write` |
+| `DeleteFieldPermission` | (gated at the gateway; reverts a field to the default) |
+
+### NATS subjects
+
+**Emits** (publish-after-commit): `auth.userLoggedIn`, `auth.tokenRevoked`,
+`auth.tokenRefreshed`, `auth.roleAssigned`, `auth.userRegistered`,
+`auth.emailVerified`, `auth.passwordResetRequested`, `auth.passwordChanged`,
+`auth.sessionRevoked`, `auth.privacyPrefsReset`, `auth.userDeactivated`,
+`auth.userReactivated`, `auth.userUpdatedByAdmin`. Plus `gdpr.erasureCompleted`
+as a saga participant.
+
+**Consumes:** `gdpr.erasureRequested` (durable `gdpr-auth`).
+
+### Dependencies
+
+`@adopt-dont-shop/{authz, config-secrets, db, events, lib.types, observability,
+proto, service-bootstrap}`. No cross-service gRPC calls (it is the identity
+layer everyone else calls).
+
+### Testing strategy
+
+Vitest. Pure handlers `(deps, principal, request) → response` with bcrypt/JWT
+adapters injected (so tests don't pay real crypto cost) — assert every
+INVALID_ARGUMENT / UNAUTHENTICATED / PERMISSION_DENIED / NOT_FOUND path, token
+rotation + denylist + idempotency, enumeration-safe register/forgot flows,
+`super_admin` bypass, and publish-after-commit ordering.

--- a/services/chat/README.md
+++ b/services/chat/README.md
@@ -81,3 +81,69 @@ pnpm dev
 pnpm build
 pnpm start
 ```
+
+---
+
+## Canonical reference (ADS-817)
+
+### Responsibility
+
+Owns application-scoped messaging between adopters and rescue staff: opening
+chats, sending / reading messages, reactions, read receipts, and full-text
+search. Real-time delivery is event-driven — the service publishes `chat.*`
+events on NATS that the gateway's WebSocket subscriber fans out to connected
+clients. Schema: `chat`.
+
+### Schema (`chat`)
+
+| Table | Purpose |
+| --- | --- |
+| `chats` | Chat rows, anchored to an application. |
+| `chat_participants` | Two-party participants with read watermarks. |
+| `messages` | Text messages (with a full-text search vector). |
+| `message_reactions` | Emoji reactions per message. |
+| `message_reads` | Read receipts (`message_id`, `user_id`, `read_at`). |
+
+Migrations: `services/chat/src/migrations/001`–`006` (004 installs the
+search-vector trigger).
+
+### gRPC RPCs
+
+`ChatService`. Most RPCs additionally require **participant membership** in the
+chat; `super_admin` bypasses the membership check.
+
+| RPC | Permission |
+| --- | --- |
+| `OpenChat` | `chat.create` |
+| `SendMessage` | `chat.send` + participant |
+| `ListMessages` | `chat.read` + participant |
+| `ListChats` | `chat.read` |
+| `MarkRead` | `chat.read` + participant |
+| `React` | `chat.send` + participant |
+| `SearchChats` | `chat.read` |
+| `GetChatUnreadCount` | `chat.read` + participant |
+| `DeleteMessage` | sender, or `chat.message.delete:any` |
+| `GetChat` | `chat.read` + participant |
+| `DeleteChat` | `chat.read` + participant |
+
+### NATS subjects
+
+**Emits** (publish-after-commit): `chat.created`, `chat.messageCreated`,
+`chat.messageRead`, `chat.reactionAdded`, `chat.reactionRemoved`,
+`chat.messageDeleted`, `chat.deleted`. Plus `gdpr.erasureCompleted` as a saga
+participant.
+
+**Consumes:** `gdpr.erasureRequested` (durable `gdpr-chat`).
+
+### Dependencies
+
+`@adopt-dont-shop/{authz, config-secrets, db, events, lib.types, observability,
+proto, service-bootstrap}`. No cross-service gRPC calls (reads participants from
+its own schema).
+
+### Testing strategy
+
+Vitest. Pure handlers with pool + NATS injected — assert permission +
+participant-membership gates, read-watermark / unread-count logic, sender-or-
+admin delete authorization, and publish-after-commit ordering for every
+`chat.*` event.

--- a/services/cms/README.md
+++ b/services/cms/README.md
@@ -1,0 +1,118 @@
+# service.cms
+
+Content management for public-facing pages — help articles, blog posts, static
+pages — and navigation menus. CMS owns the content lifecycle (draft → published
+→ unpublished → archived) with per-edit version history, serves the **public**
+read surface unauthenticated, and gates all authoring behind `cms.*`
+permissions.
+
+## Responsibility
+
+- Owns the `cms` Postgres schema: content rows (with version history) and
+  navigation-menu trees.
+- Public read API: list / get published content by slug — no auth.
+- Admin authoring: create / update / delete content, publish / unpublish /
+  archive, view + restore versions, and CRUD navigation menus.
+- Publishes content + menu lifecycle events on NATS for downstream consumers
+  (e.g. search indexing, cache invalidation) and participates in the GDPR
+  erasure saga.
+
+## Schema (`cms`)
+
+| Table | Purpose |
+| --- | --- |
+| `cms_content` | Pages / blog posts / help articles. Holds status (`draft`/`published`/`archived`), slug, body, and per-edit version history. |
+| `cms_navigation_menus` | Navigation menu trees (nestable items). |
+
+Migrations: `services/cms/src/migrations/001_create_cms_content.ts`,
+`002_create_cms_navigation_menus.ts`, `003_cms_content_author_nullable.ts`.
+
+## gRPC RPCs
+
+`CmsService` (`packages/proto/proto/adopt_dont_shop/cms/v1/cms.proto`). Admin /
+super_admin short-circuit the permission check.
+
+| RPC | Permission |
+| --- | --- |
+| `ListPublicContent` | none (public) |
+| `GetPublicContentBySlug` | none (public) |
+| `ListContent` | `cms.content.read` |
+| `GetContent` | `cms.content.read` |
+| `GetContentBySlug` | `cms.content.read` |
+| `CreateContent` | `cms.content.create` |
+| `UpdateContent` | `cms.content.update` |
+| `DeleteContent` | `cms.content.delete` |
+| `PublishContent` | `cms.content.publish` |
+| `UnpublishContent` | `cms.content.publish` |
+| `ArchiveContent` | `cms.content.publish` |
+| `GetVersionHistory` | `cms.content.read` |
+| `RestoreVersion` | `cms.content.update` |
+| `ListMenus` | `cms.menu.read` |
+| `GetMenu` | `cms.menu.read` |
+| `CreateMenu` | `cms.menu.create` |
+| `UpdateMenu` | `cms.menu.update` |
+| `DeleteMenu` | `cms.menu.delete` |
+
+## NATS subjects
+
+All published after the DB transaction commits (publish-after-commit).
+
+**Emits:**
+
+| Subject | When |
+| --- | --- |
+| `cms.contentCreated` | `CreateContent` |
+| `cms.contentUpdated` | `UpdateContent` |
+| `cms.contentDeleted` | `DeleteContent` |
+| `cms.contentPublished` | `PublishContent` |
+| `cms.contentUnpublished` | `UnpublishContent` |
+| `cms.contentArchived` | `ArchiveContent` |
+| `cms.contentRestored` | `RestoreVersion` |
+| `cms.menuCreated` | `CreateMenu` |
+| `cms.menuUpdated` | `UpdateMenu` |
+| `cms.menuDeleted` | `DeleteMenu` |
+
+**Consumes:**
+
+| Subject | Effect |
+| --- | --- |
+| `gdpr.erasureRequested` | Erases the requesting user's CMS-authored rows in a transaction, then publishes `gdpr.erasureCompleted` (durable `gdpr-cms` consumer). |
+
+## Dependencies
+
+Workspace packages: `@adopt-dont-shop/{authz, config-secrets, db, events,
+lib.types, observability, proto, service-bootstrap}`.
+
+Cross-service gRPC calls: **none** — CMS is self-contained.
+
+## Configuration
+
+| Env var | Default | Required | Purpose |
+| --- | --- | --- | --- |
+| `CMS_PORT` | `5010` | | HTTP port for `/health/simple`. |
+| `CMS_GRPC_PORT` | `6010` | | gRPC port `CmsService` binds. |
+| `CMS_HOST` | `0.0.0.0` | | Bind interface. |
+| `CMS_SCHEMA` | `cms` | | Postgres schema (override for parallel test DBs). |
+| `DATABASE_URL` | — | ✅ | Postgres connection string. |
+| `NATS_URL` | `nats://nats:4222` | | NATS bus URL. |
+| `NODE_ENV` | `development` | | Surfaces in health + logs. |
+
+Plus the standard observability env vars consumed by
+`@adopt-dont-shop/observability`.
+
+## Testing strategy
+
+Vitest (`pnpm test`). Handlers are pure functions `(deps, principal, request) →
+Promise<response>` with the DB pool + NATS injected, so tests assert behaviour
+directly: every PERMISSION_DENIED / INVALID_ARGUMENT / NOT_FOUND path, the
+public-vs-authenticated split, version-history capture + restore, and the
+publish-after-commit ordering (the event fires only after `COMMIT`). The gRPC
+adapter and NATS transport are thin and exercised at the edges.
+
+## Running
+
+```bash
+pnpm dev      # hot reload
+pnpm build && pnpm start
+pnpm db:migrate
+```

--- a/services/gateway/README.md
+++ b/services/gateway/README.md
@@ -167,3 +167,75 @@ to the monolith.
   as defence-in-depth, matching the CAD pattern).
 - A natural strangler-fig boundary — extracting any service is "add a
   route plugin to the gateway, delete the route from the monolith."
+
+---
+
+## Canonical reference (ADS-817)
+
+### Responsibility
+
+The single REST/WebSocket edge in front of the gRPC services. It authenticates
+every request (validates `Authorization: Bearer` via `service.auth.ValidateToken`
+and stamps server-derived `x-user-*` metadata, stripping any spoofed inbound
+headers), fans REST routes out to the right service over gRPC, terminates the
+Socket.IO connection and broadcasts NATS events to clients, enforces global rate
+limiting, and wraps each downstream client in a circuit breaker. A handful of
+small surfaces are served in-process (legal markdown, `/config`, analytics,
+dashboard composition, uploads, GDPR erasure kickoff). **No schema** — the
+gateway owns no Postgres tables.
+
+### Downstream gRPC clients
+
+`auth`, `notifications`, `pets`, `rescue`, `applications`, `chat`, `moderation`,
+`matching`, `audit`, `cms` — one client per service, addressed at
+`service-<name>:<grpcPort>` (`*_GRPC_URL` env vars).
+
+### Route groups (`/api/v1/*`)
+
+`auth`, `sessions`, `field-permissions`, `users` → auth; `notifications`,
+`devices`, `email`, `broadcast` → notifications; `pets` → pets; `rescue`,
+`rescues` (public), `staff`/`foster`/`invitations` → rescue; `applications`,
+`application-documents` → applications; `chats` → chat; `moderation`,
+`admin/moderation`, `support` → moderation; `matching` → matching; `audit`,
+`reports` → audit; `cms` → cms. Gateway-folded (in-process): `legal`, `config`,
+`analytics`, `dashboard`, `uploads`, and `users/me/erasure-request` (GDPR).
+There is **no catch-all monolith proxy** — unowned `/api/*` paths return 404.
+
+### gRPC RPCs
+
+None — the gateway is a gRPC **client**, not a server. It exposes the REST/WS
+surface above plus the health + `/metrics` endpoints.
+
+### NATS subjects
+
+**Emits:** `gdpr.erasureRequested` (from `POST /api/v1/users/me/erasure-request`,
+kicking off the erasure saga).
+
+**Consumes (for WebSocket fan-out):** `notifications.created`,
+`notifications.dismissed`, `chat.messageCreated`, `chat.messageRead`,
+`chat.reactionAdded`, `chat.reactionRemoved`. It also ensures the
+`DOMAIN_EVENTS` JetStream stream exists at boot.
+
+### Metrics (beyond the shared substrate)
+
+- `gateway_rate_limit_hits_total{route}` — counter, incremented on every 429
+  (`src/server.ts`).
+- `grpc_circuit_state{service}` — gauge, `0`=closed / `1`=half-open / `2`=open,
+  one per downstream service (`src/grpc-clients/resilience.ts`).
+
+Both feed the alerts in
+[`infra/prometheus/rules/gateway-resilience.yml`](../../infra/prometheus/rules/gateway-resilience.yml).
+
+### Dependencies
+
+`@adopt-dont-shop/{config-secrets, events, observability, proto,
+service-bootstrap, storage}` plus the generated clients for all ten services. No
+own database.
+
+### Testing strategy
+
+Vitest. Route handlers are tested against stubbed gRPC clients (the REST→gRPC
+translation + response adaptation), the authenticate middleware against a stub
+`ValidateToken`, the rate-limit + circuit-breaker behaviour directly, and the WS
+subscribers against a fake NATS — asserting header-stripping, 401/404 paths, and
+event→socket fan-out without a live transport.

--- a/services/matching/README.md
+++ b/services/matching/README.md
@@ -44,3 +44,64 @@ discovery + search + swipe modules.
 | `DATABASE_URL`       | —                  | ✅       | Postgres connection string.     |
 | `NATS_URL`           | `nats://nats:4222` |          | NATS bus URL.                   |
 | `NODE_ENV`           | `development`      |          | Surfaces in health + logs.      |
+
+---
+
+## Canonical reference (ADS-817)
+
+### Responsibility
+
+A stateless recommender powering swipe-based pet discovery. Records swipe
+sessions + a behavioural swipe log, holds adopter match profiles, and returns
+ranked candidates via a pure scoring function. Reads live pet candidates from
+service.pets on demand (no denormalised projection). Schema: `matching`.
+
+### Schema (`matching`)
+
+| Table | Purpose |
+| --- | --- |
+| `swipe_sessions` | Browsing sessions with filter context + counters. |
+| `swipe_actions` | Append-only behavioural log (swipe / like / pass / super-like). |
+| `adopter_match_profiles` | Adopter preferences (types, sizes, energy, lifestyle, allergies). |
+
+Migrations: `services/matching/src/migrations/001`–`004`.
+
+### gRPC RPCs
+
+`MatchingService`. Most actions require `pets.view` (discovery reads the pets
+catalogue) plus session ownership where applicable; profile RPCs are self-
+scoped. `super_admin` bypasses.
+
+| RPC | Permission |
+| --- | --- |
+| `StartSession` | `pets.view` |
+| `EndSession` | `pets.view` + session owner |
+| `RecordSwipe` | `pets.view` + session owner |
+| `ListSwipeHistory` | `pets.view` |
+| `Recommend` | `pets.view` (reads candidates via pets gRPC) |
+| `SearchPets` | `pets.view` (reads candidates via pets gRPC) |
+| `GetMatchProfile` | self-scoped (reads own profile) |
+| `UpsertMatchProfile` | self-scoped (writes own profile) |
+| `GetUserSwipeStats` | self-scoped; `matching.swipes.read:any` for other users |
+| `GetSessionStats` | session owner |
+
+### NATS subjects
+
+**Emits** (publish-after-commit): `matching.sessionStarted`,
+`matching.sessionEnded`, `matching.swipeRecorded`. Plus `gdpr.erasureCompleted`
+as a saga participant.
+
+**Consumes:** `gdpr.erasureRequested` (durable `gdpr-matching`).
+
+### Dependencies
+
+`@adopt-dont-shop/{authz, config-secrets, db, events, lib.types, observability,
+proto, service-bootstrap}`. Cross-service gRPC: calls **service.pets**
+(`PETS_GRPC_URL`) in `Recommend` / `SearchPets` to fetch candidate pets.
+
+### Testing strategy
+
+Vitest. The scoring/ranking function is pure and tested directly against fixture
+candidates; handlers are tested with pool + NATS (+ a stub pets client)
+injected — assert permission / ownership gates, swipe-log append, profile
+upsert, and publish-after-commit ordering.

--- a/services/moderation/README.md
+++ b/services/moderation/README.md
@@ -57,3 +57,77 @@ gRPC; consumes events (`chat.messageCreated`, `pets.created`,
 | `DATABASE_URL`         | —                  | ✅       | Postgres connection string.     |
 | `NATS_URL`             | `nats://nats:4222` |          | NATS bus URL.                   |
 | `NODE_ENV`             | `development`      |          | Surfaces in health + logs.      |
+
+---
+
+## Canonical reference (ADS-817)
+
+### Responsibility
+
+Owns content moderation and user discipline: report filing, moderator
+assignment / resolution, logged moderator actions + evidence, user sanctions
+(warnings, restrictions, bans) + appeals, and support tickets. Subscribes to
+content events from other services to auto-scan and auto-file reports as the
+system user. Schema: `moderation`.
+
+### Schema (`moderation`)
+
+| Table | Purpose |
+| --- | --- |
+| `reports` | User/staff/system-filed reports of violations. |
+| `report_status_transitions` | Report state-change audit. |
+| `moderator_actions` | Logged actions (warn, remove, suspend, ban, restrict). |
+| `moderation_evidence` | Polymorphic evidence attached to reports/actions. |
+| `user_sanctions` | Sanctions — warning / restriction / temporary or permanent ban. |
+| `support_tickets` | User support requests. |
+| `support_ticket_responses` | Staff + user responses on a ticket. |
+
+Migrations: `services/moderation/src/migrations/001`–`010` (003 installs a
+status-propagation trigger).
+
+### gRPC RPCs
+
+`ModerationService`. `super_admin` / admin bypass.
+
+| RPC | Permission |
+| --- | --- |
+| `FileReport` | authenticated (any user) |
+| `GetReport` | `moderation.reports.view` (reporter may read own) |
+| `ListReports` | `moderation.reports.view` |
+| `AssignReport` | `moderation.reports.manage` |
+| `ResolveReport` | `moderation.reports.manage` |
+| `LogModeratorAction` | `moderation.actions.manage` |
+| `ListModeratorActions` | `moderation.actions.manage` |
+| `AddEvidence` | `moderation.actions.manage` |
+| `IssueSanction` | `moderation.sanctions.manage` |
+| `ListUserSanctions` | self-scoped; `moderation.sanctions.manage` for others |
+| `AppealSanction` | self-scoped (the sanctioned user) |
+| `OpenSupportTicket` | authenticated (any user) |
+| `GetSupportTicket` | owner, or `moderation.tickets.manage` |
+| `ListSupportTickets` | self-scoped; `moderation.tickets.manage` for all |
+| `RespondToTicket` | owner, or `moderation.tickets.manage` |
+
+### NATS subjects
+
+**Emits** (publish-after-commit): `moderation.reportFiled`,
+`moderation.reportAssigned`, `moderation.reportResolved`,
+`moderation.actionLogged`, `moderation.sanctionIssued`,
+`moderation.sanctionAppealed`, `moderation.ticketOpened`. Plus
+`gdpr.erasureCompleted` as a saga participant.
+
+**Consumes:** `chat.messageCreated`, `pets.created`, `applications.submitted`
+(content scanning → auto-report), and `gdpr.erasureRequested` (durable
+`gdpr-moderation`).
+
+### Dependencies
+
+`@adopt-dont-shop/{authz, config-secrets, db, events, lib.types, observability,
+proto, service-bootstrap}`. No cross-service gRPC calls (composition done at the
+gateway).
+
+### Testing strategy
+
+Vitest. Pure handlers split per surface (reports / actions+evidence / sanctions
+/ tickets) with pool + NATS injected — assert each permission gate + self-scope
+exception, the report/sanction state machines, the content-scanner auto-report
+path, and publish-after-commit ordering.

--- a/services/notifications/README.md
+++ b/services/notifications/README.md
@@ -92,3 +92,82 @@ pnpm dev
 pnpm build
 pnpm start
 ```
+
+---
+
+## Canonical reference (ADS-817)
+
+### Responsibility
+
+Owns in-app, email, and push notifications: creating + listing + dismissing
+notifications, per-user preferences (channels, DND, category toggles), email
+queue + templates (Resend / console / Ethereal), push device tokens (FCM /
+web-push), and digest scheduling. Subscribes to domain events from other
+services to auto-fan notifications, and exposes `Broadcast` for admin cohort
+announcements. Schema: `notifications`.
+
+### Schema (`notifications`)
+
+| Table | Purpose |
+| --- | --- |
+| `notifications` | In-app rows (status / channel / read tracking). |
+| `device_tokens` | FCM / APNs / web-push tokens per user. |
+| `user_notification_prefs` | Per-user channel + category preferences. |
+| `email_queue` | Transactional email queue. |
+| `email_templates` | Reusable email templates. |
+| `email_preferences` | Per-user email opt-in / unsubscribe state. |
+| `processed_events` | Event-dedup table for idempotent consumers. |
+
+Migrations: `services/notifications/src/migrations/001`–`008`.
+
+### gRPC RPCs
+
+`NotificationService`. User-facing reads/writes are **self-scoped** (a `*:any`
+permission unlocks acting on another user); admin surfaces require an explicit
+permission. `super_admin` bypasses.
+
+| RPC | Permission |
+| --- | --- |
+| `Create` | `notifications.create` |
+| `List` / `GetNotification` / `GetUnreadCount` | self-scoped |
+| `Dismiss` / `MarkAllRead` / `DeleteNotification` | self-scoped |
+| `GetNotificationPreferences` | self; `notification-prefs:read:any` for others |
+| `UpdateNotificationPreferences` / `ResetNotificationPreferences` | self; `notification-prefs:update:any` for others |
+| `CleanupExpiredNotifications` | `notifications.cleanup` |
+| `SendEmail` | `notifications.email.send` (or service-to-service) |
+| `GetEmailPreferences` | self; `email-prefs:read:any` for others |
+| `UpdateEmailPreferences` | self; `email-prefs:update:any` for others |
+| `ListEmailTemplates` / `GetEmailTemplate` / `PreviewEmailTemplate` | `notifications.email.templates.read` |
+| `CreateEmailTemplate` | `notifications.email.templates.create` |
+| `UpdateEmailTemplate` | `notifications.email.templates.update` |
+| `DeleteEmailTemplate` | `notifications.email.templates.delete` |
+| `RegisterDeviceToken` / `UnregisterDeviceToken` | self-scoped |
+| `ListDeviceTokens` | self; `device-tokens:list:any` for others |
+| `Broadcast` | `admin.notifications.broadcast` |
+
+### NATS subjects
+
+**Emits** (publish-after-commit): `notifications.created` (Create),
+`notifications.dismissed` (Dismiss). Plus `gdpr.erasureCompleted` as a saga
+participant.
+
+**Consumes:** `applications.{submitted,approved,rejected,adopted,
+homeVisitScheduled,homeVisitCompleted}`, `auth.{roleAssigned,userLoggedIn}`,
+`chat.messageCreated`, `pets.{statusChanged,deleted}`,
+`rescue.{verified,rejected,staffInvited}`, and `gdpr.erasureRequested` (durable
+`gdpr-notifications`).
+
+### Dependencies
+
+`@adopt-dont-shop/{authz, config-secrets, db, events, lib.types, observability,
+proto, service-bootstrap}`. Cross-service gRPC (all optional — feature no-ops if
+the URL is unset): **service.auth** (`ListUserIdsByCohort` for `Broadcast`),
+**service.pets** (`ListFavoriters` for `pets.statusChanged` fan-out),
+**service.rescue** (`ListStaffMembers` / `Get` for rescue fan-out).
+
+### Testing strategy
+
+Vitest. Pure handlers + the email/push workers tested with pool, NATS, and stub
+provider/clients injected — assert self-scope vs `*:any` permission gates,
+idempotent dismiss / dedup via `processed_events`, the event→notification
+translation for each consumed subject, and publish-after-commit ordering.

--- a/services/pets/README.md
+++ b/services/pets/README.md
@@ -134,3 +134,66 @@ pnpm dev
 pnpm build
 pnpm start
 ```
+
+---
+
+## Canonical reference (ADS-817)
+
+### Responsibility
+
+Owns the pet listing catalogue: classical CRUD plus an event-sourced status
+state machine (`available` → `pending` → `adopted`, plus
+`foster`/`medical_hold`/`behavioral_hold`/`deceased`). Each status transition
+appends an audit row and publishes `pets.statusChanged`. Serves privilege-aware
+reads (internal notes + off-market statuses hidden from public readers),
+favourite/rating aggregates, and per-rescue stats. Schema: `pets`.
+
+### Schema (`pets`)
+
+| Table | Purpose |
+| --- | --- |
+| `breeds` | Reference lookup — species + breed name. |
+| `pets` | Main listing row — classification, status, fees, flags, counters, timestamps. |
+| `pet_media` | Images / videos attached to a listing. |
+| `pet_status_transitions` | Append-only status-change audit (`from`/`to`/`by`/`reason`). |
+| `ratings` | Adopter ratings / reviews. |
+| `user_favorites` | Adopter bookmarks (`user_id` + `pet_id`). |
+
+Migrations: `services/pets/src/migrations/001`–`007`.
+
+### gRPC RPCs
+
+`PetService`. Permission scope is the pet's `rescue_id`; admin / `super_admin`
+bypass the scope.
+
+| RPC | Permission |
+| --- | --- |
+| `Create` | `pets.create` (scoped to target rescue) |
+| `Get` | `pets.read` (public projection for non-privileged readers) |
+| `List` | `pets.read` (non-privileged → public pets only; staff pinned to own rescue) |
+| `Update` | `pets.update` (scoped to pet's rescue) |
+| `UpdateStatus` | `pets.update` (scoped; appends a status transition) |
+| `Delete` | `pets.delete` (scoped; soft-delete) |
+| `GetStats` | `pets.read` (self-scoped; `pets.read:any` to override rescue filter) |
+| `ListFavoriters` | `pets.read` (service-to-service read) |
+
+### NATS subjects
+
+**Emits:** `pets.created` (Create), `pets.updated` (Update),
+`pets.statusChanged` (UpdateStatus), `pets.deleted` (Delete) — all
+publish-after-commit. Plus `gdpr.erasureCompleted` as a saga participant.
+
+**Consumes:** `gdpr.erasureRequested` (durable `gdpr-pets`; erases the user's
+favourites/ratings in a transaction).
+
+### Dependencies
+
+`@adopt-dont-shop/{authz, config-secrets, db, events, lib.types, observability,
+proto, service-bootstrap}`. No cross-service gRPC calls.
+
+### Testing strategy
+
+Vitest. Pure handlers `(deps, principal, request) → response` with pool + NATS
+injected — assert each permission/validation path, the public-vs-privileged
+read projection, the status state-machine transitions + audit-row append, and
+publish-after-commit ordering.

--- a/services/rescue/README.md
+++ b/services/rescue/README.md
@@ -149,3 +149,71 @@ pnpm dev
 pnpm build
 pnpm start
 ```
+
+---
+
+## Canonical reference (ADS-817)
+
+### Responsibility
+
+Owns rescue organisations and their operational infrastructure: rescue CRUD, a
+verification state machine (`pending` → `verified`/`rejected`/`suspended`/
+`inactive`, admin-gated), staff invitations (one-time-readable token) + staff
+membership, custom application questions, and foster placements. Validates
+foster pet ownership via a gRPC call to service.pets. Schema: `rescue`.
+
+### Schema (`rescue`)
+
+| Table | Purpose |
+| --- | --- |
+| `rescues` | Core org row — identity, contact, registration numbers, status, verification metadata. |
+| `rescue_settings` | Per-rescue typed settings. |
+| `staff_members` | Staff membership — `user_id` + `rescue_id`, title, verified flag. |
+| `invitations` | Pending staff invitations — email, token, expiry, used flag. |
+| `foster_placements` | Foster assignments — rescue, pet, foster user, dates, status. |
+| `application_questions` | Custom adoption-application questions a rescue defines. |
+
+Migrations: `services/rescue/src/migrations/001`–`007`.
+
+### gRPC RPCs
+
+`RescueService`. Permission scope is the `rescue_id`; admin / `super_admin`
+bypass scope.
+
+| RPC | Permission |
+| --- | --- |
+| `Create` | `rescues.create` |
+| `Get` | `rescues.read` |
+| `List` | `rescues.read` (defaults to verified-only; name + geo filters) |
+| `Update` | `rescues.update` (scoped; does not change status) |
+| `Verify` | `admin.security.manage` (admin-only status transition) |
+| `InviteStaff` | `staff.create` (scoped; mints token, returned once) |
+| `GetMyStaffMembership` | authenticated (self-scoped) |
+| `ListStaffMembers` | `staff.read` |
+| `CreateFosterPlacement` | `foster.create` (scoped; validates pet via pets gRPC) |
+| `ListFosterPlacements` | `foster.read` (scoped; `foster.read:any` for admin) |
+| `GetFosterPlacement` | `foster.read` (scoped) |
+| `EndFosterPlacement` | `foster.update` (scoped; idempotent) |
+| `GetInvitationByToken` | none (the token is the credential) |
+
+### NATS subjects
+
+**Emits** (publish-after-commit): `rescue.created`, `rescue.updated`,
+`rescue.verified` / `rescue.rejected` (Verify), `rescue.staffInvited`,
+`rescue.fosterPlacementCreated`, `rescue.fosterPlacementEnded`. Plus
+`gdpr.erasureCompleted` as a saga participant.
+
+**Consumes:** `gdpr.erasureRequested` (durable `gdpr-rescue`).
+
+### Dependencies
+
+`@adopt-dont-shop/{authz, config-secrets, db, events, lib.types, observability,
+proto, service-bootstrap}`. Cross-service gRPC: calls **service.pets**
+(`PETS_GRPC_URL`) in `CreateFosterPlacement` to validate the pet.
+
+### Testing strategy
+
+Vitest. Pure handlers with pool + NATS (+ a stub pets client) injected — assert
+each permission/scope path, the verification state machine, one-time invitation
+token behaviour, foster-placement validation against the pets client, and
+publish-after-commit ordering.


### PR DESCRIPTION
Docs & observability content across four tickets. Docs/config only — no service source, no CI/turbo/package.json changes.

## ADS-820 — API versioning & deprecation
- New `docs/api-versioning.md`: the `/api/v<N>/` URL scheme (every route on v1 today), an OpenAPI-aligned definition of a breaking change, the deprecation lifecycle with a **6-month default window** (noted as default), RFC 8594 `Deprecation` + `Sunset` (+ `Link rel="deprecation"`) headers, the process (conventional `BREAKING CHANGE:` footer + an ADR + a timeline), and OpenAPI `deprecated: true`.
- Linked from `docs/README.md` (docs-index check passes).

## ADS-806 — SLOs + alerting rules
- New `docs/slo.md`: per-service SLOs over a 30-day window with error budgets; maps each alert to the SLO it protects. Supersedes the monolith-era `docs/observability-alerting.md` (kept, not deleted, per the ticket).
- New loadable rule files under `infra/prometheus/rules/` (+ README): `service-down`, `high-error-rate` (HTTP + gRPC), `p95-latency` (HTTP + gRPC), `gateway-resilience` (circuit-open + rate-limit spike), and `gdpr-saga` (failed / timed_out / erasureRequested-without-completed).
- **Rules target metrics that actually exist today**: the `http_request_duration_seconds` / `grpc_handler_duration_seconds` histograms from `packages/observability`, the `gdpr_sagas` gauge in `services/audit`, the `gateway_rate_limit_hits_total` counter, and the `grpc_circuit_state` gauge. There is no `http_requests_total` in this stack, so error rates derive from the histogram `_count` series; `slo.md` notes where ADS-803 domain metrics will slot in.
- Alertmanager routing/receivers are **out of scope** (no real destination) — noted in both `slo.md` and the rules README.

## ADS-811 — Backup/restore + runbooks
- Reconciled `docs/db-backup-runbook.md`: the cited `service.backend/scripts/db-backup.sh`/`db-restore.sh` no longer exist; updated all references to the live `scripts/snapshot-postgres.sh` (plain-SQL `dump.sql.gz` → S3) and added RTO (≤2h) / RPO (24h) targets.
- New `scripts/restore-postgres.sh` (gunzip | psql; S3 or local source; refuses to overwrite the live DB without `CONFIRM_RESTORE`).
- New runbooks: `docs/runbooks/jetstream-backlog.md` (DOMAIN_EVENTS / DLQ, `MAX_DELIVER=7`) and `docs/runbooks/gdpr-erasure-incident.md` (saga states, 30-min deadline, 3 retries).
- New scheduled `.github/workflows/backup.yml` (cron `0 2 * * *`) that ships and runs the snapshot script on the prod host.
- "Restore tested in staging" is **out of scope** (no live env) — documented a staging restore-drill procedure instead.

## ADS-817 — Per-service READMEs + indexes
- New `services/cms/README.md` (the only service that had none).
- Appended a "Canonical reference (ADS-817)" section to the other ten service READMEs: Responsibility, Schema (table), gRPC RPCs **with the permission each requires**, NATS subjects emitted vs consumed, Dependencies (incl. cross-service gRPC), and Testing strategy.
- New `services/README.md` (one row per service: purpose, HTTP/gRPC ports, schema, key deps) and `packages/README.md` (lib.* + service-only packages + eslint configs, one-line purposes).
- All facts derived from each service's proto, gRPC handlers, NATS subscribers, migrations, and package.json — RPC names, permission strings, and NATS subjects verified against source.

## Checks run
- `python3 -c yaml.safe_load` on all 5 rule files + `backup.yml` — valid.
- `bash -n scripts/restore-postgres.sh` — valid.
- `node scripts/check-docs-index.mjs` — all new docs linked; the only remaining failures are 4 pre-existing unlinked files on `main` (not touched here).
- `node scripts/check-workflow-paths.mjs` — passes (backup.yml has no path filter).
- Verified every link target in the new index files resolves.

Note: `backup.yml` pins `appleboy/ssh-action` by SHA (matching `rollback.yml`); `appleboy/scp-action` is left on a version tag with a "pin before merge" comment.

https://claude.ai/code/session_01Cq35z47L2XmwwcjBtqeCX4

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cq35z47L2XmwwcjBtqeCX4)_