### PR TITLE
test(e2e): un-park batch A1 client read journeys (ADS-865)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -502,6 +502,14 @@ jobs:
             echo "CUTOVER_AUDIT=true"
             echo "CUTOVER_CHAT=true"
             echo "CUTOVER_CMS=true"
+            # Raise the gateway's global per-IP rate limit for e2e. A full
+            # Playwright run drives the whole SPA (favourites, chats,
+            # notifications, permissions, legal, match, csrf) across parallel
+            # workers from a single docker-side IP, bursting past the 100/min
+            # production default and 429-ing page loads. (apiAs also caches its
+            # login token per role to stay under the stricter 10/min auth-login
+            # limit.) Production keeps the 100/min default.
+            echo "GATEWAY_RATE_LIMIT_MAX=100000"
           } > .env
 
       - name: Start database and cache

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -377,6 +377,12 @@ services:
       # ADS-800: same shared key as the *ms-env services — the gateway is
       # the signer, the services are the verifiers.
       PRINCIPAL_SIGNING_KEY: ${PRINCIPAL_SIGNING_KEY:-}
+      # Global per-IP rate limit (req/min). Defaults to the production-like 100
+      # so dev is unchanged; the e2e CI stack raises it via .env — a full
+      # Playwright run drives the whole SPA (favourites, chats, notifications,
+      # permissions, legal, match, csrf) from a single docker-side IP, bursting
+      # past 100/min.
+      GATEWAY_RATE_LIMIT_MAX: ${GATEWAY_RATE_LIMIT_MAX:-100}
     ports:
       - '127.0.0.1:4000:4000'
     depends_on:

--- a/e2e/fixtures/api.ts
+++ b/e2e/fixtures/api.ts
@@ -19,17 +19,25 @@ function readUserId(body: LoginResponse): string {
   return body.user?.userId ?? body.user?.id ?? body.data?.user?.userId ?? body.data?.user?.id ?? '';
 }
 
-export async function loginViaApi(roleKey: RoleKey): Promise<ApiClient> {
+// Cache the access token per role for the lifetime of the worker process.
+// apiAs() is called from many specs, and the gateway rate-limits
+// POST /api/v1/auth/login to 10/min per IP — logging in on every call trips a
+// 429 once more than a handful of authenticated specs run (all e2e traffic
+// shares one docker-side IP). Access tokens are JWTs valid well beyond a suite
+// run, so one login per role per worker is plenty. Each apiAs() call still gets
+// its own disposable request context; only the login is shared.
+const tokenCache = new Map<RoleKey, { accessToken: string; userId: string }>();
+
+async function getRoleToken(roleKey: RoleKey): Promise<{ accessToken: string; userId: string }> {
+  const cached = tokenCache.get(roleKey);
+  if (cached) {
+    return cached;
+  }
   const role = ROLES[roleKey];
   // The Fastify gateway authenticates with Bearer tokens, not the deleted
   // monolith's httpOnly-cookie + CSRF model: login returns
-  // `{ user, tokens: { accessToken, refreshToken } }` in the body and there
-  // is no /csrf-token endpoint. Mint a context whose Authorization header
-  // carries the access token so every subsequent request from this client
-  // is authenticated.
+  // `{ user, tokens: { accessToken, refreshToken } }` in the body.
   const loginCtx = await playwrightRequest.newContext({ baseURL: URLS.api });
-  let accessToken: string | undefined;
-  let userId = '';
   try {
     const response = await loginCtx.post('/api/v1/auth/login', {
       data: { email: role.email, password: role.password },
@@ -41,15 +49,22 @@ export async function loginViaApi(roleKey: RoleKey): Promise<ApiClient> {
       throw new Error(`API login failed for ${role.email}: ${status} ${text.slice(0, 500)}`);
     }
     const body = (await response.json()) as LoginResponse;
-    accessToken = body.tokens?.accessToken ?? body.tokens?.access_token;
-    userId = readUserId(body);
+    const accessToken = body.tokens?.accessToken ?? body.tokens?.access_token;
+    if (!accessToken) {
+      throw new Error(`API login for ${role.email} returned no access token`);
+    }
+    const token = { accessToken, userId: readUserId(body) };
+    tokenCache.set(roleKey, token);
+    return token;
   } finally {
     await loginCtx.dispose();
   }
-  if (!accessToken) {
-    throw new Error(`API login for ${role.email} returned no access token`);
-  }
+}
 
+export async function loginViaApi(roleKey: RoleKey): Promise<ApiClient> {
+  // Mint a context whose Authorization header carries the (cached) access
+  // token so every subsequent request from this client is authenticated.
+  const { accessToken, userId } = await getRoleToken(roleKey);
   const context = await playwrightRequest.newContext({
     baseURL: URLS.api,
     extraHTTPHeaders: { Authorization: `Bearer ${accessToken}` },

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -41,10 +41,13 @@ const UNPARKED: Record<'client' | 'rescue' | 'admin', string[]> = {
     '**/rescue-publishes-adopter-discovers.spec.ts',
     // cannot-apply: fixed to use the viewable 'pending' pet (adopted pets are
     // hidden → 404, no detail page to gate). session-expiry: anon /favorites →
-    // Login Required. notification-badge: unread-count → read-all → 0.
+    // Login Required.
     '**/cannot-apply-to-unavailable-pet.spec.ts',
     '**/session-expiry.spec.ts',
-    '**/notification-badge-updates.spec.ts',
+    // Deferred: notification-badge-updates — marking notifications read needs
+    // `notifications.update`, which the adopter lacks in the ADS-863 matrix
+    // (has only notifications.read) → 403. Needs a follow-up auth migration to
+    // grant adopters self-scoped notifications.update. Tracked in ADS-865.
   ],
   rescue: [],
   admin: [],

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -31,7 +31,16 @@ export const AUTH_FILES = {
 // project's testDir stays parked. Extend a list once its journey is green in
 // CI. The still-parked specs are tracked in e2e/README.md.
 const UNPARKED: Record<'client' | 'rescue' | 'admin', string[]> = {
-  client: ['**/registration-and-login.spec.ts', '**/adoption-application.spec.ts'],
+  client: [
+    '**/registration-and-login.spec.ts',
+    '**/adoption-application.spec.ts',
+    // ADS-865 (batch A1) — read-only journeys grounded in the pets seed
+    // (services/pets/src/db/seed-data.ts), unblocked by the ADS-863 RBAC grants.
+    '**/pet-discovery.spec.ts',
+    '**/distance-sorted-search.spec.ts',
+    '**/cannot-apply-to-unavailable-pet.spec.ts',
+    '**/rescue-publishes-adopter-discovers.spec.ts',
+  ],
   rescue: [],
   admin: [],
 };

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -34,15 +34,17 @@ const UNPARKED: Record<'client' | 'rescue' | 'admin', string[]> = {
   client: [
     '**/registration-and-login.spec.ts',
     '**/adoption-application.spec.ts',
-    // ADS-865 (batch A1) — read-only journeys grounded in the pets seed
-    // (services/pets/src/db/seed-data.ts), unblocked by the ADS-863 RBAC grants.
-    // Each verified green in CI before listing here.
+    // ADS-865 (batch A1) — read journeys grounded in the seed, unblocked by
+    // the ADS-863 RBAC grants. Each verified green in CI before listing here.
     '**/pet-discovery.spec.ts',
     '**/distance-sorted-search.spec.ts',
     '**/rescue-publishes-adopter-discovers.spec.ts',
-    // Deferred: cannot-apply-to-unavailable-pet — /pets/{adopted} renders no
-    // <h1> (page never loads a heading), failing the load guard. Likely a real
-    // adopted-pet detail-view bug, not a seed/RBAC gap; tracked in ADS-865.
+    // cannot-apply: fixed to use the viewable 'pending' pet (adopted pets are
+    // hidden → 404, no detail page to gate). session-expiry: anon /favorites →
+    // Login Required. notification-badge: unread-count → read-all → 0.
+    '**/cannot-apply-to-unavailable-pet.spec.ts',
+    '**/session-expiry.spec.ts',
+    '**/notification-badge-updates.spec.ts',
   ],
   rescue: [],
   admin: [],

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -36,10 +36,13 @@ const UNPARKED: Record<'client' | 'rescue' | 'admin', string[]> = {
     '**/adoption-application.spec.ts',
     // ADS-865 (batch A1) — read-only journeys grounded in the pets seed
     // (services/pets/src/db/seed-data.ts), unblocked by the ADS-863 RBAC grants.
+    // Each verified green in CI before listing here.
     '**/pet-discovery.spec.ts',
     '**/distance-sorted-search.spec.ts',
-    '**/cannot-apply-to-unavailable-pet.spec.ts',
     '**/rescue-publishes-adopter-discovers.spec.ts',
+    // Deferred: cannot-apply-to-unavailable-pet — /pets/{adopted} renders no
+    // <h1> (page never loads a heading), failing the load guard. Likely a real
+    // adopted-pet detail-view bug, not a seed/RBAC gap; tracked in ADS-865.
   ],
   rescue: [],
   admin: [],

--- a/e2e/tests/client/cannot-apply-to-unavailable-pet.spec.ts
+++ b/e2e/tests/client/cannot-apply-to-unavailable-pet.spec.ts
@@ -2,13 +2,24 @@ import { test, expect } from '../../fixtures';
 import { SEEDED_PET_IDS } from '../../helpers/seeds';
 
 /**
- * Behaviourally: a pet that is not available (adopted, on hold, archived)
- * must NOT expose an enabled "Apply" button on its detail page.  The e2e
- * fixtures seeder guarantees an adopted pet at SEEDED_PET_IDS.adopted.
+ * Behaviourally: a pet that is viewable but NOT available for adoption must
+ * not expose an enabled "Apply" CTA. The seeded 'pending' pet (Luna) is the
+ * right fixture — PetDetailsPage only renders the Apply CTA when
+ * `pet.status === 'available'`, so on a pending pet the CTA is absent (the
+ * gate working).
+ *
+ * Note on the stronger statuses: adopted / not_available / deceased pets are
+ * hidden from public callers entirely by the pets service
+ * (PUBLIC_HIDDEN_STATUSES), so they 404 to a "Pet Not Found" page — there is
+ * no detail page (or Apply CTA) to gate at all. This spec deliberately uses
+ * the viewable-but-unavailable case, which is where a gate is actually needed.
  */
 test.describe('availability gating', () => {
-  test('the apply CTA is hidden or disabled for an adopted pet', async ({ page }) => {
-    await page.goto(`/pets/${SEEDED_PET_IDS.adopted}`);
+  test('the apply CTA is absent or disabled for a viewable but unavailable (pending) pet', async ({
+    page,
+  }) => {
+    await page.goto(`/pets/${SEEDED_PET_IDS.pending}`);
+    // The pending pet is viewable, so its detail page renders the name as <h1>.
     await expect(page.getByRole('heading', { level: 1 }).first()).toBeVisible({ timeout: 15_000 });
 
     const apply = page
@@ -19,7 +30,7 @@ test.describe('availability gating', () => {
       const isDisabled = await apply.isDisabled().catch(() => false);
       expect(isDisabled).toBe(true);
     }
-    // If the apply CTA isn't rendered at all, that's also a valid
-    // implementation of the gating rule.
+    // If the apply CTA isn't rendered at all (the status gate hides it), that
+    // is also a valid implementation of the gating rule.
   });
 });

--- a/e2e/tests/client/notification-badge-updates.spec.ts
+++ b/e2e/tests/client/notification-badge-updates.spec.ts
@@ -21,13 +21,10 @@ test.describe('notification badge', () => {
     const initialCount = beforeBody.count ?? beforeBody.data?.count ?? 0;
     expect(typeof initialCount).toBe('number');
 
-    // POST mark-all-read.
-    const csrfRes = await adopterApi.context.get('/api/v1/csrf-token');
-    expect(csrfRes.ok()).toBe(true);
-    const { csrfToken } = (await csrfRes.json()) as { csrfToken?: string };
-    const markRes = await adopterApi.context.post('/api/v1/notifications/read-all', {
-      headers: { 'x-csrf-token': csrfToken! },
-    });
+    // POST mark-all-read. The gateway authenticates with Bearer tokens and
+    // exposes no /csrf-token endpoint, so the adopter's Bearer context (set by
+    // apiAs) is all that's needed — no CSRF dance.
+    const markRes = await adopterApi.context.post('/api/v1/notifications/read-all');
     expect([200, 204]).toContain(markRes.status());
 
     const afterRes = await adopterApi.context.get('/api/v1/notifications/unread/count');


### PR DESCRIPTION
## What

First batch of the e2e un-park effort (ADS-864). Un-parks **5 adopter journeys** (ADS-863 now grants the seeded adopter its RBAC permissions) plus a **rate-limit fix** the wider batch surfaced.

**Un-parked (each passed cleanly across runs):**
`pet-discovery`, `distance-sorted-search`, `rescue-publishes-adopter-discovers`, `cannot-apply-to-unavailable-pet` (fixed fixture), `session-expiry`.

## Notable fixes & findings (iterated via CI)

1. **`cannot-apply` fixture** — `/pets/{adopted}` 404s ("Pet Not Found", `<h2>`) because the pets service hides `adopted`/`not_available`/`deceased` from public callers. Retargeted to the viewable **`pending`** pet (Luna), whose Apply CTA is correctly absent (`status !== 'available'`).
2. **Rate limits** — all e2e traffic shares one docker IP, hitting two gateway limits. Fixed: `apiAs` now **caches its login token per role/worker** (the `/auth/login` 10/min cap), and `GATEWAY_RATE_LIMIT_MAX` is overridable — e2e `.env` raises the global 100/min limit (dev/prod keep 100). This unblocks all later batches too.
3. **`notification-badge` deferred → ADS-869** — its `read-all` POST 403s: adopters have `notifications.read` but not `notifications.update`, so they can't mark their own notifications read. A real RBAC gap needing a **separate migration PR** (016 is immutable), out of scope here.

## Deferred (tracked in ADS-865/869)

`notification-badge-updates` (ADS-869), `notification-preferences` (route + likely same grant), `logout-flow`/`api-csrf` (CSRF/token contracts), `profile-update`/`password-reset` (UI), `application-tracking`/`application-status-roundtrip` (no application seed), `swipe-and-favourite` (no favourites seed).

Runs under the `run-e2e` label. Part of ADS-864 · ADS-865.

🤖 Generated with [Claude Code](https://claude.com/claude-code)