### PR TITLE
feat(auth): block login until email verified; un-park roundtrip (ADS-871)

### DIFF
--- a/e2e/helpers/token-peek.ts
+++ b/e2e/helpers/token-peek.ts
@@ -45,6 +45,28 @@ export async function peekAuthTokens(email: string): Promise<AuthTokens> {
 }
 
 /**
+ * Drive the email-verification step for a freshly-registered throwaway account:
+ * read its verification token via the peek seam and POST it to
+ * /auth/verify-email. Required before an API login, because login now rejects
+ * an unverified (pending_verification) account with an emailVerificationRequired
+ * flag and no tokens. Throws loudly if no token is outstanding or verify fails.
+ */
+export async function verifyEmailViaPeek(email: string): Promise<void> {
+  const { verificationToken } = await peekAuthTokens(email);
+  if (!verificationToken) {
+    throw new Error(`no verification token outstanding for ${email} — cannot verify`);
+  }
+  await withAnonApi(async ctx => {
+    const res = await ctx.post('/api/v1/auth/verify-email', { data: { verificationToken } });
+    if (!res.ok()) {
+      throw new Error(
+        `verify-email failed for ${email}: ${res.status()} ${(await res.text()).slice(0, 200)}`
+      );
+    }
+  });
+}
+
+/**
  * Read the most recent pending staff-invitation token for an email from the
  * test-token-peek seam. Returns null when no pending invitation exists.
  */

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -84,12 +84,12 @@ const UNPARKED: Record<'client' | 'rescue' | 'admin', string[]> = {
     // token via the seam → reset → log in with the new password. Proves the
     // seam works end-to-end.
     '**/password-reset-roundtrip.spec.ts',
-    // email-verification-roundtrip: PARKED. It asserts a freshly-registered
-    // user is BLOCKED from logging in until verified, but the auth service
-    // only blocks 'suspended'/'deactivated' — login before email-verify is
-    // currently allowed. The spec's premise is a product question, not a bug;
-    // park until the intended "must verify before login" behaviour is decided
-    // (tracked under ADS-871).
+    // ADS-871 — login now REQUIRES a verified email. The auth Login handler
+    // answers a fresh (pending_verification) account with an
+    // emailVerificationRequired flag and no tokens (mirroring the 2FA flow);
+    // verifying via the emailed token (read through the token-peek seam) then
+    // lets login complete. register → blocked → verify → login succeeds.
+    '**/email-verification-roundtrip.spec.ts',
     // Batch D (ADS-868) — rewritten from the monolith's CSRF + cookie-session
     // model to the gateway's actual Bearer contract:
     // - api-auth-contract (renamed from api-csrf-and-cookie-contract): asserts

--- a/e2e/tests/admin/2fa-enrollment.spec.ts
+++ b/e2e/tests/admin/2fa-enrollment.spec.ts
@@ -3,6 +3,7 @@ import { generateSync } from 'otplib';
 import { test, expect, request as playwrightRequest } from '@playwright/test';
 
 import { uniqueEmail } from '../../helpers/factories';
+import { verifyEmailViaPeek } from '../../helpers/token-peek';
 import { URLS } from '../../playwright.config';
 
 /**
@@ -42,6 +43,10 @@ test.describe('2FA enrollment', () => {
       },
     });
     expect([200, 201]).toContain(reg.status());
+
+    // Login now requires a verified email, so verify the throwaway account via
+    // the token-peek seam before the password login can mint tokens.
+    await verifyEmailViaPeek(email);
 
     const loginRes = await anon.post('/api/v1/auth/login', { data: { email, password } });
     expect(loginRes.ok()).toBe(true);

--- a/e2e/tests/client/email-verification-roundtrip.spec.ts
+++ b/e2e/tests/client/email-verification-roundtrip.spec.ts
@@ -33,11 +33,20 @@ test.describe('email verification round-trip (ADS-871)', () => {
       });
       expect([200, 201]).toContain(registerRes.status());
 
-      // 2. Login is rejected while the account is unverified.
+      // 2. Login is blocked while the account is unverified. Mirroring the
+      //    2FA flow, the gateway answers 200 with an
+      //    `emailVerificationRequired` flag and NO tokens — the client turns
+      //    that into a "verify your email" prompt rather than a session.
       const unverifiedLogin = await api.post('/api/v1/auth/login', {
         data: { email, password: PASSWORD },
       });
-      expect(unverifiedLogin.ok()).toBe(false);
+      expect(unverifiedLogin.ok()).toBe(true);
+      const unverifiedBody = (await unverifiedLogin.json()) as {
+        emailVerificationRequired?: boolean;
+        tokens?: { accessToken?: string };
+      };
+      expect(unverifiedBody.emailVerificationRequired).toBe(true);
+      expect(unverifiedBody.tokens?.accessToken).toBeUndefined();
 
       // 3. Read the verification token via the test-token-peek seam.
       const tokens = await peekAuthTokens(email);

--- a/packages/lib.auth/src/components/LoginForm.test.tsx
+++ b/packages/lib.auth/src/components/LoginForm.test.tsx
@@ -3,6 +3,7 @@ import userEvent from '@testing-library/user-event';
 import { describe, expect, it, vi } from 'vitest';
 
 import { AuthContext, type AuthContextType } from '../contexts/AuthContext';
+import { authService } from '../services/auth-service';
 import { LoginForm } from './LoginForm';
 
 const buildAuthValue = (overrides: Partial<AuthContextType> = {}): AuthContextType => ({
@@ -75,6 +76,49 @@ describe('LoginForm 2FA token field [C2-2]', () => {
     await user.paste(backupCode);
 
     expect(token).toHaveValue(backupCode);
+  });
+});
+
+describe('LoginForm email-verification prompt [ADS-871]', () => {
+  // Step into the verify-email state by stubbing login to throw the
+  // well-known "email verification required" error the form keys on. The
+  // form then shows the verify prompt with a resend action instead of a
+  // session — mirroring the 2FA flow.
+  const enterVerifyEmailMode = async () => {
+    const user = userEvent.setup();
+    const login = vi.fn().mockRejectedValue(new Error('Email verification required'));
+
+    renderLoginForm(buildAuthValue({ login }));
+
+    await user.type(screen.getByPlaceholderText(/enter your email/i), 'fresh@b.com');
+    await user.type(screen.getByPlaceholderText(/enter your password/i), 'password');
+    await user.click(screen.getByRole('button', { name: /sign in/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/please verify your email/i)).toBeInTheDocument();
+    });
+
+    return { user };
+  };
+
+  it('shows the verify-email prompt instead of logging in', async () => {
+    await enterVerifyEmailMode();
+
+    expect(screen.queryByRole('button', { name: /sign in/i })).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /resend verification email/i })).toBeInTheDocument();
+  });
+
+  it('resends the verification email for the entered address', async () => {
+    const resendSpy = vi.spyOn(authService, 'resendVerification').mockResolvedValue();
+    const { user } = await enterVerifyEmailMode();
+
+    await user.click(screen.getByRole('button', { name: /resend verification email/i }));
+
+    expect(resendSpy).toHaveBeenCalledWith('fresh@b.com');
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /verification email sent/i })).toBeInTheDocument();
+    });
+    resendSpy.mockRestore();
   });
 });
 

--- a/packages/lib.auth/src/components/LoginForm.tsx
+++ b/packages/lib.auth/src/components/LoginForm.tsx
@@ -2,7 +2,11 @@ import React, { useState } from 'react';
 import { Alert, Button, Input } from '@adopt-dont-shop/lib.components';
 import { LoginRequestSchema } from '@adopt-dont-shop/lib.validation';
 import { useAuth } from '../hooks/useAuth';
-import { TWO_FACTOR_REQUIRED_MESSAGE } from '../services/auth-service';
+import {
+  TWO_FACTOR_REQUIRED_MESSAGE,
+  EMAIL_VERIFICATION_REQUIRED_MESSAGE,
+  authService,
+} from '../services/auth-service';
 import { LoginRequest } from '../types';
 import * as styles from './LoginForm.css';
 
@@ -49,6 +53,8 @@ export const LoginForm: React.FC<LoginFormProps> = ({
   const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({});
   const [needs2FA, setNeeds2FA] = useState(false);
   const [twoFactorToken, setTwoFactorToken] = useState('');
+  const [needsEmailVerification, setNeedsEmailVerification] = useState(false);
+  const [resendStatus, setResendStatus] = useState<'idle' | 'sending' | 'sent'>('idle');
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -88,6 +94,13 @@ export const LoginForm: React.FC<LoginFormProps> = ({
         return;
       }
 
+      if (errorMessage.includes(EMAIL_VERIFICATION_REQUIRED_MESSAGE)) {
+        setNeedsEmailVerification(true);
+        setResendStatus('idle');
+        setError(null);
+        return;
+      }
+
       setError(errorMessage);
     }
   };
@@ -108,7 +121,20 @@ export const LoginForm: React.FC<LoginFormProps> = ({
   const handleBack = () => {
     setNeeds2FA(false);
     setTwoFactorToken('');
+    setNeedsEmailVerification(false);
+    setResendStatus('idle');
     setError(null);
+  };
+
+  const handleResendVerification = async () => {
+    setResendStatus('sending');
+    try {
+      await authService.resendVerification(formData.email);
+    } finally {
+      // The gateway always responds with success to avoid leaking which
+      // addresses have accounts, so we report "sent" regardless.
+      setResendStatus('sent');
+    }
   };
 
   return (
@@ -120,7 +146,31 @@ export const LoginForm: React.FC<LoginFormProps> = ({
       )}
 
       <form className={styles.form} onSubmit={handleSubmit}>
-        {!needs2FA ? (
+        {needsEmailVerification ? (
+          <div className={styles.twoFactorGroup}>
+            <div className={styles.twoFactorLabel}>Please verify your email</div>
+            <p className={styles.twoFactorDescription}>
+              Your email address needs to be verified before you can sign in. Check your inbox for
+              the verification link we sent you.
+            </p>
+            <Button
+              type="button"
+              size="md"
+              variant="secondary"
+              onClick={handleResendVerification}
+              disabled={resendStatus === 'sending'}
+            >
+              {resendStatus === 'sending'
+                ? 'Sending...'
+                : resendStatus === 'sent'
+                  ? 'Verification email sent'
+                  : 'Resend verification email'}
+            </Button>
+            <button className={styles.backLink} type="button" onClick={handleBack}>
+              Back to login
+            </button>
+          </div>
+        ) : !needs2FA ? (
           <>
             <div className={styles.formGroup}>
               <Input
@@ -190,19 +240,21 @@ export const LoginForm: React.FC<LoginFormProps> = ({
           </div>
         )}
 
-        <Button
-          type="submit"
-          size="lg"
-          variant="primary"
-          disabled={
-            isLoading ||
-            (!needs2FA && (!formData.email || !formData.password)) ||
-            (needs2FA && twoFactorToken.length < 6)
-          }
-          style={{ width: '100%' }}
-        >
-          {isLoading ? 'Signing In...' : needs2FA ? 'Verify' : 'Sign In'}
-        </Button>
+        {!needsEmailVerification && (
+          <Button
+            type="submit"
+            size="lg"
+            variant="primary"
+            disabled={
+              isLoading ||
+              (!needs2FA && (!formData.email || !formData.password)) ||
+              (needs2FA && twoFactorToken.length < 6)
+            }
+            style={{ width: '100%' }}
+          >
+            {isLoading ? 'Signing In...' : needs2FA ? 'Verify' : 'Sign In'}
+          </Button>
+        )}
 
         {helperText && <small className={styles.helperText}>{helperText}</small>}
       </form>

--- a/packages/lib.auth/src/services/auth-service.ts
+++ b/packages/lib.auth/src/services/auth-service.ts
@@ -38,6 +38,11 @@ const AUTH_ENDPOINTS = {
 // on it to swap to the 2FA code prompt and re-submit with twoFactorToken.
 export const TWO_FACTOR_REQUIRED_MESSAGE = 'Two-factor authentication code required';
 
+// The login flow signals "password OK, but your email isn't verified yet" by
+// throwing an Error whose message contains this string. LoginForm matches on
+// it to swap to the "verify your email" prompt with a resend action.
+export const EMAIL_VERIFICATION_REQUIRED_MESSAGE = 'Email verification required';
+
 /**
  * AuthService - Authentication and user management service
  *
@@ -69,6 +74,13 @@ export class AuthService {
     // session.
     if (response.twoFactorRequired) {
       throw new Error(TWO_FACTOR_REQUIRED_MESSAGE);
+    }
+
+    // Password was correct but the account's email isn't verified. The body
+    // carries no user/tokens — surface the signal as an error the LoginForm
+    // prompts on, WITHOUT persisting a partial session.
+    if (response.emailVerificationRequired) {
+      throw new Error(EMAIL_VERIFICATION_REQUIRED_MESSAGE);
     }
 
     // Persist the user + the Bearer token pair the gateway returned in the
@@ -227,6 +239,16 @@ export class AuthService {
       throw new Error('No user email found');
     }
     await apiService.post(AUTH_ENDPOINTS.RESEND_VERIFICATION, { email: user.email });
+  }
+
+  /**
+   * Resend the verification email for a given address. Used by the login
+   * "verify your email" prompt, where there is no persisted session to read
+   * the email from. The gateway always responds with success to avoid
+   * leaking which addresses have accounts.
+   */
+  async resendVerification(email: string): Promise<void> {
+    await apiService.post(AUTH_ENDPOINTS.RESEND_VERIFICATION, { email });
   }
 
   /**

--- a/packages/lib.auth/src/types/auth.ts
+++ b/packages/lib.auth/src/types/auth.ts
@@ -212,6 +212,11 @@ export interface AuthResponse {
   // client re-submits login with twoFactorToken. auth-service turns this
   // into the TWO_FACTOR_REQUIRED_MESSAGE error the LoginForm prompts on.
   twoFactorRequired?: boolean;
+  // Set when the password was correct but the account's email is not yet
+  // verified. user/tokens are absent in that case — the client prompts the
+  // user to verify their email (and can resend it). auth-service turns this
+  // into the EMAIL_VERIFICATION_REQUIRED_MESSAGE error the LoginForm prompts on.
+  emailVerificationRequired?: boolean;
 }
 
 export interface ChangePasswordRequest {

--- a/packages/proto/proto/adopt_dont_shop/auth/v1/auth.proto
+++ b/packages/proto/proto/adopt_dont_shop/auth/v1/auth.proto
@@ -327,6 +327,11 @@ message LoginResponse {
   // no (valid) two_factor_token was supplied. user/tokens are empty in
   // this case — the client re-submits Login with the TOTP code.
   bool two_factor_required = 4;
+  // Set when the password was correct but the account's email is not yet
+  // verified. user/tokens are empty in this case — the client prompts the
+  // user to verify their email (and can resend the verification email)
+  // before login can complete.
+  bool email_verification_required = 5;
 }
 
 // --- Logout ----------------------------------------------------------

--- a/packages/proto/src/generated/proto/adopt_dont_shop/auth/v1/auth.ts
+++ b/packages/proto/src/generated/proto/adopt_dont_shop/auth/v1/auth.ts
@@ -395,6 +395,13 @@ export interface LoginResponse {
    * this case — the client re-submits Login with the TOTP code.
    */
   twoFactorRequired: boolean;
+  /**
+   * Set when the password was correct but the account's email is not yet
+   * verified. user/tokens are empty in this case — the client prompts the
+   * user to verify their email (and can resend the verification email)
+   * before login can complete.
+   */
+  emailVerificationRequired: boolean;
 }
 
 export interface LogoutRequest {
@@ -1734,7 +1741,13 @@ export const LoginRequest: MessageFns<LoginRequest> = {
 };
 
 function createBaseLoginResponse(): LoginResponse {
-  return { user: undefined, tokens: undefined, permissions: [], twoFactorRequired: false };
+  return {
+    user: undefined,
+    tokens: undefined,
+    permissions: [],
+    twoFactorRequired: false,
+    emailVerificationRequired: false,
+  };
 }
 
 export const LoginResponse: MessageFns<LoginResponse> = {
@@ -1750,6 +1763,9 @@ export const LoginResponse: MessageFns<LoginResponse> = {
     }
     if (message.twoFactorRequired !== false) {
       writer.uint32(32).bool(message.twoFactorRequired);
+    }
+    if (message.emailVerificationRequired !== false) {
+      writer.uint32(40).bool(message.emailVerificationRequired);
     }
     return writer;
   },
@@ -1793,6 +1809,14 @@ export const LoginResponse: MessageFns<LoginResponse> = {
           message.twoFactorRequired = reader.bool();
           continue;
         }
+        case 5: {
+          if (tag !== 40) {
+            break;
+          }
+
+          message.emailVerificationRequired = reader.bool();
+          continue;
+        }
       }
       if ((tag & 7) === 4 || tag === 0) {
         break;
@@ -1814,6 +1838,11 @@ export const LoginResponse: MessageFns<LoginResponse> = {
         : isSet(object.two_factor_required)
           ? globalThis.Boolean(object.two_factor_required)
           : false,
+      emailVerificationRequired: isSet(object.emailVerificationRequired)
+        ? globalThis.Boolean(object.emailVerificationRequired)
+        : isSet(object.email_verification_required)
+          ? globalThis.Boolean(object.email_verification_required)
+          : false,
     };
   },
 
@@ -1831,6 +1860,9 @@ export const LoginResponse: MessageFns<LoginResponse> = {
     if (message.twoFactorRequired !== false) {
       obj.twoFactorRequired = message.twoFactorRequired;
     }
+    if (message.emailVerificationRequired !== false) {
+      obj.emailVerificationRequired = message.emailVerificationRequired;
+    }
     return obj;
   },
 
@@ -1847,6 +1879,7 @@ export const LoginResponse: MessageFns<LoginResponse> = {
         : undefined;
     message.permissions = object.permissions?.map(e => e) || [];
     message.twoFactorRequired = object.twoFactorRequired ?? false;
+    message.emailVerificationRequired = object.emailVerificationRequired ?? false;
     return message;
   },
 };

--- a/services/auth/src/grpc/auth-metrics.ts
+++ b/services/auth/src/grpc/auth-metrics.ts
@@ -15,7 +15,8 @@ export type LoginOutcome =
   | 'success'
   | 'invalid_credentials'
   | 'account_locked'
-  | 'account_suspended';
+  | 'account_suspended'
+  | 'email_unverified';
 
 export type RegistrationOutcome = 'success' | 'duplicate_email' | 'invalid_input';
 

--- a/services/auth/src/grpc/handlers.test.ts
+++ b/services/auth/src/grpc/handlers.test.ts
@@ -330,6 +330,64 @@ describe('login', () => {
     expect(res.tokens?.accessToken).toBe('access.jwt.token');
     expect(mocks.issuerMock.mint).toHaveBeenCalledTimes(1);
   });
+
+  // --- Email-verification enforcement --------------------------------
+
+  it('blocks login (no tokens) when the email is not verified', async () => {
+    mocks.poolMock.query.mockResolvedValueOnce({
+      rows: [userRowFixture({ email_verified: false })],
+    });
+    mocks.hasherMock.compare.mockResolvedValueOnce(true);
+
+    const res = await login(mocks.deps, null, BASE_LOGIN_REQ);
+
+    expect(res.emailVerificationRequired).toBe(true);
+    expect(res.tokens).toBeUndefined();
+    expect(res.user).toBeUndefined();
+    // No token was minted — the login is not complete until the email is verified.
+    expect(mocks.issuerMock.mint).not.toHaveBeenCalled();
+  });
+
+  it('gates email verification BEFORE the second factor', async () => {
+    // An unverified account with 2FA on is still blocked on verification
+    // first — we never reach the TOTP check, so no code is requested.
+    const secret = generateSecret();
+    mocks.poolMock.query.mockResolvedValueOnce({
+      rows: [
+        userRowFixture({
+          email_verified: false,
+          two_factor_enabled: true,
+          two_factor_secret: secret,
+        }),
+      ],
+    });
+    mocks.hasherMock.compare.mockResolvedValueOnce(true);
+
+    const res = await login(mocks.deps, null, BASE_LOGIN_REQ);
+
+    expect(res.emailVerificationRequired).toBe(true);
+    expect(res.twoFactorRequired).toBe(false);
+    expect(mocks.issuerMock.mint).not.toHaveBeenCalled();
+  });
+
+  it('completes the login (flag false) when the email is verified', async () => {
+    mocks.poolMock.query.mockResolvedValueOnce({
+      rows: [userRowFixture({ email_verified: true })],
+    });
+    mocks.hasherMock.compare.mockResolvedValueOnce(true);
+    mocks.issuerMock.mint.mockResolvedValueOnce(mintedFixture());
+    mocks.clientMock.query.mockResolvedValue({ rows: [] });
+    mocks.poolMock.query
+      .mockResolvedValueOnce({ rows: [{ user_type: 'adopter' }] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [{ name: 'pets.read' }] });
+
+    const res = await login(mocks.deps, null, BASE_LOGIN_REQ);
+
+    expect(res.emailVerificationRequired).toBe(false);
+    expect(res.tokens?.accessToken).toBe('access.jwt.token');
+    expect(mocks.issuerMock.mint).toHaveBeenCalledTimes(1);
+  });
 });
 
 // --- logout ----------------------------------------------------------

--- a/services/auth/src/grpc/handlers.ts
+++ b/services/auth/src/grpc/handlers.ts
@@ -391,13 +391,23 @@ export async function login(
     throw new HandlerError('UNAUTHENTICATED', 'invalid credentials');
   }
 
+  // Email verification gate. The password is correct, but an account whose
+  // email has not been verified cannot log in. We answer with
+  // email_verification_required (no tokens minted) so the client can prompt
+  // the user to verify — and resend the verification email — before
+  // re-attempting login.
+  if (!user.email_verified) {
+    loginCounter.inc({ outcome: 'email_unverified' });
+    return { permissions: [], twoFactorRequired: false, emailVerificationRequired: true };
+  }
+
   // Second factor. The password is correct; if the account has 2FA on we
   // require a valid TOTP code before minting any tokens. A first login
   // call (no code) is answered with two_factor_required so the client can
   // prompt and re-submit; a wrong code is an auth failure.
   if (user.two_factor_enabled) {
     if (!req.twoFactorToken) {
-      return { permissions: [], twoFactorRequired: true };
+      return { permissions: [], twoFactorRequired: true, emailVerificationRequired: false };
     }
     if (!user.two_factor_secret || !verifyTotp(req.twoFactorToken, user.two_factor_secret)) {
       loginCounter.inc({ outcome: 'invalid_credentials' });
@@ -441,6 +451,7 @@ export async function login(
     tokens: minted.pair,
     permissions: principal.permissions,
     twoFactorRequired: false,
+    emailVerificationRequired: false,
   };
 }
 


### PR DESCRIPTION
## ADS-871 — require a verified email to log in

Login now **blocks until the email is verified**, surfaced exactly like the existing 2FA login flow: a flag on the login response + a "verify your email" panel with a "resend verification email" action. This un-parks `email-verification-roundtrip.spec.ts`.

### Backend (auth service)
- `auth.proto`: `LoginResponse` gains `bool email_verification_required` (regenerated; only the auth generated file committed, prettier'd to additions-only).
- Login handler: after the password check, **before** the 2FA branch, an unverified account returns `{ permissions: [], emailVerificationRequired: true }` with **no tokens** (mirrors the 2FA no-token branch). Success path sets the flag `false`. New `email_unverified` login metric outcome.
- **Resend reused, not rebuilt:** the `ResendVerification` RPC, `POST /api/v1/auth/resend-verification`, the `verify-email` route, and the token-peek seam already existed. The gateway login route already passes the new flag through, so no gateway change was needed.

### Frontend (lib.auth)
- `EMAIL_VERIFICATION_REQUIRED_MESSAGE` exported; `login()` throws it on the flag; added `resendVerification(email)`.
- `LoginForm` shows a "Please verify your email" panel (reusing the 2FA styles) with a resend button.

### e2e
- `email-verification-roundtrip.spec.ts`: step 2 adjusted — the flag flow returns 200 with `emailVerificationRequired === true` and no access token (intent preserved: no session until verified). Rest of the round-trip (peek token → verify → login succeeds) was already correct.
- Added to `UNPARKED.client`.

### Blast radius
Seeded personas are `email_verified = true`, so global-setup and the existing suite are unaffected; `registration-and-login.spec.ts` only asserts the register response.

### Tests
auth 244 · lib.auth 127 · proto 66 · gateway 702 — all green + type-checks; e2e type-check passes. Full e2e runs here in CI behind `run-e2e`.

Refs ADS-871.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012iL3quEiMUvaNiH4xZNN9E)_