### PR TITLE
refactor: replace unsafe req.body casts in gateway auth routes with typed parsing

### DIFF
--- a/services/gateway/src/routes/auth.test.ts
+++ b/services/gateway/src/routes/auth.test.ts
@@ -548,6 +548,185 @@ describe('auth account-lifecycle routes', () => {
   });
 });
 
+describe('auth account-lifecycle input validation (ADS-853)', () => {
+  it('POST /auth/register defaults missing fields without invoking the client unsafely', async () => {
+    const m = makeClient();
+    const app = await makeApp(m.client);
+    try {
+      m.registerMock.mockResolvedValueOnce({ permissions: [] });
+      // Only email + password supplied — the rest must default exactly as before.
+      await app.inject({
+        method: 'POST',
+        url: '/api/v1/auth/register',
+        payload: { email: 'a@example.com', password: 'longenoughpw' },
+      });
+      expect(m.registerMock.mock.calls[0][0]).toMatchObject({
+        email: 'a@example.com',
+        password: 'longenoughpw',
+        firstName: '',
+        lastName: '',
+        termsAccepted: false,
+        privacyPolicyAccepted: false,
+      });
+      expect(m.registerMock.mock.calls[0][0].phoneNumber).toBeUndefined();
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('POST /auth/register rejects a non-string string field with 400, not a downstream call', async () => {
+    const m = makeClient();
+    const app = await makeApp(m.client);
+    try {
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/v1/auth/register',
+        payload: { email: 123, password: 'longenoughpw' },
+      });
+      expect(res.statusCode).toBe(400);
+      expect(m.registerMock).not.toHaveBeenCalled();
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('POST /auth/register rejects a non-boolean terms flag with 400', async () => {
+    const m = makeClient();
+    const app = await makeApp(m.client);
+    try {
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/v1/auth/register',
+        payload: { email: 'a@example.com', password: 'pw', termsAccepted: 'yes' },
+      });
+      expect(res.statusCode).toBe(400);
+      expect(m.registerMock).not.toHaveBeenCalled();
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('POST /auth/verify-email rejects a non-string token with 400', async () => {
+    const m = makeClient();
+    const app = await makeApp(m.client);
+    try {
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/v1/auth/verify-email',
+        payload: { verificationToken: 42 },
+      });
+      expect(res.statusCode).toBe(400);
+      expect(m.verifyEmailMock).not.toHaveBeenCalled();
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('POST /auth/resend-verification rejects a non-string email with 400', async () => {
+    const m = makeClient();
+    const app = await makeApp(m.client);
+    try {
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/v1/auth/resend-verification',
+        payload: { email: false },
+      });
+      expect(res.statusCode).toBe(400);
+      expect(m.resendVerificationMock).not.toHaveBeenCalled();
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('POST /auth/forgot-password rejects a non-string email with 400', async () => {
+    const m = makeClient();
+    const app = await makeApp(m.client);
+    try {
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/v1/auth/forgot-password',
+        payload: { email: { nested: true } },
+      });
+      expect(res.statusCode).toBe(400);
+      expect(m.forgotPasswordMock).not.toHaveBeenCalled();
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('POST /auth/reset-password rejects a non-string new password with 400', async () => {
+    const m = makeClient();
+    const app = await makeApp(m.client);
+    try {
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/v1/auth/reset-password',
+        payload: { resetToken: 't', newPassword: 999 },
+      });
+      expect(res.statusCode).toBe(400);
+      expect(m.resetPasswordMock).not.toHaveBeenCalled();
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('POST /auth/change-password rejects a non-string field with 400', async () => {
+    const m = makeClient();
+    const app = await makeApp(m.client);
+    try {
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/v1/auth/change-password',
+        payload: { currentPassword: 'old', newPassword: [] },
+      });
+      expect(res.statusCode).toBe(400);
+      expect(m.changePasswordMock).not.toHaveBeenCalled();
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('PATCH /users/account rejects a non-string field with 400', async () => {
+    const m = makeClient();
+    const app = await makeApp(m.client);
+    try {
+      const res = await app.inject({
+        method: 'PATCH',
+        url: '/api/v1/users/account',
+        payload: { firstName: 7 },
+      });
+      expect(res.statusCode).toBe(400);
+      expect(m.updateAccountMock).not.toHaveBeenCalled();
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('falls through camelCase to snake_case only when the camel key is absent', async () => {
+    const m = makeClient();
+    const app = await makeApp(m.client);
+    try {
+      m.registerMock.mockResolvedValueOnce({ permissions: [] });
+      await app.inject({
+        method: 'POST',
+        url: '/api/v1/auth/register',
+        payload: {
+          email: 'a@example.com',
+          password: 'pw',
+          first_name: 'SnakeFirst',
+          lastName: 'CamelLast',
+        },
+      });
+      expect(m.registerMock.mock.calls[0][0]).toMatchObject({
+        firstName: 'SnakeFirst',
+        lastName: 'CamelLast',
+      });
+    } finally {
+      await app.close();
+    }
+  });
+});
+
 describe('auth rate limiting (ADS-844)', () => {
   it('throttles a per-EMAIL flood spread across many IPs', async () => {
     const m = makeClient();

--- a/services/gateway/src/routes/auth.ts
+++ b/services/gateway/src/routes/auth.ts
@@ -271,28 +271,28 @@ export const registerAuthRoutes = async (
       try {
         const res = await client.register(
           {
-            email: (b.email as string) ?? '',
-            password: (b.password as string) ?? '',
-            firstName: (b.firstName as string) ?? (b.first_name as string) ?? '',
-            lastName: (b.lastName as string) ?? (b.last_name as string) ?? '',
-            phoneNumber: (b.phoneNumber as string) ?? (b.phone_number as string),
+            email: pickString(b, ['email'], ''),
+            password: pickString(b, ['password'], ''),
+            firstName: pickString(b, ['firstName', 'first_name'], ''),
+            lastName: pickString(b, ['lastName', 'last_name'], ''),
+            phoneNumber: pickString(b, ['phoneNumber', 'phone_number']),
             ipAddress: req.ip,
             userAgent: req.headers['user-agent'],
-            termsAccepted:
-              (b.termsAccepted as boolean) ??
-              (b.terms_accepted as boolean) ??
-              (b.acceptedTerms as boolean) ??
-              false,
-            privacyPolicyAccepted:
-              (b.privacyPolicyAccepted as boolean) ??
-              (b.privacy_policy_accepted as boolean) ??
-              false,
+            termsAccepted: pickBool(b, ['termsAccepted', 'terms_accepted', 'acceptedTerms'], false),
+            privacyPolicyAccepted: pickBool(
+              b,
+              ['privacyPolicyAccepted', 'privacy_policy_accepted'],
+              false
+            ),
           },
           buildMetadata(req)
         );
         const json = AuthV1.RegisterResponse.toJSON(res) as Record<string, unknown>;
         return reply.code(201).send(withApiUser(json, res.user));
       } catch (err) {
+        if (err instanceof BadRequestError) {
+          return reply.code(400).send({ error: err.message });
+        }
         return handleGrpcError(err, reply);
       }
     }
@@ -306,14 +306,16 @@ export const registerAuthRoutes = async (
       try {
         const res = await client.verifyEmail(
           {
-            verificationToken:
-              (b.verificationToken as string) ?? (b.verification_token as string) ?? '',
+            verificationToken: pickString(b, ['verificationToken', 'verification_token'], ''),
           },
           buildMetadata(req)
         );
         const json = AuthV1.VerifyEmailResponse.toJSON(res) as Record<string, unknown>;
         return reply.send(withApiUser(json, res.user));
       } catch (err) {
+        if (err instanceof BadRequestError) {
+          return reply.code(400).send({ error: err.message });
+        }
         return handleGrpcError(err, reply);
       }
     }
@@ -329,11 +331,14 @@ export const registerAuthRoutes = async (
       const b = (req.body ?? {}) as Record<string, unknown>;
       try {
         const res = await client.resendVerification(
-          { email: (b.email as string) ?? '' },
+          { email: pickString(b, ['email'], '') },
           buildMetadata(req)
         );
         return reply.send(AuthV1.ResendVerificationResponse.toJSON(res));
       } catch (err) {
+        if (err instanceof BadRequestError) {
+          return reply.code(400).send({ error: err.message });
+        }
         return handleGrpcError(err, reply);
       }
     }
@@ -349,11 +354,14 @@ export const registerAuthRoutes = async (
       const b = (req.body ?? {}) as Record<string, unknown>;
       try {
         const res = await client.forgotPassword(
-          { email: (b.email as string) ?? '' },
+          { email: pickString(b, ['email'], '') },
           buildMetadata(req)
         );
         return reply.send(AuthV1.ForgotPasswordResponse.toJSON(res));
       } catch (err) {
+        if (err instanceof BadRequestError) {
+          return reply.code(400).send({ error: err.message });
+        }
         return handleGrpcError(err, reply);
       }
     }
@@ -372,13 +380,16 @@ export const registerAuthRoutes = async (
       try {
         const res = await client.resetPassword(
           {
-            resetToken: (b.resetToken as string) ?? (b.reset_token as string) ?? '',
-            newPassword: (b.newPassword as string) ?? (b.new_password as string) ?? '',
+            resetToken: pickString(b, ['resetToken', 'reset_token'], ''),
+            newPassword: pickString(b, ['newPassword', 'new_password'], ''),
           },
           buildMetadata(req)
         );
         return reply.send(AuthV1.ResetPasswordResponse.toJSON(res));
       } catch (err) {
+        if (err instanceof BadRequestError) {
+          return reply.code(400).send({ error: err.message });
+        }
         return handleGrpcError(err, reply);
       }
     }
@@ -392,13 +403,16 @@ export const registerAuthRoutes = async (
       try {
         const res = await client.changePassword(
           {
-            currentPassword: (b.currentPassword as string) ?? (b.current_password as string) ?? '',
-            newPassword: (b.newPassword as string) ?? (b.new_password as string) ?? '',
+            currentPassword: pickString(b, ['currentPassword', 'current_password'], ''),
+            newPassword: pickString(b, ['newPassword', 'new_password'], ''),
           },
           buildMetadata(req)
         );
         return reply.send(AuthV1.ChangePasswordResponse.toJSON(res));
       } catch (err) {
+        if (err instanceof BadRequestError) {
+          return reply.code(400).send({ error: err.message });
+        }
         return handleGrpcError(err, reply);
       }
     }
@@ -457,30 +471,29 @@ export const registerAuthRoutes = async (
     { config: { rateLimit: AUTH_RATE_LIMITS.updateAccount } },
     async (req, reply) => {
       const b = (req.body ?? {}) as Record<string, unknown>;
-      const str = (k1: string, k2?: string): string | undefined => {
-        const v = (b[k1] ?? (k2 ? b[k2] : undefined)) as unknown;
-        return typeof v === 'string' ? v : undefined;
-      };
       try {
         const res = await client.updateAccount(
           {
-            firstName: str('firstName', 'first_name'),
-            lastName: str('lastName', 'last_name'),
-            phoneNumber: str('phoneNumber', 'phone_number'),
-            bio: str('bio'),
-            timezone: str('timezone'),
-            language: str('language'),
-            country: str('country'),
-            city: str('city'),
-            addressLine1: str('addressLine1', 'address_line_1'),
-            addressLine2: str('addressLine2', 'address_line_2'),
-            postalCode: str('postalCode', 'postal_code'),
+            firstName: pickString(b, ['firstName', 'first_name']),
+            lastName: pickString(b, ['lastName', 'last_name']),
+            phoneNumber: pickString(b, ['phoneNumber', 'phone_number']),
+            bio: pickString(b, ['bio']),
+            timezone: pickString(b, ['timezone']),
+            language: pickString(b, ['language']),
+            country: pickString(b, ['country']),
+            city: pickString(b, ['city']),
+            addressLine1: pickString(b, ['addressLine1', 'address_line_1']),
+            addressLine2: pickString(b, ['addressLine2', 'address_line_2']),
+            postalCode: pickString(b, ['postalCode', 'postal_code']),
           },
           buildMetadata(req)
         );
         const json = AuthV1.UpdateAccountResponse.toJSON(res) as Record<string, unknown>;
         return reply.send(withApiUser(json, res.user));
       } catch (err) {
+        if (err instanceof BadRequestError) {
+          return reply.code(400).send({ error: err.message });
+        }
         return handleGrpcError(err, reply);
       }
     }
@@ -503,6 +516,59 @@ export const registerAuthRoutes = async (
 };
 
 // --- Helpers ---------------------------------------------------------
+
+// Thrown by the body parsers below when a present field carries the wrong
+// type. Caught per-handler and mapped to a 400 — a non-string smuggled into a
+// string proto field is a client error, not a downstream INTERNAL.
+class BadRequestError extends Error {}
+
+const isPresent = (v: unknown): boolean => v !== undefined && v !== null;
+
+// Resolve a string from the first present key (camelCase preferred, then any
+// aliases), preserving the `firstName ?? first_name ?? fallback` semantics. A
+// present-but-non-string value is rejected rather than silently forwarded.
+function pickString(
+  body: Record<string, unknown>,
+  keys: readonly string[],
+  fallback: string
+): string;
+function pickString(body: Record<string, unknown>, keys: readonly string[]): string | undefined;
+function pickString(
+  body: Record<string, unknown>,
+  keys: readonly string[],
+  fallback?: string
+): string | undefined {
+  for (const key of keys) {
+    const value = body[key];
+    if (!isPresent(value)) {
+      continue;
+    }
+    if (typeof value !== 'string') {
+      throw new BadRequestError(`${key} must be a string`);
+    }
+    return value;
+  }
+  return fallback;
+}
+
+// Boolean counterpart to pickString, preserving the `?? ?? false` chains.
+function pickBool(
+  body: Record<string, unknown>,
+  keys: readonly string[],
+  fallback: boolean
+): boolean {
+  for (const key of keys) {
+    const value = body[key];
+    if (!isPresent(value)) {
+      continue;
+    }
+    if (typeof value !== 'boolean') {
+      throw new BadRequestError(`${key} must be a boolean`);
+    }
+    return value;
+  }
+  return fallback;
+}
 
 // Accept the canonical DB role string (`adopter`, `rescue_staff`, …)
 // OR the SCREAMING proto form (`USER_ROLE_ADOPTER`). The handler's


### PR DESCRIPTION
The account-lifecycle handlers (register, verify-email, resend-verification, forgot-password, reset-password, change-password, PATCH users/account) read `req.body` as `Record<string, unknown>` then applied ~18 `as string`/`as boolean` casts when building the gRPC request — a lie at runtime that smuggled non-strings into string proto fields. Introduces `pickString`/`pickBool` helpers that resolve the first present key (preserving the exact `camelCase ?? snake_case ?? fallback` chains) and reject a present-but-wrong-type value with a 400 instead of forwarding it. Missing fields still default to `''`/`false`/`undefined`, so happy-path behaviour and the gRPC request shape are unchanged. Removes every `as string`/`as boolean` cast against `req.body` values in this file.

Validated: `turbo run test type-check lint --filter=@adopt-dont-shop/service.gateway` → all green (719 tests).

Notes: Zod (ticket's preferred approach) isn't a gateway dependency (would break `--frozen-lockfile`), so used the ticket's endorsed interim — typed helpers extending the existing `str()` pattern. One intentional behaviour change in PATCH `/users/account`: a non-string value now returns 400 instead of being silently coerced to `undefined`, matching the ticket's AC and the other routes.

Closes ADS-853

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QLtddqhQsBJ6wP1PcKJ9vf

---
_Generated by [Claude Code](https://claude.ai/code/session_01QLtddqhQsBJ6wP1PcKJ9vf)_