### PR TITLE
fix: evict expired buckets from in-memory email rate limiter

### DIFF
--- a/services/gateway/src/routes/email-rate-limiter.test.ts
+++ b/services/gateway/src/routes/email-rate-limiter.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest';
 
-import { createEmailRateLimiter, normalizeEmail } from './email-rate-limiter.js';
+import {
+  createEmailRateLimiter,
+  MEMORY_LIMITER_MAX_BUCKETS,
+  normalizeEmail,
+} from './email-rate-limiter.js';
 
 describe('normalizeEmail', () => {
   it('lower-cases and trims so casing / whitespace cannot dodge the cap', () => {
@@ -43,6 +47,52 @@ describe('createEmailRateLimiter (in-memory)', () => {
 
     now += 1_001; // window elapsed
     expect(await limiter.consume('a@example.com')).toBe(true);
+  });
+
+  it('evicts expired buckets so resident size does not grow with unique emails', async () => {
+    let now = 1_000_000;
+    const limiter = createEmailRateLimiter({ max: 5, windowMs: 1_000, now: () => now });
+
+    // First window: seed a batch of one-shot emails.
+    for (let i = 0; i < 100; i += 1) {
+      await limiter.consume(`first-${i}@example.com`);
+    }
+
+    now += 1_001; // every first-window bucket is now expired
+
+    // Second window: a fresh batch. The expired buckets must be reclaimed,
+    // not accumulated on top of the new ones.
+    for (let i = 0; i < 100; i += 1) {
+      await limiter.consume(`second-${i}@example.com`);
+    }
+
+    expect(limiter.size?.()).toBeLessThanOrEqual(101);
+  });
+
+  it('stays bounded under a flood of unique emails within a single window', async () => {
+    const limiter = createEmailRateLimiter({ max: 5, windowMs: 60_000 });
+
+    for (let i = 0; i < MEMORY_LIMITER_MAX_BUCKETS * 3; i += 1) {
+      await limiter.consume(`flood-${i}@example.com`);
+    }
+
+    expect(limiter.size?.()).toBeLessThanOrEqual(MEMORY_LIMITER_MAX_BUCKETS);
+  });
+
+  it('keeps throttling a repeatedly-hit email while other live emails churn below the cap', async () => {
+    const limiter = createEmailRateLimiter({ max: 3, windowMs: 60_000 });
+
+    expect(await limiter.consume('victim@example.com')).toBe(true);
+    expect(await limiter.consume('victim@example.com')).toBe(true);
+    expect(await limiter.consume('victim@example.com')).toBe(true);
+
+    // Interleave other live emails, staying well under the cap.
+    for (let i = 0; i < 50; i += 1) {
+      await limiter.consume(`noise-${i}@example.com`);
+    }
+
+    // The victim's 4th attempt is still throttled — its bucket survived.
+    expect(await limiter.consume('victim@example.com')).toBe(false);
   });
 });
 

--- a/services/gateway/src/routes/email-rate-limiter.ts
+++ b/services/gateway/src/routes/email-rate-limiter.ts
@@ -31,9 +31,22 @@ export type EmailRateLimiterOptions = {
 export type EmailRateLimiter = {
   // Returns true when the attempt is within the cap, false when throttled.
   consume: (email: string) => Promise<boolean>;
+  // Current resident bucket count. Only the in-memory limiter tracks state
+  // locally; the Redis-backed limiter keeps none, so it omits this.
+  size?: () => number;
 };
 
 const KEY_PREFIX = 'auth-email-rl';
+
+// Hard ceiling on the in-memory limiter's bucket map. The opportunistic sweep
+// reclaims expired buckets across windows (the real attack vector — a flood of
+// unique one-shot emails), but a single-window flood of unique emails has no
+// expired entries to reclaim, so this cap bounds the resident set regardless.
+export const MEMORY_LIMITER_MAX_BUCKETS = 10_000;
+
+// Run the expired-bucket sweep once per this many new buckets. Amortizes the
+// O(n) scan so steady traffic reclaims memory long before the hard cap.
+const SWEEP_EVERY_N_INSERTS = 64;
 
 // Normalize an email so casing / whitespace variants share one bucket. Returns
 // undefined when the value isn't a usable email-ish string.
@@ -81,16 +94,50 @@ const redisLimiter = (
 
 const memoryLimiter = (max: number, windowMs: number, now: () => number): EmailRateLimiter => {
   const buckets = new Map<string, { count: number; resetAt: number }>();
+  let insertsSinceSweep = 0;
+
+  // Drop every bucket whose window has elapsed. Reclaims one-shot emails that
+  // would otherwise linger for the rest of the process lifetime.
+  const sweepExpired = (ts: number): void => {
+    for (const [email, bucket] of buckets) {
+      if (ts >= bucket.resetAt) {
+        buckets.delete(email);
+      }
+    }
+  };
+
+  // Map iteration is insertion-ordered, so the first key is the oldest seen.
+  // Used as a last-resort ceiling when a single-window flood leaves nothing to
+  // sweep — bounded eviction beats unbounded growth.
+  const evictOldest = (): void => {
+    const oldest = buckets.keys().next();
+    if (!oldest.done) {
+      buckets.delete(oldest.value);
+    }
+  };
+
   return {
     consume: (email: string): Promise<boolean> => {
       const ts = now();
       const existing = buckets.get(email);
       if (!existing || ts >= existing.resetAt) {
+        insertsSinceSweep += 1;
+        if (
+          insertsSinceSweep >= SWEEP_EVERY_N_INSERTS ||
+          buckets.size >= MEMORY_LIMITER_MAX_BUCKETS
+        ) {
+          sweepExpired(ts);
+          insertsSinceSweep = 0;
+        }
+        while (buckets.size >= MEMORY_LIMITER_MAX_BUCKETS) {
+          evictOldest();
+        }
         buckets.set(email, { count: 1, resetAt: ts + windowMs });
         return Promise.resolve(true);
       }
       existing.count += 1;
       return Promise.resolve(existing.count <= max);
     },
+    size: (): number => buckets.size,
   };
 };

--- a/services/gateway/src/routes/email-rate-limiter.ts
+++ b/services/gateway/src/routes/email-rate-limiter.ts
@@ -122,13 +122,14 @@ const memoryLimiter = (max: number, windowMs: number, now: () => number): EmailR
       const existing = buckets.get(email);
       if (!existing || ts >= existing.resetAt) {
         insertsSinceSweep += 1;
-        if (
-          insertsSinceSweep >= SWEEP_EVERY_N_INSERTS ||
-          buckets.size >= MEMORY_LIMITER_MAX_BUCKETS
-        ) {
+        if (insertsSinceSweep >= SWEEP_EVERY_N_INSERTS) {
           sweepExpired(ts);
           insertsSinceSweep = 0;
         }
+        // Hard ceiling: O(1) per eviction. Don't sweep here — at capacity that
+        // would run a full O(n) scan on every insert during a single-window
+        // flood (nothing is expired to reclaim), the amortized sweep above
+        // already reclaims cross-window buckets.
         while (buckets.size >= MEMORY_LIMITER_MAX_BUCKETS) {
           evictOldest();
         }


### PR DESCRIPTION
The in-memory fallback limiter's bucket Map only reclaimed an email's entry when that same email was re-seen, so a one-shot email lingered for the process lifetime — unbounded growth under an enumeration / reset-spam flood in single-replica deploys. Adds an amortized expired-bucket sweep (every Nth new bucket) plus a hard `MEMORY_LIMITER_MAX_BUCKETS` ceiling that evicts the oldest entry when a single-window flood leaves nothing to reclaim. Throttling for a repeatedly-hit email is unchanged; the Redis-backed limiter is untouched. Adds adversarial tests driving many unique emails through `consume` and asserting resident size stays bounded.

Validated: `turbo run test type-check lint --filter=@adopt-dont-shop/service.gateway` → all green (712 tests).

Note: the ticket's preferred `lru-cache` option was rejected because it isn't a gateway dependency (would break `pnpm install --frozen-lockfile`); used the zero-dependency sweep + hard cap instead, which meets all acceptance criteria.

Closes ADS-852

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QLtddqhQsBJ6wP1PcKJ9vf

---
_Generated by [Claude Code](https://claude.ai/code/session_01QLtddqhQsBJ6wP1PcKJ9vf)_