### PR TITLE
test(e2e): un-park client UI journeys; fix custom-question render (ADS-870)

### DIFF
--- a/apps/client/src/pages/ApplicationPage.tsx
+++ b/apps/client/src/pages/ApplicationPage.tsx
@@ -221,10 +221,10 @@ export const ApplicationPage: React.FC = () => {
       }
 
       const [questionsResponse, defaults] = await Promise.all([
-        apiService.get<{ questions: Question[] }>(`/api/v1/rescues/${petData.rescue_id}/questions`),
+        apiService.get<{ data: Question[] }>(`/api/v1/rescues/${petData.rescue_id}/questions`),
         applicationProfileService.getApplicationDefaults().catch(() => null),
       ]);
-      const enabledQuestions = questionsResponse.questions.filter((q: Question) => q.isEnabled);
+      const enabledQuestions = questionsResponse.data.filter((q: Question) => q.isEnabled);
       setAllQuestions(enabledQuestions);
       setCategories(groupQuestionsByMacroStep(enabledQuestions, petData.name));
 

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -102,15 +102,15 @@ const UNPARKED: Record<'client' | 'rescue' | 'admin', string[]> = {
     '**/api-auth-contract.spec.ts',
     '**/logout-flow.spec.ts',
     '**/rate-limit-application-submission.spec.ts',
-    // ADS-870 — 2FA driven through the client login UI. The throwaway account
-    // registers, VERIFIES its email (login now requires it), enables 2FA via
-    // API, then the UI half is exercised: gateway → two_factor_required →
-    // auth-service throws TWO_FACTOR_REQUIRED_MESSAGE → LoginForm shows the
-    // `000000` field + "Verify" button → a fresh TOTP completes login.
-    '**/2fa-login-ui.spec.ts',
-    // ADS-870 — PARKED (files retained, not listed): two UI journeys that fail
-    // in CI on causes only reproducible with the full docker stack UP, which
-    // can't be run in the un-parking environment:
+    // ADS-870 — PARKED (files retained, not listed): three UI journeys that
+    // fail in CI on causes only reproducible with the full docker stack UP,
+    // which can't be run in the un-parking environment:
+    // - 2fa-login-ui: a freshly-registered throwaway account can't be driven to
+    //   a token — the API login returns no access token, and reading the
+    //   verification token via the peek seam comes back null, even though
+    //   registration sets it and the identical peek works for the green
+    //   email-verification-roundtrip. Needs the live stack to see why the token
+    //   is absent before the UI 2FA challenge can be exercised.
     // - favourite-add-via-ui: the pet detail "Add to Favorites" control never
     //   flips to "Favorited" in CI (the assert at spec line 33 timed out across
     //   all retries) — needs the running UI to see whether the click, the

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -102,26 +102,24 @@ const UNPARKED: Record<'client' | 'rescue' | 'admin', string[]> = {
     '**/api-auth-contract.spec.ts',
     '**/logout-flow.spec.ts',
     '**/rate-limit-application-submission.spec.ts',
-    // ADS-870 — UI-level journeys for features that previously had API-only
-    // e2e coverage. Debugged by code-reading the spec against the SPA/API it
-    // drives:
-    // - 2fa-login-ui: the throwaway account is logged in (and the access token
-    //   captured) BEFORE 2FA is enabled, so the setup login returns a token —
-    //   the same flow the green admin/2fa-enrollment.spec.ts uses. The UI half
-    //   (gateway → two_factor_required → auth-service throws
-    //   TWO_FACTOR_REQUIRED_MESSAGE → LoginForm shows the `000000` field +
-    //   "Verify" button) is wired correctly end-to-end.
-    // - favourite-add-via-ui: PetDetailsPage's button renders "♥ Favorited"
-    //   after petService.addToFavorites resolves (optimistic flip); the
-    //   favourites infra is the same path the green swipe-and-favourite.spec.ts
-    //   exercises.
-    // - custom-question-on-application-form: fixed a real SPA bug — the apply
-    //   form read the questions list as `{ questions }` but the gateway route
-    //   GET /api/v1/rescues/:id/questions returns `{ data: [...] }`, so the
-    //   read threw and no question rendered (apps/client ApplicationPage).
+    // ADS-870 — 2FA driven through the client login UI. The throwaway account
+    // registers, VERIFIES its email (login now requires it), enables 2FA via
+    // API, then the UI half is exercised: gateway → two_factor_required →
+    // auth-service throws TWO_FACTOR_REQUIRED_MESSAGE → LoginForm shows the
+    // `000000` field + "Verify" button → a fresh TOTP completes login.
     '**/2fa-login-ui.spec.ts',
-    '**/favourite-add-via-ui.spec.ts',
-    '**/custom-question-on-application-form.spec.ts',
+    // ADS-870 — PARKED (files retained, not listed): two UI journeys that fail
+    // in CI on causes only reproducible with the full docker stack UP, which
+    // can't be run in the un-parking environment:
+    // - favourite-add-via-ui: the pet detail "Add to Favorites" control never
+    //   flips to "Favorited" in CI (the assert at spec line 33 timed out across
+    //   all retries) — needs the running UI to see whether the click, the
+    //   POST /pets/:id/favorite, or the state refresh is at fault.
+    // - custom-question-on-application-form: even after fixing the apply form's
+    //   `{ data }` read (the gateway returns `{ data: [...] }`, not
+    //   `{ questions }`), the custom question still doesn't render on /apply in
+    //   CI (spec line 69) — a second cause that needs runtime debugging.
+    // Un-park each once reproduced green against a live stack (tracked ADS-870).
     // profile-update-persistence: RE-PARKED. Investigation showed the root
     // cause is deeper than a stale cache: the SPA's profile save calls
     // authService.updateProfile → PUT /api/v1/auth/me, but the gateway has no

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -103,19 +103,35 @@ const UNPARKED: Record<'client' | 'rescue' | 'admin', string[]> = {
     '**/logout-flow.spec.ts',
     '**/rate-limit-application-submission.spec.ts',
     // ADS-870 — UI-level journeys for features that previously had API-only
-    // e2e coverage. The specs are written (2fa-login-ui, favourite-add-via-ui,
-    // custom-question-on-application-form) but PARKED: their first CI run went
-    // 53 pass / 3 fail — each of these three failed on a UI assumption that
-    // needs debugging with the docker stack UP (a token-setup login returned no
-    // token; the favourite button didn't flip to "Favorited"; the custom
-    // question didn't render on /apply). Un-park once each is reproduced green
-    // locally. Tracked under ADS-870.
-    // profile-update-persistence: deferred. The bio edit submits and the
-    // gateway/auth map+persist `bio`, and GET /auth/me returns it, but the
-    // value does not round-trip back into the edit form after a reload (the
-    // assertion at spec line 47 timed out across all 3 CI retries). Likely the
-    // client hydrates a stale cached user instead of refetching /me — needs
-    // dedicated runtime debugging before un-parking (tracked under ADS-868).
+    // e2e coverage. Debugged by code-reading the spec against the SPA/API it
+    // drives:
+    // - 2fa-login-ui: the throwaway account is logged in (and the access token
+    //   captured) BEFORE 2FA is enabled, so the setup login returns a token —
+    //   the same flow the green admin/2fa-enrollment.spec.ts uses. The UI half
+    //   (gateway → two_factor_required → auth-service throws
+    //   TWO_FACTOR_REQUIRED_MESSAGE → LoginForm shows the `000000` field +
+    //   "Verify" button) is wired correctly end-to-end.
+    // - favourite-add-via-ui: PetDetailsPage's button renders "♥ Favorited"
+    //   after petService.addToFavorites resolves (optimistic flip); the
+    //   favourites infra is the same path the green swipe-and-favourite.spec.ts
+    //   exercises.
+    // - custom-question-on-application-form: fixed a real SPA bug — the apply
+    //   form read the questions list as `{ questions }` but the gateway route
+    //   GET /api/v1/rescues/:id/questions returns `{ data: [...] }`, so the
+    //   read threw and no question rendered (apps/client ApplicationPage).
+    '**/2fa-login-ui.spec.ts',
+    '**/favourite-add-via-ui.spec.ts',
+    '**/custom-question-on-application-form.spec.ts',
+    // profile-update-persistence: RE-PARKED. Investigation showed the root
+    // cause is deeper than a stale cache: the SPA's profile save calls
+    // authService.updateProfile → PUT /api/v1/auth/me, but the gateway has no
+    // such route (server.ts's catch-all returns 404 for PUT /api/*; the real
+    // persistence route is PATCH /api/v1/users/account). So the bio never
+    // persists and the round-trip can't succeed. The correct fix re-points
+    // updateProfile to PATCH /users/account AND refetches the user (and resyncs
+    // ProfileEditForm's snapshot) — a shared-lib.auth change with admin/rescue
+    // blast radius and existing tests asserting the PUT-/auth/me flow, so it
+    // needs runtime verification before landing. Tracked under ADS-868.
   ],
   rescue: [
     // ADS-866 (batch A2) — rescue-staff journeys, unblocked by the ADS-863

--- a/e2e/tests/client/2fa-login-ui.spec.ts
+++ b/e2e/tests/client/2fa-login-ui.spec.ts
@@ -4,6 +4,7 @@ import { request as playwrightRequest } from '@playwright/test';
 
 import { test, expect } from '../../fixtures';
 import { uniqueEmail } from '../../helpers/factories';
+import { peekAuthTokens } from '../../helpers/token-peek';
 import { URLS } from '../../playwright.config';
 
 /**
@@ -41,6 +42,15 @@ test.describe('2FA via the login UI', () => {
         },
       });
       expect([200, 201]).toContain(reg.status());
+
+      // Login now requires a verified email, so verify the throwaway via the
+      // token-peek seam before the password login can mint a token.
+      const { verificationToken } = await peekAuthTokens(email);
+      expect(verificationToken).toBeTruthy();
+      const verifyRes = await api.post('/api/v1/auth/verify-email', {
+        data: { verificationToken },
+      });
+      expect(verifyRes.ok()).toBe(true);
 
       const loginRes = await api.post('/api/v1/auth/login', { data: { email, password } });
       expect(loginRes.ok()).toBe(true);


### PR DESCRIPTION
## ADS-870 — un-park client UI journeys (outcome: 1 bug fix, 3 parked)

Attempted to un-park the parked client UI specs by debugging against the SPA/API. The docker stack isn't runnable in this environment, so specs whose failures can only be seen in the live UI are kept parked with diagnoses rather than guessed at.

### Real bug fixed (kept)
- **`ApplicationPage`** read the questions list as `{ questions }`, but `GET /api/v1/rescues/:id/questions` returns `{ data: [...] }`. Re-pointed the read to `.data`. Correct regardless of the spec's parking.

### Parked (3) — need the running stack to debug
- **`2fa-login-ui`** — a freshly-registered throwaway can't be driven to a token: the API login returns no access token, and the verification token read via the peek seam comes back `null` — even though registration sets it and the identical peek works for the green `email-verification-roundtrip`. Two fix attempts (capture-token-first; verify-then-login) both failed on this runtime-opaque cause.
- **`favourite-add-via-ui`** — the pet-detail "Add to Favorites" control never flips to "Favorited" in CI (line 33 timeout). Needs the live UI to localise the cause.
- **`custom-question-on-application-form`** — even after the `{ data }` fix, the custom question still doesn't render on `/apply` in CI (line 69) — a second cause needing runtime debugging.

`profile-update-persistence` stays parked with its corrected diagnosis (`updateProfile` hits a non-existent `PUT /api/v1/auth/me`; real route is `PATCH /api/v1/users/account`).

### Net
This PR lands the `ApplicationPage` bug fix plus precise parked-spec diagnoses for whoever picks them up with a local stack. Green (no parked specs run). If you'd rather not carry it, it can be closed — the diagnoses are in `playwright.config.ts`.

Refs ADS-870.

🤖 Generated with [Claude Code](https://claude.com/claude-code)