### PR TITLE
feat(gateway): add /admin/users surface; un-park bulk-user-actions (ADS-868)

### DIFF
--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -118,10 +118,9 @@ const UNPARKED: Record<'client' | 'rescue' | 'admin', string[]> = {
     // bulk-edit-pets is a page-load smoke for /analytics (mislabeled file) —
     // same low-risk pattern as the other rescue page-loads.
     '**/bulk-edit-pets.spec.ts',
-    // Deferred (need new gateway routes wired, ADS-868):
+    // Still deferred (need new gateway routes wired, ADS-868):
     // - custom-application-questions → no /api/v1/rescues/:id/questions route
-    // - messaging via /admin/users/:id/action, /auth/2fa/* (bulk-user-actions,
-    //   2fa-enrollment) → those routes aren't registered in the gateway.
+    // - 2fa-enrollment → /auth/2fa/* RPCs not built yet
   ],
   admin: [
     // ADS-867 (batch A3) — admin journeys. superadmin storageState
@@ -137,6 +136,11 @@ const UNPARKED: Record<'client' | 'rescue' | 'admin', string[]> = {
     '**/content-moderation-queue.spec.ts',
     '**/support-ticket-triage.spec.ts',
     '**/blog-post-publishing.spec.ts',
+    // Batch E (ADS-868) — new gateway routes. bulk-user-actions exercises the
+    // /api/v1/admin/users surface (list, detail, PATCH :id/action suspend|
+    // reactivate) wired in services/gateway/src/routes/users.ts onto the
+    // existing auth admin RPCs.
+    '**/bulk-user-actions.spec.ts',
   ],
 };
 

--- a/services/gateway/src/routes/users.test.ts
+++ b/services/gateway/src/routes/users.test.ts
@@ -524,6 +524,109 @@ type SearchUsersReqShape = {
   userTypeFilter: AuthV1.UserRole;
 };
 
+describe('/api/v1/admin/users surface', () => {
+  let app: FastifyInstance;
+  let auth: ReturnType<typeof makeAuthClient>;
+  let notif: ReturnType<typeof makeNotifClient>;
+
+  beforeEach(async () => {
+    auth = makeAuthClient();
+    notif = makeNotifClient();
+    app = await buildApp(auth, notif);
+  });
+  afterEach(async () => {
+    await app.close();
+  });
+
+  it('GET lists users with canonical status/userType strings', async () => {
+    auth.searchUsersMock.mockResolvedValueOnce({
+      users: [ADMIN_USER_FIXTURE],
+      total: 1,
+      page: 1,
+      totalPages: 1,
+    });
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/v1/admin/users?limit=50',
+      headers: { 'x-user-id': 'svc-admin', 'x-user-roles': 'admin' },
+    });
+    expect(res.statusCode).toBe(200);
+    const body = res.json() as { data: Array<{ userType: string; status: string }> };
+    expect(body.data[0].userType).toBe('adopter');
+    expect(body.data[0].status).toBe('active');
+  });
+
+  it('GET :userId returns the user with a canonical status string', async () => {
+    auth.adminGetUserMock.mockResolvedValueOnce({ user: ADMIN_USER_FIXTURE });
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/v1/admin/users/usr-9',
+      headers: { 'x-user-id': 'svc-admin', 'x-user-roles': 'admin' },
+    });
+    expect(res.statusCode).toBe(200);
+    const body = res.json() as { data: { userId: string; status: string } };
+    expect(body.data.userId).toBe('usr-9');
+    expect(body.data.status).toBe('active');
+  });
+
+  it('PATCH action=suspend sets status SUSPENDED and returns "suspended"', async () => {
+    const suspended = { ...ADMIN_USER_FIXTURE, status: AuthV1.UserStatus.USER_STATUS_SUSPENDED };
+    auth.adminUpdateUserMock.mockResolvedValueOnce({ user: suspended });
+    const res = await app.inject({
+      method: 'PATCH',
+      url: '/api/v1/admin/users/usr-9/action',
+      headers: {
+        'x-user-id': 'svc-admin',
+        'x-user-roles': 'admin',
+        'content-type': 'application/json',
+      },
+      payload: JSON.stringify({ action: 'suspend', reason: 'probe' }),
+    });
+    expect(res.statusCode).toBe(200);
+    const [grpcReq] = auth.adminUpdateUserMock.mock.calls[0] as [
+      { userId: string; status: AuthV1.UserStatus },
+      Metadata,
+    ];
+    expect(grpcReq.userId).toBe('usr-9');
+    expect(grpcReq.status).toBe(AuthV1.UserStatus.USER_STATUS_SUSPENDED);
+    const body = res.json() as { data: { status: string } };
+    expect(body.data.status).toBe('suspended');
+  });
+
+  it('PATCH action=reactivate routes to reactivateUser', async () => {
+    auth.reactivateUserMock.mockResolvedValueOnce({ user: ADMIN_USER_FIXTURE });
+    const res = await app.inject({
+      method: 'PATCH',
+      url: '/api/v1/admin/users/usr-9/action',
+      headers: {
+        'x-user-id': 'svc-admin',
+        'x-user-roles': 'admin',
+        'content-type': 'application/json',
+      },
+      payload: JSON.stringify({ action: 'reactivate' }),
+    });
+    expect(res.statusCode).toBe(200);
+    expect(auth.reactivateUserMock).toHaveBeenCalledTimes(1);
+    expect(auth.adminUpdateUserMock).not.toHaveBeenCalled();
+  });
+
+  it('PATCH with an unknown action → 400 without calling any RPC', async () => {
+    const res = await app.inject({
+      method: 'PATCH',
+      url: '/api/v1/admin/users/usr-9/action',
+      headers: {
+        'x-user-id': 'svc-admin',
+        'x-user-roles': 'admin',
+        'content-type': 'application/json',
+      },
+      payload: JSON.stringify({ action: 'frobnicate' }),
+    });
+    expect(res.statusCode).toBe(400);
+    expect(auth.adminUpdateUserMock).not.toHaveBeenCalled();
+    expect(auth.reactivateUserMock).not.toHaveBeenCalled();
+  });
+});
+
 describe('GET /api/v1/users/statistics', () => {
   let app: FastifyInstance;
   let auth: ReturnType<typeof makeAuthClient>;

--- a/services/gateway/src/routes/users.ts
+++ b/services/gateway/src/routes/users.ts
@@ -36,6 +36,7 @@ import type { NotificationsClient } from '../grpc-clients/notifications-client.j
 import { buildMetadata } from '../middleware/metadata.js';
 import { handleGrpcError } from '../middleware/grpc-error.js';
 import { parsePagination } from '../middleware/pagination.js';
+import { userToApiJson } from './auth-user-json.js';
 
 export type UsersRoutesOptions = {
   authClient: AuthClient;
@@ -356,6 +357,95 @@ export const registerUsersRoutes = async (
           message: 'User reactivated',
           data: AuthV1.User.toJSON(res.user!),
         });
+      } catch (err) {
+        return handleGrpcError(err, reply);
+      }
+    }
+  );
+
+  // ---- Admin user surface: /api/v1/admin/users/* -------------------
+  // The admin SPA (and the e2e bulk-action flow) address users under an
+  // /admin/users prefix. These map onto the same auth RPCs as the
+  // /users/:userId admin routes above, but serialise via userToApiJson so
+  // userType/status come back as the canonical strings the admin UI reads
+  // ('admin', 'suspended') rather than the proto SCREAMING_SNAKE names.
+
+  // GET /api/v1/admin/users — list/search.
+  app.get('/api/v1/admin/users', async (req, reply) => {
+    const metadata = buildMetadata(req);
+    const q = req.query as Record<string, string | undefined>;
+    const pagination = parsePagination(q, { limit: 0 });
+    if (!pagination.ok) {
+      return reply.code(400).send({ success: false, error: pagination.error });
+    }
+    const grpcReq: SearchUsersRequest = {
+      search: q.search,
+      statusFilter: statusFilterFromString(q.status),
+      userTypeFilter: userTypeFilterFromString(q.userType ?? q.user_type),
+      emailVerified: q.emailVerified ? q.emailVerified === 'true' : undefined,
+      createdFrom: q.createdFrom ?? q.created_from,
+      createdTo: q.createdTo ?? q.created_to,
+      page: pagination.page,
+      limit: pagination.limit,
+      sortBy: q.sortBy ?? q.sort_by,
+      sortOrder: q.sortOrder ?? q.sort_order,
+    };
+    try {
+      const res = await authClient.searchUsers(grpcReq, metadata);
+      return reply.send({
+        success: true,
+        data: res.users.map(userToApiJson),
+        pagination: {
+          page: res.page,
+          limit: grpcReq.limit || 20,
+          total: res.total,
+          totalPages: res.totalPages,
+        },
+      });
+    } catch (err) {
+      return handleGrpcError(err, reply);
+    }
+  });
+
+  // GET /api/v1/admin/users/:userId — single user detail.
+  app.get<{ Params: { userId: string } }>('/api/v1/admin/users/:userId', async (req, reply) => {
+    const metadata = buildMetadata(req);
+    try {
+      const res = await authClient.adminGetUser({ userId: req.params.userId }, metadata);
+      return reply.send({ success: true, data: userToApiJson(res.user!) });
+    } catch (err) {
+      return handleGrpcError(err, reply);
+    }
+  });
+
+  // PATCH /api/v1/admin/users/:userId/action — the per-user moderation
+  // action the admin UI's bulk button calls once per row. Maps a small
+  // action vocabulary onto the existing admin RPCs.
+  app.patch<{ Params: { userId: string } }>(
+    '/api/v1/admin/users/:userId/action',
+    async (req, reply) => {
+      const metadata = buildMetadata(req);
+      const body = (req.body ?? {}) as { action?: string };
+      try {
+        if (body.action === 'suspend') {
+          const grpcReq: AdminUpdateUserRequest = {
+            userId: req.params.userId,
+            status: AuthV1.UserStatus.USER_STATUS_SUSPENDED,
+            userType: AuthV1.UserRole.USER_ROLE_UNSPECIFIED,
+            emailVerified: undefined,
+            firstName: undefined,
+            lastName: undefined,
+          };
+          const res = await authClient.adminUpdateUser(grpcReq, metadata);
+          return reply.send({ success: true, data: userToApiJson(res.user!) });
+        }
+        if (body.action === 'reactivate') {
+          const res = await authClient.reactivateUser({ userId: req.params.userId }, metadata);
+          return reply.send({ success: true, data: userToApiJson(res.user!) });
+        }
+        return reply
+          .code(400)
+          .send({ success: false, error: `unknown action: ${body.action ?? ''}` });
       } catch (err) {
         return handleGrpcError(err, reply);
       }


### PR DESCRIPTION
## Summary

First of the "new gateway routes" tickets (ADS-868). The admin SPA and the e2e bulk-action journey address users under an **`/admin/users`** prefix, but the gateway only exposed the equivalent admin routes under `/users/*`. This adds the three routes the flow needs — each a thin REST→gRPC mapping onto **existing** auth admin RPCs:

| Route | Maps to |
|---|---|
| `GET /api/v1/admin/users` | `authClient.searchUsers` |
| `GET /api/v1/admin/users/:userId` | `authClient.adminGetUser` |
| `PATCH /api/v1/admin/users/:userId/action` | `suspend` → `adminUpdateUser(status=SUSPENDED)`, `reactivate` → `reactivateUser` |

## Key detail

All three serialise the user via **`userToApiJson`** (not raw `AuthV1.User.toJSON`), so `userType`/`status` come back as the canonical strings the admin UI reads (`'admin'`, `'suspended'`) rather than the proto `USER_STATUS_SUSPENDED` form. That's exactly what the e2e spec asserts (`status === 'suspended'`), and it's why the existing `/users/:id` routes (which return raw `toJSON`) couldn't back this journey. An unknown action returns **400** before any RPC fires.

## Tests

- `services/gateway/src/routes/users.test.ts` — 5 new cases (list canonicalisation, detail canonicalisation, suspend→SUSPENDED + `'suspended'` body, reactivate routing, unknown-action 400). **26/26 pass.**
- Un-parks `admin/bulk-user-actions.spec.ts`.
- `service.gateway` type-check + `@adopt-dont-shop/e2e` type-check both clean.

## Scope note

This is **1 of 3** remaining un-park tickets. The other two are larger and will be separate PRs: `custom-application-questions` (rescue-service questions RPCs + `/rescues/:id/questions` route) and `2fa-enrollment` (a full feature build — no `/auth/2fa/*` handlers exist yet).

Validated green behind the `run-e2e` label before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012iL3quEiMUvaNiH4xZNN9E)_