### PR TITLE
fix(auth): grant adopters self-scoped notification writes (ADS-869)

### DIFF
--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -49,10 +49,12 @@ const UNPARKED: Record<'client' | 'rescue' | 'admin', string[]> = {
     // failing — they assert the dashboard reads the persisted state.
     '**/application-tracking.spec.ts',
     '**/application-status-roundtrip.spec.ts',
-    // Deferred: notification-badge-updates — marking notifications read needs
-    // `notifications.update`, which the adopter lacks in the ADS-863 matrix
-    // (has only notifications.read) → 403. Needs a follow-up auth migration to
-    // grant adopters self-scoped notifications.update. Tracked in ADS-865.
+    // Unblocked by ADS-869 (migration 017 grants adopters self-scoped
+    // notifications.update + notifications.prefs.{read,update}).
+    // notification-preferences also needed the gateway route (/notifications/
+    // preferences, not /users) and the `email` body field — fixed in the spec.
+    '**/notification-badge-updates.spec.ts',
+    '**/notification-preferences.spec.ts',
   ],
   rescue: [
     // ADS-866 (batch A2) — rescue-staff journeys, unblocked by the ADS-863

--- a/e2e/tests/client/notification-preferences.spec.ts
+++ b/e2e/tests/client/notification-preferences.spec.ts
@@ -22,7 +22,9 @@ test.describe('notification preferences', () => {
       data?: Record<string, unknown>;
     };
     const initialPrefs = (before.data ?? before) as Record<string, unknown>;
-    const initialEmail = readEmailEnabled(initialPrefs) ?? true;
+    // The gateway returns proto3 JSON, which OMITS boolean fields when they're
+    // false (the proto3 default). So an absent emailEnabled means `false`.
+    const initialEmail = readEmailEnabled(initialPrefs) ?? false;
 
     // The gateway accepts the bare `email` field (or the proto-aligned
     // `emailEnabled`) and returns the prefs as `emailEnabled`.
@@ -37,7 +39,7 @@ test.describe('notification preferences', () => {
       data?: Record<string, unknown>;
     };
     const finalPrefs = (after.data ?? after) as Record<string, unknown>;
-    expect(readEmailEnabled(finalPrefs)).toBe(!initialEmail);
+    expect(readEmailEnabled(finalPrefs) ?? false).toBe(!initialEmail);
 
     // Restore so the suite is repeatable.
     await putWithCsrf(adopterApi.context, '/api/v1/notifications/preferences', {

--- a/e2e/tests/client/notification-preferences.spec.ts
+++ b/e2e/tests/client/notification-preferences.spec.ts
@@ -16,21 +16,23 @@ test.describe('notification preferences', () => {
   }) => {
     const adopterApi = await apiAs('adopter');
 
-    const beforeRes = await adopterApi.context.get('/api/v1/users/preferences');
-    await expectOk(beforeRes, 'GET /users/preferences (initial)');
+    const beforeRes = await adopterApi.context.get('/api/v1/notifications/preferences');
+    await expectOk(beforeRes, 'GET /notifications/preferences (initial)');
     const before = (await beforeRes.json()) as Record<string, unknown> & {
       data?: Record<string, unknown>;
     };
     const initialPrefs = (before.data ?? before) as Record<string, unknown>;
     const initialEmail = readEmailEnabled(initialPrefs) ?? true;
 
-    const flipRes = await putWithCsrf(adopterApi.context, '/api/v1/users/preferences', {
-      emailNotifications: !initialEmail,
+    // The gateway accepts the bare `email` field (or the proto-aligned
+    // `emailEnabled`) and returns the prefs as `emailEnabled`.
+    const flipRes = await putWithCsrf(adopterApi.context, '/api/v1/notifications/preferences', {
+      email: !initialEmail,
     });
-    await expectOk(flipRes, 'PUT /users/preferences (flip)');
+    await expectOk(flipRes, 'PUT /notifications/preferences (flip)');
 
-    const afterRes = await adopterApi.context.get('/api/v1/users/preferences');
-    await expectOk(afterRes, 'GET /users/preferences (after flip)');
+    const afterRes = await adopterApi.context.get('/api/v1/notifications/preferences');
+    await expectOk(afterRes, 'GET /notifications/preferences (after flip)');
     const after = (await afterRes.json()) as Record<string, unknown> & {
       data?: Record<string, unknown>;
     };
@@ -38,8 +40,8 @@ test.describe('notification preferences', () => {
     expect(readEmailEnabled(finalPrefs)).toBe(!initialEmail);
 
     // Restore so the suite is repeatable.
-    await putWithCsrf(adopterApi.context, '/api/v1/users/preferences', {
-      emailNotifications: initialEmail,
+    await putWithCsrf(adopterApi.context, '/api/v1/notifications/preferences', {
+      email: initialEmail,
     });
   });
 });

--- a/services/auth/src/migrations/017_grant_adopter_notification_writes.ts
+++ b/services/auth/src/migrations/017_grant_adopter_notification_writes.ts
@@ -1,0 +1,63 @@
+import type { MigrationBuilder } from 'node-pg-migrate';
+
+// Grant adopters their self-scoped notification write permissions (ADS-869).
+//
+// 016 gave the adopter role `notifications.read` but none of the notification
+// WRITE permissions, so an adopter could read notifications but not:
+//   - mark them read  → service.notifications MarkAllRead / MarkRead gate on
+//     `notifications.update` and 403'd (surfaced by the e2e notification-badge
+//     spec).
+//   - manage their own in-app preferences → GetNotificationPreferences /
+//     UpdateNotificationPreferences gate on `notifications.prefs.read` /
+//     `notifications.prefs.update`.
+//
+// All three are SELF-scoped in the handlers and cannot touch another user's
+// data:
+//   - MarkAllRead updates `WHERE user_id = principal.userId`; single-row
+//     MarkRead requires the row's user_id to match the caller.
+//   - the prefs handlers read/write only the caller's own user_notification_prefs
+//     row (no userId in the request — the *_SELF permission names reflect this).
+// So this lets adopters manage only THEIR OWN notifications, never anyone
+// else's.
+//
+// 016 is immutable (already shipped); this is an additive follow-on. Idempotent
+// (ON CONFLICT DO NOTHING), mirroring 016's role_permissions seeding.
+
+const ROLE = 'adopter';
+const PERMISSIONS = [
+  'notifications.update',
+  'notifications.prefs.read',
+  'notifications.prefs.update',
+] as const;
+
+export const up = async (pgm: MigrationBuilder): Promise<void> => {
+  for (const permission of PERMISSIONS) {
+    // The permission row may not exist yet — 016 only inserted permissions it
+    // actually granted, and none of these were granted to any role.
+    pgm.sql(
+      `INSERT INTO auth.permissions (permission_name) VALUES ('${permission}') ON CONFLICT (permission_name) DO NOTHING`
+    );
+    pgm.sql(`
+      INSERT INTO auth.role_permissions (role_id, permission_id)
+      SELECT r.role_id, p.permission_id
+      FROM auth.roles r
+      CROSS JOIN auth.permissions p
+      WHERE r.role_name = '${ROLE}' AND p.permission_name = '${permission}'
+      ON CONFLICT (role_id, permission_id) DO NOTHING
+    `);
+  }
+};
+
+export const down = async (pgm: MigrationBuilder): Promise<void> => {
+  // Reverse only the grants; leave the reference permission rows in place.
+  for (const permission of PERMISSIONS) {
+    pgm.sql(`
+      DELETE FROM auth.role_permissions rp
+      USING auth.roles r, auth.permissions p
+      WHERE rp.role_id = r.role_id
+        AND rp.permission_id = p.permission_id
+        AND r.role_name = '${ROLE}'
+        AND p.permission_name = '${permission}'
+    `);
+  }
+};


### PR DESCRIPTION
## What

Closes **ADS-869**: adopters had `notifications.read` but no notification *write* permissions, so they could read notifications but not mark them read or manage their own preferences (403). Adds migration **017** granting the adopter role three self-scoped permissions, and un-parks the two notification e2e specs.

## Security note (RBAC change — please review)

All three grants are **self-scoped in the handlers** — an adopter can only touch their own data:
- `notifications.update` — `MarkAllRead` updates `WHERE user_id = principal.userId`; single-row `MarkRead` requires the row's `user_id` to match the caller.
- `notifications.prefs.read` / `notifications.prefs.update` — the prefs handlers read/write only the caller's own `user_notification_prefs` row (no `userId` in the request; the `*_SELF` permission names reflect this).

016 is immutable (shipped), so 017 is an additive, idempotent (`ON CONFLICT DO NOTHING`) follow-on. Grants are adopter-only (the failing journeys are adopter-scoped); rescue/admin marking their own notifications read is a latent gap left for a separate change.

## e2e

- **notification-badge-updates** — un-parked (needed only `notifications.update`).
- **notification-preferences** — also hit the wrong gateway route (`/users/preferences` → **`/notifications/preferences`**) and sent `emailNotifications`, which `buildPrefsPatch` ignores (it accepts `email`/`emailEnabled`). Fixed the spec and un-parked it.

## Validation

`run-e2e` label (full suite). Draft until green. Auth migration test (sequential + up/down) passes; auth + e2e type-check clean.

Part of ADS-864 · closes ADS-869.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012iL3quEiMUvaNiH4xZNN9E)_