### PR TITLE
docs: purge stale service.backend references from docs

### DIFF
--- a/docs/ANALYTICS-REPORTS.md
+++ b/docs/ANALYTICS-REPORTS.md
@@ -21,20 +21,25 @@ Browser  ──WS────►  Socket.IO  ──►  analytics:invalidate / m
 
 ### Backend layout
 
-| Path | Purpose |
+The analytics/reports feature is owned by the `audit` service (`services/audit`).
+The paths below are the original monolith layout, kept as a map of the moving
+parts; the equivalent code now lives under `services/audit/src/` (with the HTTP
+layer fronted by the gateway).
+
+| Path (former-monolith layout) | Purpose |
 | --- | --- |
-| `service.backend/src/migrations/00-baseline-041..046-*.ts` | Tables: `reports`, `report_status_transitions`, `report_templates`, `report_shares`, `saved_reports`, `scheduled_reports` |
-| `service.backend/src/models/{ReportTemplate,SavedReport,ScheduledReport,ReportShare}.ts` | Sequelize models (audit-columns + paranoid soft-delete) |
-| `service.backend/src/schemas/reports.schema.ts` | Canonical Zod schemas for the report config |
-| `service.backend/src/services/reports.service.ts` | CRUD + execute + share + schedule orchestration |
-| `service.backend/src/services/report-cache.service.ts` | Redis cache with TTLs scaled to widget freshness |
-| `service.backend/src/services/report-renderer.service.ts` | PDF (`pdfkit`) + CSV (`papaparse`) renderers |
-| `service.backend/src/lib/redis.ts` | Lazy ioredis client; no-op when `REDIS_URL` is unset |
-| `service.backend/src/lib/queue.ts` | BullMQ `reports` queue + worker factory |
-| `service.backend/src/workers/reports.worker.ts` | Two job types: `report:scheduled-run`, `report:render-and-email` |
-| `service.backend/src/socket/analytics-emitter.ts` | Server → client Socket.IO events with debouncing |
-| `service.backend/src/controllers/reports.controller.ts` | HTTP layer; enforces rescue-scope authorization |
-| `service.backend/src/routes/reports.routes.ts` | Mounted at `/api/v1/reports` |
+| `src/migrations/00-baseline-041..046-*.ts` | Tables: `reports`, `report_status_transitions`, `report_templates`, `report_shares`, `saved_reports`, `scheduled_reports` |
+| `src/models/{ReportTemplate,SavedReport,ScheduledReport,ReportShare}.ts` | Sequelize models (audit-columns + paranoid soft-delete) |
+| `src/schemas/reports.schema.ts` | Canonical Zod schemas for the report config |
+| `src/services/reports.service.ts` | CRUD + execute + share + schedule orchestration |
+| `src/services/report-cache.service.ts` | Redis cache with TTLs scaled to widget freshness |
+| `src/services/report-renderer.service.ts` | PDF (`pdfkit`) + CSV (`papaparse`) renderers |
+| `src/lib/redis.ts` | Lazy ioredis client; no-op when `REDIS_URL` is unset |
+| `src/lib/queue.ts` | BullMQ `reports` queue + worker factory |
+| `src/workers/reports.worker.ts` | Two job types: `report:scheduled-run`, `report:render-and-email` |
+| `src/socket/analytics-emitter.ts` | Server → client Socket.IO events with debouncing |
+| `src/controllers/reports.controller.ts` | HTTP layer; enforces rescue-scope authorization |
+| `src/routes/reports.routes.ts` | Mounted at `/api/v1/reports` |
 
 ### Frontend layout
 
@@ -196,7 +201,9 @@ Then in app.admin:
 
 ## Testing
 
-- `service.backend/src/__tests__/services/reports.service.test.ts`
-  covers execute dispatch, cache hit/miss, view-permission matrix.
-- `service.backend/src/__tests__/services/report-cache.service.test.ts`
-  asserts graceful degradation when Redis is unreachable.
+- The audit service's reports-service tests (originally
+  `src/__tests__/services/reports.service.test.ts`)
+  cover execute dispatch, cache hit/miss, view-permission matrix.
+- The report-cache tests (originally
+  `src/__tests__/services/report-cache.service.test.ts`)
+  assert graceful degradation when Redis is unreachable.

--- a/docs/DATA-STANDARDS.md
+++ b/docs/DATA-STANDARDS.md
@@ -1,6 +1,6 @@
 # DATA-STANDARDS.md
 
-Engineering reference for all data modelling decisions in the `adopt-dont-shop` monorepo. These rules apply to every model in `service.backend/src/models/` and every migration in `service.backend/src/migrations/`. When a rule is marked **Aspirational**, the standard is defined here but not yet fully enforced in code.
+Engineering reference for all data modelling decisions in the `adopt-dont-shop` monorepo. These rules apply to every model and every migration owned by the backend services (each service under `services/<name>/src/models/` and `services/<name>/src/migrations/`). When a rule is marked **Aspirational**, the standard is defined here but not yet fully enforced in code.
 
 ---
 
@@ -23,7 +23,7 @@ export type RescueId = Brand<string, 'RescueId'>;
 
 Passing a `PetId` where a `UserId` is expected is a compile-time error.
 
-Helper: `service.backend/src/utils/uuid.ts`.
+Helper: a `uuid` utility in each service's `src/utils/` (originally `src/utils/uuid.ts` in the now-removed monolith).
 
 ---
 
@@ -128,7 +128,7 @@ Every **transactional** model (i.e. any model that records a business event or s
 
 Reference tables (`roles`, `permissions`, `breeds`) are exempt.
 
-Helper factory: `service.backend/src/models/audit-columns.ts`.
+Helper factory: an `audit-columns` factory in each service's `src/models/` (originally `src/models/audit-columns.ts` in the now-removed monolith).
 
 ---
 
@@ -229,7 +229,7 @@ Two-factor authentication secrets (`twoFactorSecret`) are encrypted at rest usin
 
 `EmailPreference.unsubscribeToken` must be generated with `crypto.randomBytes(32).toString('base64url')` — not with `generateReadableId`, which produces guessable output.
 
-Helpers: `service.backend/src/utils/secrets.ts`.
+Helpers: a `secrets` utility in each service's `src/utils/` (originally `src/utils/secrets.ts` in the now-removed monolith).
 
 ---
 
@@ -305,7 +305,7 @@ A retried request with the same key returns the cached response without executin
 
 ## 20. Standards Enforcement Test
 
-`service.backend/src/__tests__/models/standards.test.ts` is the ongoing enforcement mechanism. It iterates `sequelize.models` at runtime and asserts that every model satisfies:
+A `standards` model test in each service (originally `src/__tests__/models/standards.test.ts` in the now-removed monolith) is the ongoing enforcement mechanism. It iterates `sequelize.models` at runtime and asserts that every model satisfies:
 
 - `options.underscored === true`
 - Primary key is UUID with a default (whitelisted INTEGER PKs on reference tables are exempt)
@@ -321,10 +321,12 @@ This test must pass on every PR. A model that is missing any required property c
 
 ## Where the Rules Live
 
-| Concern | File |
+Each backend service carries its own copy of these helpers under `services/<name>/src/` (the paths below are the original monolith locations, retained as a quick lookup of what each helper is called):
+
+| Concern | File (former-monolith path) |
 |---|---|
-| Sequelize dialect helpers (`getJsonType`, `getUuidType`, etc.) | `service.backend/src/sequelize.ts` |
-| Audit column factory (`created_by`, `updated_by`, `version`) | `service.backend/src/models/audit-columns.ts` |
-| Secret hashing and encryption helpers | `service.backend/src/utils/secrets.ts` |
-| UUIDv7 generator | `service.backend/src/utils/uuid.ts` |
-| Standards enforcement test | `service.backend/src/__tests__/models/standards.test.ts` |
+| Sequelize dialect helpers (`getJsonType`, `getUuidType`, etc.) | `src/sequelize.ts` |
+| Audit column factory (`created_by`, `updated_by`, `version`) | `src/models/audit-columns.ts` |
+| Secret hashing and encryption helpers | `src/utils/secrets.ts` |
+| UUIDv7 generator | `src/utils/uuid.ts` |
+| Standards enforcement test | `src/__tests__/models/standards.test.ts` |

--- a/docs/GDPR-ROPA.md
+++ b/docs/GDPR-ROPA.md
@@ -54,7 +54,7 @@ field's purpose / retention here, update PRIVACY.md too.
 | Recipients | Other participants in the chat thread |
 | International transfers | None |
 | Retention | Lifetime of the related application + 6 years (tied to the application above). On erasure: message bodies replaced with tombstone (`[message removed at user request]`), participant rows preserved for thread continuity. |
-| Security measures | Participant-only read access; content moderation via `service.backend/services/content-moderation.service` |
+| Security measures | Participant-only read access; content moderation via the moderation service (`services/moderation`) |
 
 ## 4. Support tickets
 

--- a/docs/PRIVACY.md
+++ b/docs/PRIVACY.md
@@ -7,7 +7,7 @@ Last updated: 2026-04-27 (plan 6.2 + 5.2).
 
 ## 1. What we collect
 
-Walk through the actual models in `service.backend/src/models/`. Every field listed below exists in code today.
+Walk through the actual models defined across the backend services (`services/*/src`). Every field listed below exists in code today.
 
 ### User (`users` table)
 

--- a/docs/SECURITY-CENTER.md
+++ b/docs/SECURITY-CENTER.md
@@ -21,10 +21,9 @@ Two new RBAC permissions gate the Security Center:
 - `admin.security.manage` — mutating operations (revoke sessions,
   add/remove IP rules, lock/unlock accounts).
 
-Both are granted to `super_admin` and `admin` roles by the role-permissions
-reference seeder (`service.backend/src/seeders/reference/role-permissions.ts`,
-exported as `seedRolePermissions`). Re-run `pnpm db:seed:reference`
-on existing environments to pick them up.
+Both are granted to `super_admin` and `admin` roles by the auth service's
+role-permissions reference seeder (`seedRolePermissions`). Re-run the
+reference seed on existing environments to pick them up.
 
 ## Best practices
 
@@ -52,8 +51,8 @@ on existing environments to pick them up.
 - Block rules win over allow rules: a sub-range block inside a broader
   allow range still denies.
 - IPv4 supports CIDR (`10.0.0.0/8`); IPv6 currently supports only
-  exact-address rules. If you need IPv6 ranges, swap the matcher in
-  `service.backend/src/utils/ip-match.ts` for `ipaddr.js`.
+  exact-address rules. If you need IPv6 ranges, swap the auth service's
+  IP-matching helper for `ipaddr.js`.
 - Rules can carry an `expires_at` for temporary blocks (e.g. a 24-hour
   block during an active incident). Expired rules are ignored without
   needing a cleanup job.

--- a/docs/UK_LOCALIZATION.md
+++ b/docs/UK_LOCALIZATION.md
@@ -166,7 +166,7 @@ export interface RescueAddress {
 
 ### Backend Model
 
-**Location:** `service.backend/src/models/Rescue.ts`
+**Location:** the Rescue model in the rescue service (`services/rescue`; originally `src/models/Rescue.ts` in the now-removed monolith)
 
 **Key Changes:**
 

--- a/docs/architecture/adr-socket-sticky-sessions.md
+++ b/docs/architecture/adr-socket-sticky-sessions.md
@@ -3,14 +3,14 @@
 - Status: Accepted
 - Date: 2026-06-04
 - Linear: ADS-678
-- Related code: `service.backend/src/socket/socket-registry.ts`,
-  `service.backend/src/middleware/socket-rate-limit.ts`
+- Related code: the socket registry and socket rate-limit middleware
+  (originally in the monolith, now in `services/gateway/src/ws/`)
 
 ## Context
 
 The backend enforces a per-user concurrent Socket.IO connection cap
-(`MAX_CONNECTIONS_PER_USER`, currently 5) in
-`service.backend/src/socket/socket-registry.ts`. The cap exists so a
+(`MAX_CONNECTIONS_PER_USER`, currently 5) in the socket registry
+(originally in the monolith, now in `services/gateway/src/ws/`). The cap exists so a
 single authenticated user cannot exhaust file descriptors on a backend
 instance by repeatedly opening sockets (DoS protection covering the
 multi-device + multi-tab case: laptop + phone + a second laptop = 3,
@@ -18,8 +18,8 @@ with headroom for brief overlap during reconnects).
 
 The cap is tracked in a process-local `Map<userId, Set<socketId>>`. It
 is NOT shared between backend replicas. By contrast, the inbound
-per-event rate limiter at
-`service.backend/src/middleware/socket-rate-limit.ts` (ADS-709) is
+per-event rate limiter in the socket rate-limit middleware
+(originally in the monolith, now in `services/gateway/src/ws/`; ADS-709) is
 backed by Redis (`INCR` + `EXPIRE` Lua script) with an in-memory
 fallback so its counters are global across replicas.
 

--- a/docs/backend/database-schema.md
+++ b/docs/backend/database-schema.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-PostgreSQL 16 with the PostGIS extension and Sequelize 7. Models live in `service.backend/src/models/` and are mirrored 1:1 by baseline migrations under `service.backend/src/migrations/`. This document is a high-level reference — the source of truth is always the model file.
+PostgreSQL 16 with the PostGIS extension and Sequelize 7. Each service owns its slice of the schema: models live under `services/<name>/src/models/` and are mirrored by migrations under `services/<name>/src/migrations/`. This document is a high-level reference — the source of truth is always the model file.
 
 ## Entity Relationships
 
@@ -229,7 +229,7 @@ Read receipts are tracked in a separate `MessageRead` table; reactions in `Messa
 
 ### Swipe Actions
 
-**Purpose**: User swipe behavior tracking. See `service.backend/src/models/SwipeAction.ts` for the authoritative shape.
+**Purpose**: User swipe behavior tracking. See the owning service's `src/models/SwipeAction.ts` for the authoritative shape.
 
 | Field            | Type           | Description                                                  |
 | ---------------- | -------------- | ------------------------------------------------------------ |
@@ -361,7 +361,7 @@ Most tables use soft delete (deleted_at timestamp) instead of hard delete for:
 
 ### Migration Management
 
-Migrations live in `service.backend/src/migrations/` as numbered TypeScript files (e.g. `00-baseline-001-users.ts`, `01-add-user-type-support-agent-super-admin.ts`). The project uses [Umzug](https://github.com/sequelize/umzug) via a custom runner at `service.backend/src/migrations/runner.ts` — **`sequelize-cli` is not installed**. Create a new migration by adding the next sequential file following the existing pattern.
+Each service keeps its migrations under `services/<name>/src/migrations/` as numbered TypeScript files (e.g. `00-baseline-001-users.ts`, `01-add-user-type-support-agent-super-admin.ts`) and runs them itself on startup — **`sequelize-cli` is not installed**. Create a new migration by adding the next sequential file in the owning service following the existing pattern.
 
 ```bash
 # From the repo root, while the dev stack is running:
@@ -373,7 +373,7 @@ pnpm db:migrate:undo      # ts-node src/migrations/runner.ts down
 pnpm db:migrate:status    # ts-node src/migrations/runner.ts status
 ```
 
-The backend exposes three migration scripts in `service.backend/package.json`: `db:migrate`, `db:migrate:undo`, `db:migrate:status`.
+Each service's `package.json` exposes the migration scripts: `db:migrate`, `db:migrate:undo`, `db:migrate:status`.
 
 ### Best Practices
 

--- a/docs/backend/deployment.md
+++ b/docs/backend/deployment.md
@@ -8,7 +8,7 @@ The backend ships as a Docker image alongside three frontend images. Production 
 
 ### Runtime
 
-- **Node.js**: v22 (pinned in `.nvmrc` and `package.json` engines `>=22 <23`). The production image is `node:22-alpine` (see `service.backend/Dockerfile`).
+- **Node.js**: v22 (pinned in `.nvmrc` and `package.json` engines `>=22 <23`). The production images are `node:22-alpine` (each service ships its own `services/<name>/Dockerfile`).
 - **PostgreSQL**: 16 with the **PostGIS** extension (`postgis/postgis:16-3.4` in `docker-compose.yml`). Location features depend on PostGIS — a plain Postgres install is not enough.
 - **Redis**: 7+ (`redis:7-alpine`) — used for sessions, BullMQ job queues, and rate-limiting.
 
@@ -90,7 +90,7 @@ Behind the scenes:
 
 ## Database migrations
 
-Migrations are managed by an Umzug runner (`service.backend/src/migrations/`). No `sequelize-cli`.
+Each service owns and runs its own migrations under `services/<name>/src/migrations/`. No `sequelize-cli`.
 
 ```bash
 pnpm migrate              # apply pending migrations
@@ -115,4 +115,4 @@ On a production deploy, run `pnpm migrate` inside the running backend container 
 - [`docs/runbooks/deploy-rollback.md`](../runbooks/deploy-rollback.md) — incident rollback procedure.
 - [`docs/runbooks/migration-failure.md`](../runbooks/migration-failure.md) — when migrations fail mid-deploy.
 - [`docs/INFRA.md`](../INFRA.md) — infra topology (nginx, uploads, signed URLs).
-- [`service.backend/SECURITY.md`](../../service.backend/SECURITY.md) — production security checklist.
+- [`docs/security/`](../security/) — production security guidance (data protection, gRPC trust, webhook replay protection, image signing).

--- a/docs/backend/implementation-guide.md
+++ b/docs/backend/implementation-guide.md
@@ -37,7 +37,7 @@ From the repository root the typical workflow uses Docker — the container boot
 
 4. **Initialize the database (first run, or after `docker:reset`)**
 
-   The migration runner is a custom Umzug script at `service.backend/src/migrations/runner.ts` (the project does not use `sequelize-cli`). Seeds are split into reference / demo / fixtures with no "do everything" alias — pick the right one for what you're doing.
+   Each service runs its own migrations from `services/<name>/src/migrations/` on startup (the project does not use `sequelize-cli`). Seeds are split into reference / demo / fixtures with no "do everything" alias — pick the right one for what you're doing.
 
    ```bash
    # From the repo root — wrappers shell into the service-backend container
@@ -59,7 +59,7 @@ From the repository root the typical workflow uses Docker — the container boot
 If you prefer to run the backend on the host (you must provide Postgres and Redis yourself):
 
 ```bash
-cd service.backend
+cd services/<name>       # e.g. services/gateway, services/auth, services/pets
 pnpm dev                  # tsx watch --clear-screen=false src/index.ts
 ```
 
@@ -188,7 +188,7 @@ uploads/
 
 ## Database Management
 
-The project uses a custom [Umzug](https://github.com/sequelize/umzug) runner (`service.backend/src/migrations/runner.ts`) and a custom seed CLI (`service.backend/src/seeders/cli.ts`) — `sequelize-cli` is **not** installed. Migrations live in `service.backend/src/migrations/`; seeders in `service.backend/src/seeders/`.
+Each service runs its own migrations and seeders — `sequelize-cli` is **not** installed. Migrations live in `services/<name>/src/migrations/`; seeders (where a service has them) in `services/<name>/src/seeders/`.
 
 ### Migrations
 
@@ -200,8 +200,8 @@ pnpm db:migrate
 docker compose exec service-backend pnpm db:migrate:status
 docker compose exec service-backend pnpm db:migrate:undo
 
-# Authoring a new migration: copy an existing file in
-# service.backend/src/migrations/ and follow the numbered naming pattern
+# Authoring a new migration: copy an existing file in the owning service's
+# services/<name>/src/migrations/ and follow the numbered naming pattern
 # (e.g. 01-add-something.ts). The runner picks them up automatically.
 ```
 
@@ -217,13 +217,13 @@ docker compose exec service-backend pnpm db:seed:reset       # truncate demo+fix
 docker compose exec service-backend pnpm db:bootstrap        # first-run admin in production
 ```
 
-See `service.backend/src/seeders/README.md` for the full split.
+See the owning service's `src/seeders/` directory for the full split.
 
 ## Testing
 
 ### Run Tests
 
-The backend uses **Vitest**. Run from `service.backend/` (or via `pnpm exec turbo test --filter=@adopt-dont-shop/service-backend` at the root).
+The backend services use **Vitest**. Run from the relevant `services/<name>` package (or via `pnpm exec turbo test --filter=@adopt-dont-shop/service.<name>` at the root).
 
 ```bash
 # All tests
@@ -296,16 +296,16 @@ docker compose logs -f service-backend
 ### Production
 
 ```bash
-# Build production image (multi-stage target in the shared Dockerfile)
+# Build a service's production image (multi-stage target; each service ships its own Dockerfile)
 docker build \
   --target production \
-  -t adoptdontshop/backend:latest \
-  -f service.backend/Dockerfile .
+  -t adoptdontshop/gateway:latest \
+  -f services/gateway/Dockerfile .
 
 # Run production container
 docker run -p 5000:5000 \
   --env-file .env.production \
-  adoptdontshop/backend:latest
+  adoptdontshop/gateway:latest
 ```
 
 The root `docker-compose.prod.yml` overlay exercises this path end-to-end — see [Deployment Guide](./deployment.md) and [Docker Infrastructure Guide](../DOCKER.md).
@@ -323,7 +323,7 @@ The root `docker-compose.prod.yml` overlay exercises this path end-to-end — se
 
 ### Add Database Model
 
-1. **Create migration** by copying the latest file in `service.backend/src/migrations/` and renaming it (the runner is a custom Umzug script — no generator). Follow the existing numbered naming pattern (`NN-create-my-table.ts`).
+1. **Create migration** by copying the latest file in the owning service's `services/<name>/src/migrations/` and renaming it (the runner picks files up automatically — no generator). Follow the existing numbered naming pattern (`NN-create-my-table.ts`).
 2. **Define schema** in the migration file under `src/migrations/`
 3. **Create model** `src/models/MyModel.ts`
 4. **Run migration** `pnpm db:migrate` (from the repo root)
@@ -380,8 +380,8 @@ pnpm dev  # Will recreate automatically
 ### Performance Issues
 
 ```bash
-# Toggle Sequelize query logging by setting DB_LOGGING=true in .env and restarting the backend
-# (`service.backend/src/sequelize.ts` reads DB_LOGGING).
+# Toggle Sequelize query logging by setting DB_LOGGING=true in .env and restarting the service
+# (each service's `src/sequelize.ts` reads DB_LOGGING).
 
 # Monitor in development dashboard
 open http://localhost:5000/monitoring/dashboard

--- a/docs/backend/testing.md
+++ b/docs/backend/testing.md
@@ -10,13 +10,13 @@ Testing Pyramid
 └── Service / behaviour tests — Services, utilities, middleware, models (src/__tests__/services/, etc.)
 ```
 
-Tests live under `service.backend/src/__tests__/` organised by layer (`services/`, `controllers/`, `integration/`, `middleware/`, `models/`, `security/`, `utils/`, `validation/`).
+Tests live alongside the code in each service under `services/<name>/src/`, organised by layer (services, controllers/handlers, integration, middleware, models, security, utils, validation).
 
 ## Quick Start
 
 ### Running Tests
 
-From `service.backend/` (or via `pnpm exec turbo test --filter=@adopt-dont-shop/service-backend` at the repo root):
+From the relevant `services/<name>` package (or via `pnpm exec turbo test --filter=@adopt-dont-shop/service.<name>` at the repo root):
 
 ```bash
 # All tests
@@ -43,7 +43,7 @@ Follow the [project CLAUDE.md](../../.claude/CLAUDE.md) guidance: aim for 100% b
 
 ## Configuration
 
-Vitest is configured in `service.backend/vitest.config.ts`. The service does not use Jest; any legacy `jest.config.js` should be treated as stale.
+Vitest is configured per service in `services/<name>/vitest.config.ts`. The services do not use Jest; any legacy `jest.config.js` should be treated as stale.
 
 ### Test Database
 

--- a/docs/dependency-graph.md
+++ b/docs/dependency-graph.md
@@ -1,6 +1,6 @@
 # Dependency Graph
 
-This monorepo is wired together by Turborepo. The dependency graph captures every workspace package (apps, libraries, the backend service) and the `^build` edges between them — i.e. which packages must finish building before a consumer can start. Generating and reading it is the fastest way to understand the blast radius of a change and to debug Turbo cache or ordering surprises.
+This monorepo is wired together by Turborepo. The dependency graph captures every workspace package (apps, libraries, the `services/*` backend services) and the `^build` edges between them — i.e. which packages must finish building before a consumer can start. Generating and reading it is the fastest way to understand the blast radius of a change and to debug Turbo cache or ordering surprises.
 
 ## Generate the graph
 
@@ -22,16 +22,16 @@ lib.types                    # zero-dependency type definitions
 other lib.*                  # lib.api, lib.auth, lib.components, lib.utils, ...
    |
    v
-apps (app.admin, app.client, app.rescue) + service.backend
+apps (app.admin, app.client, app.rescue) + services/* (gateway, auth, pets, ...)
 ```
 
 - **lib.types** is the foundation. It exports shared TypeScript types and Zod schemas with no workspace dependencies of its own.
 - **Other libraries** (`lib.api`, `lib.auth`, `lib.components`, etc.) depend on `lib.types` and occasionally on each other (e.g. `lib.api` consumes `lib.auth`).
-- **Apps** (`app.admin`, `app.client`, `app.rescue`) and **`service.backend`** sit at the top — they consume the libraries but nothing consumes them.
+- **Apps** (`app.admin`, `app.client`, `app.rescue`) and the **`services/*`** backend services sit at the top — they consume the libraries but nothing consumes them.
 
 ### Why changing lib.types cascades
 
-Because `lib.types` sits at the bottom, every other workspace transitively depends on it. A change to `lib.types` invalidates the Turbo cache for every downstream library, which in turn invalidates every app and `service.backend`. Expect `pnpm build` after a `lib.types` edit to rebuild essentially the whole graph. Conversely, editing an isolated leaf like `app.admin` only rebuilds that one package.
+Because `lib.types` sits at the bottom, every other workspace transitively depends on it. A change to `lib.types` invalidates the Turbo cache for every downstream library, which in turn invalidates every app and `services/*` package. Expect `pnpm build` after a `lib.types` edit to rebuild essentially the whole graph. Conversely, editing an isolated leaf like `app.admin` only rebuilds that one package.
 
 If you want to see this in action, generate the graph and trace the inbound edges into `lib.types` — that fan-out is the cascade.
 

--- a/docs/frontend/react-native-mobile-migration.md
+++ b/docs/frontend/react-native-mobile-migration.md
@@ -66,7 +66,7 @@ adopt-dont-shop/
 │   ├── package.json                       # @adopt-dont-shop/app.mobile
 │   └── tsconfig.json
 ├── lib.*/                                 # shared libraries (unchanged)
-└── service.backend/                       # API (the contract mobile consumes)
+└── services/                              # backend services; the gateway is the API mobile consumes
 ```
 
 Integration points:
@@ -75,7 +75,7 @@ Integration points:
 - **Turborepo:** `build`, `lint`, `type-check`, and `test` tasks work out of the box once `app.mobile/package.json` defines those scripts. Mobile-specific tasks (`expo start`, EAS builds) live as additional scripts and run outside the normal web pipeline.
 - **TypeScript:** extend `tsconfig.base.json` as the other packages do.
 - **Testing:** the repo standard is Vitest; React Native's ecosystem standard is Jest + `@testing-library/react-native`. This is a real divergence — see Open Questions.
-- **API contract:** mobile talks to `service.backend` over HTTP using the same Zod schemas/types from `lib.api`/`lib.types`, so the contract stays in sync without a separate codegen step.
+- **API contract:** mobile talks to the gateway (`services/gateway`) over HTTP using the same Zod schemas/types from `lib.api`/`lib.types`, so the contract stays in sync without a separate codegen step.
 
 ## High-level migration phases
 
@@ -83,7 +83,7 @@ Each phase should leave the repo in a working, shippable state (per our TDD / sm
 
 1. **Scaffold** → verify: `pnpm dlx create-expo-app app.mobile` (TypeScript template), add to workspaces, `pnpm install` resolves, `expo start` boots the blank app on a simulator.
 2. **Wire shared libs** → verify: import a type from `lib.types` and a schema from `lib.validation` in a screen; `pnpm type-check` passes for `app.mobile`.
-3. **Auth + API client** → verify: log in against `service.backend` (or staging) using `lib.api` contracts; token persisted; an authenticated request succeeds.
+3. **Auth + API client** → verify: log in against the gateway (`services/gateway`, or staging) using `lib.api` contracts; token persisted; an authenticated request succeeds.
 4. **Core adopter flows** → verify: browse pets, view pet detail, submit/track an application — driven by tests against the real API contract.
 5. **Native capabilities** → verify: push notifications, image upload from camera/gallery, offline-friendly caching (React Query) behave on device.
 6. **CI + release** → verify: GitHub Actions runs `type-check`/`lint`/tests for `app.mobile`; **EAS Build** produces iOS/Android artifacts; TestFlight + Play internal testing distribution works.

--- a/docs/frontend/recommendations-plan.md
+++ b/docs/frontend/recommendations-plan.md
@@ -34,7 +34,7 @@ Weighted sum of normalised feature scores (0–1):
 | Special-needs match | 0.05 |
 | Sponsored boost (non-overriding) | 0.05 |
 
-Weights live in `service.backend/src/services/recommendation.service.ts` as a typed config. Statsig dynamic config can override at runtime so tuning doesn't require a deploy.
+Weights live in the matching service (`services/matching`) as a typed config. Statsig dynamic config can override at runtime so tuning doesn't require a deploy.
 
 ### Output
 
@@ -64,11 +64,11 @@ Weights live in `service.backend/src/services/recommendation.service.ts` as a ty
 
 ### Service shape
 
-- `service.backend/src/services/recommendation.service.ts`
+- Recommendation logic in the matching service (`services/matching`):
   - `computeFeatureVector(user, pet)` → numeric features
   - `score(features, weights)` → number
   - `getRecommendations(userId, filters, limit)` → ordered `PetId[]`
-- Wired behind `GET /api/v1/discovery/recommendations` in `service.backend/src/routes/discovery.routes.ts`.
+- Exposed behind `GET /api/v1/discovery/recommendations` via the gateway (`services/gateway`).
 - Excludes `discoverySession.viewedPetIds` via query param `excludePetIds=...` (frontend sends from localStorage).
 - Caches per `(userId, filterHash)` for 60s in Redis to keep p95 under 300ms when the queue is paginated.
 

--- a/docs/frontend/technical-architecture.md
+++ b/docs/frontend/technical-architecture.md
@@ -57,7 +57,7 @@ Technical architecture for the Rescue App (app.rescue) - a comprehensive managem
 
 ### Backend Integration
 
-- **API Gateway**: service.backend endpoints
+- **API Gateway**: `services/gateway` endpoints
 - **Authentication**: JWT with refresh tokens
 - **Rate Limiting**: Protection against abuse
 - **Validation**: Request/response validation

--- a/docs/infrastructure/DEPLOYMENT-PLAN.md
+++ b/docs/infrastructure/DEPLOYMENT-PLAN.md
@@ -52,7 +52,7 @@ Server layout (single CPX42):
 | `.github/workflows/deploy.yml` | Build → push → deploy workflow |
 | `.github/workflows/rollback.yml` | Redeploy a previous SHA |
 | `Makefile` | CLI commands (`make staging`, `make prod`, `make rollback`) |
-| `service.backend/src/migrations/runner.ts` | Custom Umzug migration runner |
+| `services/<name>/src/migrations/` | Per-service migrations (each service runs its own) |
 
 ---
 
@@ -205,9 +205,9 @@ Auto-renewal handled by certbot container in gateway stack (renews every 12h via
 
 ### Migrations
 
-- Migrations use a custom Umzug runner (`service.backend/src/migrations/runner.ts`)
-- `sequelize-cli` is **not** installed — use `pnpm db:migrate` / `pnpm db:migrate:undo`
-- Deploy workflow runs `pnpm db:migrate` after health check passes
+- Each service owns its migrations under `services/<name>/src/migrations/` and runs them itself
+- A service applies its own schema on container start (entrypoint runs `pnpm run --if-present db:migrate`)
+- Deploy workflow waits for each service's migration step to complete before health check passes
 
 ### First deploy — baseline
 

--- a/docs/infrastructure/INFRASTRUCTURE.md
+++ b/docs/infrastructure/INFRASTRUCTURE.md
@@ -25,9 +25,9 @@ The Adopt Don't Shop platform uses a modern microservices architecture with shar
                       │
                       ▼
               ┌─────────────┐
-              │service.backend│
-              │   (Node.js)  │
-              │   Port:5000  │
+              │service.gateway│
+              │  (Fastify)   │
+              │   Port:4000  │
               └─────────────┘
                       │
         ┌─────────────┼─────────────┐
@@ -67,12 +67,12 @@ The Adopt Don't Shop platform uses a modern microservices architecture with shar
 
 ### Backend Services
 
-**service.backend** - Main API
+**service.gateway** - Main API edge
 
-- Technology: Node.js + Express + TypeScript
-- Port: 5000
+- Technology: Node.js + Fastify + TypeScript
+- Port: 4000
 - Domain: api.localhost / api.adoptdontshop.com
-- Features: REST API, WebSocket messaging, authentication
+- Features: REST API, WebSocket messaging, authentication. Fronts the gRPC microservices (auth, pets, rescue, applications, notifications, moderation, matching, audit, chat, cms).
 
 ### Databases & Storage
 
@@ -176,14 +176,14 @@ docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d
 - `localhost` → app.client (port 3000)
 - `admin.localhost` → app.admin (port 3001)
 - `rescue.localhost` → app.rescue (port 3002)
-- `api.localhost` → service.backend (port 5000)
+- `api.localhost` → service.gateway (port 4000)
 
 **Production:**
 
 - `www.adoptdontshop.com` → app.client
 - `admin.adoptdontshop.com` → app.admin
 - `rescue.adoptdontshop.com` → app.rescue
-- `api.adoptdontshop.com` → service.backend
+- `api.adoptdontshop.com` → service.gateway
 
 ## Development Workflow
 
@@ -225,22 +225,14 @@ cd lib.api && pnpm dev
 
 ### Database Migrations
 
-The backend uses a custom Umzug runner (`service.backend/src/migrations/runner.ts`) and a custom seed CLI (`service.backend/src/seeders/cli.ts`). `sequelize-cli` is not installed.
+Each service owns its migrations under `services/<name>/src/migrations/` and runs them itself — a service applies its own schema automatically when its container starts (the entrypoint runs `pnpm run --if-present db:migrate`).
 
 ```bash
-# From the repo root (containers must be running):
-pnpm db:migrate                                              # ts-node src/migrations/runner.ts up
-docker compose exec service-backend pnpm db:migrate:undo     # rollback
-docker compose exec service-backend pnpm db:migrate:status   # show applied / pending
+# Migrate one service by hand (containers must be running):
+docker compose exec service-auth pnpm db:migrate
 
-# Seeders are split by safety profile — no "do everything" alias:
-docker compose exec service-backend pnpm db:seed:reference   # idempotent reference data
-docker compose exec service-backend pnpm db:seed:demo        # Faker (dev/staging; ALLOW_DEMO_SEED=true)
-docker compose exec service-backend pnpm db:seed:fixtures    # deterministic e2e fixtures
-docker compose exec service-backend pnpm db:seed:reset       # truncate demo+fixture tables
-
-# Authoring a new migration: copy the latest file in
-# service.backend/src/migrations/ and follow the numbered naming pattern.
+# Authoring a new migration: copy the latest file in the relevant
+# services/<name>/src/migrations/ directory and follow the numbered naming pattern.
 ```
 
 ## CI/CD Pipeline

--- a/docs/infrastructure/MICROSERVICES-STANDARDS.md
+++ b/docs/infrastructure/MICROSERVICES-STANDARDS.md
@@ -63,7 +63,7 @@ All libraries follow these standards:
 
 - **Module System**: ES Modules first; a few libraries (`lib.api`, `lib.permissions`, `lib.types`, `lib.validation`) also emit a CJS bundle for backend consumers
 - **Build Tool**: TypeScript Compiler (`tsc`) for most libs; `lib.components` uses Vite to bundle assets and styles
-- **Testing**: Vitest in every package (`lib.*`, `service.backend`, and the React apps). Each library ships its own `vitest.config.ts` and an `pnpm test` script that runs `vitest run`.
+- **Testing**: Vitest in every package (`lib.*`, every `services/*` and `packages/*`, and the React apps). Each library ships its own `vitest.config.ts` and an `pnpm test` script that runs `vitest run`.
 - **Code Quality**: ESLint + Prettier
 - **Documentation**: Each library has its own README next to the source
 

--- a/docs/infrastructure/new-app-generator.md
+++ b/docs/infrastructure/new-app-generator.md
@@ -18,7 +18,7 @@ pnpm new-app <app-name> --template <template>
 - **template**: One of `minimal`, `standard`, `enterprise` (defaults to `standard` if omitted)
 - **--overwrite**: Replace an existing app directory of the same name
 
-The generator only scaffolds React apps under `app.*`. Backend services are not produced by this script — `service.backend` is the single backend; add new domain code there.
+The generator only scaffolds React apps under `app.*`. Backend services are not produced by this script — the backend is a set of microservices under `services/<name>/`; add a new backend domain by creating a new service there, not via this generator.
 
 ### Templates
 

--- a/docs/legal/privacy.md
+++ b/docs/legal/privacy.md
@@ -5,9 +5,9 @@
 
 > Placeholder copy — must be reviewed and approved by legal counsel before
 > production launch. The version string above is the canonical identifier
-> recorded against the user via `users.privacy_policy_accepted_at`
-> (`service.backend/src/models/User.ts`) and surfaced through the
-> `ConsentRecord` type in `service.backend/src/services/consent.service.ts`.
+> recorded against the user via `users.privacy_policy_accepted_at` (on the
+> User model in the auth service) and surfaced through the `ConsentRecord`
+> type in the auth service's consent service.
 
 ## 1. Who we are
 
@@ -50,8 +50,8 @@ You may at any time:
 - Swipe actions: 24-month rolling window.
 - Home-visit records: 5 years (regulatory retention).
 
-These periods are enforced by an automated retention job; see
-`service.backend/src/jobs/retention.job.ts`.
+These periods are enforced by an automated retention job in the backend
+services.
 
 ## 6. Children's data
 

--- a/docs/legal/screen-reader-runbook.md
+++ b/docs/legal/screen-reader-runbook.md
@@ -35,7 +35,7 @@ Checklist:
 
 Setup:
 
-- Get a user whose `details.tosVersion` (or `privacyVersion`) is older than the currently published `TERMS_VERSION` / `PRIVACY_VERSION`. Easiest path: in `service.backend`, run a quick SQL update on a seeded user, e.g. `UPDATE users SET details = jsonb_set(details, '{tosVersion}', '"2020-01-01"') WHERE email='adopter@example.test';`.
+- Get a user whose `details.tosVersion` (or `privacyVersion`) is older than the currently published `TERMS_VERSION` / `PRIVACY_VERSION`. Easiest path: against the auth service database (which owns the `users` table), run a quick SQL update on a seeded user, e.g. `UPDATE users SET details = jsonb_set(details, '{tosVersion}', '"2020-01-01"') WHERE email='adopter@example.test';`.
 - Sign in as that user in `app.client`.
 
 Checklist:

--- a/docs/legal/terms.md
+++ b/docs/legal/terms.md
@@ -5,9 +5,9 @@
 
 > Placeholder copy — must be reviewed and approved by legal counsel before
 > production launch. The version string above is the canonical identifier
-> recorded against the user via `users.terms_accepted_at`
-> (`service.backend/src/models/User.ts`) and surfaced through the
-> `ConsentRecord` type in `service.backend/src/services/consent.service.ts`.
+> recorded against the user via `users.terms_accepted_at` (on the User
+> model in the auth service) and surfaced through the `ConsentRecord` type
+> in the auth service's consent service.
 
 ## 1. Acceptance of terms
 

--- a/docs/migrations/schema-audit-runbook.md
+++ b/docs/migrations/schema-audit-runbook.md
@@ -1,5 +1,11 @@
 # Schema Audit Runbook
 
+> **Historical context.** This runbook describes a tool built for the (now-removed)
+> monolith backend, whose Sequelize models and scripts all lived under a single
+> `service.backend/` package. The codebase is now microservices (each service owns its
+> own schema under `services/<name>/`). The monolith paths below are retained to
+> document the original tool and the rebaseline plan it gated.
+
 `service.backend/scripts/schema-audit.ts` is a read-only diff tool. It compares the Sequelize models registered in `service.backend/src/models/index.ts` against a live database and prints a per-table report of any drift. Its purpose is to gate the per-model rebaseline plan in [`per-model-rebaseline.md`](./per-model-rebaseline.md): the SequelizeMeta pre-seed step (§3) is only safe if the live DB already matches what the per-model baseline files would create. The audit answers "does it?".
 
 ## Running the script

--- a/docs/migrations/schema-equivalence-runbook.md
+++ b/docs/migrations/schema-equivalence-runbook.md
@@ -1,5 +1,12 @@
 # Schema Equivalence Runbook
 
+> **Historical context.** This runbook describes the schema-equivalence gate as it
+> existed for the (now-removed) monolith backend, whose Sequelize models, migrations,
+> and helper scripts all lived under a single `service.backend/` package. The codebase
+> is now microservices (each service owns its migrations under
+> `services/<name>/src/migrations/`), and the live CI workflow has been reworked
+> accordingly. The monolith paths below are retained to document the original tool.
+
 The schema-equivalence gate is the per-model rebaseline's safety net (see [`per-model-rebaseline.md` §3.4](./per-model-rebaseline.md#34-verification-step)). It enforces a single invariant:
 
 > A database bootstrapped via `sequelize-cli db:migrate` must be byte-equivalent (modulo documented asymmetries) to a database bootstrapped via `sequelize.sync()` against the same model code.

--- a/docs/runbooks/db-pool-exhaustion.md
+++ b/docs/runbooks/db-pool-exhaustion.md
@@ -13,11 +13,11 @@ otherwise `warning` (`P95LatencyHigh`).
 - Postgres `pg_stat_activity` shows many `idle in transaction` or
   long-running queries.
 - 5xx may rise once the `DB_POOL_ACQUIRE_MS` timeout (default 30s) is
-  hit — see `service.backend/src/sequelize.ts`.
+  hit — see the service's database connection config.
 
 ## Pool config (current defaults)
 
-From `service.backend/src/sequelize.ts:40-51`:
+From the service's database connection config:
 
 | Env var                              | Default | Meaning                                   |
 | ------------------------------------ | ------- | ----------------------------------------- |

--- a/docs/runbooks/migration-failure.md
+++ b/docs/runbooks/migration-failure.md
@@ -83,8 +83,8 @@ and have the DBA on the line.
 ### C. Lock contention (`could not obtain lock`)
 
 A long-running query is holding the table. The migration exits on
-`DB_LOCK_TIMEOUT_MS` (default 10s — see
-`service.backend/src/sequelize.ts`).
+`DB_LOCK_TIMEOUT_MS` (default 10s — see the service's database
+connection config).
 
 ```bash
 # Find the blocker.

--- a/docs/runbooks/redis-outage.md
+++ b/docs/runbooks/redis-outage.md
@@ -9,17 +9,14 @@ probe fails for 2m)
   `failures: [{ service: 'redis', ... }]`.
 - Kubernetes / LB drops pods from rotation; effective capacity falls.
 - BullMQ reports queue stops processing (the `queue` probe fails
-  alongside Redis — see
-  `service.backend/src/services/health-check.service.ts`).
+  alongside Redis — see the gateway's health-check service).
 - Auth `/login`, `/register` either rate-limit oddly or fail to
-  enforce limits across replicas (see
-  `service.backend/src/middleware/auth-rate-limit.ts` — Redis-backed
-  `RedisStore` falls back to in-memory **per-replica** when Redis is
-  unconfigured, but **errors out** mid-request if Redis was up and
-  then dies).
+  enforce limits across replicas (the Redis-backed rate-limit
+  middleware's `RedisStore` falls back to in-memory **per-replica**
+  when Redis is unconfigured, but **errors out** mid-request if Redis
+  was up and then dies).
 - Cache-fronted endpoints stay up but slow down — the read-through
-  helper in `service.backend/src/cache/redis-cache.ts` falls through
-  to the loader on any Redis failure.
+  cache helper falls through to the loader on any Redis failure.
 
 ## What still works vs. what doesn't
 

--- a/docs/security/data-protection.md
+++ b/docs/security/data-protection.md
@@ -40,12 +40,15 @@ Record your provider + verification command in the team runbook (`docs/runbooks/
 
 ## Columns covered by application-layer encryption
 
-| Column / table | Algorithm | Code reference |
+Code references below point at the auth service (the former monolith paths
+shown are now removed; equivalent logic lives under `services/auth/`).
+
+| Column / table | Algorithm | Code reference (former monolith) |
 | --- | --- | --- |
-| `users.password` | bcrypt (12 rounds) | `service.backend/src/models/User.ts` |
-| `users.totp_secret` | AES-256-GCM (env-key `ENCRYPTION_KEY`) | `service.backend/src/services/two-factor.service.ts` |
+| `users.password` | bcrypt (12 rounds) | `src/models/User.ts` |
+| `users.totp_secret` | AES-256-GCM (env-key `ENCRYPTION_KEY`) | `src/services/two-factor.service.ts` |
 | `users.backup_codes` | bcrypt (per code) | same |
-| `password_reset_tokens.token_hash`, `email_verification.token_hash` | SHA-256 | `service.backend/src/services/auth.service.ts` |
+| `password_reset_tokens.token_hash`, `email_verification.token_hash` | SHA-256 | `src/services/auth.service.ts` |
 
 Anything **not** listed above is plaintext at the application layer and
 relies on the storage layer for at-rest confidentiality.
@@ -62,7 +65,7 @@ In the `users`, `profile`, `application_drafts`, `pets` and audit-log tables:
 - free-text fields submitted as part of adoption applications (cover
   letters, lifestyle answers) — `application_drafts.payload` JSONB
 - audit-log `details` JSONB (subject to Winston redaction at write time —
-  see `service.backend/src/utils/logger-helpers.ts`)
+  via the shared redaction in the observability package)
 
 ## Backup / snapshot encryption
 

--- a/docs/security/webhook-replay-protection.md
+++ b/docs/security/webhook-replay-protection.md
@@ -6,7 +6,7 @@
 
 ## Current state
 
-`service.backend/src/middleware/webhook-signature.ts` verifies provider
+The notifications service's webhook-signature middleware verifies provider
 signatures (SendGrid ECDSA, Postmark HMAC, SES shared-secret, generic
 HMAC) and rejects requests whose timestamp is outside the tolerated skew.
 Since ADS-734 that window is **120 seconds** by default (was 5 minutes),
@@ -39,13 +39,16 @@ composite primary key.
 
 **Files:**
 
-| Layer | Path |
+All of these live in the notifications service (the former monolith paths
+below are now removed; equivalent logic lives under `services/notifications/`):
+
+| Layer | Former monolith path |
 | --- | --- |
-| Migration | `service.backend/src/migrations/12-create-webhook-event-ids.ts` |
-| Model | `service.backend/src/models/WebhookEventId.ts` |
-| Service | `service.backend/src/services/email/webhook-idempotency.service.ts` |
-| Wiring | `service.backend/src/controllers/email.controller.ts` (`handleDeliveryWebhook`) |
-| Cleanup | `service.backend/src/jobs/webhook-events-purge.job.ts` |
+| Migration | `src/migrations/12-create-webhook-event-ids.ts` |
+| Model | `src/models/WebhookEventId.ts` |
+| Service | `src/services/email/webhook-idempotency.service.ts` |
+| Wiring | `src/controllers/email.controller.ts` (`handleDeliveryWebhook`) |
+| Cleanup | `src/jobs/webhook-events-purge.job.ts` |
 
 **Table shape:**
 
@@ -93,16 +96,17 @@ no-ops if Redis is unavailable, mirroring the other system purges
 
 ## Tests
 
-Per-event idempotency behaviour is covered by:
+Per-event idempotency behaviour is covered by (former monolith test
+paths; now removed, equivalent coverage lives under `services/notifications/`):
 
-- `service.backend/src/__tests__/services/webhook-idempotency.service.test.ts`
+- `src/__tests__/services/webhook-idempotency.service.test.ts`
   — service-level: new event inserts a row, replay throws
   `WebhookReplayError`, same event_id across providers is two rows.
-- `service.backend/src/__tests__/routes/email-webhook-idempotency.routes.test.ts`
+- `src/__tests__/routes/email-webhook-idempotency.routes.test.ts`
   — route-level: replay returns `200 { deduplicated: true }` and does
   NOT re-invoke `emailService.handleDeliveryWebhook`; different
   `status` for the same `messageId` is a distinct event.
-- `service.backend/src/__tests__/jobs/webhook-events-purge.test.ts`
+- `src/__tests__/jobs/webhook-events-purge.test.ts`
   — purge job deletes rows older than the 7-day cutoff.
 
 Existing timestamp-window coverage remains in

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -7,12 +7,12 @@ covered by automated tests in this repository.
 
 | Runner   | Where it lives                                  | What it covers                                     |
 | -------- | ----------------------------------------------- | -------------------------------------------------- |
-| Vitest   | `service.backend`, `app.*`, every `lib.*`       | Behaviour-driven tests for services, components, libraries |
+| Vitest   | every `services/*`, `app.*`, and `lib.*`        | Behaviour-driven tests for services, components, libraries |
 | Playwright | `e2e/`                                          | Cross-app integration journeys against the docker-compose stack |
 
-`service.backend` test config lives in `service.backend/vitest.config.ts`
-and enforces coverage thresholds (see ADS-418). `pnpm test:coverage`
-in that workspace fails the build below the thresholds.
+Each backend service owns its own `vitest.config.ts` under
+`services/<name>/`, which enforces coverage thresholds (see ADS-418).
+`pnpm test:coverage` in that workspace fails the build below the thresholds.
 
 ## E2E gating
 


### PR DESCRIPTION
`service.backend` was the monolith backend, deleted in the microservices migration. ~169 stale `service.backend/` references across `docs/` pointed contributors at file paths that no longer exist. Repointed to the current microservices (`services/<name>/`) where the domain maps cleanly (recommendations → matching, socket/rate-limiter/API edge → gateway, moderation → moderation, analytics reports → audit), and reworded to former-monolith phrasing where the monolith's internal layout has no 1:1 equivalent. Done file-by-file with judgement, not blind find-replace. (30 files, +166/−149)

Validated: `rg "service\.backend" docs/` reduced from **169 occurrences / 39 files → 72 / 11 files**; `node scripts/check-docs-script-references.mjs` → exit 0.

**Intentionally kept (72, all historical):** retained-for-context upgrade plans (with Status banners), monolith-tooling migration runbooks (now prefaced with historical-context notes), correct "now-removed" statements, and the `INFRA.md` changelog — rewriting these would falsify the record.

**Out of scope (flagged):** hyphenated `service-backend` Docker container names and `service-backend-prd.md` doc links are a separate, pre-existing staleness class (don't match this ticket's `service.backend/` dot-target). The ticket's optional item 3 (a new `check-stale-references.mjs` CI guard) was left for a follow-up.

Closes ADS-857

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QLtddqhQsBJ6wP1PcKJ9vf

---
_Generated by [Claude Code](https://claude.ai/code/session_01QLtddqhQsBJ6wP1PcKJ9vf)_