### PR TITLE
ci: gate e2e behind the run-e2e label again

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -355,22 +355,21 @@ jobs:
   test-e2e:
     name: E2E Tests (Playwright)
     needs: [test-frontend, test-services]
-    # ADS-870: E2E now runs on EVERY PR, but the scope depends on opt-in:
-    #   * push to main / workflow_dispatch / a PR labelled `run-e2e`
-    #       → the FULL suite (the pre-deploy / branch-ready integration gate).
-    #   * any other PR
-    #       → a SMOKE subset (`--grep @smoke`) so in-progress PRs get fast
-    #         feedback on the headline journeys without paying the full run.
-    # The full docker-stack still has to come up either way (smoke specs span
-    # all three apps + the gateway), so the saving is the Playwright run time,
-    # not the stack bring-up. The `ci-required` aggregator treats a skipped E2E
-    # job (when the frontend/backend filters skip its `needs`) as success.
+    # E2E is opt-in on pull requests — the full docker-stack build + Playwright
+    # run is too slow to pay on every push during development, and gating it on
+    # the `run-e2e` label keeps unlabelled PRs fast and lets us land small,
+    # isolated changes without waiting on the suite. It runs when:
+    #   * pushing to main (the pre-deploy integration gate), or
+    #   * a PR carries the `run-e2e` label (opt in when the branch is ready), or
+    #   * triggered manually via workflow_dispatch.
+    # On any other PR it is skipped, which the `ci-required` aggregator treats as
+    # success — so E2E never blocks normal in-progress PRs.
     if: |
       always() &&
       (
         github.event_name == 'workflow_dispatch' ||
         (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
-        github.event_name == 'pull_request'
+        (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'run-e2e'))
       ) &&
       (needs.test-frontend.result == 'success' || needs.test-frontend.result == 'skipped') &&
       (needs.test-services.result == 'success' || needs.test-services.result == 'skipped')
@@ -672,20 +671,16 @@ jobs:
           done
 
       - name: Run Playwright suite
-        # ADS-870: full suite when opted in (main push, `run-e2e` label, or
-        # manual dispatch); otherwise a @smoke subset for fast PR feedback.
-        # `pnpm test:e2e:smoke` runs `playwright test --grep @smoke`.
+        # E2E only reaches this point when explicitly requested (main push,
+        # `run-e2e` label, or manual dispatch), so always run the full suite —
+        # the point of opting in is to get complete integration coverage, not a
+        # smoke subset. Tag tests with @smoke and run `pnpm test:e2e:smoke`
+        # locally for a quick subset.
         #
         # Retries are configured in e2e/playwright.config.ts (retries: CI ? 2 : 0).
         run: |
-          if [ "${{ github.event_name }}" = "pull_request" ] && \
-             [ "${{ contains(github.event.pull_request.labels.*.name, 'run-e2e') }}" != "true" ]; then
-            echo "unlabelled PR — running @smoke subset"
-            pnpm test:e2e:smoke
-          else
-            echo "${{ github.event_name }} on ${{ github.ref }} — running full suite"
-            pnpm test:e2e
-          fi
+          echo "${{ github.event_name }} on ${{ github.ref }} — running full suite"
+          pnpm test:e2e
 
       # ADS-386: Surface flaky-retry signal so engineers can see which tests
       # needed retries without having to open the full HTML report.


### PR DESCRIPTION
## Revert e2e to opt-in (label-gated)

#1095 (ADS-870) made the E2E job run on **every** PR — the `@smoke` subset on unlabelled PRs, the full suite on opt-in. In practice the full docker-stack still has to come up for smoke (the smoke specs span all three apps + the gateway), so unlabelled PRs paid the slow stack bring-up for little benefit, slowing down small isolated changes.

This restores the previous **opt-in** model. The E2E job runs only when:

- pushing to `main` (the pre-deploy integration gate), or
- a PR carries the `run-e2e` label (opt in when the branch is ready), or
- triggered manually via `workflow_dispatch`.

On any other PR it's skipped, which the `ci-required` aggregator treats as success — so unlabelled PRs stay fast and never block on e2e.

### What's kept
The `@smoke` tags on the headline specs stay (still useful for `pnpm test:e2e:smoke` locally) — only the CI **trigger** reverts to label-gated.

### Validation
- `ci.yml` YAML validated.
- Diff is limited to the `test-e2e` job's `if:` condition and the Playwright invocation step (+ their comments).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012iL3quEiMUvaNiH4xZNN9E)_