### PR TITLE
docs(readme): note per-service schema ownership for db:migrate

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,8 @@ pnpm exec turbo build --filter=@adopt-dont-shop/app.admin
 pnpm exec turbo test --filter=@adopt-dont-shop/service.gateway
 ```
 
+> **Schema ownership.** Only the schema-owning services (auth, pets, rescue, applications, chat, notifications, moderation, matching, cms, audit) define and run a `db:migrate` script — each owns its own tables. The gateway owns no tables, so it has no `db:migrate` script; `docker compose exec service-gateway pnpm db:migrate` will fail with a missing-script error, which is expected. Skip it in any per-service migration loop.
+
 ## Hot Reload
 
 The Docker dev stack is configured for HMR on Windows/macOS/Linux:


### PR DESCRIPTION
Adds a one-line note near the existing per-service migration mention clarifying which services own schema. Only the 10 schema-owning services define a `db:migrate` script; the gateway owns no tables and has none, so `docker compose exec service-gateway pnpm db:migrate` fails with a missing-script error by design. Surfacing this stops contributors hitting an unexpected error and tells them to skip the gateway in per-service migration loops.

(The Makefile-deploy and self-hosted-Turbo-cache parts of the original ticket were already present in `main` and left untouched. No doc link was added: the only candidate, `docs/backend/database-schema.md`, still references the deleted `service.backend` monolith and would mislead — tracked separately under ADS-857.)

Closes ADS-862

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QLtddqhQsBJ6wP1PcKJ9vf

---
_Generated by [Claude Code](https://claude.ai/code/session_01QLtddqhQsBJ6wP1PcKJ9vf)_