### PR TITLE
perf(gateway): make streamFile stat async to avoid blocking the event loop

### DIFF
--- a/services/gateway/src/routes/uploads.test.ts
+++ b/services/gateway/src/routes/uploads.test.ts
@@ -279,6 +279,17 @@ describe('GET /uploads-signed/:expiresAt/:signature/*', () => {
     expect(res.statusCode).toBe(404);
   });
 
+  it('returns 404 when the resolved path is a directory, not a file', async () => {
+    const expiresAt = Math.floor(Date.now() / 1000) + 60;
+    const filePath = 'pets';
+    const signature = computeUploadSignature(filePath, expiresAt, SECRET);
+    const res = await app.inject({
+      method: 'GET',
+      url: `/uploads-signed/${expiresAt}/${signature}/${filePath}`,
+    });
+    expect(res.statusCode).toBe(404);
+  });
+
   it('returns 503 when no signing secret is configured', async () => {
     await app.close();
     app = await buildApp(tmp, undefined);

--- a/services/gateway/src/routes/uploads.ts
+++ b/services/gateway/src/routes/uploads.ts
@@ -200,7 +200,7 @@ export const registerUploadsRoutes = async (
       if (resolved === null) {
         return reply.code(400).send({ error: 'Invalid file path' });
       }
-      return streamFile(resolved, reply);
+      return await streamFile(resolved, reply);
     }
   );
 };
@@ -297,10 +297,10 @@ async function tryRedirectToProvider(
   }
 }
 
-function streamFile(resolved: string, reply: FastifyReply): FastifyReply {
+async function streamFile(resolved: string, reply: FastifyReply): Promise<FastifyReply> {
   let stats: fs.Stats;
   try {
-    stats = fs.statSync(resolved);
+    stats = await fs.promises.stat(resolved);
   } catch {
     return reply.code(404).send({ error: 'File not found' });
   }


### PR DESCRIPTION
`streamFile` used synchronous `fs.statSync` inside the signed-serve HTTP handler, blocking the Node event loop for every other in-flight request on the replica. Switches to `await fs.promises.stat`, makes `streamFile` async, and `await`s it at the single call site. The 404-on-missing/non-file behaviour, response headers, and `createReadStream` pipe semantics are unchanged. Adds a test for the directory (non-file) 404 branch.

Validated: `turbo run test type-check lint --filter=@adopt-dont-shop/service.gateway` → all green (uploads.test.ts: 18 tests incl. 1 new).

Closes ADS-851

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QLtddqhQsBJ6wP1PcKJ9vf

---
_Generated by [Claude Code](https://claude.ai/code/session_01QLtddqhQsBJ6wP1PcKJ9vf)_