### PR TITLE
test: fix lib.auth getProfile assertion and bump service.auth hash ti…

### DIFF
--- a/packages/lib.auth/src/__tests__/auth-service.test.ts
+++ b/packages/lib.auth/src/__tests__/auth-service.test.ts
@@ -54,11 +54,9 @@ describe('AuthService', () => {
 
   beforeEach(() => {
     authService = new AuthService();
-    // resetAllMocks (not clearAllMocks) so any leaked mock implementation or
-    // queued `...Once` value is fully drained between tests. Under reduced
-    // test isolation (e.g. CI's pool), a stale resolved/rejected value on the
-    // shared apiService mock could otherwise bleed into a later test — this is
-    // what made `getProfile` intermittently receive `undefined` in CI.
+    // resetAllMocks (not just clearAllMocks) so any mock implementation or
+    // queued `...Once` value set by a test is fully drained before the next,
+    // keeping the shared apiService mock's behaviour isolated per test.
     vi.resetAllMocks();
     mockLocalStorage.clear.mockClear();
     mockLocalStorage.getItem.mockReset();
@@ -346,17 +344,23 @@ describe('AuthService', () => {
   });
 
   describe('getProfile', () => {
-    it('should unwrap the user from the gateway /me envelope', async () => {
+    it('should request the /me endpoint and resolve to the unwrapped user', async () => {
       (apiService.get as ReturnType<typeof vi.fn>).mockResolvedValue({
         user: mockUser,
         roles: ['adopter'],
         permissions: ['pets.read'],
       });
 
-      const profile = await authService.getProfile();
+      const result = await authService.getProfile();
 
       expect(apiService.get).toHaveBeenCalledWith('/api/v1/auth/me');
-      expect(profile).toEqual(mockUser);
+      expect(result).toEqual(mockUser);
+    });
+
+    it('should propagate an API failure', async () => {
+      (apiService.get as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('Unauthorized'));
+
+      await expect(authService.getProfile()).rejects.toThrow('Unauthorized');
     });
   });
 
@@ -434,27 +438,6 @@ describe('AuthService', () => {
 
       expect(apiService.post).toHaveBeenCalledWith('/api/v1/auth/2fa/backup-codes');
       expect(result).toEqual(mockResponse);
-    });
-  });
-
-  describe('getProfile', () => {
-    it('should request the current-user profile endpoint', async () => {
-      (apiService.get as ReturnType<typeof vi.fn>).mockResolvedValue(mockUser);
-
-      await authService.getProfile();
-
-      // Assert the behavioural contract: getProfile reads from /me. We do not
-      // assert the resolved value here because under CI's module resolution the
-      // mocked singleton's resolved value (but not its rejection — see the next
-      // test) is not reliably observed through the source's import binding; the
-      // method body is a trivial `return await apiService.get(ME)` passthrough.
-      expect(apiService.get).toHaveBeenCalledWith('/api/v1/auth/me');
-    });
-
-    it('should propagate an API failure', async () => {
-      (apiService.get as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('Unauthorized'));
-
-      await expect(authService.getProfile()).rejects.toThrow('Unauthorized');
     });
   });
 

--- a/services/auth/src/grpc/password-hasher.test.ts
+++ b/services/auth/src/grpc/password-hasher.test.ts
@@ -28,5 +28,5 @@ describe('createBcryptPasswordHasher', () => {
     expect(hash.startsWith('$2')).toBe(true); // bcrypt format
     expect(await hasher.compare('hunter2', hash)).toBe(true);
     expect(await hasher.compare('wrong', hash)).toBe(false);
-  }, 10_000); // cost 12 → ~250ms per hash; give it plenty of headroom
+  }, 30_000); // cost 12 → ~250ms per hash; generous headroom for parallel CI load
 });


### PR DESCRIPTION
…meout

lib.auth: getProfile() unwraps a { user } envelope (since the gateway↔SPA auth-contract change), but the test mocked apiService.get with a bare user, so response.user resolved to undefined. Because CI tests the PR merged with main (which had the envelope-unwrapping source) while a local branch built against the old passthrough source, this looked CI-only — it is in fact deterministic. Mock the real { user } envelope and assert getProfile resolves to the unwrapped user; remove the temporary endpoint-only narrowing and its misleading comments.

service.auth: raise the per-test timeout on the one real-KDF bcrypt(cost 12) test from 10s to 30s so it stops flaking under parallel CI load. No cost/security parameters changed, no test skipped.

<!-- Before opening: make sure you've read [CONTRIBUTING.md](../CONTRIBUTING.md) and that all CI checks pass. -->

## Summary

<!-- What does this PR do? 1-3 bullet points. -->

-

## Changes

<!-- List the key files/areas changed. -->

-

## Before requesting review

<!-- Quick PR-readiness signal — see CONTRIBUTING.md for context. -->

- [ ] Ran `pnpm ci:local:quick` locally (or installed the pre-push hook — see CONTRIBUTING.md)
- [ ] Tests for new behaviour added (TDD)
- [ ] If touching `.env` requirements, updated `.env.example`'s REQUIRED block
- [ ] If touching a `lib.*`, considered consumer impact across `app.*` and `service.backend`

## Test plan

<!-- How did you verify this works? Check off items as you go. -->

- [ ] Existing tests pass (`pnpm test`)
- [ ] New behaviour is covered by tests
- [ ] Tested manually (describe how)
- [ ] No TypeScript errors (`pnpm type-check`)
- [ ] Lint passes (`pnpm lint`)

## Screenshots / recordings

<!-- For UI changes, attach a screenshot or recording. Delete if not applicable. -->

## Related

<!-- Link to Linear ticket, related PRs, or issues. -->
