### PR TITLE
feat: add @adopt-dont-shop/test-utils shared test-utils package

### DIFF
--- a/packages/test-utils/package.json
+++ b/packages/test-utils/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "@adopt-dont-shop/test-utils",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Shared test utilities for gRPC microservices: stub gRPC server harness, principal/metadata builders, and NATS/JetStream test doubles. Dev-only — never shipped in service images.",
+  "type": "module",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "exports": {
+    ".": {
+      "types": "./src/index.ts",
+      "import": "./src/index.ts",
+      "default": "./src/index.ts"
+    }
+  },
+  "files": [
+    "src"
+  ],
+  "scripts": {
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage",
+    "lint": "eslint src",
+    "lint:fix": "eslint src --fix",
+    "format": "prettier --write \"src/**/*.ts\"",
+    "format:check": "prettier --check \"src/**/*.ts\"",
+    "type-check": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@adopt-dont-shop/authz": "workspace:*",
+    "@adopt-dont-shop/lib.types": "workspace:*",
+    "@grpc/grpc-js": "^1.14.4",
+    "nats": "^2.29.3",
+    "vitest": "^4.1.9"
+  },
+  "devDependencies": {
+    "@adopt-dont-shop/proto": "workspace:*",
+    "@types/node": "^25.9.1",
+    "typescript": "^6.0.0"
+  },
+  "peerDependencies": {
+    "vitest": "^4.1.9"
+  }
+}

--- a/packages/test-utils/src/grpc-server.test.ts
+++ b/packages/test-utils/src/grpc-server.test.ts
@@ -1,0 +1,106 @@
+// Behaviour tests for the stub gRPC server harness.
+//
+// These tests prove that `startStubGrpcServer`:
+//   - Boots a real gRPC server on an ephemeral port (i.e. port > 0).
+//   - Accepts and dispatches RPC calls end-to-end (via a real grpc-js client).
+//   - Shuts down cleanly after `close()` is called.
+//
+// We use the `PingService` from `@adopt-dont-shop/proto` as the service
+// under test since it is the simplest available definition (one unary
+// method, no principal required).
+
+import { promisify } from 'node:util';
+import { credentials } from '@grpc/grpc-js';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+// Proto package is available as a devDependency wired via workspace:*.
+import { PingV1 } from '@adopt-dont-shop/proto';
+
+import { startStubGrpcServer, type StubGrpcServer } from './grpc-server.js';
+
+// A minimal echo handler that returns the request message with a fixed timestamp.
+const echoHandler: PingV1.PingServer = {
+  echo: (call, callback) => {
+    callback(null, {
+      message: call.request.message,
+      receivedAt: '2026-01-01T00:00:00Z',
+    });
+  },
+};
+
+describe('startStubGrpcServer', () => {
+  let stub: StubGrpcServer;
+
+  beforeAll(async () => {
+    stub = await startStubGrpcServer(PingV1.PingService, echoHandler);
+  });
+
+  afterAll(async () => {
+    await stub.close();
+  });
+
+  it('binds to an ephemeral port (port number > 0)', () => {
+    const port = parseInt(stub.address.split(':')[1] ?? '0', 10);
+    expect(port).toBeGreaterThan(0);
+  });
+
+  it('serves a live RPC call end-to-end', async () => {
+    const client = new PingV1.PingClient(stub.address, credentials.createInsecure());
+    const echo = promisify<PingV1.EchoRequest, PingV1.EchoResponse>(client.echo.bind(client));
+
+    const response = await echo({ message: 'hello from test' });
+
+    expect(response.message).toBe('hello from test');
+    expect(response.receivedAt).toBe('2026-01-01T00:00:00Z');
+  });
+
+  it('responds to multiple sequential calls on the same server', async () => {
+    const client = new PingV1.PingClient(stub.address, credentials.createInsecure());
+    const echo = promisify<PingV1.EchoRequest, PingV1.EchoResponse>(client.echo.bind(client));
+
+    const [first, second] = await Promise.all([
+      echo({ message: 'ping-1' }),
+      echo({ message: 'ping-2' }),
+    ]);
+
+    expect(first.message).toBe('ping-1');
+    expect(second.message).toBe('ping-2');
+  });
+});
+
+describe('startStubGrpcServer — independent instance', () => {
+  it('each call starts a server on a distinct ephemeral port', async () => {
+    const handlerA: PingV1.PingServer = {
+      echo: (call, callback) => callback(null, { message: 'A', receivedAt: '' }),
+    };
+    const handlerB: PingV1.PingServer = {
+      echo: (call, callback) => callback(null, { message: 'B', receivedAt: '' }),
+    };
+
+    const [stubA, stubB] = await Promise.all([
+      startStubGrpcServer(PingV1.PingService, handlerA),
+      startStubGrpcServer(PingV1.PingService, handlerB),
+    ]);
+
+    try {
+      expect(stubA.address).not.toBe(stubB.address);
+
+      const clientA = new PingV1.PingClient(stubA.address, credentials.createInsecure());
+      const clientB = new PingV1.PingClient(stubB.address, credentials.createInsecure());
+
+      const [respA, respB] = await Promise.all([
+        promisify<PingV1.EchoRequest, PingV1.EchoResponse>(clientA.echo.bind(clientA))({
+          message: 'ignored',
+        }),
+        promisify<PingV1.EchoRequest, PingV1.EchoResponse>(clientB.echo.bind(clientB))({
+          message: 'ignored',
+        }),
+      ]);
+
+      expect(respA.message).toBe('A');
+      expect(respB.message).toBe('B');
+    } finally {
+      await Promise.all([stubA.close(), stubB.close()]);
+    }
+  });
+});

--- a/packages/test-utils/src/grpc-server.ts
+++ b/packages/test-utils/src/grpc-server.ts
@@ -1,0 +1,68 @@
+// Stub gRPC server harness for in-process testing.
+//
+// `startStubGrpcServer` boots a real grpc.Server on an OS-assigned ephemeral
+// port (host "127.0.0.1:0") so tests get a live gRPC transport without
+// managing fixed ports. The returned `StubGrpcServer` value carries the
+// bound address and a `close()` that shuts the server down cleanly.
+//
+// Typical usage pattern (Vitest):
+//
+//   let stub: StubGrpcServer;
+//   beforeAll(async () => {
+//     stub = await startStubGrpcServer(MyServiceDefinition, myHandlers);
+//   });
+//   afterAll(() => stub.close());
+//
+//   it('calls my RPC', async () => {
+//     const client = new MyServiceClient(stub.address, grpc.credentials.createInsecure());
+//     const resp = await promisify(client.myMethod.bind(client))({});
+//     expect(resp.field).toBe('expected');
+//   });
+
+import { promisify } from 'node:util';
+import {
+  Server,
+  ServerCredentials,
+  type ServiceDefinition,
+  type UntypedServiceImplementation,
+} from '@grpc/grpc-js';
+
+export type StubGrpcServer = {
+  /** The bound address in `host:port` form, e.g. `127.0.0.1:54321`. */
+  address: string;
+  /** Shut the server down. Returns a Promise that resolves when teardown completes. */
+  close: () => Promise<void>;
+};
+
+/**
+ * Start an in-process gRPC stub server on an ephemeral port.
+ *
+ * @param definition - The grpc-js ServiceDefinition (from ts-proto or hand-rolled).
+ * @param handlers   - The unary (and streaming) handler implementations.
+ * @returns A `StubGrpcServer` with the bound `address` and a `close()` teardown.
+ */
+export const startStubGrpcServer = async (
+  definition: ServiceDefinition,
+  handlers: UntypedServiceImplementation
+): Promise<StubGrpcServer> => {
+  const server = new Server();
+  server.addService(definition, handlers);
+
+  const bindAsync = promisify<string, ServerCredentials, number>(server.bindAsync.bind(server));
+  const port = await bindAsync('127.0.0.1:0', ServerCredentials.createInsecure());
+
+  const address = `127.0.0.1:${port}`;
+
+  const close = (): Promise<void> =>
+    new Promise<void>(resolve => {
+      server.tryShutdown(err => {
+        if (err) {
+          // Force-drain in case tryShutdown timed out.
+          server.forceShutdown();
+        }
+        resolve();
+      });
+    });
+
+  return { address, close };
+};

--- a/packages/test-utils/src/index.ts
+++ b/packages/test-utils/src/index.ts
@@ -1,0 +1,24 @@
+// @adopt-dont-shop/test-utils
+//
+// Shared test utilities for gRPC microservices. Dev-only — add as a
+// devDependency, never as a runtime dependency.
+//
+// Exports:
+//   startStubGrpcServer   — start an in-process gRPC server on an ephemeral
+//                           port for contract / integration tests.
+//   StubGrpcServer        — the return type of startStubGrpcServer.
+//   testPrincipal         — build a Principal with sensible defaults.
+//   TestPrincipalOverrides — partial override type for testPrincipal.
+//   metadataFor           — serialise a Principal into x-user-* gRPC Metadata.
+//   makeNatsDouble        — NATS / JetStream publish-recording double.
+//   NatsDouble            — the return type of makeNatsDouble.
+//   NatsPublishCall       — a single recorded publish call.
+
+export { startStubGrpcServer } from './grpc-server.js';
+export type { StubGrpcServer } from './grpc-server.js';
+
+export { testPrincipal, metadataFor } from './principal-builders.js';
+export type { TestPrincipalOverrides } from './principal-builders.js';
+
+export { makeNatsDouble } from './nats-doubles.js';
+export type { NatsDouble, NatsPublishCall } from './nats-doubles.js';

--- a/packages/test-utils/src/nats-doubles.test.ts
+++ b/packages/test-utils/src/nats-doubles.test.ts
@@ -1,0 +1,201 @@
+// Behaviour tests for the NATS test double.
+//
+// These tests prove that `makeNatsDouble`:
+//   - Records `publish()` calls on the core NATS connection via a Vitest spy.
+//   - Records `jetstream().publish()` calls (the primary path services use).
+//   - Records both in the same `publishSpy` and `published` list so assertions
+//     don't care which publish path the handler uses.
+//   - `clearPublished()` resets both the spy and the plain-array record.
+//   - `published` is ordered (FIFO) to match the sequence of calls.
+//   - The spy is compatible with `.mockImplementation()` so tests that need
+//     to interleave publish calls in an ordered-call log still work.
+
+import { describe, expect, it, vi } from 'vitest';
+
+import { makeNatsDouble } from './nats-doubles.js';
+
+describe('makeNatsDouble — core publish', () => {
+  it('records a plain publish call via the spy', () => {
+    const nat = makeNatsDouble();
+    nat.connection.publish('auth.userRegistered');
+
+    expect(nat.publishSpy).toHaveBeenCalledTimes(1);
+    expect(nat.publishSpy).toHaveBeenCalledWith('auth.userRegistered', undefined);
+  });
+
+  it('populates the plain-array published list', () => {
+    const nat = makeNatsDouble();
+    nat.connection.publish('auth.userRegistered');
+
+    expect(nat.published).toHaveLength(1);
+    expect(nat.published[0]?.subject).toBe('auth.userRegistered');
+    expect(nat.published[0]?.data).toBeUndefined();
+  });
+
+  it('records the data payload when supplied', () => {
+    const nat = makeNatsDouble();
+    const payload = new TextEncoder().encode(JSON.stringify({ userId: 'u-1' }));
+
+    nat.connection.publish('auth.userRegistered', payload);
+
+    expect(nat.published[0]?.data).toEqual(payload);
+    expect(nat.publishSpy.mock.calls[0]?.[1]).toEqual(payload);
+  });
+
+  it('records multiple publish calls in order', () => {
+    const nat = makeNatsDouble();
+
+    nat.connection.publish('auth.login');
+    nat.connection.publish('auth.logout');
+    nat.connection.publish('auth.passwordReset');
+
+    expect(nat.publishSpy).toHaveBeenCalledTimes(3);
+    expect(nat.published.map(c => c.subject)).toEqual([
+      'auth.login',
+      'auth.logout',
+      'auth.passwordReset',
+    ]);
+  });
+
+  it('supports mockImplementation for ordered-call-sequence tests', () => {
+    const nat = makeNatsDouble();
+    const log: string[] = [];
+
+    // e.g. a test that tracks interleaved DB and NATS calls:
+    nat.publishSpy.mockImplementation((subject: string) => {
+      log.push(`NATS:${subject}`);
+    });
+
+    nat.connection.publish('auth.login');
+    log.push('DB_COMMIT');
+    nat.connection.publish('auth.logout');
+
+    expect(log).toEqual(['NATS:auth.login', 'DB_COMMIT', 'NATS:auth.logout']);
+  });
+});
+
+describe('makeNatsDouble — JetStream publish', () => {
+  it('records a jetstream publish call via the spy', async () => {
+    const nat = makeNatsDouble();
+    await nat.connection.jetstream().publish('events.petAdopted');
+
+    expect(nat.publishSpy).toHaveBeenCalledTimes(1);
+    expect(nat.publishSpy).toHaveBeenCalledWith('events.petAdopted', undefined);
+  });
+
+  it('records jetstream publish in the plain-array list', async () => {
+    const nat = makeNatsDouble();
+
+    await nat.connection.jetstream().publish('events.petAdopted');
+
+    expect(nat.published).toHaveLength(1);
+    expect(nat.published[0]?.subject).toBe('events.petAdopted');
+  });
+
+  it('records jetstream publish with data payload', async () => {
+    const nat = makeNatsDouble();
+    const payload = new TextEncoder().encode('{"petId":"p-1"}');
+
+    await nat.connection.jetstream().publish('events.petAdopted', payload);
+
+    expect(nat.published[0]?.data).toEqual(payload);
+  });
+
+  it('returns a PubAck-like result so callers that await publish do not crash', async () => {
+    const nat = makeNatsDouble();
+
+    const result = await nat.connection.jetstream().publish('events.petAdopted');
+
+    expect(result.seq).toBeGreaterThan(0);
+    expect(result.stream).toBeDefined();
+  });
+});
+
+describe('makeNatsDouble — spy mock.calls access', () => {
+  it('exposes subject and data via mock.calls for existing test patterns', async () => {
+    const nat = makeNatsDouble();
+    const payload = new TextEncoder().encode('{"foo":"bar"}');
+
+    nat.connection.publish('notifications.created', payload);
+
+    const [subject, body] = nat.publishSpy.mock.calls[0] as [string, Uint8Array];
+    expect(subject).toBe('notifications.created');
+    expect(body).toEqual(payload);
+  });
+});
+
+describe('makeNatsDouble — mixed publish paths', () => {
+  it('records both core and JetStream publishes in the same spy and list', async () => {
+    const nat = makeNatsDouble();
+
+    nat.connection.publish('core.subject');
+    await nat.connection.jetstream().publish('js.subject');
+
+    expect(nat.publishSpy).toHaveBeenCalledTimes(2);
+    expect(nat.published[0]?.subject).toBe('core.subject');
+    expect(nat.published[1]?.subject).toBe('js.subject');
+  });
+});
+
+describe('makeNatsDouble — clearPublished', () => {
+  it('resets both the spy and the plain array', async () => {
+    const nat = makeNatsDouble();
+
+    nat.connection.publish('first');
+    await nat.connection.jetstream().publish('second');
+    expect(nat.publishSpy).toHaveBeenCalledTimes(2);
+    expect(nat.published).toHaveLength(2);
+
+    nat.clearPublished();
+
+    expect(nat.publishSpy).toHaveBeenCalledTimes(0);
+    expect(nat.published).toHaveLength(0);
+  });
+
+  it('records new calls after clearing', () => {
+    const nat = makeNatsDouble();
+
+    nat.connection.publish('old');
+    nat.clearPublished();
+    nat.connection.publish('new');
+
+    expect(nat.publishSpy).toHaveBeenCalledTimes(1);
+    expect(nat.published[0]?.subject).toBe('new');
+  });
+});
+
+describe('makeNatsDouble — each call returns a fresh double', () => {
+  it('separate doubles do not share spy state', () => {
+    const natA = makeNatsDouble();
+    const natB = makeNatsDouble();
+
+    natA.connection.publish('a.subject');
+
+    expect(natA.publishSpy).toHaveBeenCalledTimes(1);
+    expect(natB.publishSpy).toHaveBeenCalledTimes(0);
+    expect(natA.published).toHaveLength(1);
+    expect(natB.published).toHaveLength(0);
+  });
+});
+
+describe('makeNatsDouble — vi.fn compatibility', () => {
+  it('publishSpy is a real Vitest spy that supports toHaveBeenCalledWith', () => {
+    const nat = makeNatsDouble();
+    const data = new Uint8Array([1, 2, 3]);
+
+    nat.connection.publish('my.subject', data);
+
+    // Vitest's toHaveBeenCalledWith matcher
+    expect(nat.publishSpy).toHaveBeenCalledWith('my.subject', data);
+  });
+
+  it('publishSpy can be spied on with vi.spyOn-style mockResolvedValue', async () => {
+    const nat = makeNatsDouble();
+    // Override to simulate a throw
+    nat.publishSpy.mockImplementationOnce(() => {
+      throw new Error('NATS unavailable');
+    });
+
+    expect(() => nat.connection.publish('auth.login')).toThrow('NATS unavailable');
+  });
+});

--- a/packages/test-utils/src/nats-doubles.ts
+++ b/packages/test-utils/src/nats-doubles.ts
@@ -1,0 +1,140 @@
+// NATS / JetStream test doubles.
+//
+// Services communicate via NATS JetStream (`nats.jetstream().publish()`) and
+// plain core NATS (`nats.publish()`). These doubles let tests assert what was
+// published without requiring a live NATS server.
+//
+// `makeNatsDouble()` returns a lightweight fake that:
+//   - Exposes a `publishSpy` — a Vitest `vi.fn()` recorded on every publish
+//     call regardless of whether it went through core NATS or JetStream.
+//   - Implements `jetstream()` returning an object whose `.publish()` routes
+//     to the same spy (matching the pattern every service uses).
+//   - Is structurally compatible with `NatsConnection` from the `nats` package
+//     so it can be passed directly to service handler deps without a cast in
+//     test code.
+//   - The `published` array mirrors the spy calls as `NatsPublishCall` records
+//     for tests that prefer the plain-array style over spy assertions.
+//
+// Usage with Vitest spy API:
+//   const nat = makeNatsDouble();
+//   // ...run handler...
+//   expect(nat.publishSpy).toHaveBeenCalledWith('auth.login', expect.any(Uint8Array));
+//   expect(nat.publishSpy.mock.calls[0][0]).toBe('auth.login');
+//
+// Usage with plain-array assertions:
+//   expect(nat.published).toHaveLength(1);
+//   expect(nat.published[0].subject).toBe('auth.login');
+
+import { vi } from 'vitest';
+import type { NatsConnection } from 'nats';
+
+/**
+ * A recorded NATS publish call.
+ */
+export type NatsPublishCall = {
+  subject: string;
+  data: Uint8Array | undefined;
+};
+
+/**
+ * A NATS test double that records publish calls via a Vitest spy and
+ * exposes them for assertion via both the spy API and a plain array.
+ */
+export type NatsDouble = {
+  /**
+   * The fake `NatsConnection` to inject into handler deps.
+   * Structurally compatible so no cast is needed.
+   */
+  connection: NatsConnection;
+  /**
+   * Vitest spy recording every publish call (core NATS and JetStream both
+   * route here). Compatible with `.mockImplementation()`, `.mock.calls`, etc.
+   * Call signature: `(subject: string, data?: Uint8Array) => void`.
+   */
+  publishSpy: ReturnType<typeof vi.fn>;
+  /**
+   * All publish calls recorded in order. Each entry carries the subject and
+   * optional data payload. Updated automatically as calls are made.
+   */
+  published: readonly NatsPublishCall[];
+  /**
+   * Clear the recorded publish calls and reset the spy (call in `beforeEach`
+   * when reusing the double across tests).
+   */
+  clearPublished: () => void;
+};
+
+/**
+ * Build a NATS test double.
+ *
+ * The returned `connection` can be injected directly as `HandlerDeps.nats`.
+ * Both `connection.publish()` and `connection.jetstream().publish()` route to
+ * the same Vitest spy, matching how services publish events.
+ *
+ * @example
+ * const nat = makeNatsDouble();
+ * const deps = { pool: poolDouble.pool, nats: nat.connection };
+ * await myHandler(deps, principal, request);
+ *
+ * // Vitest spy API:
+ * expect(nat.publishSpy).toHaveBeenCalledTimes(1);
+ * const [subject] = nat.publishSpy.mock.calls[0];
+ * expect(subject).toBe('auth.userRegistered');
+ *
+ * // Plain-array API:
+ * expect(nat.published).toHaveLength(1);
+ * expect(nat.published[0].subject).toBe('auth.userRegistered');
+ */
+export const makeNatsDouble = (): NatsDouble => {
+  const records: NatsPublishCall[] = [];
+  const publishSpy = vi.fn((subject: string, data?: Uint8Array): void => {
+    records.push({ subject, data });
+  });
+
+  // Minimal structural implementation of what services call on NatsConnection.
+  const connection = {
+    publish: (subject: string, data?: Uint8Array) => publishSpy(subject, data),
+    jetstream: () => ({
+      publish: async (subject: string, data?: Uint8Array) => {
+        publishSpy(subject, data);
+        // Return a minimal PubAck-like object so callers that await publish don't crash.
+        return { seq: 1, stream: 'stub', duplicate: false };
+      },
+    }),
+    // Stub remaining NatsConnection methods that might be called during boot/shutdown.
+    drain: async () => undefined,
+    close: async () => undefined,
+    status: () => ({ type: 'disconnect' }),
+    closed: () => Promise.resolve(),
+    isClosed: () => false,
+    isDraining: () => false,
+    getServer: () => 'nats://127.0.0.1:4222',
+    flush: async () => undefined,
+    subscribe: () => {
+      throw new Error(
+        'NatsDouble.subscribe() is not implemented — use makeNatsDouble only for publish assertions'
+      );
+    },
+    jetstreamManager: async () => {
+      throw new Error(
+        'NatsDouble.jetstreamManager() is not implemented — use makeNatsDouble only for publish assertions'
+      );
+    },
+    services: () => {
+      throw new Error('NatsDouble.services() is not implemented');
+    },
+    info: undefined,
+  } as unknown as NatsConnection;
+
+  return {
+    connection,
+    publishSpy,
+    get published() {
+      return records as readonly NatsPublishCall[];
+    },
+    clearPublished: () => {
+      records.length = 0;
+      publishSpy.mockClear();
+    },
+  };
+};

--- a/packages/test-utils/src/principal-builders.test.ts
+++ b/packages/test-utils/src/principal-builders.test.ts
@@ -1,0 +1,127 @@
+// Behaviour tests for principal and metadata builders.
+//
+// These tests prove that:
+//   - `testPrincipal()` returns a valid Principal with sensible defaults.
+//   - Overrides are applied correctly without affecting unspecified fields.
+//   - `metadataFor()` stamps the correct x-user-* headers that the gateway
+//     forwards to downstream services.
+//   - x-rescue-id is only set when the principal carries one.
+
+import { Metadata } from '@grpc/grpc-js';
+import { describe, expect, it } from 'vitest';
+import type { Permission, RescueId, UserId, UserRole } from '@adopt-dont-shop/lib.types';
+
+import { metadataFor, testPrincipal } from './principal-builders.js';
+
+describe('testPrincipal — default shape', () => {
+  it('returns a non-empty userId', () => {
+    const p = testPrincipal();
+    expect(p.userId).toBeTruthy();
+  });
+
+  it('returns at least one role', () => {
+    const p = testPrincipal();
+    expect(p.roles.length).toBeGreaterThan(0);
+  });
+
+  it('returns an empty permissions list by default', () => {
+    const p = testPrincipal();
+    expect(p.permissions).toEqual([]);
+  });
+
+  it('does not include rescueId by default', () => {
+    const p = testPrincipal();
+    expect(p.rescueId).toBeUndefined();
+  });
+});
+
+describe('testPrincipal — overrides', () => {
+  it('applies a custom userId', () => {
+    const p = testPrincipal({ userId: 'usr-custom' as UserId });
+    expect(p.userId).toBe('usr-custom');
+  });
+
+  it('applies custom roles', () => {
+    const p = testPrincipal({ roles: ['admin'] as UserRole[] });
+    expect(p.roles).toEqual(['admin']);
+  });
+
+  it('applies custom permissions', () => {
+    const p = testPrincipal({ permissions: ['pets.read'] as Permission[] });
+    expect(p.permissions).toEqual(['pets.read']);
+  });
+
+  it('applies rescueId when provided', () => {
+    const p = testPrincipal({ rescueId: 'rsc-42' as RescueId });
+    expect(p.rescueId).toBe('rsc-42');
+  });
+
+  it('does not include rescueId when explicitly undefined in override', () => {
+    const p = testPrincipal({ rescueId: undefined });
+    expect(p.rescueId).toBeUndefined();
+  });
+
+  it('leaves unspecified fields at their defaults', () => {
+    const p = testPrincipal({ userId: 'usr-partial' as UserId });
+    // roles and permissions should still be the defaults
+    expect(p.roles.length).toBeGreaterThan(0);
+    expect(p.permissions).toEqual([]);
+  });
+});
+
+describe('metadataFor — header stamping', () => {
+  it('stamps x-user-id with the principal userId', () => {
+    const p = testPrincipal({ userId: 'usr-meta-test' as UserId });
+    const m = metadataFor(p);
+
+    expect(getHeader(m, 'x-user-id')).toBe('usr-meta-test');
+  });
+
+  it('stamps x-user-roles as comma-separated roles', () => {
+    const p = testPrincipal({ roles: ['admin', 'rescue_staff'] as UserRole[] });
+    const m = metadataFor(p);
+
+    expect(getHeader(m, 'x-user-roles')).toBe('admin,rescue_staff');
+  });
+
+  it('stamps x-user-permissions as a comma-separated list', () => {
+    const p = testPrincipal({ permissions: ['pets.read', 'pets.update'] as Permission[] });
+    const m = metadataFor(p);
+
+    expect(getHeader(m, 'x-user-permissions')).toBe('pets.read,pets.update');
+  });
+
+  it('stamps x-user-permissions as empty string when permissions are empty', () => {
+    const p = testPrincipal({ permissions: [] });
+    const m = metadataFor(p);
+
+    expect(getHeader(m, 'x-user-permissions')).toBe('');
+  });
+
+  it('stamps x-rescue-id when the principal carries one', () => {
+    const p = testPrincipal({ rescueId: 'rsc-7' as RescueId });
+    const m = metadataFor(p);
+
+    expect(getHeader(m, 'x-rescue-id')).toBe('rsc-7');
+  });
+
+  it('does not stamp x-rescue-id when the principal has none', () => {
+    const p = testPrincipal();
+    const m = metadataFor(p);
+
+    expect(m.get('x-rescue-id')).toHaveLength(0);
+  });
+
+  it('returns a Metadata instance', () => {
+    const m = metadataFor(testPrincipal());
+    expect(m).toBeInstanceOf(Metadata);
+  });
+});
+
+// Helpers
+
+function getHeader(m: Metadata, key: string): string {
+  const values = m.get(key);
+  const first = values[0];
+  return typeof first === 'string' ? first : String(first ?? '');
+}

--- a/packages/test-utils/src/principal-builders.ts
+++ b/packages/test-utils/src/principal-builders.ts
@@ -1,0 +1,64 @@
+// Principal and gRPC metadata builders for tests.
+//
+// These mirror the gateway's `x-user-*` metadata-stamping pattern
+// (services/gateway/src/middleware/metadata.ts) so any test that needs
+// to construct a realistic caller identity can do so without copy-pasting
+// the same ad-hoc object literals into every test file.
+//
+// `testPrincipal(overrides?)` — builds a Principal with sensible defaults.
+// `metadataFor(principal)` — serialises a Principal into gRPC Metadata,
+//   stamping exactly the headers the gateway forwards:
+//     x-user-id / x-user-roles / x-user-permissions / x-rescue-id
+
+import { Metadata } from '@grpc/grpc-js';
+import type { Principal } from '@adopt-dont-shop/authz';
+import type { Permission, RescueId, UserId, UserRole } from '@adopt-dont-shop/lib.types';
+
+/**
+ * Partial overrides accepted by `testPrincipal`. Every field is optional —
+ * the builder fills sensible defaults for the rest.
+ */
+export type TestPrincipalOverrides = {
+  userId?: UserId;
+  roles?: UserRole[];
+  permissions?: Permission[];
+  rescueId?: RescueId;
+};
+
+/**
+ * Build a test `Principal` with sensible defaults.
+ *
+ * @param overrides - Optional fields to override the defaults.
+ * @returns A fully populated `Principal`.
+ */
+export const testPrincipal = (overrides: TestPrincipalOverrides = {}): Principal => ({
+  userId: overrides.userId ?? ('usr-test' as UserId),
+  roles: overrides.roles ?? (['adopter'] as UserRole[]),
+  permissions: overrides.permissions ?? [],
+  ...(overrides.rescueId !== undefined ? { rescueId: overrides.rescueId } : {}),
+});
+
+/**
+ * Serialise a `Principal` into gRPC `Metadata` using the same header names
+ * the gateway stamps when forwarding an authenticated request to a downstream
+ * service. Matches `services/gateway/src/middleware/metadata.ts`.
+ *
+ * Headers stamped:
+ *   - `x-user-id`          — the user's UUID
+ *   - `x-user-roles`       — comma-separated roles
+ *   - `x-user-permissions` — comma-separated permissions (may be empty string)
+ *   - `x-rescue-id`        — only set when `principal.rescueId` is defined
+ *
+ * @param principal - The principal to serialise.
+ * @returns A populated `Metadata` instance ready to attach to a gRPC call.
+ */
+export const metadataFor = (principal: Principal): Metadata => {
+  const m = new Metadata();
+  m.set('x-user-id', principal.userId);
+  m.set('x-user-roles', principal.roles.join(','));
+  m.set('x-user-permissions', principal.permissions.join(','));
+  if (principal.rescueId !== undefined) {
+    m.set('x-rescue-id', principal.rescueId);
+  }
+  return m;
+};

--- a/packages/test-utils/tsconfig.json
+++ b/packages/test-utils/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "target": "ES2022",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "noEmit": true,
+    "types": ["node", "vitest/globals"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/test-utils/vitest.config.ts
+++ b/packages/test-utils/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    name: 'test-utils',
+    environment: 'node',
+    include: ['src/**/*.test.ts'],
+    testTimeout: 10_000,
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1622,6 +1622,34 @@ importers:
         specifier: ^11.0.4
         version: 11.0.4
 
+  packages/test-utils:
+    dependencies:
+      '@adopt-dont-shop/authz':
+        specifier: workspace:*
+        version: link:../authz
+      '@adopt-dont-shop/lib.types':
+        specifier: workspace:*
+        version: link:../lib.types
+      '@grpc/grpc-js':
+        specifier: ^1.14.4
+        version: 1.14.4
+      nats:
+        specifier: ^2.29.3
+        version: 2.29.3
+      vitest:
+        specifier: ^4.1.9
+        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@25.9.3)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.14.6(@types/node@25.9.3)(typescript@6.0.3))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+    devDependencies:
+      '@adopt-dont-shop/proto':
+        specifier: workspace:*
+        version: link:../proto
+      '@types/node':
+        specifier: ^25.9.1
+        version: 25.9.3
+      typescript:
+        specifier: ^6.0.0
+        version: 6.0.3
+
   services/applications:
     dependencies:
       '@adopt-dont-shop/authz':
@@ -1954,6 +1982,9 @@ importers:
         specifier: ^3.19.0
         version: 3.19.0
     devDependencies:
+      '@adopt-dont-shop/test-utils':
+        specifier: workspace:*
+        version: link:../../packages/test-utils
       '@types/pg':
         specifier: ^8.15.5
         version: 8.20.0
@@ -2110,6 +2141,9 @@ importers:
         specifier: ^3.19.0
         version: 3.19.0
     devDependencies:
+      '@adopt-dont-shop/test-utils':
+        specifier: workspace:*
+        version: link:../../packages/test-utils
       '@types/nodemailer':
         specifier: ^8.0.0
         version: 8.0.1

--- a/services/gateway/package.json
+++ b/services/gateway/package.json
@@ -57,6 +57,7 @@
     "winston": "^3.19.0"
   },
   "devDependencies": {
+    "@adopt-dont-shop/test-utils": "workspace:*",
     "@types/pg": "^8.15.5",
     "socket.io-client": "^4.8.3"
   }

--- a/services/gateway/src/grpc-clients/auth-client.contract.test.ts
+++ b/services/gateway/src/grpc-clients/auth-client.contract.test.ts
@@ -13,8 +13,6 @@
 
 import {
   Metadata,
-  Server,
-  ServerCredentials,
   type ServerUnaryCall,
   type sendUnaryData,
   type ServiceError,
@@ -29,7 +27,9 @@ import {
   type ValidateTokenResponse,
 } from '@adopt-dont-shop/proto';
 
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { describe, expect, it } from 'vitest';
+
+import { startStubGrpcServer, type StubGrpcServer } from '@adopt-dont-shop/test-utils';
 
 import { createAuthClient } from './auth-client.js';
 
@@ -86,29 +86,15 @@ const makeHandlers = (overrides: Partial<AuthV1.AuthServiceServer>): AuthV1.Auth
   ...overrides,
 });
 
+// Start a stub gRPC server for a single test case; the returned `stub`
+// carries `stub.address` and `stub.close()`. Callers are responsible for
+// calling `stub.close()` in a `finally` block.
+const startTestServer = (handlers: AuthV1.AuthServiceServer): Promise<StubGrpcServer> =>
+  startStubGrpcServer(AuthV1.AuthServiceService, handlers);
+
 // ── suite ─────────────────────────────────────────────────────────────
 
 describe('auth-client — gRPC contract', () => {
-  let server: Server;
-  let port: number;
-
-  beforeEach(() => {
-    server = new Server();
-  });
-
-  afterEach(async () => {
-    await new Promise<void>(resolve => server.tryShutdown(() => resolve()));
-  });
-
-  const startServer = (handlers: AuthV1.AuthServiceServer): Promise<number> =>
-    new Promise<number>((resolve, reject) => {
-      server.addService(AuthV1.AuthServiceService, handlers);
-      server.bindAsync('127.0.0.1:0', ServerCredentials.createInsecure(), (err, boundPort) => {
-        if (err) reject(err);
-        else resolve(boundPort);
-      });
-    });
-
   // ── 1. Happy-path read: validateToken ────────────────────────────
 
   it('validateToken — returns typed response round-trip', async () => {
@@ -124,7 +110,7 @@ describe('auth-client — gRPC contract', () => {
 
     let receivedToken = '';
 
-    port = await startServer(
+    const stub = await startTestServer(
       makeHandlers({
         validateToken: (
           call: ServerUnaryCall<ValidateTokenRequest, ValidateTokenResponse>,
@@ -136,7 +122,7 @@ describe('auth-client — gRPC contract', () => {
       })
     );
 
-    const client = createAuthClient({ address: `127.0.0.1:${port}` });
+    const client = createAuthClient({ address: stub.address });
     try {
       const result = await client.validateToken({ accessToken: 'tok-abc' }, new Metadata());
       expect(receivedToken).toBe('tok-abc');
@@ -144,6 +130,7 @@ describe('auth-client — gRPC contract', () => {
       expect(result.expiresAt).toBe('2026-01-01T00:00:00Z');
     } finally {
       client.close();
+      await stub.close();
     }
   });
 
@@ -174,7 +161,7 @@ describe('auth-client — gRPC contract', () => {
     let capturedEmail = '';
     let capturedPassword = '';
 
-    port = await startServer(
+    const stub = await startTestServer(
       makeHandlers({
         login: (
           call: ServerUnaryCall<LoginRequest, LoginResponse>,
@@ -187,7 +174,7 @@ describe('auth-client — gRPC contract', () => {
       })
     );
 
-    const client = createAuthClient({ address: `127.0.0.1:${port}` });
+    const client = createAuthClient({ address: stub.address });
     try {
       const result = await client.login(
         { email: 'login@example.com', password: 'secret' },
@@ -199,13 +186,14 @@ describe('auth-client — gRPC contract', () => {
       expect(result.user?.userId).toBe('user-456');
     } finally {
       client.close();
+      await stub.close();
     }
   });
 
   // ── 3. Error contract ────────────────────────────────────────────
 
   it('validateToken — NOT_FOUND from the server surfaces with .code === status.NOT_FOUND', async () => {
-    port = await startServer(
+    const stub = await startTestServer(
       makeHandlers({
         validateToken: (
           _call: ServerUnaryCall<ValidateTokenRequest, ValidateTokenResponse>,
@@ -216,7 +204,7 @@ describe('auth-client — gRPC contract', () => {
       })
     );
 
-    const client = createAuthClient({ address: `127.0.0.1:${port}` });
+    const client = createAuthClient({ address: stub.address });
     try {
       await client.validateToken({ accessToken: 'missing' }, new Metadata());
       expect.fail('expected rejection');
@@ -224,6 +212,7 @@ describe('auth-client — gRPC contract', () => {
       expect((err as { code?: number }).code).toBe(status.NOT_FOUND);
     } finally {
       client.close();
+      await stub.close();
     }
   });
 
@@ -236,7 +225,7 @@ describe('auth-client — gRPC contract', () => {
   // this keeps the elapsed time bounded to a single 5s deadline.
 
   it('deadline — a never-responding server produces DEADLINE_EXCEEDED within ~6s', async () => {
-    port = await startServer(
+    const stub = await startTestServer(
       makeHandlers({
         login: (
           _call: ServerUnaryCall<LoginRequest, LoginResponse>,
@@ -247,7 +236,7 @@ describe('auth-client — gRPC contract', () => {
       })
     );
 
-    const client = createAuthClient({ address: `127.0.0.1:${port}` });
+    const client = createAuthClient({ address: stub.address });
     const start = Date.now();
     try {
       await client.login({ email: 'test@example.com', password: 'secret' }, new Metadata());
@@ -261,6 +250,7 @@ describe('auth-client — gRPC contract', () => {
       expect(elapsed).toBeLessThan(7_000);
     } finally {
       client.close();
+      await stub.close();
     }
   }, 8_000); // explicit timeout > 5s deadline
 });

--- a/services/notifications/package.json
+++ b/services/notifications/package.json
@@ -51,6 +51,7 @@
     "winston": "^3.19.0"
   },
   "devDependencies": {
+    "@adopt-dont-shop/test-utils": "workspace:*",
     "@types/nodemailer": "^8.0.0",
     "@types/pg": "^8.15.5"
   }

--- a/services/notifications/src/grpc/handlers.test.ts
+++ b/services/notifications/src/grpc/handlers.test.ts
@@ -1,8 +1,6 @@
-import type { NatsConnection } from 'nats';
 import type { Pool, PoolClient } from 'pg';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import type { Principal } from '@adopt-dont-shop/authz';
 import type { Permission, UserId } from '@adopt-dont-shop/lib.types';
 import {
   NotificationsV1,
@@ -10,6 +8,8 @@ import {
   type DismissNotificationRequest,
   type ListNotificationsRequest,
 } from '@adopt-dont-shop/proto';
+
+import { makeNatsDouble, testPrincipal } from '@adopt-dont-shop/test-utils';
 
 import {
   createNotification,
@@ -20,7 +20,7 @@ import {
 
 // --- Test fixtures --------------------------------------------------
 
-const SYSTEM_PRINCIPAL: Principal = {
+const SYSTEM_PRINCIPAL = testPrincipal({
   userId: 'svc-application' as UserId,
   roles: ['admin'],
   permissions: [
@@ -28,19 +28,19 @@ const SYSTEM_PRINCIPAL: Principal = {
     'notifications.read' as Permission,
     'notifications.update' as Permission,
   ],
-};
+});
 
-const SUPER_ADMIN_PRINCIPAL: Principal = {
+const SUPER_ADMIN_PRINCIPAL = testPrincipal({
   userId: 'svc-super' as UserId,
   roles: ['super_admin'],
   permissions: [],
-};
+});
 
-const ADOPTER_PRINCIPAL: Principal = {
+const ADOPTER_PRINCIPAL = testPrincipal({
   userId: 'usr-adopter' as UserId,
   roles: ['adopter'],
   permissions: ['notifications.read' as Permission, 'notifications.update' as Permission],
-};
+});
 
 function rowFixture(overrides: Record<string, unknown> = {}) {
   return {
@@ -82,23 +82,16 @@ function makeMocks() {
     connect: vi.fn().mockResolvedValue(client),
     query: vi.fn(),
   };
-  const natsPublish = vi.fn();
-  // JetStream publish routes to the same spy so existing publish assertions
-  // keep working; withTransaction now publishes via nats.jetstream().publish().
-  const nats = {
-    publish: natsPublish,
-    jetstream: () => ({ publish: natsPublish }),
-  };
+  const nat = makeNatsDouble();
   return {
     pool: pool as unknown as Pool,
     client: client as unknown as PoolClient,
-    nats: nats as unknown as NatsConnection,
     poolMock: pool,
     clientMock: client,
-    natsMock: nats,
+    natsMock: nat,
     deps: {
       pool: pool as unknown as Pool,
-      nats: nats as unknown as NatsConnection,
+      nats: nat.connection,
     },
   };
 }
@@ -165,8 +158,9 @@ describe('createNotification', () => {
       }
       return { rows: [] };
     });
-    mocks.natsMock.publish.mockImplementation(() => {
+    mocks.natsMock.publishSpy.mockImplementation((subject: string) => {
       calls.push('NATS_PUBLISH');
+      void subject;
     });
 
     const res = await createNotification(mocks.deps, SYSTEM_PRINCIPAL, BASE_CREATE_REQ);
@@ -190,7 +184,7 @@ describe('createNotification', () => {
 
     await createNotification(mocks.deps, SYSTEM_PRINCIPAL, BASE_CREATE_REQ);
 
-    const [subject, body] = mocks.natsMock.publish.mock.calls[0];
+    const [subject, body] = mocks.natsMock.publishSpy.mock.calls[0] as [string, Uint8Array];
     expect(subject).toBe('notifications.created');
     const envelope = JSON.parse(
       body instanceof Uint8Array ? new TextDecoder().decode(body) : (body as string)
@@ -213,7 +207,7 @@ describe('createNotification', () => {
       'duplicate key'
     );
 
-    expect(mocks.natsMock.publish).not.toHaveBeenCalled();
+    expect(mocks.natsMock.publishSpy).not.toHaveBeenCalled();
   });
 });
 
@@ -244,7 +238,7 @@ describe('listNotifications', () => {
     };
     const res = await listNotifications(mocks.deps, ADOPTER_PRINCIPAL, req);
 
-    const [, params] = mocks.poolMock.query.mock.calls[0];
+    const [, params] = mocks.poolMock.query.mock.calls[0] as [string, unknown[]];
     expect(params[0]).toBe(ADOPTER_PRINCIPAL.userId);
     // limit+1 = 21 by default
     expect(params[params.length - 1]).toBe(21);
@@ -272,7 +266,7 @@ describe('listNotifications', () => {
     expect(res.notifications).toHaveLength(20);
     expect(res.nextCursor).toBeDefined();
     const decoded = JSON.parse(Buffer.from(res.nextCursor!, 'base64').toString('utf8'));
-    expect(decoded.notificationId).toBe(rows[19].notification_id);
+    expect(decoded.notificationId).toBe(rows[19]!.notification_id);
   });
 
   it('rejects a limit > 100 — INVALID_ARGUMENT', async () => {
@@ -310,7 +304,7 @@ describe('listNotifications', () => {
       typeFilter: 0,
     });
 
-    const [sql, params] = mocks.poolMock.query.mock.calls[0];
+    const [sql, params] = mocks.poolMock.query.mock.calls[0] as [string, unknown[]];
     expect(sql).toMatch(/status = \$2/);
     expect(params[1]).toBe('pending');
   });
@@ -378,7 +372,7 @@ describe('dismissNotification', () => {
 
     // Only the SELECT happened — no transaction, no publish.
     expect(mocks.poolMock.connect).not.toHaveBeenCalled();
-    expect(mocks.natsMock.publish).not.toHaveBeenCalled();
+    expect(mocks.natsMock.publishSpy).not.toHaveBeenCalled();
     expect(res.notification.status).toBe(
       NotificationsV1.NotificationStatus.NOTIFICATION_STATUS_READ
     );
@@ -401,8 +395,9 @@ describe('dismissNotification', () => {
       }
       return { rows: [] };
     });
-    mocks.natsMock.publish.mockImplementation(() => {
+    mocks.natsMock.publishSpy.mockImplementation((subject: string) => {
       calls.push('NATS_PUBLISH');
+      void subject;
     });
 
     const res = await dismissNotification(mocks.deps, ADOPTER_PRINCIPAL, dismissReq);
@@ -411,7 +406,7 @@ describe('dismissNotification', () => {
     expect(res.notification.status).toBe(
       NotificationsV1.NotificationStatus.NOTIFICATION_STATUS_READ
     );
-    const [subject, body] = mocks.natsMock.publish.mock.calls[0];
+    const [subject, body] = mocks.natsMock.publishSpy.mock.calls[0] as [string, Uint8Array];
     expect(subject).toBe('notifications.dismissed');
     const envelope = JSON.parse(
       body instanceof Uint8Array ? new TextDecoder().decode(body) : (body as string)
@@ -450,8 +445,9 @@ describe('createNotification idempotency (dedup)', () => {
       calls.push(sql.trim().split(/\s+/)[0]);
       return { rows: [] };
     });
-    mocks.natsMock.publish.mockImplementation(() => {
+    mocks.natsMock.publishSpy.mockImplementation((subject: string) => {
       calls.push('PUBLISH');
+      void subject;
     });
   };
 
@@ -477,7 +473,7 @@ describe('createNotification idempotency (dedup)', () => {
 
     expect(calls).toEqual(['BEGIN', 'CLAIM', 'COMMIT']);
     expect(res.notification).toBeUndefined();
-    expect(mocks.natsMock.publish).not.toHaveBeenCalled();
+    expect(mocks.natsMock.publishSpy).not.toHaveBeenCalled();
   });
 
   it('does not claim anything when no dedup option is supplied (direct gRPC path)', async () => {


### PR DESCRIPTION
## Summary

- Adds new dev-only workspace package `@adopt-dont-shop/test-utils` exporting three shared test harness utilities: `startStubGrpcServer`, `testPrincipal`/`metadataFor`, and `makeNatsDouble`
- Migrates `services/gateway` auth-client contract tests to use `startStubGrpcServer` (proof: stub-server consumer)
- Migrates `services/notifications` gRPC handler tests to use `testPrincipal` and `makeNatsDouble` (proof: principal-builder + NATS double consumers)

## What's in the package

### `startStubGrpcServer(definition, handlers)`
Boots a real `@grpc/grpc-js` server on an ephemeral port (`127.0.0.1:0`) and returns `{ address, close() }`. Eliminates the per-service boilerplate of manual `Server`, `bindAsync`, and `tryShutdown` wiring that was duplicated in every contract/handler test.

### `testPrincipal(overrides?)` + `metadataFor(principal)`
Builds a `Principal` object with sensible defaults (`userId: 'usr-test'`, `roles: ['adopter']`, `permissions: []`) and stamps it onto gRPC `Metadata` using the gateway's `x-user-*` header convention. Replaces hand-rolled constant objects in every service test.

### `makeNatsDouble()`
Returns `{ connection, publishSpy, published, clearPublished }`. Both `connection.publish()` (core) and `connection.jetstream().publish()` (JetStream) route through the same `vi.fn()` spy, so tests can use either Vitest spy assertions (`toHaveBeenCalledWith`, `mockImplementation`, `mock.calls`) or the plain `published` array — whichever style the test prefers. `clearPublished()` resets both the spy and the array.

## Test plan

- [ ] `pnpm exec turbo test --filter=@adopt-dont-shop/test-utils` — 37 tests across 3 test files (grpc-server, principal-builders, nats-doubles), all passing
- [ ] `pnpm exec turbo test --filter=@adopt-dont-shop/service.notifications` — 277 tests passing (migrated handlers.test.ts)
- [ ] `pnpm exec turbo test --filter=@adopt-dont-shop/service.gateway` — 727 tests passing (migrated auth-client.contract.test.ts)
- [ ] `pnpm exec turbo type-check --filter=@adopt-dont-shop/test-utils --filter=@adopt-dont-shop/service.gateway --filter=@adopt-dont-shop/service.notifications` — all 3 packages pass tsc `--noEmit`

Refs ADS-837

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KCSKu6LHL9184ff1hK9Yr8

---
_Generated by [Claude Code](https://claude.ai/code/session_01KCSKu6LHL9184ff1hK9Yr8)_