### PR TITLE
ci: route per-app lint through Turbo for caching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -186,8 +186,7 @@ jobs:
           name: lib-dist
 
       - name: Lint
-        run: pnpm lint
-        working-directory: apps/${{ matrix.app }}
+        run: pnpm exec turbo run lint --filter='@adopt-dont-shop/app.${{ matrix.app }}'
 
       - name: Test (with coverage thresholds)
         run: pnpm test:coverage


### PR DESCRIPTION
The `Lint` step in the `test-frontend` matrix job ran `pnpm lint` directly with a `working-directory`, bypassing Turbo's cache. This routes it through `pnpm exec turbo run lint --filter='@adopt-dont-shop/app.${{ matrix.app }}'`, mirroring the adjacent `type-check` step's exact filter form, and drops the now-redundant `working-directory`. No other steps in the job are touched. Validated: `ci.yml` parses as valid YAML; filter matches the real package names (`@adopt-dont-shop/app.{client,admin,rescue}`).

Closes ADS-859

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QLtddqhQsBJ6wP1PcKJ9vf

---
_Generated by [Claude Code](https://claude.ai/code/session_01QLtddqhQsBJ6wP1PcKJ9vf)_