### PR TITLE
test(e2e): un-park batch C client auth/profile journeys (ADS-868)

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -14,6 +14,8 @@ The suite exercises real user journeys across the three React apps (`app.client`
 > **Still parked** (every other spec under `tests/client`, `tests/rescue`, `tests/admin`): un-park each by adding its glob to `UNPARKED[project]` once it passes in CI. Some non-auth specs (chat / moderation / cms / matching / notifications detail) may need follow-up gateway work — the same enum/envelope normalisation #1076 applied to auth likely applies to those domains' responses too.
 >
 > **Blocked on architecture, not yet un-parked** — these assert the monolith's CSRF + cookie-session model, which the Bearer-only gateway deliberately removed (there is no `GET /api/v1/csrf-token` endpoint and JWTs are stateless): `client/api-csrf-and-cookie-contract.spec.ts`, `client/logout-flow.spec.ts`, `client/rate-limit-application-submission.spec.ts`. `client/swipe-and-favourite.spec.ts` additionally needs a favourites seed in the pets service. Each needs a rewrite to the Bearer contract (and a seed) rather than a config flip. `rescue/custom-application-questions`, `admin/bulk-user-actions`, `admin/2fa-enrollment` need new gateway routes built (ADS-868).
+>
+> **`client/profile-update-persistence.spec.ts` — deferred, needs runtime debugging.** The whole server path is wired (the SPA submits `bio`; the gateway `PUT /users/profile` maps it; `account-handlers` persists it; `GET /auth/me` returns it via `withApiUser`), yet the bio does not round-trip back into the edit form after a reload (the assertion timed out across all CI retries). The likely cause is the client hydrating a stale cached user rather than refetching `/me` — confirm at runtime before un-parking (ADS-868).
 
 ## Layout
 

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -12,6 +12,8 @@ The suite exercises real user journeys across the three React apps (`app.client`
 > - `client/adoption-application.spec.ts` — the `@smoke` full adoption journey (submit → rescue approves → adopter sees approval). The `apiAs` fixture and `seeds.ts` mutation helpers now authenticate with Bearer tokens (no CSRF), matching the gateway.
 >
 > **Still parked** (every other spec under `tests/client`, `tests/rescue`, `tests/admin`): un-park each by adding its glob to `UNPARKED[project]` once it passes in CI. Some non-auth specs (chat / moderation / cms / matching / notifications detail) may need follow-up gateway work — the same enum/envelope normalisation #1076 applied to auth likely applies to those domains' responses too.
+>
+> **Blocked on architecture, not yet un-parked** — these assert the monolith's CSRF + cookie-session model, which the Bearer-only gateway deliberately removed (there is no `GET /api/v1/csrf-token` endpoint and JWTs are stateless): `client/api-csrf-and-cookie-contract.spec.ts`, `client/logout-flow.spec.ts`, `client/rate-limit-application-submission.spec.ts`. `client/swipe-and-favourite.spec.ts` additionally needs a favourites seed in the pets service. Each needs a rewrite to the Bearer contract (and a seed) rather than a config flip. `rescue/custom-application-questions`, `admin/bulk-user-actions`, `admin/2fa-enrollment` need new gateway routes built (ADS-868).
 
 ## Layout
 

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -70,12 +70,15 @@ const UNPARKED: Record<'client' | 'rescue' | 'admin', string[]> = {
     // - password-reset: /forgot-password shows a confirmation; /reset-password
     //   with a bad token is rejected. Gateway already has POST
     //   /auth/forgot-password + /auth/reset-password.
-    // - profile-update: a bio edit round-trips via PUT /users/profile
-    //   (account-handlers persists `bio`) and survives navigation.
     '**/form-validation-per-field.spec.ts',
     '**/email-verification-gating.spec.ts',
     '**/password-reset-flow.spec.ts',
-    '**/profile-update-persistence.spec.ts',
+    // profile-update-persistence: deferred. The bio edit submits and the
+    // gateway/auth map+persist `bio`, and GET /auth/me returns it, but the
+    // value does not round-trip back into the edit form after a reload (the
+    // assertion at spec line 47 timed out across all 3 CI retries). Likely the
+    // client hydrates a stale cached user instead of refetching /me — needs
+    // dedicated runtime debugging before un-parking (tracked under ADS-868).
   ],
   rescue: [
     // ADS-866 (batch A2) — rescue-staff journeys, unblocked by the ADS-863

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -60,6 +60,22 @@ const UNPARKED: Record<'client' | 'rescue' | 'admin', string[]> = {
     // These post a message via API and read it back from the other side.
     '**/adopter-rescue-chat.spec.ts',
     '**/realtime-chat-propagation.spec.ts',
+    // Batch C (ADS-868) — UI-only auth/profile journeys. No new gateway routes,
+    // no CSRF (the gateway is Bearer-only), grounded in the existing John Smith
+    // seed:
+    // - form-validation: anonymous /register rejects a malformed email
+    //   client-side (Zod) — pure UI, no backend.
+    // - email-verification-gating: the seeded (verified) adopter is NOT blocked
+    //   from the apply flow — a subset of the merged adoption-application path.
+    // - password-reset: /forgot-password shows a confirmation; /reset-password
+    //   with a bad token is rejected. Gateway already has POST
+    //   /auth/forgot-password + /auth/reset-password.
+    // - profile-update: a bio edit round-trips via PUT /users/profile
+    //   (account-handlers persists `bio`) and survives navigation.
+    '**/form-validation-per-field.spec.ts',
+    '**/email-verification-gating.spec.ts',
+    '**/password-reset-flow.spec.ts',
+    '**/profile-update-persistence.spec.ts',
   ],
   rescue: [
     // ADS-866 (batch A2) — rescue-staff journeys, unblocked by the ADS-863


### PR DESCRIPTION
## Summary

Continues the incremental e2e un-park (ADS-868). Un-parks **three** UI-driven client specs that need no new gateway routes, no CSRF (the gateway is Bearer-only), and no new seed data — they ride the existing John Smith persona already seeded by the auth/applications services:

- **`form-validation-per-field`** — anonymous `/register` rejects a malformed email client-side (Zod). Pure UI, no backend dependency. ✅ green in CI.
- **`email-verification-gating`** — the seeded (verified) adopter is **not** gated out of the apply flow; a subset of the already-merged `adoption-application` journey. ✅ green in CI.
- **`password-reset-flow`** — `/forgot-password` surfaces a confirmation; `/reset-password` with a bad token is rejected. Gateway already exposes `POST /auth/forgot-password` + `/auth/reset-password`. ✅ green in CI (both cases).

## Deferred (was a 4th candidate)

**`profile-update-persistence`** — CI run `27747588276` showed the bio edit does **not** round-trip back into the edit form after a reload (assertion timed out across all 3 retries). The full server path is wired (SPA submits `bio` → gateway `PUT /users/profile` maps it → `account-handlers` persists it → `GET /auth/me` returns it via `withApiUser`), so the gap is in the client's reload/hydration path — likely a stale cached user instead of a fresh `/me` refetch. Kept parked pending dedicated runtime debugging (documented in `e2e/README.md`).

## Why the rest stay parked

Now documented in `e2e/README.md`:

- `api-csrf-and-cookie-contract`, `logout-flow`, `rate-limit-application-submission` assert the **monolith's removed CSRF + cookie-session model** (no `GET /csrf-token` endpoint; JWTs are stateless) — each needs a rewrite to the Bearer contract.
- `swipe-and-favourite` additionally needs a favourites seed in the pets service.
- `rescue/custom-application-questions`, `admin/bulk-user-actions`, `admin/2fa-enrollment` need **new gateway routes** built.

## CI

First label run: **43 passed, 1 failed** (the deferred profile-update). After dropping it, the three remaining journeys are green. Re-validating on the latest push behind the `run-e2e` label before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)