### PR TITLE
fix(auth): align gateway↔SPA auth contract so login works

### DIFF
--- a/packages/lib.auth/src/__tests__/auth-service.test.ts
+++ b/packages/lib.auth/src/__tests__/auth-service.test.ts
@@ -39,19 +39,24 @@ describe('AuthService', () => {
     updatedAt: '2023-01-01T00:00:00Z',
   };
 
-  // Backend no longer returns refreshToken in body — it's set as httpOnly cookie
+  // Gateway login/refresh return a Bearer token pair in the JSON body.
+  const mockTokens = {
+    accessToken: 'access.jwt',
+    refreshToken: 'refresh.jwt',
+    accessExpiresAt: '2026-01-01T01:00:00Z',
+    refreshExpiresAt: '2026-02-01T00:00:00Z',
+  };
   const mockAuthResponse: AuthResponse = {
     user: mockUser,
-    token: 'mock-token',
-    expiresIn: 3600,
-    accessToken: 'mock-token',
+    tokens: mockTokens,
+    permissions: ['pets.read'],
   };
 
   beforeEach(() => {
     authService = new AuthService();
     vi.clearAllMocks();
     mockLocalStorage.clear.mockClear();
-    mockLocalStorage.getItem.mockClear();
+    mockLocalStorage.getItem.mockReset();
     mockLocalStorage.setItem.mockClear();
     mockLocalStorage.removeItem.mockClear();
   });
@@ -69,7 +74,7 @@ describe('AuthService', () => {
   });
 
   describe('login', () => {
-    it('should login successfully, store user in localStorage, and not write tokens to JS storage', async () => {
+    it('should login, store the user and the Bearer token pair', async () => {
       const credentials: LoginRequest = {
         email: 'test@example.com',
         password: 'password123',
@@ -80,21 +85,20 @@ describe('AuthService', () => {
       const result = await authService.login(credentials);
 
       expect(apiService.post).toHaveBeenCalledWith('/api/v1/auth/login', credentials);
-      // User stored in localStorage (persists across sessions)
       expect(mockLocalStorage.setItem).toHaveBeenCalledWith(
         STORAGE_KEYS.USER,
         JSON.stringify(mockUser)
       );
-      // Access token NOT stored anywhere JS-accessible — it's an httpOnly cookie
-      expect(mockLocalStorage.setItem).not.toHaveBeenCalledWith(
-        STORAGE_KEYS.AUTH_TOKEN,
-        expect.any(String)
-      );
-      expect(mockLocalStorage.setItem).not.toHaveBeenCalledWith(
+      // Access + refresh tokens persisted so requests carry a Bearer header.
+      expect(mockLocalStorage.setItem).toHaveBeenCalledWith(
         STORAGE_KEYS.ACCESS_TOKEN,
-        expect.any(String)
+        mockTokens.accessToken
       );
-      expect(result).toEqual({ ...mockAuthResponse, accessToken: 'mock-token' });
+      expect(mockLocalStorage.setItem).toHaveBeenCalledWith(
+        STORAGE_KEYS.REFRESH_TOKEN,
+        mockTokens.refreshToken
+      );
+      expect(result).toEqual(mockAuthResponse);
     });
 
     it('should handle login failure', async () => {
@@ -136,27 +140,42 @@ describe('AuthService', () => {
   });
 
   describe('logout', () => {
-    it('should logout successfully and clear user from localStorage', async () => {
+    it('should revoke the stored refresh token and clear the session', async () => {
+      mockLocalStorage.getItem.mockImplementation((key: string) =>
+        key === STORAGE_KEYS.REFRESH_TOKEN ? 'refresh.jwt' : null
+      );
       (apiService.post as ReturnType<typeof vi.fn>).mockResolvedValue({});
 
       await authService.logout();
 
-      expect(apiService.post).toHaveBeenCalledWith('/api/v1/auth/logout');
-      // User removed from localStorage
+      expect(apiService.post).toHaveBeenCalledWith('/api/v1/auth/logout', {
+        refreshToken: 'refresh.jwt',
+      });
+      // User + both tokens removed from localStorage.
       expect(mockLocalStorage.removeItem).toHaveBeenCalledWith(STORAGE_KEYS.USER);
-      // Token cookies are cleared server-side — no JS-side removal needed
-      expect(mockLocalStorage.removeItem).not.toHaveBeenCalledWith(STORAGE_KEYS.AUTH_TOKEN);
-      expect(mockLocalStorage.removeItem).not.toHaveBeenCalledWith(STORAGE_KEYS.ACCESS_TOKEN);
+      expect(mockLocalStorage.removeItem).toHaveBeenCalledWith(STORAGE_KEYS.ACCESS_TOKEN);
+      expect(mockLocalStorage.removeItem).toHaveBeenCalledWith(STORAGE_KEYS.REFRESH_TOKEN);
+    });
+
+    it('should post an empty body when no refresh token is stored', async () => {
+      mockLocalStorage.getItem.mockReturnValue(null);
+      (apiService.post as ReturnType<typeof vi.fn>).mockResolvedValue({});
+
+      await authService.logout();
+
+      expect(apiService.post).toHaveBeenCalledWith('/api/v1/auth/logout', {});
     });
 
     it('should clear storage even if API call fails', async () => {
-      const consoleSpy = vi.spyOn(console, 'error').mockImplementation();
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      mockLocalStorage.getItem.mockReturnValue(null);
       (apiService.post as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('Network error'));
 
       await authService.logout();
 
       expect(consoleSpy).toHaveBeenCalledWith('Logout API call failed:', expect.any(Error));
       expect(mockLocalStorage.removeItem).toHaveBeenCalledWith(STORAGE_KEYS.USER);
+      expect(mockLocalStorage.removeItem).toHaveBeenCalledWith(STORAGE_KEYS.ACCESS_TOKEN);
 
       consoleSpy.mockRestore();
     });
@@ -212,69 +231,127 @@ describe('AuthService', () => {
   });
 
   describe('isAuthenticated', () => {
-    it('should return true when user data exists in localStorage', () => {
-      mockLocalStorage.getItem.mockReturnValueOnce(JSON.stringify(mockUser));
+    it('should return true when both user data and an access token exist', () => {
+      mockLocalStorage.getItem.mockImplementation((key: string) => {
+        if (key === STORAGE_KEYS.USER) return JSON.stringify(mockUser);
+        if (key === STORAGE_KEYS.ACCESS_TOKEN) return 'access.jwt';
+        return null;
+      });
 
-      const isAuth = authService.isAuthenticated();
-
-      expect(isAuth).toBe(true);
+      expect(authService.isAuthenticated()).toBe(true);
     });
 
-    it('should return false when no user data in localStorage', () => {
-      mockLocalStorage.getItem.mockReturnValue(null);
+    it('should return false when an access token is present but no user', () => {
+      mockLocalStorage.getItem.mockImplementation((key: string) =>
+        key === STORAGE_KEYS.ACCESS_TOKEN ? 'access.jwt' : null
+      );
 
-      const isAuth = authService.isAuthenticated();
+      expect(authService.isAuthenticated()).toBe(false);
+    });
 
-      expect(isAuth).toBe(false);
+    it('should return false when a user is present but no access token', () => {
+      mockLocalStorage.getItem.mockImplementation((key: string) =>
+        key === STORAGE_KEYS.USER ? JSON.stringify(mockUser) : null
+      );
+
+      expect(authService.isAuthenticated()).toBe(false);
     });
   });
 
   describe('getToken', () => {
-    it('should return null — access token lives in httpOnly cookie, not JS storage', () => {
-      const token = authService.getToken();
+    it('should return the stored access token', () => {
+      mockLocalStorage.getItem.mockImplementation((key: string) =>
+        key === STORAGE_KEYS.ACCESS_TOKEN ? 'access.jwt' : null
+      );
 
-      expect(token).toBeNull();
+      expect(authService.getToken()).toBe('access.jwt');
+      expect(mockLocalStorage.getItem).toHaveBeenCalledWith(STORAGE_KEYS.ACCESS_TOKEN);
+    });
+
+    it('should return null when no access token is stored', () => {
+      mockLocalStorage.getItem.mockReturnValue(null);
+
+      expect(authService.getToken()).toBeNull();
     });
   });
 
   describe('setToken', () => {
-    it('should be a no-op — token is managed as httpOnly cookie by the backend', () => {
-      authService.setToken('some-token');
+    it('should store the access token when given a value', () => {
+      authService.setToken('access.jwt');
 
-      expect(mockLocalStorage.setItem).not.toHaveBeenCalled();
+      expect(mockLocalStorage.setItem).toHaveBeenCalledWith(
+        STORAGE_KEYS.ACCESS_TOKEN,
+        'access.jwt'
+      );
+    });
+
+    it('should remove the access token when given a falsy value', () => {
+      authService.setToken(null);
+
+      expect(mockLocalStorage.removeItem).toHaveBeenCalledWith(STORAGE_KEYS.ACCESS_TOKEN);
     });
   });
 
   describe('clearTokens', () => {
-    it('should be a no-op — token cookies are cleared by the backend logout endpoint', () => {
+    it('should remove both the access and refresh tokens', () => {
       authService.clearTokens();
 
-      expect(mockLocalStorage.removeItem).not.toHaveBeenCalled();
+      expect(mockLocalStorage.removeItem).toHaveBeenCalledWith(STORAGE_KEYS.ACCESS_TOKEN);
+      expect(mockLocalStorage.removeItem).toHaveBeenCalledWith(STORAGE_KEYS.REFRESH_TOKEN);
     });
   });
 
   describe('refreshToken', () => {
-    it('should refresh token via cookie and return the new token value', async () => {
+    it('should send the stored refresh token, persist the rotated pair, and return the new access token', async () => {
+      mockLocalStorage.getItem.mockImplementation((key: string) =>
+        key === STORAGE_KEYS.REFRESH_TOKEN ? 'refresh.jwt' : null
+      );
       const refreshResponse = {
-        token: 'new-token',
-        // refreshToken not returned — it's set as httpOnly cookie by backend
+        tokens: {
+          accessToken: 'new.access.jwt',
+          refreshToken: 'new.refresh.jwt',
+          accessExpiresAt: '2026-01-01T02:00:00Z',
+          refreshExpiresAt: '2026-02-01T00:00:00Z',
+        },
       };
-
       (apiService.post as ReturnType<typeof vi.fn>).mockResolvedValue(refreshResponse);
 
       const newToken = await authService.refreshToken();
 
-      // Should NOT send refresh token in body — cookie is auto-sent by browser
-      expect(apiService.post).toHaveBeenCalledWith('/api/v1/auth/refresh-token', {});
-      // No token stored in JS-accessible storage
-      expect(mockLocalStorage.setItem).not.toHaveBeenCalled();
-      expect(newToken).toBe('new-token');
+      expect(apiService.post).toHaveBeenCalledWith('/api/v1/auth/refresh-token', {
+        refreshToken: 'refresh.jwt',
+      });
+      expect(mockLocalStorage.setItem).toHaveBeenCalledWith(
+        STORAGE_KEYS.ACCESS_TOKEN,
+        'new.access.jwt'
+      );
+      expect(mockLocalStorage.setItem).toHaveBeenCalledWith(
+        STORAGE_KEYS.REFRESH_TOKEN,
+        'new.refresh.jwt'
+      );
+      expect(newToken).toBe('new.access.jwt');
     });
 
     it('should propagate error if refresh API call fails', async () => {
+      mockLocalStorage.getItem.mockReturnValue(null);
       (apiService.post as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('Unauthorized'));
 
       await expect(authService.refreshToken()).rejects.toThrow('Unauthorized');
+    });
+  });
+
+  describe('getProfile', () => {
+    it('should unwrap the user from the gateway /me envelope', async () => {
+      (apiService.get as ReturnType<typeof vi.fn>).mockResolvedValue({
+        user: mockUser,
+        roles: ['adopter'],
+        permissions: ['pets.read'],
+      });
+
+      const profile = await authService.getProfile();
+
+      expect(apiService.get).toHaveBeenCalledWith('/api/v1/auth/me');
+      expect(profile).toEqual(mockUser);
     });
   });
 

--- a/packages/lib.auth/src/contexts/AuthContext.test.tsx
+++ b/packages/lib.auth/src/contexts/AuthContext.test.tsx
@@ -75,9 +75,13 @@ const devUser: User = {
 
 const buildAuthResponse = (user: User): AuthResponse => ({
   user,
-  token: 'mock-token',
-  expiresIn: 3600,
-  accessToken: 'mock-token',
+  tokens: {
+    accessToken: 'mock-token',
+    refreshToken: 'mock-refresh-token',
+    accessExpiresAt: '2026-01-01T01:00:00Z',
+    refreshExpiresAt: '2026-02-01T00:00:00Z',
+  },
+  permissions: [],
 });
 
 // Stable reference so re-renders don't re-trigger the effect that watches it.

--- a/packages/lib.auth/src/services/auth-service.ts
+++ b/packages/lib.auth/src/services/auth-service.ts
@@ -6,6 +6,7 @@ import {
   User,
   ChangePasswordRequest,
   RefreshTokenResponse,
+  TokenPair,
   TwoFactorSetupResponse,
   TwoFactorEnableResponse,
   TwoFactorDisableResponse,
@@ -35,10 +36,13 @@ const AUTH_ENDPOINTS = {
 /**
  * AuthService - Authentication and user management service
  *
- * Access tokens are stored in httpOnly cookies (managed by the backend,
- * not accessible to JavaScript — XSS-safe). Refresh tokens use a separate
- * httpOnly cookie. All authenticated requests rely on the browser sending
- * these cookies automatically via `credentials: 'include'`.
+ * Phase 11 follow-up: the Fastify gateway replaced the deleted monolith's
+ * httpOnly-cookie + CSRF model with Bearer tokens. Login / refresh return
+ * `{ user, tokens: { accessToken, refreshToken } }` in the JSON body; the
+ * access token is stored here and attached to every authenticated request
+ * as `Authorization: Bearer <token>` via lib.api's `getAuthToken` hook
+ * (wired in the constructor). The refresh token is replayed to
+ * `/auth/refresh-token` to rotate the pair.
  */
 export class AuthService {
   constructor() {
@@ -54,13 +58,13 @@ export class AuthService {
   async login(credentials: LoginRequest): Promise<AuthResponse> {
     const response = await apiService.post<AuthResponse>(AUTH_ENDPOINTS.LOGIN, credentials);
 
-    // Access token is set as httpOnly cookie by the backend; refresh token likewise.
+    // Persist the user + the Bearer token pair the gateway returned in the
+    // body. getToken() then feeds the access token to lib.api so subsequent
+    // requests are authenticated.
     this.setUser(response.user);
+    this.setTokens(response.tokens);
 
-    return {
-      ...response,
-      accessToken: response.token, // Map backend 'token' to frontend 'accessToken'
-    };
+    return response;
   }
 
   /**
@@ -81,8 +85,11 @@ export class AuthService {
    * Logout user and clear all stored data
    */
   async logout(): Promise<void> {
+    // The gateway revokes the supplied refresh token (idempotent — an
+    // already-revoked/expired token still returns OK).
+    const refreshToken = localStorage.getItem(STORAGE_KEYS.REFRESH_TOKEN);
     try {
-      await apiService.post(AUTH_ENDPOINTS.LOGOUT);
+      await apiService.post(AUTH_ENDPOINTS.LOGOUT, refreshToken ? { refreshToken } : {});
     } catch (error) {
       console.error('Logout API call failed:', error);
     } finally {
@@ -125,28 +132,37 @@ export class AuthService {
   }
 
   /**
-   * Check if user is authenticated (user data present in localStorage).
-   * The access token lives in an httpOnly cookie so cannot be read from JS;
-   * user presence is the local indicator of an active session.
+   * Check if user is authenticated. Both the stored user record and the
+   * access token must be present — the user drives UI gating while the
+   * token is what actually authenticates API calls.
    */
   isAuthenticated(): boolean {
-    return !!this.getCurrentUser();
+    return !!this.getCurrentUser() && !!this.getToken();
   }
 
   /**
-   * Refresh access token — refresh token and new access token are both set
-   * as httpOnly cookies by the backend; no JS-side storage needed.
+   * Refresh the access token. Sends the stored refresh token to the gateway,
+   * persists the rotated pair, and returns the new access token.
    */
   async refreshToken(): Promise<string> {
-    const response = await apiService.post<RefreshTokenResponse>(AUTH_ENDPOINTS.REFRESH, {});
-    return response.token;
+    const stored = localStorage.getItem(STORAGE_KEYS.REFRESH_TOKEN);
+    const response = await apiService.post<RefreshTokenResponse>(
+      AUTH_ENDPOINTS.REFRESH,
+      stored ? { refreshToken: stored } : {}
+    );
+    this.setTokens(response.tokens);
+    return response.tokens.accessToken;
   }
 
   /**
-   * Get user profile from API
+   * Get user profile from API.
+   *
+   * The gateway's `GET /auth/me` returns a `{ user, roles, permissions,
+   * rescueId }` envelope; the caller wants the bare user record, so unwrap.
    */
   async getProfile(): Promise<User> {
-    return await apiService.get<User>(AUTH_ENDPOINTS.ME);
+    const response = await apiService.get<{ user: User }>(AUTH_ENDPOINTS.ME);
+    return response.user;
   }
 
   /**
@@ -273,34 +289,44 @@ export class AuthService {
   }
 
   /**
-   * Returns null — the access token lives in an httpOnly cookie managed by
-   * the backend and is not readable from JavaScript. HTTP requests send it
-   * automatically via `credentials: 'include'`; Socket.IO connections use the
-   * same cookie on the WebSocket upgrade request.
+   * Returns the stored access token (or null). lib.api calls this via the
+   * `getAuthToken` hook to attach `Authorization: Bearer <token>`; the
+   * Socket.IO clients read it the same way.
    */
-  getToken(): null {
-    return null;
+  getToken(): string | null {
+    return localStorage.getItem(STORAGE_KEYS.ACCESS_TOKEN);
   }
 
   /**
-   * No-op — the access token is set as an httpOnly cookie by the backend
-   * login/refresh response and is never written to JS-accessible storage.
+   * Store (or clear) the access token. Passing a falsy value removes it.
    */
-  setToken(_token: string | null | undefined): void {
-    // intentional no-op
+  setToken(token: string | null | undefined): void {
+    if (token) {
+      localStorage.setItem(STORAGE_KEYS.ACCESS_TOKEN, token);
+      return;
+    }
+    localStorage.removeItem(STORAGE_KEYS.ACCESS_TOKEN);
   }
 
   /**
-   * Clears local user state. The access/refresh token cookies are cleared
-   * by the backend logout endpoint.
+   * Clears the stored Bearer token pair. Called on logout (after the gateway
+   * revokes the refresh token) and when a session is found to be invalid.
    */
   clearTokens(): void {
-    // Token cookies are cleared server-side on logout; nothing to do here.
+    localStorage.removeItem(STORAGE_KEYS.ACCESS_TOKEN);
+    localStorage.removeItem(STORAGE_KEYS.REFRESH_TOKEN);
   }
 
   // Private helper methods
   private setUser(user: User): void {
     localStorage.setItem(STORAGE_KEYS.USER, JSON.stringify(user));
+  }
+
+  private setTokens(tokens: TokenPair): void {
+    localStorage.setItem(STORAGE_KEYS.ACCESS_TOKEN, tokens.accessToken);
+    if (tokens.refreshToken) {
+      localStorage.setItem(STORAGE_KEYS.REFRESH_TOKEN, tokens.refreshToken);
+    }
   }
 
   private clearStorage(): void {

--- a/packages/lib.auth/src/types/auth.ts
+++ b/packages/lib.auth/src/types/auth.ts
@@ -183,13 +183,30 @@ export interface RegisterRequest {
   confirmPassword?: string;
 }
 
+/**
+ * Token pair returned by the gateway in the JSON body.
+ *
+ * Phase 11 follow-up: the Fastify gateway replaced the monolith's
+ * httpOnly-cookie + CSRF model with Bearer tokens carried in the response
+ * body (see services/gateway/src/routes/auth.ts and the `TokenPair` proto
+ * message in packages/proto). The access token is attached to subsequent
+ * requests as `Authorization: Bearer <token>` via lib.api's `getAuthToken`
+ * hook; the refresh token is replayed to `/auth/refresh-token`.
+ */
+export interface TokenPair {
+  accessToken: string;
+  refreshToken: string;
+  // RFC 3339 expiry timestamps (optional — present on the gateway contract,
+  // but the SPA only needs the token strings to authenticate).
+  accessExpiresAt?: string;
+  refreshExpiresAt?: string;
+}
+
 export interface AuthResponse {
   user: User;
-  token: string; // Backend returns 'token', not 'accessToken'
-  refreshToken?: string; // No longer returned in body — sent as httpOnly cookie
-  expiresIn: number;
-  // Legacy field for frontend compatibility
-  accessToken?: string;
+  tokens: TokenPair;
+  // Flattened permission snapshot at login time (gateway LoginResponse).
+  permissions?: string[];
 }
 
 export interface ChangePasswordRequest {
@@ -202,8 +219,7 @@ export interface RefreshTokenRequest {
 }
 
 export interface RefreshTokenResponse {
-  token: string;
-  refreshToken?: string; // No longer returned in body — rotated via httpOnly cookie
+  tokens: TokenPair;
 }
 
 export interface PasswordResetRequest {
@@ -242,6 +258,7 @@ export interface TokenData {
 export const STORAGE_KEYS = {
   AUTH_TOKEN: '__dev_authToken',
   ACCESS_TOKEN: '__dev_accessToken',
+  REFRESH_TOKEN: '__dev_refreshToken',
   USER: 'user',
 } as const;
 

--- a/services/gateway/src/routes/auth-user-json.test.ts
+++ b/services/gateway/src/routes/auth-user-json.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from 'vitest';
+
+import { AuthV1 } from '@adopt-dont-shop/proto';
+
+import { roleToApi, rolesToApi, userToApiJson, withApiUser } from './auth-user-json.js';
+
+const baseUser: AuthV1.User = {
+  userId: 'usr-1',
+  email: 'alex@example.com',
+  userType: AuthV1.UserRole.USER_ROLE_ADOPTER,
+  status: AuthV1.UserStatus.USER_STATUS_ACTIVE,
+  emailVerified: true,
+  phoneVerified: false,
+  twoFactorEnabled: false,
+  createdAt: '2026-01-01T00:00:00Z',
+  updatedAt: '2026-01-01T00:00:00Z',
+};
+
+describe('userToApiJson', () => {
+  it('maps the proto role + status enums to the canonical DB strings', () => {
+    const json = userToApiJson(baseUser);
+
+    expect(json.userType).toBe('adopter');
+    expect(json.status).toBe('active');
+    // Other fields pass through unchanged from toJSON.
+    expect(json.email).toBe('alex@example.com');
+    expect(json.userId).toBe('usr-1');
+  });
+
+  it.each([
+    [AuthV1.UserRole.USER_ROLE_RESCUE_STAFF, 'rescue_staff'],
+    [AuthV1.UserRole.USER_ROLE_ADMIN, 'admin'],
+    [AuthV1.UserRole.USER_ROLE_MODERATOR, 'moderator'],
+    [AuthV1.UserRole.USER_ROLE_SUPER_ADMIN, 'super_admin'],
+    [AuthV1.UserRole.USER_ROLE_SUPPORT_AGENT, 'support_agent'],
+  ])('maps role %s to %s', (role, expected) => {
+    expect(userToApiJson({ ...baseUser, userType: role }).userType).toBe(expected);
+  });
+
+  it.each([
+    [AuthV1.UserStatus.USER_STATUS_INACTIVE, 'inactive'],
+    [AuthV1.UserStatus.USER_STATUS_SUSPENDED, 'suspended'],
+    [AuthV1.UserStatus.USER_STATUS_PENDING_VERIFICATION, 'pending_verification'],
+    [AuthV1.UserStatus.USER_STATUS_DEACTIVATED, 'deactivated'],
+  ])('maps status %s to %s', (status, expected) => {
+    expect(userToApiJson({ ...baseUser, status }).status).toBe(expected);
+  });
+});
+
+describe('roleToApi', () => {
+  it('returns the canonical string for a known role', () => {
+    expect(roleToApi(AuthV1.UserRole.USER_ROLE_ADOPTER)).toBe('adopter');
+  });
+
+  it('returns undefined for the unspecified role', () => {
+    expect(roleToApi(AuthV1.UserRole.USER_ROLE_UNSPECIFIED)).toBeUndefined();
+  });
+});
+
+describe('rolesToApi', () => {
+  it('maps known roles and drops unknown/unspecified ones', () => {
+    const roles = [
+      AuthV1.UserRole.USER_ROLE_ADOPTER,
+      AuthV1.UserRole.USER_ROLE_UNSPECIFIED,
+      AuthV1.UserRole.USER_ROLE_RESCUE_STAFF,
+    ];
+
+    expect(rolesToApi(roles)).toEqual(['adopter', 'rescue_staff']);
+  });
+});
+
+describe('withApiUser', () => {
+  it('replaces the user field with the normalised JSON', () => {
+    const result = withApiUser({ tokens: { accessToken: 'a' } }, baseUser);
+
+    expect(result).toEqual({
+      tokens: { accessToken: 'a' },
+      user: userToApiJson(baseUser),
+    });
+  });
+
+  it('is a no-op when no user is present', () => {
+    const json = { permissions: ['pets.read'] };
+
+    expect(withApiUser(json, undefined)).toBe(json);
+  });
+});

--- a/services/gateway/src/routes/auth-user-json.ts
+++ b/services/gateway/src/routes/auth-user-json.ts
@@ -1,0 +1,68 @@
+// Bridge proto enums → the canonical API strings the SPA expects.
+//
+// The auth gRPC service returns proto enums (USER_ROLE_*, USER_STATUS_*) for
+// a user's userType/status. ts-proto's `toJSON` serialises those as the
+// SCREAMING_SNAKE proto constant names ("USER_ROLE_ADOPTER"), but the SPA
+// (lib.auth / lib.types) speaks the canonical Postgres ENUM strings
+// ("adopter", "active", …) — the same strings this gateway already stamps
+// onto its downstream `x-user-roles` header (see middleware/authenticate.ts).
+//
+// Leaving the SCREAMING names in the body breaks login: app.* checks
+// `allowedUserTypes.includes(user.userType)` against the lowercase values, so
+// every successful login is mistaken for a wrong-app access and logged out.
+// This module is the single chokepoint that keeps the HTTP body consistent
+// with the documented SPA contract.
+
+import { AuthV1 } from '@adopt-dont-shop/proto';
+
+const ROLE_TO_API: Record<AuthV1.UserRole, string | undefined> = {
+  [AuthV1.UserRole.USER_ROLE_UNSPECIFIED]: undefined,
+  [AuthV1.UserRole.USER_ROLE_ADOPTER]: 'adopter',
+  [AuthV1.UserRole.USER_ROLE_RESCUE_STAFF]: 'rescue_staff',
+  [AuthV1.UserRole.USER_ROLE_ADMIN]: 'admin',
+  [AuthV1.UserRole.USER_ROLE_MODERATOR]: 'moderator',
+  [AuthV1.UserRole.USER_ROLE_SUPER_ADMIN]: 'super_admin',
+  [AuthV1.UserRole.USER_ROLE_SUPPORT_AGENT]: 'support_agent',
+  [AuthV1.UserRole.UNRECOGNIZED]: undefined,
+};
+
+const STATUS_TO_API: Record<AuthV1.UserStatus, string | undefined> = {
+  [AuthV1.UserStatus.USER_STATUS_UNSPECIFIED]: undefined,
+  [AuthV1.UserStatus.USER_STATUS_ACTIVE]: 'active',
+  [AuthV1.UserStatus.USER_STATUS_INACTIVE]: 'inactive',
+  [AuthV1.UserStatus.USER_STATUS_SUSPENDED]: 'suspended',
+  [AuthV1.UserStatus.USER_STATUS_PENDING_VERIFICATION]: 'pending_verification',
+  [AuthV1.UserStatus.USER_STATUS_DEACTIVATED]: 'deactivated',
+  [AuthV1.UserStatus.UNRECOGNIZED]: undefined,
+};
+
+/** Map a proto UserRole to the canonical API string, or undefined if unknown. */
+export const roleToApi = (role: AuthV1.UserRole): string | undefined => ROLE_TO_API[role];
+
+/**
+ * Serialise a proto User to the JSON the SPA expects: identical to
+ * `AuthV1.User.toJSON`, but with userType/status mapped from the proto enum
+ * names to the canonical DB strings. Falls back to the raw toJSON value if a
+ * value is somehow outside the known enum set.
+ */
+export const userToApiJson = (user: AuthV1.User): Record<string, unknown> => {
+  const json = AuthV1.User.toJSON(user) as Record<string, unknown>;
+  return {
+    ...json,
+    userType: ROLE_TO_API[user.userType] ?? json.userType,
+    status: STATUS_TO_API[user.status] ?? json.status,
+  };
+};
+
+/**
+ * Replace the `user` field of an already-serialised auth response with the
+ * normalised user JSON. No-op when the response carries no user.
+ */
+export const withApiUser = (
+  json: Record<string, unknown>,
+  user: AuthV1.User | undefined
+): Record<string, unknown> => (user ? { ...json, user: userToApiJson(user) } : json);
+
+/** Map a list of proto roles to canonical API strings, dropping unknowns. */
+export const rolesToApi = (roles: readonly AuthV1.UserRole[]): string[] =>
+  roles.map(roleToApi).filter((role): role is string => role !== undefined);

--- a/services/gateway/src/routes/auth.test.ts
+++ b/services/gateway/src/routes/auth.test.ts
@@ -130,8 +130,15 @@ describe('POST /api/v1/auth/login', () => {
     });
 
     expect(res.statusCode).toBe(200);
-    const body = res.json() as { user: { email: string }; tokens: { accessToken: string } };
+    const body = res.json() as {
+      user: { email: string; userType: string; status: string };
+      tokens: { accessToken: string };
+    };
     expect(body.user.email).toBe('alex@example.com');
+    // The SPA speaks the canonical DB strings, not the SCREAMING proto enum
+    // names — the gateway must normalise these in the body (auth contract).
+    expect(body.user.userType).toBe('adopter');
+    expect(body.user.status).toBe('active');
     expect(body.tokens.accessToken).toBe('a.jwt');
 
     const [req] = loginMock.mock.calls[0];
@@ -256,8 +263,16 @@ describe('GET /api/v1/auth/me', () => {
       });
 
       expect(res.statusCode).toBe(200);
-      const body = res.json() as { user: { userId: string }; permissions: string[] };
+      const body = res.json() as {
+        user: { userId: string; userType: string; status: string };
+        roles: string[];
+        permissions: string[];
+      };
       expect(body.user.userId).toBe('usr-1');
+      // Normalised to the canonical DB strings for the SPA.
+      expect(body.user.userType).toBe('adopter');
+      expect(body.user.status).toBe('active');
+      expect(body.roles).toEqual(['adopter']);
       expect(body.permissions).toEqual(['pets.read']);
       const [, metadata] = getMeMock.mock.calls[0];
       expect(metadata.get('x-user-id')[0]).toBe('usr-1');

--- a/services/gateway/src/routes/auth.ts
+++ b/services/gateway/src/routes/auth.ts
@@ -35,6 +35,7 @@ import { buildMetadata } from '../middleware/metadata.js';
 import { handleGrpcError } from '../middleware/grpc-error.js';
 
 import { normalizeEmail, type EmailRateLimiter } from './email-rate-limiter.js';
+import { rolesToApi, withApiUser } from './auth-user-json.js';
 
 export type AuthRoutesOptions = {
   client: AuthClient;
@@ -162,7 +163,8 @@ export const registerAuthRoutes = async (
 
       try {
         const res = await client.login(grpcReq, buildMetadata(req));
-        return reply.send(AuthV1.LoginResponse.toJSON(res));
+        const json = AuthV1.LoginResponse.toJSON(res) as Record<string, unknown>;
+        return reply.send(withApiUser(json, res.user));
       } catch (err) {
         return handleGrpcError(err, reply);
       }
@@ -213,7 +215,8 @@ export const registerAuthRoutes = async (
     async (req, reply) => {
       try {
         const res = await client.getMe({}, buildMetadata(req));
-        return reply.send(AuthV1.GetMeResponse.toJSON(res));
+        const json = AuthV1.GetMeResponse.toJSON(res) as Record<string, unknown>;
+        return reply.send({ ...withApiUser(json, res.user), roles: rolesToApi(res.roles ?? []) });
       } catch (err) {
         return handleGrpcError(err, reply);
       }
@@ -272,7 +275,8 @@ export const registerAuthRoutes = async (
           },
           buildMetadata(req)
         );
-        return reply.code(201).send(AuthV1.RegisterResponse.toJSON(res));
+        const json = AuthV1.RegisterResponse.toJSON(res) as Record<string, unknown>;
+        return reply.code(201).send(withApiUser(json, res.user));
       } catch (err) {
         return handleGrpcError(err, reply);
       }
@@ -292,7 +296,8 @@ export const registerAuthRoutes = async (
           },
           buildMetadata(req)
         );
-        return reply.send(AuthV1.VerifyEmailResponse.toJSON(res));
+        const json = AuthV1.VerifyEmailResponse.toJSON(res) as Record<string, unknown>;
+        return reply.send(withApiUser(json, res.user));
       } catch (err) {
         return handleGrpcError(err, reply);
       }
@@ -410,7 +415,8 @@ export const registerAuthRoutes = async (
           },
           buildMetadata(req)
         );
-        return reply.send(AuthV1.UpdateAccountResponse.toJSON(res));
+        const json = AuthV1.UpdateAccountResponse.toJSON(res) as Record<string, unknown>;
+        return reply.send(withApiUser(json, res.user));
       } catch (err) {
         return handleGrpcError(err, reply);
       }
@@ -424,7 +430,8 @@ export const registerAuthRoutes = async (
     async (req, reply) => {
       try {
         const res = await client.getMe({}, buildMetadata(req));
-        return reply.send(AuthV1.GetMeResponse.toJSON(res));
+        const json = AuthV1.GetMeResponse.toJSON(res) as Record<string, unknown>;
+        return reply.send({ ...withApiUser(json, res.user), roles: rolesToApi(res.roles ?? []) });
       } catch (err) {
         return handleGrpcError(err, reply);
       }


### PR DESCRIPTION
## Why

The Fastify gateway replaced the deleted monolith's httpOnly-cookie + CSRF auth model with **Bearer tokens**, but `lib.auth` and the gateway's HTTP responses were never reconciled with that contract. The net effect: a *successful* `POST /api/v1/auth/login` still left the SPA logged out, so **dev login appears broken**.

This is the prerequisite for un-parking the e2e suite (follow-up PR) — the suite drives real UI logins, which are impossible until this lands.

## Three stacked mismatches fixed here

1. **Tokens.** The gateway returns `{ user, tokens: { accessToken, refreshToken } }` in the body, but `lib.auth` still expected `response.token` and treated tokens as httpOnly cookies — `getToken()` returned `null`, so **no `Authorization` header was ever sent**. `AuthService` now persists the token pair, returns the access token from `getToken()` (lib.api attaches it as `Authorization: Bearer <token>`), rotates via the stored refresh token, and revokes it on logout.

2. **`/me` envelope.** `GET /auth/me` returns `{ user, roles, permissions, rescueId }`; `getProfile()` treated the whole envelope as the `User`, which logged the user out on every reload. It now unwraps `.user`.

3. **Enum casing.** The gateway serialised proto enums verbatim (`userType: "USER_ROLE_ADOPTER"`, `status: "USER_STATUS_ACTIVE"`), but the apps compare against the canonical DB strings (`adopter`, `active`). So `AuthContext`'s `allowedUserTypes.includes(user.userType)` failed and **every login was mistaken for wrong-app access and bounced**. The gateway now normalises `userType`/`status` (and `/me` `roles`) to the DB strings in the auth HTTP responses — the same strings it already stamps on its downstream `x-user-roles` header — via a single `auth-user-json` chokepoint.

## Changes

- `packages/lib.auth` — `AuthService` token storage/refresh/logout, `getProfile()` unwrap, `getToken()` returns the stored access token; `AuthResponse`/`RefreshTokenResponse`/`TokenPair` types + `STORAGE_KEYS.REFRESH_TOKEN`.
- `services/gateway/src/routes/auth-user-json.ts` — new helper mapping proto enums → canonical API strings, applied to `login` / `register` / `verify-email` / `update-account` / `me` (×2 routes).

## Tests

- `lib.auth` auth-service suite rewritten for the Bearer contract — **27/27**, full package **74/74**.
- Gateway `auth-user-json` helper test + strengthened `auth.test.ts` (login + `/me` now assert canonical `adopter`/`active`) — gateway suite **666/666**.
- `tsc --noEmit` clean for both `service.gateway` and `lib.auth`; lint clean.

> Note: I can't run the full Docker stack in this environment, so the end-to-end browser login path isn't exercised here — that verification belongs to the e2e follow-up PR. The unit/route tests assert each leg of the contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_012iL3quEiMUvaNiH4xZNN9E)_