### PR TITLE
test(e2e): finish A2 rescue — onboarding + archive-adopted-pet (ADS-866)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -510,6 +510,10 @@ jobs:
             # login token per role to stay under the stricter 10/min auth-login
             # limit.) Production keeps the 100/min default.
             echo "GATEWAY_RATE_LIMIT_MAX=100000"
+            # Also lift the stricter per-route auth limits (login 10/min,
+            # register 5/min, ...) — a full suite logs in/registers many times
+            # from one IP across workers. Production leaves this unset.
+            echo "GATEWAY_AUTH_RATE_LIMIT_MAX=100000"
           } > .env
 
       - name: Start database and cache

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -383,6 +383,10 @@ services:
       # permissions, legal, match, csrf) from a single docker-side IP, bursting
       # past 100/min.
       GATEWAY_RATE_LIMIT_MAX: ${GATEWAY_RATE_LIMIT_MAX:-100}
+      # Per-route auth limits (login/register/...). Unset in dev/prod (strict
+      # anti-abuse defaults stand); the e2e stack raises it so a full Playwright
+      # run's many logins from one IP don't trip the 10/min login cap.
+      GATEWAY_AUTH_RATE_LIMIT_MAX: ${GATEWAY_AUTH_RATE_LIMIT_MAX:-}
     ports:
       - '127.0.0.1:4000:4000'
     depends_on:

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -68,6 +68,14 @@ const UNPARKED: Record<'client' | 'rescue' | 'admin', string[]> = {
     // Unblocked by the applications seed — the rescue (Paws) inbox now lists
     // John Smith's seeded application. Tolerant of the status PATCH failing.
     '**/application-review.spec.ts',
+    // rescue-onboarding: rescue publishes a pet (createAvailablePet, same path
+    // the merged adoption journey exercises) → adopter discovery feed lists it.
+    // archive-adopted-pet: reads the seeded adopted pet 'Max' (now Paws-owned)
+    // as Paws staff; rescue_staff has pets.read + pets.archive.
+    '**/rescue-onboarding.spec.ts',
+    '**/archive-adopted-pet.spec.ts',
+    // Deferred: custom-application-questions — the gateway exposes no
+    // /api/v1/rescues/:id/questions route (not cut over) → 404. Batch B.
   ],
   admin: [],
 };

--- a/services/gateway/src/routes/auth.ts
+++ b/services/gateway/src/routes/auth.ts
@@ -75,21 +75,29 @@ type AssignRoleBody = {
 // is admin-only and gets a wider window. All keyed on req.ip via
 // the default key generator. Production deploys can swap in a Redis
 // store via the plugin's `redis` option without touching this file.
+//
+// e2e override: a full Playwright run logs in / registers many times from a
+// single docker-side IP, tripping these strict anti-abuse limits. When
+// GATEWAY_AUTH_RATE_LIMIT_MAX is set (only in the e2e stack) it raises every
+// per-route max; unset in dev/prod, so the strict defaults below stand.
+const E2E_AUTH_MAX = Number(process.env.GATEWAY_AUTH_RATE_LIMIT_MAX);
+const authMax = (def: number): number =>
+  Number.isFinite(E2E_AUTH_MAX) && E2E_AUTH_MAX > 0 ? E2E_AUTH_MAX : def;
 const AUTH_RATE_LIMITS = {
-  login: { max: 10, timeWindow: '1 minute' },
-  logout: { max: 30, timeWindow: '1 minute' },
-  refreshToken: { max: 30, timeWindow: '1 minute' },
-  getMe: { max: 60, timeWindow: '1 minute' },
-  assignRole: { max: 30, timeWindow: '1 minute' },
+  login: { max: authMax(10), timeWindow: '1 minute' },
+  logout: { max: authMax(30), timeWindow: '1 minute' },
+  refreshToken: { max: authMax(30), timeWindow: '1 minute' },
+  getMe: { max: authMax(60), timeWindow: '1 minute' },
+  assignRole: { max: authMax(30), timeWindow: '1 minute' },
   // Account lifecycle — tighter on the unauthenticated paths to slow
   // enumeration / spam.
-  register: { max: 5, timeWindow: '1 minute' },
-  verifyEmail: { max: 10, timeWindow: '1 minute' },
-  resendVerification: { max: 5, timeWindow: '1 minute' },
-  forgotPassword: { max: 5, timeWindow: '1 minute' },
-  resetPassword: { max: 10, timeWindow: '1 minute' },
-  changePassword: { max: 10, timeWindow: '1 minute' },
-  updateAccount: { max: 30, timeWindow: '1 minute' },
+  register: { max: authMax(5), timeWindow: '1 minute' },
+  verifyEmail: { max: authMax(10), timeWindow: '1 minute' },
+  resendVerification: { max: authMax(5), timeWindow: '1 minute' },
+  forgotPassword: { max: authMax(5), timeWindow: '1 minute' },
+  resetPassword: { max: authMax(10), timeWindow: '1 minute' },
+  changePassword: { max: authMax(10), timeWindow: '1 minute' },
+  updateAccount: { max: authMax(30), timeWindow: '1 minute' },
 } as const;
 
 export const registerAuthRoutes = async (

--- a/services/pets/src/db/seed-data.ts
+++ b/services/pets/src/db/seed-data.ts
@@ -51,7 +51,11 @@ export const SEED_PETS: readonly SeedPet[] = [
   },
   {
     petId: 'e2e0a000-0000-4000-8000-000000000001',
-    rescueId: HAPPY_TAILS_RESCUE_ID,
+    // Paws-owned so the rescue.manager persona (Paws staff) can read this
+    // adopted pet — adopted pets are hidden from non-owning callers
+    // (handlers.ts PUBLIC_HIDDEN_STATUSES), which the archive-adopted-pet
+    // e2e spec exercises.
+    rescueId: PAWS_RESCUE_ID,
     name: 'Max',
     type: 'dog',
     gender: 'male',


### PR DESCRIPTION
## What

Finishes the bulk of batch A2 (rescue) — un-parks 2 rescue journeys, makes the seeded adopted pet usable by the rescue persona, and lifts a rate-limit ceiling the wider suite hit.

| Spec | How it's unblocked |
|---|---|
| `rescue-onboarding` | rescue publishes a pet via `createAvailablePet` (the path the merged adoption journey exercises) → polls adopter discovery. |
| `archive-adopted-pet` | seeded adopted pet **"Max" moved Happy Tails → Paws** so rescue.manager (Paws) can read it (adopted pets hidden from non-owning callers). |

## Foundation fix (surfaced by this batch)

The run was `23 passed, 1 failed, 2 flaky` — the new specs **pass**, but every failure was an `/auth/login` **429**. The hardcoded **10/min-per-IP login cap** is now the binding constraint as the suite exercises more roles across 2 workers (the global `GATEWAY_RATE_LIMIT_MAX` doesn't affect per-route limits, and the per-worker token cache isn't enough headroom).

Fix: `AUTH_RATE_LIMITS` now honour **`GATEWAY_AUTH_RATE_LIMIT_MAX`** (set only in the e2e `.env`, passed via docker-compose). Dev/prod leave it unset → strict anti-abuse defaults stand. Mirrors the existing global-limit override; unblocks reliable runs for all current/future specs.

## Deferred

`custom-application-questions` — no `/api/v1/rescues/:id/questions` route in the gateway (404); batch B (ADS-868).

## Validation

`run-e2e` label (full suite). Draft until green. 22 gateway auth tests still pass (defaults unchanged).

Part of ADS-864 · ADS-866.

🤖 Generated with [Claude Code](https://claude.com/claude-code)