### PR TITLE
feat(testing): automated coverage-threshold ratchet

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -195,6 +195,37 @@ export default mergeConfig(shared, {
 });
 ```
 
+#### Automated ratchet (ADS-796)
+
+The shared-config baseline is raised automatically by a ratchet instead of being
+edited by hand. `scripts/ratchet-coverage.mjs` reads a v8 coverage summary
+(`coverage/coverage-summary.json`, emitted by the vitest `json-summary` reporter)
+and persists the new floor to `coverage-thresholds.json` at the repo root:
+
+```bash
+# raise the persisted baseline towards measured coverage (minus a 1% margin)
+pnpm run ratchet:coverage
+
+# preview without writing the file
+pnpm run ratchet:coverage -- --dry-run
+```
+
+The rule is one-directional and pure (unit-tested via `pnpm run test:scripts`):
+a threshold is **never lowered**, and is only raised when measured coverage
+clears the current floor by more than the safety margin. `vitest.shared.config.ts`
+reads `coverage-thresholds.json` when present and falls back to the historic 0%
+baseline when it is absent — so committing a populated file is what moves the
+floor off 0%.
+
+**Rollout:** the file is intentionally absent today (baseline stays 0%, CI
+unchanged). To switch it on, run coverage with the `json-summary` reporter, run
+`pnpm run ratchet:coverage`, and commit the generated `coverage-thresholds.json`.
+A scheduled/`main` CI job can then re-run the ratchet and open a follow-up PR.
+
+**Exemptions:** a package that cannot meet the shared floor sets a lower
+`thresholds` block in its own `vitest.config.ts` with a comment linking the
+tracking ticket. The override always wins over the shared baseline.
+
 ## Reporting bugs / proposing features
 
 Use the issue templates in [`.github/ISSUE_TEMPLATE/`](./.github/ISSUE_TEMPLATE/):

--- a/package.json
+++ b/package.json
@@ -59,6 +59,8 @@
     "check:env-example": "node scripts/check-env-example.mjs",
     "check:workflow-paths": "node scripts/check-workflow-paths.mjs",
     "check:docs-script-refs": "node scripts/check-docs-script-references.mjs",
+    "ratchet:coverage": "node scripts/ratchet-coverage.mjs",
+    "test:scripts": "vitest run --config vitest.scripts.config.ts",
     "tasks": "node scripts/generate-task-index.mjs --print",
     "tasks:write": "node scripts/generate-task-index.mjs",
     "hooks:enable": "touch .husky/.prepush-enabled && echo 'pre-push hook enabled (runs ci:local:quick on git push)'",

--- a/scripts/lib/ratchet-coverage-core.mjs
+++ b/scripts/lib/ratchet-coverage-core.mjs
@@ -1,0 +1,77 @@
+/**
+ * Pure coverage-ratchet logic (ADS-796).
+ *
+ * Kept free of any filesystem / process access so it can be unit-tested as a
+ * black box. The CLI wrapper in scripts/ratchet-coverage.mjs reads the v8
+ * `coverage-summary.json` and the persisted `coverage-thresholds.json`, calls
+ * the functions here, and writes the result back.
+ *
+ * The ratchet rule is intentionally one-directional:
+ *
+ *   - NEVER lower an existing threshold (coverage regressions stay blocked).
+ *   - Raise a threshold towards the freshly measured coverage, minus a small
+ *     safety margin, so day-to-day CI variance does not flip the build red.
+ *   - Only raise when the headroom (measured - current threshold) exceeds the
+ *     margin; otherwise leave the threshold untouched (no churn).
+ *
+ * All values are coverage percentages in the range [0, 100].
+ */
+
+export const COVERAGE_METRICS = ['statements', 'branches', 'functions', 'lines'];
+
+const DEFAULT_MARGIN = 1;
+
+/**
+ * Ratchet a single metric.
+ *
+ * @param {number} current  Existing persisted threshold (defaults to 0).
+ * @param {number} measured Freshly measured coverage percentage.
+ * @param {number} margin   Safety margin subtracted from `measured`.
+ * @returns {number} The new threshold — always >= current, never above the
+ *   measured value minus the margin (floored at 0).
+ */
+export function ratchetMetric(current, measured, margin = DEFAULT_MARGIN) {
+  const target = Math.max(0, Math.floor(measured - margin));
+  if (target <= current) {
+    return current;
+  }
+  return target;
+}
+
+/**
+ * Ratchet a full set of thresholds against a measured-coverage summary.
+ *
+ * @param {Record<string, number>} current  Existing thresholds (missing
+ *   metrics are treated as 0).
+ * @param {Record<string, number>} measured Measured coverage percentages.
+ * @param {number} margin Safety margin.
+ * @returns {Record<string, number>} A new thresholds object (input is not
+ *   mutated). Metrics absent from `measured` keep their current value.
+ */
+export function ratchetThresholds(current, measured, margin = DEFAULT_MARGIN) {
+  return COVERAGE_METRICS.reduce((acc, metric) => {
+    const currentValue = current[metric] ?? 0;
+    const measuredValue = measured[metric];
+    if (typeof measuredValue !== 'number' || Number.isNaN(measuredValue)) {
+      return { ...acc, [metric]: currentValue };
+    }
+    return { ...acc, [metric]: ratchetMetric(currentValue, measuredValue, margin) };
+  }, {});
+}
+
+/**
+ * Extract the percentage-per-metric map from a v8/istanbul
+ * `coverage-summary.json` `total` block (`{ lines: { pct }, ... }`).
+ *
+ * @param {Record<string, { pct?: number }>} total
+ * @returns {Record<string, number>}
+ */
+export function measuredFromSummaryTotal(total) {
+  return COVERAGE_METRICS.reduce((acc, metric) => {
+    const pct = total?.[metric]?.pct;
+    if (typeof pct !== 'number') {
+      return acc;
+    }
+    return { ...acc, [metric]: pct };
+  }, {});
+}

--- a/scripts/lib/ratchet-coverage-core.test.mjs
+++ b/scripts/lib/ratchet-coverage-core.test.mjs
@@ -1,0 +1,100 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  measuredFromSummaryTotal,
+  ratchetMetric,
+  ratchetThresholds,
+} from './ratchet-coverage-core.mjs';
+
+describe('ratchetMetric', () => {
+  it('raises the threshold towards measured coverage minus the safety margin', () => {
+    expect(ratchetMetric(0, 95.87)).toBe(94);
+  });
+
+  it('never lowers an existing threshold when coverage regresses', () => {
+    expect(ratchetMetric(90, 70)).toBe(90);
+  });
+
+  it('leaves the threshold unchanged when headroom is within the margin', () => {
+    // measured 90.4, margin 1 -> target 89, which is below the current 90.
+    expect(ratchetMetric(90, 90.4)).toBe(90);
+  });
+
+  it('floors the new threshold at 0 for tiny coverage', () => {
+    expect(ratchetMetric(0, 0.5)).toBe(0);
+  });
+
+  it('honours a custom margin', () => {
+    expect(ratchetMetric(0, 95.87, 5)).toBe(90);
+  });
+});
+
+describe('ratchetThresholds', () => {
+  it('ratchets every metric independently and never lowers any', () => {
+    const current = { statements: 80, branches: 95, functions: 50, lines: 80 };
+    const measured = { statements: 95.5, branches: 60, functions: 100, lines: 95.5 };
+
+    expect(ratchetThresholds(current, measured)).toEqual({
+      statements: 94,
+      branches: 95, // measured regressed — kept
+      functions: 99,
+      lines: 94,
+    });
+  });
+
+  it('treats missing current metrics as a 0 floor', () => {
+    const measured = { statements: 88.66, branches: 80.76, functions: 98.41, lines: 88.43 };
+
+    expect(ratchetThresholds({}, measured)).toEqual({
+      statements: 87,
+      branches: 79,
+      functions: 97,
+      lines: 87,
+    });
+  });
+
+  it('keeps the current value for a metric absent from the measurement', () => {
+    const current = { statements: 50, branches: 50, functions: 50, lines: 50 };
+    const measured = { statements: 90 };
+
+    expect(ratchetThresholds(current, measured)).toEqual({
+      statements: 89,
+      branches: 50,
+      functions: 50,
+      lines: 50,
+    });
+  });
+
+  it('does not mutate the inputs', () => {
+    const current = { statements: 10, branches: 10, functions: 10, lines: 10 };
+    const measured = { statements: 90, branches: 90, functions: 90, lines: 90 };
+
+    ratchetThresholds(current, measured);
+
+    expect(current).toEqual({ statements: 10, branches: 10, functions: 10, lines: 10 });
+  });
+});
+
+describe('measuredFromSummaryTotal', () => {
+  it('extracts the pct of each metric from a v8 coverage-summary total block', () => {
+    const total = {
+      lines: { total: 100, covered: 96, pct: 96 },
+      statements: { total: 100, covered: 95, pct: 95 },
+      functions: { total: 10, covered: 10, pct: 100 },
+      branches: { total: 20, covered: 18, pct: 90 },
+    };
+
+    expect(measuredFromSummaryTotal(total)).toEqual({
+      lines: 96,
+      statements: 95,
+      functions: 100,
+      branches: 90,
+    });
+  });
+
+  it('omits metrics whose pct is absent', () => {
+    const total = { lines: { pct: 80 }, statements: {} };
+
+    expect(measuredFromSummaryTotal(total)).toEqual({ lines: 80 });
+  });
+});

--- a/scripts/ratchet-coverage.mjs
+++ b/scripts/ratchet-coverage.mjs
@@ -1,0 +1,96 @@
+#!/usr/bin/env node
+/**
+ * Coverage threshold ratchet (ADS-796 / ADS-717).
+ *
+ * Reads a v8 `coverage-summary.json` (emit it with the vitest `json-summary`
+ * reporter) and a persisted `coverage-thresholds.json`, raises each persisted
+ * threshold towards the freshly measured coverage (minus a safety margin), and
+ * writes the updated thresholds back. Thresholds are NEVER lowered, so a
+ * coverage regression keeps CI red.
+ *
+ * `vitest.shared.config.ts` reads `coverage-thresholds.json` when it exists and
+ * falls back to the legacy 0% baseline when it does not — so adding this file
+ * is what actually moves enforcement off 0%. See docs/testing.md for rollout.
+ *
+ * Usage:
+ *   node scripts/ratchet-coverage.mjs [options]
+ *
+ * Options:
+ *   --summary <path>     Coverage summary JSON (default: coverage/coverage-summary.json)
+ *   --thresholds <path>  Persisted thresholds JSON (default: coverage-thresholds.json)
+ *   --margin <number>    Safety margin subtracted from measured % (default: 1)
+ *   --dry-run            Print the result without writing the thresholds file
+ */
+import { readFileSync, writeFileSync, existsSync } from 'fs';
+import { dirname, join, resolve } from 'path';
+import { fileURLToPath } from 'url';
+
+import { measuredFromSummaryTotal, ratchetThresholds } from './lib/ratchet-coverage-core.mjs';
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+
+function parseArgs(argv) {
+  const args = { dryRun: false, margin: 1 };
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === '--dry-run') {
+      args.dryRun = true;
+      continue;
+    }
+    if (arg === '--summary') {
+      args.summary = argv[(i += 1)];
+      continue;
+    }
+    if (arg === '--thresholds') {
+      args.thresholds = argv[(i += 1)];
+      continue;
+    }
+    if (arg === '--margin') {
+      args.margin = Number(argv[(i += 1)]);
+      continue;
+    }
+  }
+  return args;
+}
+
+function readJson(path) {
+  return JSON.parse(readFileSync(path, 'utf8'));
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const summaryPath = resolve(ROOT, args.summary ?? 'coverage/coverage-summary.json');
+  const thresholdsPath = resolve(ROOT, args.thresholds ?? 'coverage-thresholds.json');
+
+  if (!existsSync(summaryPath)) {
+    console.error(`No coverage summary found at ${summaryPath}.`);
+    console.error('Run coverage with the vitest "json-summary" reporter first.');
+    process.exit(1);
+  }
+
+  const summary = readJson(summaryPath);
+  const measured = measuredFromSummaryTotal(summary.total ?? {});
+  const current = existsSync(thresholdsPath) ? readJson(thresholdsPath) : {};
+
+  const next = ratchetThresholds(current, measured, args.margin);
+
+  const changed = JSON.stringify(current) !== JSON.stringify(next);
+  console.log('Coverage ratchet:');
+  console.log(`  measured:  ${JSON.stringify(measured)}`);
+  console.log(`  thresholds: ${JSON.stringify(next)}`);
+
+  if (!changed) {
+    console.log('No change — thresholds already at or above measured coverage.');
+    return;
+  }
+
+  if (args.dryRun) {
+    console.log('(dry run — not written)');
+    return;
+  }
+
+  writeFileSync(thresholdsPath, `${JSON.stringify(next, null, 2)}\n`);
+  console.log(`Wrote ${thresholdsPath}`);
+}
+
+main();

--- a/vitest.scripts.config.ts
+++ b/vitest.scripts.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from 'vitest/config';
+
+/**
+ * ADS-796: Vitest config for the repo-root maintenance scripts in scripts/.
+ * These are plain Node ESM utilities (e.g. the coverage ratchet) that live
+ * outside the workspace packages, so they need their own node-environment
+ * project rather than the jsdom-based shared config. Run with
+ * `pnpm test:scripts`.
+ */
+export default defineConfig({
+  test: {
+    name: 'scripts',
+    environment: 'node',
+    include: ['scripts/**/*.test.mjs'],
+  },
+});

--- a/vitest.shared.config.ts
+++ b/vitest.shared.config.ts
@@ -1,5 +1,62 @@
-import { basename } from 'path';
+import { existsSync, readFileSync } from 'fs';
+import { basename, dirname, join } from 'path';
+import { fileURLToPath } from 'url';
 import { defineConfig, mergeConfig, type UserConfig } from 'vitest/config';
+
+type CoverageThresholds = {
+  statements: number;
+  branches: number;
+  functions: number;
+  lines: number;
+};
+
+const ZERO_THRESHOLDS: CoverageThresholds = {
+  statements: 0,
+  branches: 0,
+  functions: 0,
+  lines: 0,
+};
+
+const COVERAGE_METRICS: ReadonlyArray<keyof CoverageThresholds> = [
+  'statements',
+  'branches',
+  'functions',
+  'lines',
+];
+
+/**
+ * ADS-796: read the persisted, automatically-ratcheted thresholds written by
+ * `scripts/ratchet-coverage.mjs` to `coverage-thresholds.json` at the repo
+ * root. When the file is absent (or unreadable) we fall back to the historic
+ * 0% baseline so existing CI is never broken by this wiring alone — moving the
+ * floor off 0% is the deliberate act of running the ratchet and committing the
+ * file. Individual packages still override these in their own vitest.config.ts.
+ */
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function loadBaselineThresholds(): CoverageThresholds {
+  const repoRoot = dirname(fileURLToPath(import.meta.url));
+  const path = join(repoRoot, 'coverage-thresholds.json');
+  if (!existsSync(path)) {
+    return ZERO_THRESHOLDS;
+  }
+  try {
+    const parsed: unknown = JSON.parse(readFileSync(path, 'utf8'));
+    if (!isRecord(parsed)) {
+      return ZERO_THRESHOLDS;
+    }
+    return COVERAGE_METRICS.reduce<CoverageThresholds>((acc, metric) => {
+      const value = parsed[metric];
+      return { ...acc, [metric]: typeof value === 'number' ? value : 0 };
+    }, ZERO_THRESHOLDS);
+  } catch {
+    return ZERO_THRESHOLDS;
+  }
+}
+
+const baselineThresholds = loadBaselineThresholds();
 
 /**
  * Shared Vitest configuration for all lib.* packages.
@@ -33,15 +90,17 @@ const sharedConfig = defineConfig({
         'src/**/*.spec.tsx',
         'src/index.ts',
       ],
-      // ADS-708: baseline coverage thresholds. Starts at 0% so today's PRs
-      // are not blocked — infrastructure is now in place for per-package
-      // ratcheting (ADS-717). Individual packages may override these in
-      // their own vitest.config.ts by setting test.coverage.thresholds.
+      // ADS-708 / ADS-796: baseline coverage thresholds. Defaults to 0% (so
+      // today's PRs are not blocked) and is raised automatically by the
+      // ratchet — `scripts/ratchet-coverage.mjs` persists the floor to
+      // `coverage-thresholds.json`, read above by loadBaselineThresholds().
+      // Individual packages may still override these in their own
+      // vitest.config.ts by setting test.coverage.thresholds.
       thresholds: {
-        statements: 0,
-        branches: 0,
-        functions: 0,
-        lines: 0,
+        statements: baselineThresholds.statements,
+        branches: baselineThresholds.branches,
+        functions: baselineThresholds.functions,
+        lines: baselineThresholds.lines,
         autoUpdate: false,
       },
     },


### PR DESCRIPTION
Adds the missing coverage-ratchet tooling so thresholds can move off 0% without hand-editing configs. A pure, unit-tested "never-lower / raise-to-current-minus-margin" function backs a CLI (`scripts/ratchet-coverage.mjs`) that reads a v8 `coverage-summary.json` and persists the floor to `coverage-thresholds.json`. `vitest.shared.config.ts` now reads that file when present and falls back to the historic 0% baseline when absent, so CI is unchanged until the file is committed during rollout. Ships `ratchet:coverage` + `test:scripts` scripts and documents the policy/rollout/exemption process in CONTRIBUTING.

Validated: new pure-ratchet unit tests (11 tests) pass; CLI dry-run/write/idempotent/regression all behave; `lib.validation`/`lib.utils`/`lib.api` suites still pass; Prettier clean on touched files.

**Scope note:** mechanism + tests + wiring + docs only. It deliberately does **not** commit a populated `coverage-thresholds.json`, so the enforced baseline stays at 0% and CI behaviour is identical to today. Repo-wide rollout (running the ratchet on real coverage, the scheduled `main` job that opens a `chore(coverage): ratchet thresholds` PR, and deciding whether `services/*`/`packages/*` join) is left as follow-up. Notably, all `lib.*` packages and the 3 apps already carry hand-set non-zero thresholds — the gap this fills is the missing automation, not the numbers.

⚠️ Touches `CONTRIBUTING.md`, which #1107 (ADS-861) also edits — expect a trivial merge order between the two.

Closes ADS-796

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QLtddqhQsBJ6wP1PcKJ9vf

---
_Generated by [Claude Code](https://claude.ai/code/session_01QLtddqhQsBJ6wP1PcKJ9vf)_