### PR TITLE
fix(gateway): guard MAX_FILE_SIZE against NaN

### DIFF
--- a/services/gateway/src/config.test.ts
+++ b/services/gateway/src/config.test.ts
@@ -105,6 +105,28 @@ describe('loadConfig', () => {
   });
 });
 
+describe('loadConfig — storage max file size (ADS-850)', () => {
+  it('defaults to 10485760 bytes when MAX_FILE_SIZE is unset', () => {
+    const config = loadConfig({});
+    expect(config.storage.maxFileSize).toBe(10485760);
+  });
+
+  it('honours a valid numeric MAX_FILE_SIZE', () => {
+    const config = loadConfig({ MAX_FILE_SIZE: '20971520' });
+    expect(config.storage.maxFileSize).toBe(20971520);
+  });
+
+  it('falls back to the default for a non-numeric MAX_FILE_SIZE', () => {
+    const config = loadConfig({ MAX_FILE_SIZE: 'not-a-number' });
+    expect(config.storage.maxFileSize).toBe(10485760);
+  });
+
+  it('falls back to the default for a non-positive MAX_FILE_SIZE', () => {
+    expect(loadConfig({ MAX_FILE_SIZE: '0' }).storage.maxFileSize).toBe(10485760);
+    expect(loadConfig({ MAX_FILE_SIZE: '-1' }).storage.maxFileSize).toBe(10485760);
+  });
+});
+
 describe('loadConfig — principal signing key (ADS-800)', () => {
   const VALID_KEY = 'a-principal-signing-key-of-at-least-32-bytes';
 

--- a/services/gateway/src/config.ts
+++ b/services/gateway/src/config.ts
@@ -277,6 +277,8 @@ function isEnabled(raw: string | undefined): boolean {
 // fields are optional); `provider` selects which one drives uploads.
 function buildStorageConfig(env: NodeJS.ProcessEnv): GatewayConfig['storage'] {
   const provider: 'local' | 's3' = env.STORAGE_PROVIDER?.trim() === 's3' ? 's3' : 'local';
+  const maxFileSizeRaw = env.MAX_FILE_SIZE?.trim();
+  const maxFileSize = maxFileSizeRaw ? Number.parseInt(maxFileSizeRaw, 10) : 10485760;
   return {
     provider,
     local: {
@@ -291,8 +293,10 @@ function buildStorageConfig(env: NodeJS.ProcessEnv): GatewayConfig['storage'] {
       cloudFrontDomain: env.CLOUDFRONT_DOMAIN?.trim(),
     },
     // Multipart body limit — 10 MiB default. Override with MAX_FILE_SIZE
-    // if larger PDFs are expected.
-    maxFileSize: Number.parseInt(env.MAX_FILE_SIZE?.trim() || '10485760', 10),
+    // if larger PDFs are expected. A non-numeric / non-positive value falls
+    // back to the default rather than plumbing NaN into the body limit
+    // (mirrors buildRateLimitConfig).
+    maxFileSize: Number.isNaN(maxFileSize) || maxFileSize <= 0 ? 10485760 : maxFileSize,
     signingSecret: readOptionalSecret('UPLOAD_SIGNING_SECRET', env, 32),
   };
 }


### PR DESCRIPTION
A non-numeric `MAX_FILE_SIZE` was parsed straight into `@fastify/multipart`'s body limit, yielding `NaN`. Now mirrors `buildRateLimitConfig` just above it: parse, then fall back to the `10485760` (10 MiB) default when the result is `NaN` or non-positive. Adds tests covering the invalid, non-positive, valid, and unset cases.

Validated: `turbo run test type-check lint --filter=@adopt-dont-shop/service.gateway` → all green (config.test.ts: 33 tests incl. 4 new).

**Design note:** the Linear ticket's proposed solution suggested boot-fail (throw) on an invalid value; I went with the fall-back-to-default approach to match the existing `buildRateLimitConfig` pattern in the same file. Easy to switch to throw-on-invalid if you'd prefer fail-fast — happy to adjust.

Closes ADS-850

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QLtddqhQsBJ6wP1PcKJ9vf

---
_Generated by [Claude Code](https://claude.ai/code/session_01QLtddqhQsBJ6wP1PcKJ9vf)_