### PR TITLE
test(e2e): un-park bulk-edit-pets rescue analytics page-load (ADS-868)

### DIFF
--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -84,8 +84,13 @@ const UNPARKED: Record<'client' | 'rescue' | 'admin', string[]> = {
     // Batch B chat (ADS-868): rescue staffer posts to the seeded chat, adopter
     // reads it back. Unblocked by the chat seed + canonical chat perms.
     '**/messaging-applicants.spec.ts',
-    // Deferred: custom-application-questions — the gateway exposes no
-    // /api/v1/rescues/:id/questions route (not cut over) → 404. Batch B.
+    // bulk-edit-pets is a page-load smoke for /analytics (mislabeled file) —
+    // same low-risk pattern as the other rescue page-loads.
+    '**/bulk-edit-pets.spec.ts',
+    // Deferred (need new gateway routes wired, ADS-868):
+    // - custom-application-questions → no /api/v1/rescues/:id/questions route
+    // - messaging via /admin/users/:id/action, /auth/2fa/* (bulk-user-actions,
+    //   2fa-enrollment) → those routes aren't registered in the gateway.
   ],
   admin: [
     // ADS-867 (batch A3) — admin journeys. superadmin storageState


### PR DESCRIPTION
## What

Un-parks **`bulk-edit-pets`** — which, despite the legacy filename, is just a **page-load smoke** for the rescue `/analytics` page (navigate → assert a heading mounts). Same low-risk pattern as the merged A2 rescue page-loads; `/analytics` is a real route in `apps/rescue/src/App.tsx`.

## Still deferred (need new gateway routes wired — bigger work)

Verified these routes **don't exist** in the gateway today, so the specs would 404:
- `bulk-user-actions` → `/api/v1/admin/users/:id/action`
- `2fa-enrollment` → `/api/v1/auth/2fa/*`
- `custom-application-questions` → `/api/v1/rescues/:id/questions`

These are the last Batch B items and each needs gateway↔service route wiring (tracked in ADS-868).

## Validation

`run-e2e` label (full suite). e2e-only change → Service/Frontend tests skip.

Part of ADS-864 · ADS-868.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012iL3quEiMUvaNiH4xZNN9E)_