### PR TITLE
fix(auth): remove false rescueId promise from loadPrincipal return type

### DIFF
--- a/services/auth/src/grpc/handlers.test.ts
+++ b/services/auth/src/grpc/handlers.test.ts
@@ -663,6 +663,24 @@ describe('validateToken', () => {
     });
   });
 
+  it('does not populate rescueId in the returned AuthPrincipal (gateway resolves it via rescue service)', async () => {
+    mocks.issuerMock.verifyAccess.mockResolvedValueOnce({
+      sub: 'usr-staff',
+      jti: 'j',
+      iat: 0,
+      exp: 9_000_000_000,
+    });
+    mocks.poolMock.query
+      .mockResolvedValueOnce({ rows: [] }) // not denylisted
+      .mockResolvedValueOnce({ rows: [{ status: 'active' }] }) // status guard
+      .mockResolvedValueOnce({ rows: [{ user_type: 'rescue_staff' }] }) // primary role
+      .mockResolvedValueOnce({ rows: [] }) // extra roles
+      .mockResolvedValueOnce({ rows: [{ name: 'pets.read' }] }); // permissions
+
+    const res = await validateToken(mocks.deps, null, { accessToken: 'tok' });
+    expect(res.principal.rescueId).toBeUndefined();
+  });
+
   it('accepts a token issued at/after the revocation watermark', async () => {
     mocks.issuerMock.verifyAccess.mockResolvedValueOnce({
       sub: 'usr-1',

--- a/services/auth/src/grpc/handlers.ts
+++ b/services/auth/src/grpc/handlers.ts
@@ -192,7 +192,7 @@ export function rowToProtoUser(row: UserRow): AuthUser {
 export async function loadPrincipal(
   deps: HandlerDeps,
   userId: string
-): Promise<{ roles: UserRole[]; permissions: Permission[]; rescueId?: string }> {
+): Promise<{ roles: UserRole[]; permissions: Permission[] }> {
   // Roles — primary user_type plus everything in user_roles.
   const userTypeRes = await deps.pool.query<{ user_type: UserRoleDb }>(
     `SELECT user_type FROM auth.users WHERE user_id = $1 AND deleted_at IS NULL`,
@@ -627,11 +627,13 @@ export async function validateToken(
   // Now (and only now) hydrate the principal. Single user_id read +
   // role/permission joins — same query loadPrincipal uses.
   const principal = await loadPrincipal(deps, claims.sub);
+  // rescueId is NOT populated here: rescue-staff membership lives in the
+  // rescue service, not auth. The gateway resolves it via RescueService
+  // after ValidateToken succeeds (ADS-863) and stamps it on the request.
   const proto: AuthPrincipal = {
     userId: claims.sub,
     roles: rolesToProto(principal.roles),
     permissions: principal.permissions,
-    rescueId: principal.rescueId,
   };
 
   return {


### PR DESCRIPTION
## Summary

Closes ADS-849

- `loadPrincipal` declared `rescueId?: string` in its return type but never populated it — the rescue-staff membership lives in the rescue service, not auth
- Since ADS-863 wired the gateway to resolve `rescueId` via `RescueService` after `ValidateToken` succeeds, the stale field was causing `validateToken` to silently pass `undefined` as `rescueId` in every `AuthPrincipal` response
- Removes `rescueId` from `loadPrincipal`'s return type and drops the dead field reference from the `validateToken` proto construction
- Adds a regression test documenting that `validateToken` does not populate `rescueId` (the gateway owns that enrichment, per ADS-863)

## Changes

- `services/auth/src/grpc/handlers.ts`: fix `loadPrincipal` return type; remove `rescueId: principal.rescueId` from proto construction in `validateToken`
- `services/auth/src/grpc/handlers.test.ts`: add test asserting `validateToken` returns `AuthPrincipal` with no `rescueId` for a rescue-staff user

## Test plan

- [x] `pnpm exec vitest run src/grpc/handlers.test.ts` — 40/40 tests pass (added 1 new)
- [x] No new TypeScript errors introduced (pre-existing `lib.types` build errors are unrelated)
- [x] Existing `validateToken` tests unchanged and passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y3f8iUpiKJ2BY9yTP2Ef6x

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y3f8iUpiKJ2BY9yTP2Ef6x)_