### PR TITLE
docs(env): warn DEV_DB_NAME is required when NODE_ENV defaults to development

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -57,6 +57,10 @@ POSTGRES_DB=adopt_dont_shop_dev
 # Database Connection (Backend Service)
 # The backend selects ONE of DEV_DB_NAME / TEST_DB_NAME / PROD_DB_NAME based
 # on NODE_ENV. There is no generic DB_NAME variable (ADS-409/452/465).
+# ⚠️ NODE_ENV defaults to `development` when unset, so the dev stack reads
+# DEV_DB_NAME — fill that one in first. A blank DEV_DB_NAME (or filling only
+# PROD_DB_NAME) lets the DB container start healthy but services then fail to
+# connect. Always set the name matching your current NODE_ENV.
 DB_HOST=database
 DB_PORT=5432
 DB_USERNAME=${POSTGRES_USER}


### PR DESCRIPTION
`NODE_ENV` defaults to `development` when unset, so the dev stack reads `DEV_DB_NAME`. A blank `DEV_DB_NAME` (or filling only `PROD_DB_NAME`) lets the database container start healthy while services then fail to connect — a silent day-1 onboarding trap. Adds a concise warning in the `.env.example` database section.

Closes ADS-858

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QLtddqhQsBJ6wP1PcKJ9vf

---
_Generated by [Claude Code](https://claude.ai/code/session_01QLtddqhQsBJ6wP1PcKJ9vf)_