### PR TITLE
test(e2e): un-park batch A3 admin journeys (ADS-867)

### DIFF
--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -77,7 +77,21 @@ const UNPARKED: Record<'client' | 'rescue' | 'admin', string[]> = {
     // Deferred: custom-application-questions — the gateway exposes no
     // /api/v1/rescues/:id/questions route (not cut over) → 404. Batch B.
   ],
-  admin: [],
+  admin: [
+    // ADS-867 (batch A3) — admin journeys. superadmin storageState
+    // short-circuits all permission checks (ADS-863), and the auth-route
+    // rate-limit ceiling was lifted for e2e (#1083). Page-load smokes prove the
+    // protected routes mount; role-boundary checks the anonymous redirect;
+    // field-permission-override hits the admin-only defaults API. Routes
+    // verified against apps/admin/src/App.tsx before listing.
+    '**/role-boundary-enforcement.spec.ts',
+    '**/field-permission-override.spec.ts',
+    '**/audit-log-and-settings.spec.ts',
+    '**/user-and-rescue-moderation.spec.ts',
+    '**/content-moderation-queue.spec.ts',
+    '**/support-ticket-triage.spec.ts',
+    '**/blog-post-publishing.spec.ts',
+  ],
 };
 
 // Run exactly the listed specs — or nothing (a never-matching pattern) when a

--- a/e2e/tests/admin/blog-post-publishing.spec.ts
+++ b/e2e/tests/admin/blog-post-publishing.spec.ts
@@ -2,8 +2,10 @@ import { test, expect } from '../../fixtures';
 
 test.describe('admin content management', () => {
   test('the content management page renders for an admin', async ({ page }) => {
-    await page.goto('/content', { waitUntil: 'domcontentloaded', timeout: 60_000 });
-    await expect(page).toHaveURL(/\/content/);
+    // The admin app mounts content management at /content-management
+    // (apps/admin/src/App.tsx); /content is not a route.
+    await page.goto('/content-management', { waitUntil: 'domcontentloaded', timeout: 60_000 });
+    await expect(page).toHaveURL(/\/content-management/);
     await expect(page.getByRole('heading').first()).toBeVisible({ timeout: 30_000 });
   });
 });


### PR DESCRIPTION
## What

Batch A3 (admin) of the e2e un-park effort (ADS-864). Un-parks all **7 admin (app.admin) journeys**. Low risk: the `superadmin` storageState short-circuits permission checks (ADS-863), and the per-route auth rate-limit ceiling was lifted for e2e (#1083). All routes verified against `apps/admin/src/App.tsx`.

| Spec | What it proves |
|---|---|
| `role-boundary-enforcement` | anonymous → `/login` redirect, no admin `<h1>` leak |
| `field-permission-override` | `GET /api/v1/field-permissions/defaults` (admin-only) returns the map |
| `audit-log-and-settings` | `/audit` mounts |
| `user-and-rescue-moderation` | `/users` mounts (+ best-effort search) |
| `content-moderation-queue` | `/moderation` mounts |
| `support-ticket-triage` | `/support` mounts |
| `blog-post-publishing` | `/content-management` mounts |

## Fix included

`blog-post-publishing` navigated to `/content`, which isn't a route — the admin app mounts content at **`/content-management`**. Corrected the spec.

## Validation

`run-e2e` label (full suite; these aren't `@smoke`). Draft until green. e2e-only change, so Service/Frontend tests skip.

Part of ADS-864 · ADS-867.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012iL3quEiMUvaNiH4xZNN9E)_