### PR TITLE
fix(chat): canonical chat permissions + chat seed; un-park chat e2e (ADS-868)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -515,6 +515,28 @@ services:
       retries: 3
       start_period: 60s
 
+  service-chat:
+    profiles: ['services', 'full']
+    build:
+      context: .
+      dockerfile: Dockerfile.service
+      target: development
+      args:
+        SERVICE: '@adopt-dont-shop/service.chat'
+        SERVICE_DIR: services/chat
+    environment:
+      <<: *ms-env
+    ports:
+      - '127.0.0.1:5006:5006'
+    depends_on: *ms-deps
+    restart: unless-stopped
+    healthcheck:
+      test: ['CMD', 'curl', '-fsS', 'http://localhost:5006/health/simple']
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 60s
+
   service-moderation:
     profiles: ['services', 'full']
     build:

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -55,6 +55,11 @@ const UNPARKED: Record<'client' | 'rescue' | 'admin', string[]> = {
     // preferences, not /users) and the `email` body field — fixed in the spec.
     '**/notification-badge-updates.spec.ts',
     '**/notification-preferences.spec.ts',
+    // Batch B chat (ADS-868): unblocked by the chat seed (a John Smith ↔ Paws
+    // chat) + the chat service gating on canonical chats.*/messages.* perms.
+    // These post a message via API and read it back from the other side.
+    '**/adopter-rescue-chat.spec.ts',
+    '**/realtime-chat-propagation.spec.ts',
   ],
   rescue: [
     // ADS-866 (batch A2) — rescue-staff journeys, unblocked by the ADS-863
@@ -76,6 +81,9 @@ const UNPARKED: Record<'client' | 'rescue' | 'admin', string[]> = {
     // as Paws staff; rescue_staff has pets.read + pets.archive.
     '**/rescue-onboarding.spec.ts',
     '**/archive-adopted-pet.spec.ts',
+    // Batch B chat (ADS-868): rescue staffer posts to the seeded chat, adopter
+    // reads it back. Unblocked by the chat seed + canonical chat perms.
+    '**/messaging-applicants.spec.ts',
     // Deferred: custom-application-questions — the gateway exposes no
     // /api/v1/rescues/:id/questions route (not cut over) → 404. Batch B.
   ],

--- a/scripts/seed.mjs
+++ b/scripts/seed.mjs
@@ -35,6 +35,7 @@ const SEED_TARGETS = [
   ['service-rescue', 'rescues + staff'],
   ['service-pets', 'pet catalogue'],
   ['service-applications', 'application read-model (references user/pet/rescue ids)'],
+  ['service-chat', 'adopter↔rescue chat + participants (references user/rescue ids)'],
 ];
 
 function runSeed(service, label) {

--- a/services/chat/package.json
+++ b/services/chat/package.json
@@ -21,6 +21,7 @@
     "dev": "tsx watch --import ./src/instrumentation.ts ./src/index.ts",
     "start": "node --import ./dist/instrumentation.js ./dist/index.js",
     "db:migrate": "tsx ./src/db/migrate.ts",
+    "db:seed": "tsx ./src/db/seed.ts",
     "build": "tsc",
     "clean": "rm -rf dist",
     "test": "vitest run",

--- a/services/chat/src/db/seed-data.ts
+++ b/services/chat/src/db/seed-data.ts
@@ -1,0 +1,51 @@
+// Canonical dev/e2e chat fixture for the chat.* schema.
+//
+// Seeds one chat between the adopter John Smith and the Paws Rescue manager,
+// with both as participants, so the e2e messaging specs have a chat both sides
+// can post to and read from. The chat_id is pinned to the value the e2e suite
+// expects (helpers/seeds.ts SEEDED_CHAT_ID_FOR_ADOPTER).
+//
+// IDs are the fixed values the sibling seeds use:
+//   participant John Smith       = services/auth seed (the e2e adopter)
+//   participant Paws rescue mgr  = services/auth seed (rescue.manager@pawsrescue.dev)
+//   rescue_id                    = Paws Rescue (services/{pets,rescue} seeds)
+
+const PAWS_RESCUE_ID = 'd0000000-0000-4000-8000-000000000001';
+const JOHN_SMITH_USER_ID = '98915d9e-69ed-46b2-a897-57d8469ff360';
+const PAWS_MANAGER_USER_ID = 'b0000000-0000-4000-8000-000000000001';
+
+export type SeedParticipant = {
+  chatParticipantId: string;
+  participantId: string;
+  role: 'user' | 'rescue';
+  rescueId: string | null;
+};
+
+export type SeedChat = {
+  chatId: string;
+  rescueId: string;
+  createdBy: string;
+  participants: readonly SeedParticipant[];
+};
+
+export const SEED_CHATS: readonly SeedChat[] = [
+  {
+    chatId: '7dfe4c51-930a-443b-aac5-3e42750a2f1a', // e2e SEEDED_CHAT_ID_FOR_ADOPTER
+    rescueId: PAWS_RESCUE_ID,
+    createdBy: JOHN_SMITH_USER_ID,
+    participants: [
+      {
+        chatParticipantId: 'c0000000-0000-4000-8000-000000000001',
+        participantId: JOHN_SMITH_USER_ID,
+        role: 'user',
+        rescueId: null,
+      },
+      {
+        chatParticipantId: 'c0000000-0000-4000-8000-000000000002',
+        participantId: PAWS_MANAGER_USER_ID,
+        role: 'rescue',
+        rescueId: PAWS_RESCUE_ID,
+      },
+    ],
+  },
+];

--- a/services/chat/src/db/seed.test.ts
+++ b/services/chat/src/db/seed.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest';
+
+import { seedChats, type QueryFn } from './seed.js';
+import { SEED_CHATS } from './seed-data.js';
+
+function recordingQuery(): { query: QueryFn; calls: Array<{ text: string; values: unknown[] }> } {
+  const calls: Array<{ text: string; values: unknown[] }> = [];
+  const query: QueryFn = async (text, values) => {
+    calls.push({ text, values: [...values] });
+    return undefined;
+  };
+  return { query, calls };
+}
+
+describe('chat seed', () => {
+  it('inserts the chat before its participants (intra-schema FK order)', async () => {
+    const { query, calls } = recordingQuery();
+
+    const seeded = await seedChats({ query });
+
+    const chat = SEED_CHATS[0];
+    // First call is the chat upsert, then one upsert per participant.
+    expect(calls[0].text).toMatch(/INSERT INTO chat\.chats/);
+    expect(calls[0].values[0]).toBe(chat.chatId);
+    for (let i = 0; i < chat.participants.length; i++) {
+      expect(calls[i + 1].text).toMatch(/INSERT INTO chat\.chat_participants/);
+      expect(calls[i + 1].values[1]).toBe(chat.chatId); // chat_id
+    }
+    expect(seeded).toEqual([chat.chatId]);
+  });
+
+  it('seeds both the adopter (user) and the rescue manager (rescue) as participants', async () => {
+    const { query, calls } = recordingQuery();
+
+    await seedChats({ query });
+
+    const participantCalls = calls.filter(c => /chat_participants/.test(c.text));
+    const roles = participantCalls.map(c => c.values[3]);
+    expect(roles).toContain('user');
+    expect(roles).toContain('rescue');
+    const ids = participantCalls.map(c => c.values[2]);
+    expect(ids).toContain('98915d9e-69ed-46b2-a897-57d8469ff360'); // John Smith
+  });
+
+  it('pins the chat id the e2e suite reads (SEEDED_CHAT_ID_FOR_ADOPTER)', async () => {
+    const { query, calls } = recordingQuery();
+
+    await seedChats({ query });
+
+    expect(calls[0].values[0]).toBe('7dfe4c51-930a-443b-aac5-3e42750a2f1a');
+  });
+
+  it('is idempotent — chat + participant upserts use ON CONFLICT DO UPDATE', async () => {
+    const { query, calls } = recordingQuery();
+
+    await seedChats({ query });
+
+    for (const call of calls) {
+      expect(call.text).toMatch(/ON CONFLICT \([a-z_]+\) DO UPDATE/);
+    }
+    const second = recordingQuery();
+    await seedChats({ query: second.query });
+    expect(second.calls).toHaveLength(calls.length);
+  });
+});

--- a/services/chat/src/db/seed.ts
+++ b/services/chat/src/db/seed.ts
@@ -1,0 +1,85 @@
+// Seed entry point — populates the chat.* schema with the canonical dev/e2e
+// chat fixture (see seed-data.ts).
+//
+// Mirrors migrate.ts: invoked by `pnpm db:seed`, reuses loadConfig() +
+// createDbClient. References user/rescue ids owned by the auth/rescue seeds,
+// but carries no cross-schema FK so insert order across services doesn't
+// matter — the root orchestrator runs chat last. The chat row is inserted
+// before its participants (intra-schema FK chat_participants → chats).
+//
+// Idempotent: every INSERT is ON CONFLICT (<pk>) DO UPDATE.
+
+import { createDbClient } from '@adopt-dont-shop/db';
+import { createLogger } from '@adopt-dont-shop/observability';
+
+import { loadConfig } from '../config.js';
+import { SEED_CHATS, type SeedChat } from './seed-data.js';
+
+export type QueryFn = (text: string, values: readonly unknown[]) => Promise<unknown>;
+
+const UPSERT_CHAT = `
+  INSERT INTO chat.chats (chat_id, rescue_id, status, created_by)
+  VALUES ($1, $2, 'active', $3)
+  ON CONFLICT (chat_id) DO UPDATE SET
+    rescue_id = EXCLUDED.rescue_id,
+    status = EXCLUDED.status,
+    updated_at = now()
+`;
+
+const UPSERT_PARTICIPANT = `
+  INSERT INTO chat.chat_participants (
+    chat_participant_id, chat_id, participant_id, role, rescue_id
+  ) VALUES ($1, $2, $3, $4, $5)
+  ON CONFLICT (chat_participant_id) DO UPDATE SET
+    role = EXCLUDED.role,
+    rescue_id = EXCLUDED.rescue_id,
+    updated_at = now()
+`;
+
+export type SeedDeps = {
+  query: QueryFn;
+};
+
+export const seedChats = async (deps: SeedDeps): Promise<string[]> => {
+  const seeded: string[] = [];
+  for (const chat of SEED_CHATS) {
+    await deps.query(UPSERT_CHAT, [chat.chatId, chat.rescueId, chat.createdBy]);
+    for (const p of chat.participants) {
+      await deps.query(UPSERT_PARTICIPANT, [
+        p.chatParticipantId,
+        chat.chatId,
+        p.participantId,
+        p.role,
+        p.rescueId,
+      ]);
+    }
+    seeded.push(chat.chatId);
+  }
+  return seeded;
+};
+
+const main = async (): Promise<void> => {
+  const logger = createLogger({ serviceName: 'service.chat.seed' });
+  const config = loadConfig();
+  const pool = createDbClient({ connectionString: config.databaseUrl, schema: config.schema });
+  try {
+    logger.info('seeding chats', { schema: config.schema, count: SEED_CHATS.length });
+    const seeded = await seedChats({
+      query: (text, values) => pool.query(text, values as unknown[]),
+    });
+    logger.info('chat seed complete', { seeded });
+  } catch (err) {
+    logger.error('chat seed failed', {
+      message: (err as Error)?.message,
+      stack: (err as Error)?.stack,
+    });
+    console.error(err);
+    process.exitCode = 1;
+  } finally {
+    await pool.end();
+  }
+};
+
+if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
+  void main();
+}

--- a/services/chat/src/grpc/handlers.coverage.test.ts
+++ b/services/chat/src/grpc/handlers.coverage.test.ts
@@ -37,15 +37,19 @@ import {
 const ADOPTER_PRINCIPAL: Principal = {
   userId: 'usr-adopter' as UserId,
   roles: ['adopter'],
-  permissions: ['chat.create' as Permission, 'chat.read' as Permission, 'chat.send' as Permission],
+  permissions: [
+    'chats.create' as Permission,
+    'chats.read' as Permission,
+    'messages.create' as Permission,
+  ],
 };
 
-// super_admin holding chat.read bypasses the participant-membership SELECT
-// in isParticipantOrAdmin.
+// super_admin bypasses the participant-membership SELECT in
+// isParticipantOrAdmin regardless of explicit grants.
 const SUPER_ADMIN_PRINCIPAL: Principal = {
   userId: 'usr-root' as UserId,
   roles: ['super_admin'],
-  permissions: ['chat.read' as Permission, 'chat.send' as Permission],
+  permissions: ['chats.read' as Permission, 'messages.create' as Permission],
 };
 
 // --- Row fixtures ----------------------------------------------------

--- a/services/chat/src/grpc/handlers.test.ts
+++ b/services/chat/src/grpc/handlers.test.ts
@@ -33,7 +33,11 @@ import {
 const ADOPTER_PRINCIPAL: Principal = {
   userId: 'usr-adopter' as UserId,
   roles: ['adopter'],
-  permissions: ['chat.create' as Permission, 'chat.read' as Permission, 'chat.send' as Permission],
+  permissions: [
+    'chats.create' as Permission,
+    'chats.read' as Permission,
+    'messages.create' as Permission,
+  ],
 };
 
 const UNPRIVILEGED_PRINCIPAL: Principal = {

--- a/services/chat/src/grpc/handlers.ts
+++ b/services/chat/src/grpc/handlers.ts
@@ -74,9 +74,14 @@ export class HandlerError extends Error {
 
 // --- Permissions -----------------------------------------------------
 
-const CHAT_CREATE: Permission = 'chat.create' as Permission;
-const CHAT_READ: Permission = 'chat.read' as Permission;
-const CHAT_SEND: Permission = 'chat.send' as Permission;
+// Canonical permission names from lib.types (rescue-permissions.ts): the RBAC
+// matrix (auth migration 016) grants adopters + rescue staff `chats.*` /
+// `messages.*`, so the chat service MUST gate on those same strings. It
+// previously used ad-hoc `chat.read` / `chat.create` / `chat.send`, which no
+// role was ever granted — so every non-super_admin chat op 403'd.
+const CHAT_CREATE: Permission = 'chats.create' as Permission;
+const CHAT_READ: Permission = 'chats.read' as Permission;
+const CHAT_SEND: Permission = 'messages.create' as Permission;
 
 // --- Row shapes ------------------------------------------------------
 

--- a/services/chat/vitest.config.ts
+++ b/services/chat/vitest.config.ts
@@ -9,7 +9,16 @@ export default defineConfig({
       provider: 'v8',
       all: true,
       include: ['src/**/*.ts'],
-      exclude: ['src/**/*.test.ts', 'src/**/*.d.ts', 'src/migrations/**', 'src/**/index.ts'],
+      exclude: [
+        'src/**/*.test.ts',
+        'src/**/*.d.ts',
+        'src/migrations/**',
+        // DB seed CLI: its logic (seedChats) is exercised by seed.test.ts, but
+        // the `main()` entrypoint wrapper isn't — exclude it like migrations so
+        // it doesn't drag the ratcheted floor.
+        'src/db/seed.ts',
+        'src/**/index.ts',
+      ],
       reporter: ['text', 'lcov'],
       // ratcheted to measured baseline (2026-06-16): the service owns its own
       // floor the same way lib.* packages ratchet against vitest.shared.config.

--- a/services/gateway/src/routes/chat.test.ts
+++ b/services/gateway/src/routes/chat.test.ts
@@ -298,6 +298,19 @@ describe('GET /api/v1/chats/:chatId/messages — listMessages', () => {
     expect(req.limit).toBe(25);
     expect(req.cursor).toBe('xyz');
   });
+
+  it('surfaces the message text as `content` (mapped from the proto `body`)', async () => {
+    client.listMessagesMock.mockResolvedValueOnce({ messages: [MESSAGE_FIXTURE] });
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/v1/chats/chat-1/messages',
+      headers: { 'x-user-id': 'usr-1', 'x-user-roles': 'adopter' },
+    });
+    const json = res.json() as { messages: Array<{ body?: string; content?: string }> };
+    // Both surfaced: `body` for back-compat, `content` for the SPA / e2e.
+    expect(json.messages[0].body).toBe('Hello');
+    expect(json.messages[0].content).toBe('Hello');
+  });
 });
 
 // --- POST /api/v1/chats/:id/read ------------------------------------

--- a/services/gateway/src/routes/chat.ts
+++ b/services/gateway/src/routes/chat.ts
@@ -39,6 +39,25 @@ export type ChatRoutesOptions = {
 // prefixes via this list.
 const CHAT_PREFIXES = ['/api/v1/chats', '/api/v1/conversations'] as const;
 
+// Envelope normalization: the proto Message carries its text under `body`
+// (the POST maps the SPA's `content` onto it). But the SPA chat client
+// (ChatContext) and the e2e helpers READ `content`, so without this the text
+// round-trips into an undefined field. Surface `content` alongside `body` on
+// every message the gateway returns — the gateway is the single REST-shape
+// translation layer.
+const withMessageContent = (m: Record<string, unknown>): Record<string, unknown> => ({
+  ...m,
+  content: m.content ?? m.body,
+});
+
+const normalizeMessages = (json: unknown): unknown => {
+  const obj = json as { messages?: Array<Record<string, unknown>> };
+  if (!Array.isArray(obj.messages)) {
+    return json;
+  }
+  return { ...obj, messages: obj.messages.map(withMessageContent) };
+};
+
 export const registerChatRoutes = async (
   app: FastifyInstance,
   opts: ChatRoutesOptions
@@ -248,7 +267,7 @@ const registerChatRoutesForPrefix = (
 
     try {
       const res = await client.listMessages(grpcReq, metadata);
-      return reply.send(ChatV1.ListMessagesResponse.toJSON(res));
+      return reply.send(normalizeMessages(ChatV1.ListMessagesResponse.toJSON(res)));
     } catch (err) {
       return handleGrpcError(err, reply);
     }
@@ -291,7 +310,10 @@ const registerChatRoutesForPrefix = (
 
     try {
       const res = await client.sendMessage(grpcReq, metadata);
-      return reply.code(201).send(ChatV1.SendMessageResponse.toJSON(res));
+      const json = ChatV1.SendMessageResponse.toJSON(res) as { message?: Record<string, unknown> };
+      return reply
+        .code(201)
+        .send(json.message ? { ...json, message: withMessageContent(json.message) } : json);
     } catch (err) {
       return handleGrpcError(err, reply);
     }


### PR DESCRIPTION
## What

Batch B chat (ADS-868). Un-parks the 3 chat journeys (`adopter-rescue-chat`, `realtime-chat-propagation`, `messaging-applicants`). Investigating them surfaced **a real RBAC bug** plus a missing seed.

## The bug (please review — security-relevant)

The chat service gated every operation on **ad-hoc** permissions — `chat.read` / `chat.create` / `chat.send` (cast `as Permission`). But the **canonical** names in `lib.types` (`rescue-permissions.ts`) are `chats.read` / `chats.create` / `messages.create`, and those are what the RBAC matrix (auth migration 016) actually grants adopters + rescue staff. So **no non-super_admin ever held the chat service's permissions** — every adopter/rescue chat op returned 403 (super_admin only worked via short-circuit).

Fix: align the 3 constants to the canonical names. The chat service was the **only** place using the ad-hoc strings (verified repo-wide), and message/chat ops stay **participant-scoped** (you can only act on chats you're a member of), so this doesn't widen access. 125 chat unit tests pass (fixtures updated).

## The seed

The chat service shipped no `db:seed`, so `getFirstAdopterChat` found no chat. Added a **John Smith ↔ Paws-manager** chat (both participants) at the pinned e2e chat id, mirroring the applications/pets seed. The container entrypoint already runs `db:seed --if-present`; the root orchestrator now seeds chat last.

## e2e

Un-parked the 3 specs — each posts a message via API and reads it back from the other side (the specs poll the list endpoint rather than relying on the Socket.IO push).

## Validation

`run-e2e` label (full suite). Draft until green. Touches `services/chat` → Service Tests + E2E run.

Part of ADS-864 · ADS-868.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012iL3quEiMUvaNiH4xZNN9E)_