### PR TITLE
fix(security): remove unsafe-inline from frontend CSP style-src (ADS-847)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,11 @@ jobs:
       - name: Verify prod/staging base images are digest-pinned
         run: node scripts/check-docker-pinning.mjs
 
+      # ADS-847: the nginx CSP baked into Dockerfile.app must not contain
+      # 'unsafe-inline' in style-src now that styled-components is gone.
+      - name: Verify CSP style-src has no unsafe-inline
+        run: node scripts/check-csp-headers.mjs
+
   # ============================================================================
   # CHANGE DETECTION — gate all downstream jobs on relevant path changes
   # ============================================================================

--- a/Dockerfile.app
+++ b/Dockerfile.app
@@ -179,9 +179,9 @@ add_header X-XSS-Protection "1; mode=block" always; \
 add_header Referrer-Policy "strict-origin-when-cross-origin" always; \
 add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload" always; \
 add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=()" always; \
-# CSP without unsafe-inline / unsafe-eval on script-src. style-src keeps \
-# unsafe-inline only because styled-components injects runtime styles. [ADS-434] \
-add_header Content-Security-Policy "default-src '"'"'self'"'"'; script-src '"'"'self'"'"'; style-src '"'"'self'"'"' '"'"'unsafe-inline'"'"'; img-src '"'"'self'"'"' data: https:; font-src '"'"'self'"'"' data:; connect-src '"'"'self'"'"' wss: https:; frame-ancestors '"'"'none'"'"'; object-src '"'"'none'"'"'; base-uri '"'"'self'"'"'; form-action '"'"'self'"'"'; upgrade-insecure-requests" always;' > /etc/nginx/security-headers.conf
+# CSP without unsafe-inline / unsafe-eval. styled-components fully replaced \
+# by vanilla-extract (.css.ts) — style-src no longer needs unsafe-inline. [ADS-847] \
+add_header Content-Security-Policy "default-src '"'"'self'"'"'; script-src '"'"'self'"'"'; style-src '"'"'self'"'"'; img-src '"'"'self'"'"' data: https:; font-src '"'"'self'"'"' data:; connect-src '"'"'self'"'"' wss: https:; frame-ancestors '"'"'none'"'"'; object-src '"'"'none'"'"'; base-uri '"'"'self'"'"'; form-action '"'"'self'"'"'; upgrade-insecure-requests" always;' > /etc/nginx/security-headers.conf
 
 # Create optimized nginx config for SPA with security headers
 RUN echo 'events { \

--- a/scripts/check-csp-headers.mjs
+++ b/scripts/check-csp-headers.mjs
@@ -1,0 +1,54 @@
+#!/usr/bin/env node
+/**
+ * CSP regression guard (ADS-847).
+ *
+ * Asserts that the nginx security-headers.conf baked into Dockerfile.app does
+ * not contain `unsafe-inline` in style-src. The codebase migrated from
+ * styled-components (which required unsafe-inline) to vanilla-extract; this
+ * check prevents backsliding.
+ *
+ * Run via `node scripts/check-csp-headers.mjs` or wired into ci.yml.
+ */
+import { readFileSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+
+const dockerfile = readFileSync(join(ROOT, 'Dockerfile.app'), 'utf8');
+
+// Extract every Content-Security-Policy header value from the Dockerfile.
+const cspPattern = /add_header Content-Security-Policy "([^"]+)"/g;
+const policies = [];
+let match;
+while ((match = cspPattern.exec(dockerfile)) !== null) {
+  policies.push(match[1]);
+}
+
+if (policies.length === 0) {
+  console.error('ERROR: No Content-Security-Policy header found in Dockerfile.app');
+  process.exit(1);
+}
+
+const failures = [];
+for (const policy of policies) {
+  // Check style-src specifically — unsafe-inline there lets CSS injection bypass CSP.
+  const styleSrcMatch = policy.match(/style-src\s+([^;]+)/);
+  if (!styleSrcMatch) continue;
+  const styleSrc = styleSrcMatch[1];
+  if (styleSrc.includes("'unsafe-inline'")) {
+    failures.push(`style-src contains 'unsafe-inline': ${policy}`);
+  }
+}
+
+if (failures.length > 0) {
+  console.error('CSP regression detected in Dockerfile.app:');
+  for (const f of failures) console.error(`  ${f}`);
+  console.error(
+    "\nThe codebase uses vanilla-extract for styling; 'unsafe-inline' in style-src is not needed.",
+    '\nRemove it from the Content-Security-Policy in Dockerfile.app. [ADS-847]',
+  );
+  process.exit(1);
+}
+
+console.log(`✓ CSP style-src is clean (${policies.length} polic${policies.length === 1 ? 'y' : 'ies'} checked)`);

--- a/services/gateway/src/routes/analytics.ts
+++ b/services/gateway/src/routes/analytics.ts
@@ -90,23 +90,24 @@ export const registerAnalyticsRoutes = async (
       },
     },
     async (req, reply) => {
-    const body = (req.body ?? {}) as PageviewBody;
-    const pagePath = body.path || body.url || req.url || 'unknown';
-    logger.info('Pageview recorded', {
-      service: 'analytics',
-      type: 'pageview',
-      data: {
-        path: cap(pagePath),
-        timestamp: body.timestamp || new Date().toISOString(),
-        userId: userIdFromHeaders(req),
-        sessionId: cap(body.sessionId),
-        referrer: cap(body.referrer),
-        userAgent: cap(body.userAgent),
-        ip: req.ip,
-      },
-    });
-    return reply.code(201).send({ success: true, message: 'Pageview recorded' });
-  });
+      const body = (req.body ?? {}) as PageviewBody;
+      const pagePath = body.path || body.url || req.url || 'unknown';
+      logger.info('Pageview recorded', {
+        service: 'analytics',
+        type: 'pageview',
+        data: {
+          path: cap(pagePath),
+          timestamp: body.timestamp || new Date().toISOString(),
+          userId: userIdFromHeaders(req),
+          sessionId: cap(body.sessionId),
+          referrer: cap(body.referrer),
+          userAgent: cap(body.userAgent),
+          ip: req.ip,
+        },
+      });
+      return reply.code(201).send({ success: true, message: 'Pageview recorded' });
+    }
+  );
 
   app.post(
     '/api/v1/analytics/events',
@@ -128,22 +129,23 @@ export const registerAnalyticsRoutes = async (
       },
     },
     async (req, reply) => {
-    const body = (req.body ?? {}) as EventBody;
-    const eventName = body.event || body.name || body.type || 'unknown';
-    logger.info('Analytics event recorded', {
-      service: 'analytics',
-      type: 'single_event',
-      data: {
-        event: cap(eventName),
-        timestamp: body.timestamp || new Date().toISOString(),
-        properties: body.properties || {},
-        userId: userIdFromHeaders(req),
-        sessionId: cap(body.sessionId),
-        ip: req.ip,
-      },
-    });
-    return reply.code(201).send({ success: true, message: 'Event recorded' });
-  });
+      const body = (req.body ?? {}) as EventBody;
+      const eventName = body.event || body.name || body.type || 'unknown';
+      logger.info('Analytics event recorded', {
+        service: 'analytics',
+        type: 'single_event',
+        data: {
+          event: cap(eventName),
+          timestamp: body.timestamp || new Date().toISOString(),
+          properties: body.properties || {},
+          userId: userIdFromHeaders(req),
+          sessionId: cap(body.sessionId),
+          ip: req.ip,
+        },
+      });
+      return reply.code(201).send({ success: true, message: 'Event recorded' });
+    }
+  );
 
   app.post(
     '/api/v1/analytics/events/batch',
@@ -162,35 +164,36 @@ export const registerAnalyticsRoutes = async (
       },
     },
     async (req, reply) => {
-    const body = (req.body ?? {}) as BatchBody;
-    if (!Array.isArray(body.events)) {
-      return reply.code(400).send({ success: false, message: 'Events must be an array' });
+      const body = (req.body ?? {}) as BatchBody;
+      if (!Array.isArray(body.events)) {
+        return reply.code(400).send({ success: false, message: 'Events must be an array' });
+      }
+      // Same cap-per-batch the monolith implied (no explicit limit but
+      // logging 10k events in one line would be wasteful). 1000 covers
+      // any sane analytics flush window.
+      const MAX_BATCH = 1000;
+      if (body.events.length > MAX_BATCH) {
+        return reply.code(400).send({ success: false, message: `Batch size exceeds ${MAX_BATCH}` });
+      }
+      logger.info('Batch events recorded', {
+        service: 'analytics',
+        type: 'batch_events',
+        count: body.events.length,
+        userId: userIdFromHeaders(req),
+        ip: req.ip,
+        events: body.events.map(event => ({
+          event: cap(event.event || event.name || event.type || 'unknown'),
+          timestamp: event.timestamp || new Date().toISOString(),
+          properties: event.properties || {},
+        })),
+      });
+      return reply.code(201).send({
+        success: true,
+        message: 'Events recorded',
+        processed: body.events.length,
+      });
     }
-    // Same cap-per-batch the monolith implied (no explicit limit but
-    // logging 10k events in one line would be wasteful). 1000 covers
-    // any sane analytics flush window.
-    const MAX_BATCH = 1000;
-    if (body.events.length > MAX_BATCH) {
-      return reply.code(400).send({ success: false, message: `Batch size exceeds ${MAX_BATCH}` });
-    }
-    logger.info('Batch events recorded', {
-      service: 'analytics',
-      type: 'batch_events',
-      count: body.events.length,
-      userId: userIdFromHeaders(req),
-      ip: req.ip,
-      events: body.events.map(event => ({
-        event: cap(event.event || event.name || event.type || 'unknown'),
-        timestamp: event.timestamp || new Date().toISOString(),
-        properties: event.properties || {},
-      })),
-    });
-    return reply.code(201).send({
-      success: true,
-      message: 'Events recorded',
-      processed: body.events.length,
-    });
-  });
+  );
 
   app.get(
     '/api/v1/analytics/health',
@@ -202,9 +205,10 @@ export const registerAnalyticsRoutes = async (
       },
     },
     async () => ({
-    success: true,
-    status: 'healthy',
-    timestamp: new Date().toISOString(),
-    service: 'analytics',
-  }));
+      success: true,
+      status: 'healthy',
+      timestamp: new Date().toISOString(),
+      service: 'analytics',
+    })
+  );
 };

--- a/services/gateway/src/routes/analytics.ts
+++ b/services/gateway/src/routes/analytics.ts
@@ -69,7 +69,27 @@ export const registerAnalyticsRoutes = async (
 ): Promise<void> => {
   const { logger } = opts;
 
-  app.post('/api/v1/analytics/pageviews', async (req, reply) => {
+  app.post(
+    '/api/v1/analytics/pageviews',
+    {
+      schema: {
+        tags: ['analytics'],
+        summary: 'Record a page view event',
+        security: [],
+        body: {
+          type: 'object',
+          properties: {
+            url: { type: 'string' },
+            title: { type: 'string' },
+            referrer: { type: 'string' },
+            sessionId: { type: 'string' },
+            userId: { type: 'string' },
+          },
+          additionalProperties: true,
+        },
+      },
+    },
+    async (req, reply) => {
     const body = (req.body ?? {}) as PageviewBody;
     const pagePath = body.path || body.url || req.url || 'unknown';
     logger.info('Pageview recorded', {
@@ -88,7 +108,26 @@ export const registerAnalyticsRoutes = async (
     return reply.code(201).send({ success: true, message: 'Pageview recorded' });
   });
 
-  app.post('/api/v1/analytics/events', async (req, reply) => {
+  app.post(
+    '/api/v1/analytics/events',
+    {
+      schema: {
+        tags: ['analytics'],
+        summary: 'Record a single analytics event',
+        security: [],
+        body: {
+          type: 'object',
+          properties: {
+            event: { type: 'string' },
+            properties: { type: 'object' },
+            sessionId: { type: 'string' },
+            userId: { type: 'string' },
+          },
+          additionalProperties: true,
+        },
+      },
+    },
+    async (req, reply) => {
     const body = (req.body ?? {}) as EventBody;
     const eventName = body.event || body.name || body.type || 'unknown';
     logger.info('Analytics event recorded', {
@@ -106,7 +145,23 @@ export const registerAnalyticsRoutes = async (
     return reply.code(201).send({ success: true, message: 'Event recorded' });
   });
 
-  app.post('/api/v1/analytics/events/batch', async (req, reply) => {
+  app.post(
+    '/api/v1/analytics/events/batch',
+    {
+      schema: {
+        tags: ['analytics'],
+        summary: 'Record a batch of analytics events',
+        security: [],
+        body: {
+          type: 'object',
+          properties: {
+            events: { type: 'array' },
+          },
+          additionalProperties: true,
+        },
+      },
+    },
+    async (req, reply) => {
     const body = (req.body ?? {}) as BatchBody;
     if (!Array.isArray(body.events)) {
       return reply.code(400).send({ success: false, message: 'Events must be an array' });
@@ -137,7 +192,16 @@ export const registerAnalyticsRoutes = async (
     });
   });
 
-  app.get('/api/v1/analytics/health', async () => ({
+  app.get(
+    '/api/v1/analytics/health',
+    {
+      schema: {
+        tags: ['analytics'],
+        summary: 'Health check for the analytics endpoint',
+        security: [],
+      },
+    },
+    async () => ({
     success: true,
     status: 'healthy',
     timestamp: new Date().toISOString(),

--- a/services/gateway/src/routes/analytics.ts
+++ b/services/gateway/src/routes/analytics.ts
@@ -76,17 +76,6 @@ export const registerAnalyticsRoutes = async (
         tags: ['analytics'],
         summary: 'Record a page view event',
         security: [],
-        body: {
-          type: 'object',
-          properties: {
-            url: { type: 'string' },
-            title: { type: 'string' },
-            referrer: { type: 'string' },
-            sessionId: { type: 'string' },
-            userId: { type: 'string' },
-          },
-          additionalProperties: true,
-        },
       },
     },
     async (req, reply) => {
@@ -116,16 +105,6 @@ export const registerAnalyticsRoutes = async (
         tags: ['analytics'],
         summary: 'Record a single analytics event',
         security: [],
-        body: {
-          type: 'object',
-          properties: {
-            event: { type: 'string' },
-            properties: { type: 'object' },
-            sessionId: { type: 'string' },
-            userId: { type: 'string' },
-          },
-          additionalProperties: true,
-        },
       },
     },
     async (req, reply) => {
@@ -154,13 +133,6 @@ export const registerAnalyticsRoutes = async (
         tags: ['analytics'],
         summary: 'Record a batch of analytics events',
         security: [],
-        body: {
-          type: 'object',
-          properties: {
-            events: { type: 'array' },
-          },
-          additionalProperties: true,
-        },
       },
     },
     async (req, reply) => {

--- a/services/gateway/src/routes/application-documents.ts
+++ b/services/gateway/src/routes/application-documents.ts
@@ -77,7 +77,19 @@ export const registerApplicationDocumentsRoutes = async (
   // field carrying the document category (e.g. "id_verification").
   app.post<{ Params: { id: string } }>(
     '/api/v1/applications/:id/documents',
-    { config: { rateLimit: DOCUMENT_UPLOAD_RATE_LIMIT } },
+    {
+      config: { rateLimit: DOCUMENT_UPLOAD_RATE_LIMIT },
+      schema: {
+        tags: ['applications'],
+        summary: 'Upload a document for an application (multipart/form-data)',
+        params: {
+          type: 'object',
+          properties: {
+            id: { type: 'string' },
+          },
+        },
+      },
+    },
     async (req, reply) => {
       if (typeof (req as { isMultipart?: () => boolean }).isMultipart !== 'function') {
         return reply.code(500).send({ error: 'multipart support not registered' });
@@ -163,7 +175,18 @@ export const registerApplicationDocumentsRoutes = async (
 
   // GET /:id/documents → { data: Document[] }. The frontend's getDocuments
   // helper unwraps `data` (defaulting to [] if absent).
-  app.get<{ Params: { id: string } }>('/api/v1/applications/:id/documents', async (req, reply) => {
+  app.get<{ Params: { id: string } }>('/api/v1/applications/:id/documents', {
+    schema: {
+      tags: ['applications'],
+      summary: 'List documents for an application',
+      params: {
+        type: 'object',
+        properties: {
+          id: { type: 'string' },
+        },
+      },
+    },
+  }, async (req, reply) => {
     try {
       const res = await client.listDocuments({ applicationId: req.params.id }, buildMetadata(req));
       return reply.send({ data: res.documents.map(documentToView) });
@@ -176,6 +199,19 @@ export const registerApplicationDocumentsRoutes = async (
   // bytes stay (cleanup is a separate retention job — not in scope).
   app.delete<{ Params: { id: string; docId: string } }>(
     '/api/v1/applications/:id/documents/:docId',
+    {
+      schema: {
+        tags: ['applications'],
+        summary: 'Delete a document from an application',
+        params: {
+          type: 'object',
+          properties: {
+            id: { type: 'string' },
+            docId: { type: 'string' },
+          },
+        },
+      },
+    },
     async (req, reply) => {
       try {
         await client.removeDocument(

--- a/services/gateway/src/routes/application-documents.ts
+++ b/services/gateway/src/routes/application-documents.ts
@@ -82,12 +82,6 @@ export const registerApplicationDocumentsRoutes = async (
       schema: {
         tags: ['applications'],
         summary: 'Upload a document for an application (multipart/form-data)',
-        params: {
-          type: 'object',
-          properties: {
-            id: { type: 'string' },
-          },
-        },
       },
     },
     async (req, reply) => {
@@ -181,12 +175,6 @@ export const registerApplicationDocumentsRoutes = async (
       schema: {
         tags: ['applications'],
         summary: 'List documents for an application',
-        params: {
-          type: 'object',
-          properties: {
-            id: { type: 'string' },
-          },
-        },
       },
     },
     async (req, reply) => {
@@ -210,13 +198,6 @@ export const registerApplicationDocumentsRoutes = async (
       schema: {
         tags: ['applications'],
         summary: 'Delete a document from an application',
-        params: {
-          type: 'object',
-          properties: {
-            id: { type: 'string' },
-            docId: { type: 'string' },
-          },
-        },
       },
     },
     async (req, reply) => {

--- a/services/gateway/src/routes/application-documents.ts
+++ b/services/gateway/src/routes/application-documents.ts
@@ -175,25 +175,32 @@ export const registerApplicationDocumentsRoutes = async (
 
   // GET /:id/documents → { data: Document[] }. The frontend's getDocuments
   // helper unwraps `data` (defaulting to [] if absent).
-  app.get<{ Params: { id: string } }>('/api/v1/applications/:id/documents', {
-    schema: {
-      tags: ['applications'],
-      summary: 'List documents for an application',
-      params: {
-        type: 'object',
-        properties: {
-          id: { type: 'string' },
+  app.get<{ Params: { id: string } }>(
+    '/api/v1/applications/:id/documents',
+    {
+      schema: {
+        tags: ['applications'],
+        summary: 'List documents for an application',
+        params: {
+          type: 'object',
+          properties: {
+            id: { type: 'string' },
+          },
         },
       },
     },
-  }, async (req, reply) => {
-    try {
-      const res = await client.listDocuments({ applicationId: req.params.id }, buildMetadata(req));
-      return reply.send({ data: res.documents.map(documentToView) });
-    } catch (err) {
-      return handleGrpcError(err, reply);
+    async (req, reply) => {
+      try {
+        const res = await client.listDocuments(
+          { applicationId: req.params.id },
+          buildMetadata(req)
+        );
+        return reply.send({ data: res.documents.map(documentToView) });
+      } catch (err) {
+        return handleGrpcError(err, reply);
+      }
     }
-  });
+  );
 
   // DELETE /:id/documents/:docId → 204. The service soft-deletes the row;
   // bytes stay (cleanup is a separate retention job — not in scope).

--- a/services/gateway/src/routes/applications.ts
+++ b/services/gateway/src/routes/applications.ts
@@ -86,10 +86,6 @@ export const registerApplicationsRoutes = async (
       schema: {
         tags: ['applications'],
         summary: 'Create and submit an adoption application',
-        body: {
-          type: 'object',
-          additionalProperties: true,
-        },
       },
     },
     async (req, reply) => {
@@ -131,20 +127,6 @@ export const registerApplicationsRoutes = async (
       schema: {
         tags: ['applications'],
         summary: 'Update application status',
-        params: {
-          type: 'object',
-          properties: {
-            id: { type: 'string' },
-          },
-        },
-        body: {
-          type: 'object',
-          properties: {
-            status: { type: 'string' },
-            notes: { type: 'string' },
-          },
-          additionalProperties: true,
-        },
       },
     },
     async (req, reply) => {
@@ -181,19 +163,6 @@ export const registerApplicationsRoutes = async (
       schema: {
         tags: ['applications'],
         summary: 'Withdraw an application',
-        params: {
-          type: 'object',
-          properties: {
-            id: { type: 'string' },
-          },
-        },
-        body: {
-          type: 'object',
-          properties: {
-            reason: { type: 'string' },
-          },
-          additionalProperties: true,
-        },
       },
     },
     async (req, reply) => {
@@ -223,16 +192,6 @@ export const registerApplicationsRoutes = async (
       schema: {
         tags: ['applications'],
         summary: 'Update application answers',
-        params: {
-          type: 'object',
-          properties: {
-            id: { type: 'string' },
-          },
-        },
-        body: {
-          type: 'object',
-          additionalProperties: true,
-        },
       },
     },
     async (req, reply) => {
@@ -265,21 +224,6 @@ export const registerApplicationsRoutes = async (
       schema: {
         tags: ['applications'],
         summary: 'Save draft answers for an application',
-        params: {
-          type: 'object',
-          properties: {
-            id: { type: 'string' },
-          },
-        },
-        body: {
-          type: 'object',
-          properties: {
-            expectedVersion: { type: 'number' },
-            answersPatchJson: { type: 'string' },
-            referencesJson: { type: 'string' },
-          },
-          additionalProperties: true,
-        },
       },
     },
     async (req, reply) => {
@@ -306,19 +250,6 @@ export const registerApplicationsRoutes = async (
       schema: {
         tags: ['applications'],
         summary: 'Submit a draft application',
-        params: {
-          type: 'object',
-          properties: {
-            id: { type: 'string' },
-          },
-        },
-        body: {
-          type: 'object',
-          properties: {
-            expectedVersion: { type: 'number' },
-          },
-          additionalProperties: true,
-        },
       },
     },
     async (req, reply) => {
@@ -345,19 +276,6 @@ export const registerApplicationsRoutes = async (
       schema: {
         tags: ['applications'],
         summary: 'Start review of an application',
-        params: {
-          type: 'object',
-          properties: {
-            id: { type: 'string' },
-          },
-        },
-        body: {
-          type: 'object',
-          properties: {
-            note: { type: 'string' },
-          },
-          additionalProperties: true,
-        },
       },
     },
     async (req, reply) => {
@@ -382,20 +300,6 @@ export const registerApplicationsRoutes = async (
       schema: {
         tags: ['applications'],
         summary: 'Schedule a home visit for an application',
-        params: {
-          type: 'object',
-          properties: {
-            id: { type: 'string' },
-          },
-        },
-        body: {
-          type: 'object',
-          properties: {
-            scheduledAt: { type: 'string' },
-            note: { type: 'string' },
-          },
-          additionalProperties: true,
-        },
       },
     },
     async (req, reply) => {
@@ -421,20 +325,6 @@ export const registerApplicationsRoutes = async (
       schema: {
         tags: ['applications'],
         summary: 'Complete a home visit for an application',
-        params: {
-          type: 'object',
-          properties: {
-            id: { type: 'string' },
-          },
-        },
-        body: {
-          type: 'object',
-          properties: {
-            outcome: { type: 'string' },
-            notes: { type: 'string' },
-          },
-          additionalProperties: true,
-        },
       },
     },
     async (req, reply) => {
@@ -460,19 +350,6 @@ export const registerApplicationsRoutes = async (
       schema: {
         tags: ['applications'],
         summary: 'Approve an application',
-        params: {
-          type: 'object',
-          properties: {
-            id: { type: 'string' },
-          },
-        },
-        body: {
-          type: 'object',
-          properties: {
-            notes: { type: 'string' },
-          },
-          additionalProperties: true,
-        },
       },
     },
     async (req, reply) => {
@@ -497,19 +374,6 @@ export const registerApplicationsRoutes = async (
       schema: {
         tags: ['applications'],
         summary: 'Reject an application',
-        params: {
-          type: 'object',
-          properties: {
-            id: { type: 'string' },
-          },
-        },
-        body: {
-          type: 'object',
-          properties: {
-            reason: { type: 'string' },
-          },
-          additionalProperties: true,
-        },
       },
     },
     async (req, reply) => {
@@ -534,19 +398,6 @@ export const registerApplicationsRoutes = async (
       schema: {
         tags: ['applications'],
         summary: 'Withdraw an application (service-shaped)',
-        params: {
-          type: 'object',
-          properties: {
-            id: { type: 'string' },
-          },
-        },
-        body: {
-          type: 'object',
-          properties: {
-            reason: { type: 'string' },
-          },
-          additionalProperties: true,
-        },
       },
     },
     async (req, reply) => {
@@ -571,12 +422,6 @@ export const registerApplicationsRoutes = async (
       schema: {
         tags: ['applications'],
         summary: 'Mark an application as adopted',
-        params: {
-          type: 'object',
-          properties: {
-            id: { type: 'string' },
-          },
-        },
       },
     },
     async (req, reply) => {
@@ -601,14 +446,6 @@ export const registerApplicationsRoutes = async (
       schema: {
         tags: ['applications'],
         summary: 'Get application statistics',
-        querystring: {
-          type: 'object',
-          properties: {
-            rescue: { type: 'string' },
-            adopter: { type: 'string' },
-          },
-          additionalProperties: true,
-        },
       },
     },
     async (req, reply) => {
@@ -632,17 +469,6 @@ export const registerApplicationsRoutes = async (
       schema: {
         tags: ['applications'],
         summary: 'List applications',
-        querystring: {
-          type: 'object',
-          properties: {
-            cursor: { type: 'string' },
-            limit: { type: 'string' },
-            status: { type: 'string' },
-            rescue: { type: 'string' },
-            adopter: { type: 'string' },
-          },
-          additionalProperties: true,
-        },
       },
     },
     async (req, reply) => {
@@ -679,19 +505,6 @@ export const registerApplicationsRoutes = async (
       schema: {
         tags: ['applications'],
         summary: 'Get an application by ID',
-        params: {
-          type: 'object',
-          properties: {
-            id: { type: 'string' },
-          },
-        },
-        querystring: {
-          type: 'object',
-          properties: {
-            timeline: { type: 'string' },
-          },
-          additionalProperties: true,
-        },
       },
     },
     async (req, reply) => {

--- a/services/gateway/src/routes/applications.ts
+++ b/services/gateway/src/routes/applications.ts
@@ -662,7 +662,26 @@ export const registerApplicationsRoutes = async (
 
   app.get<{ Params: { id: string } }>(
     '/api/v1/applications/:id',
-    { config: { rateLimit: RL_READ } },
+    {
+      config: { rateLimit: RL_READ },
+      schema: {
+        tags: ['applications'],
+        summary: 'Get an application by ID',
+        params: {
+          type: 'object',
+          properties: {
+            id: { type: 'string' },
+          },
+        },
+        querystring: {
+          type: 'object',
+          properties: {
+            timeline: { type: 'string' },
+          },
+          additionalProperties: true,
+        },
+      },
+    },
     async (req, reply) => {
       const q = req.query as Record<string, string | undefined>;
       try {

--- a/services/gateway/src/routes/applications.ts
+++ b/services/gateway/src/routes/applications.ts
@@ -79,7 +79,17 @@ export const registerApplicationsRoutes = async (
   // and stores the frontend's data blob verbatim as answers so it
   // round-trips on read (applications-view.ts parses it back into `data`).
 
-  app.post('/api/v1/applications', { config: { rateLimit: RL_WRITE } }, async (req, reply) => {
+  app.post('/api/v1/applications', {
+    config: { rateLimit: RL_WRITE },
+    schema: {
+      tags: ['applications'],
+      summary: 'Create and submit an adoption application',
+      body: {
+        type: 'object',
+        additionalProperties: true,
+      },
+    },
+  }, async (req, reply) => {
     const b = (req.body ?? {}) as Record<string, unknown>;
     const adopterId = (b.userId as string) ?? (b.adopterId as string) ?? headerUserId(req) ?? '';
     const petId = (b.petId as string) ?? '';
@@ -112,7 +122,27 @@ export const registerApplicationsRoutes = async (
   // 4-value status maps onto the service's decision commands.
   app.patch<{ Params: { id: string } }>(
     '/api/v1/applications/:id/status',
-    { config: { rateLimit: RL_WRITE } },
+    {
+      config: { rateLimit: RL_WRITE },
+      schema: {
+        tags: ['applications'],
+        summary: 'Update application status',
+        params: {
+          type: 'object',
+          properties: {
+            id: { type: 'string' },
+          },
+        },
+        body: {
+          type: 'object',
+          properties: {
+            status: { type: 'string' },
+            notes: { type: 'string' },
+          },
+          additionalProperties: true,
+        },
+      },
+    },
     async (req, reply) => {
       const b = (req.body ?? {}) as Record<string, unknown>;
       const target = b.status as string | undefined;
@@ -142,7 +172,26 @@ export const registerApplicationsRoutes = async (
   // PUT /:id/withdraw — the SPA's withdrawApplication.
   app.put<{ Params: { id: string } }>(
     '/api/v1/applications/:id/withdraw',
-    { config: { rateLimit: RL_WRITE } },
+    {
+      config: { rateLimit: RL_WRITE },
+      schema: {
+        tags: ['applications'],
+        summary: 'Withdraw an application',
+        params: {
+          type: 'object',
+          properties: {
+            id: { type: 'string' },
+          },
+        },
+        body: {
+          type: 'object',
+          properties: {
+            reason: { type: 'string' },
+          },
+          additionalProperties: true,
+        },
+      },
+    },
     async (req, reply) => {
       const b = (req.body ?? {}) as Record<string, unknown>;
       try {
@@ -165,7 +214,23 @@ export const registerApplicationsRoutes = async (
   // decided application surfaces the service's INVALID_ARGUMENT as 400.
   app.put<{ Params: { id: string } }>(
     '/api/v1/applications/:id',
-    { config: { rateLimit: RL_WRITE } },
+    {
+      config: { rateLimit: RL_WRITE },
+      schema: {
+        tags: ['applications'],
+        summary: 'Update application answers',
+        params: {
+          type: 'object',
+          properties: {
+            id: { type: 'string' },
+          },
+        },
+        body: {
+          type: 'object',
+          additionalProperties: true,
+        },
+      },
+    },
     async (req, reply) => {
       const b = (req.body ?? {}) as Record<string, unknown>;
       const id = req.params.id;
@@ -191,7 +256,28 @@ export const registerApplicationsRoutes = async (
 
   app.patch<{ Params: { id: string } }>(
     '/api/v1/applications/:id/answers',
-    { config: { rateLimit: RL_WRITE } },
+    {
+      config: { rateLimit: RL_WRITE },
+      schema: {
+        tags: ['applications'],
+        summary: 'Save draft answers for an application',
+        params: {
+          type: 'object',
+          properties: {
+            id: { type: 'string' },
+          },
+        },
+        body: {
+          type: 'object',
+          properties: {
+            expectedVersion: { type: 'number' },
+            answersPatchJson: { type: 'string' },
+            referencesJson: { type: 'string' },
+          },
+          additionalProperties: true,
+        },
+      },
+    },
     async (req, reply) => {
       const b = (req.body ?? {}) as Record<string, unknown>;
       const grpcReq: SaveDraftAnswersRequest = {
@@ -211,7 +297,26 @@ export const registerApplicationsRoutes = async (
 
   app.post<{ Params: { id: string } }>(
     '/api/v1/applications/:id/submit',
-    { config: { rateLimit: RL_WRITE } },
+    {
+      config: { rateLimit: RL_WRITE },
+      schema: {
+        tags: ['applications'],
+        summary: 'Submit a draft application',
+        params: {
+          type: 'object',
+          properties: {
+            id: { type: 'string' },
+          },
+        },
+        body: {
+          type: 'object',
+          properties: {
+            expectedVersion: { type: 'number' },
+          },
+          additionalProperties: true,
+        },
+      },
+    },
     async (req, reply) => {
       const b = (req.body ?? {}) as Record<string, unknown>;
       const grpcReq: SubmitDraftRequest = {
@@ -231,7 +336,26 @@ export const registerApplicationsRoutes = async (
 
   app.post<{ Params: { id: string } }>(
     '/api/v1/applications/:id/review',
-    { config: { rateLimit: RL_WRITE } },
+    {
+      config: { rateLimit: RL_WRITE },
+      schema: {
+        tags: ['applications'],
+        summary: 'Start review of an application',
+        params: {
+          type: 'object',
+          properties: {
+            id: { type: 'string' },
+          },
+        },
+        body: {
+          type: 'object',
+          properties: {
+            note: { type: 'string' },
+          },
+          additionalProperties: true,
+        },
+      },
+    },
     async (req, reply) => {
       const b = (req.body ?? {}) as Record<string, unknown>;
       const grpcReq: StartReviewRequest = {
@@ -249,7 +373,27 @@ export const registerApplicationsRoutes = async (
 
   app.post<{ Params: { id: string } }>(
     '/api/v1/applications/:id/home-visit/schedule',
-    { config: { rateLimit: RL_WRITE } },
+    {
+      config: { rateLimit: RL_WRITE },
+      schema: {
+        tags: ['applications'],
+        summary: 'Schedule a home visit for an application',
+        params: {
+          type: 'object',
+          properties: {
+            id: { type: 'string' },
+          },
+        },
+        body: {
+          type: 'object',
+          properties: {
+            scheduledAt: { type: 'string' },
+            note: { type: 'string' },
+          },
+          additionalProperties: true,
+        },
+      },
+    },
     async (req, reply) => {
       const b = (req.body ?? {}) as Record<string, unknown>;
       const grpcReq: ScheduleHomeVisitRequest = {
@@ -268,7 +412,27 @@ export const registerApplicationsRoutes = async (
 
   app.post<{ Params: { id: string } }>(
     '/api/v1/applications/:id/home-visit/complete',
-    { config: { rateLimit: RL_WRITE } },
+    {
+      config: { rateLimit: RL_WRITE },
+      schema: {
+        tags: ['applications'],
+        summary: 'Complete a home visit for an application',
+        params: {
+          type: 'object',
+          properties: {
+            id: { type: 'string' },
+          },
+        },
+        body: {
+          type: 'object',
+          properties: {
+            outcome: { type: 'string' },
+            notes: { type: 'string' },
+          },
+          additionalProperties: true,
+        },
+      },
+    },
     async (req, reply) => {
       const b = (req.body ?? {}) as Record<string, unknown>;
       const grpcReq: CompleteHomeVisitRequest = {
@@ -287,7 +451,26 @@ export const registerApplicationsRoutes = async (
 
   app.post<{ Params: { id: string } }>(
     '/api/v1/applications/:id/approve',
-    { config: { rateLimit: RL_WRITE } },
+    {
+      config: { rateLimit: RL_WRITE },
+      schema: {
+        tags: ['applications'],
+        summary: 'Approve an application',
+        params: {
+          type: 'object',
+          properties: {
+            id: { type: 'string' },
+          },
+        },
+        body: {
+          type: 'object',
+          properties: {
+            notes: { type: 'string' },
+          },
+          additionalProperties: true,
+        },
+      },
+    },
     async (req, reply) => {
       const b = (req.body ?? {}) as Record<string, unknown>;
       const grpcReq: ApproveRequest = {
@@ -305,7 +488,26 @@ export const registerApplicationsRoutes = async (
 
   app.post<{ Params: { id: string } }>(
     '/api/v1/applications/:id/reject',
-    { config: { rateLimit: RL_WRITE } },
+    {
+      config: { rateLimit: RL_WRITE },
+      schema: {
+        tags: ['applications'],
+        summary: 'Reject an application',
+        params: {
+          type: 'object',
+          properties: {
+            id: { type: 'string' },
+          },
+        },
+        body: {
+          type: 'object',
+          properties: {
+            reason: { type: 'string' },
+          },
+          additionalProperties: true,
+        },
+      },
+    },
     async (req, reply) => {
       const b = (req.body ?? {}) as Record<string, unknown>;
       const grpcReq: RejectRequest = {
@@ -323,7 +525,26 @@ export const registerApplicationsRoutes = async (
 
   app.post<{ Params: { id: string } }>(
     '/api/v1/applications/:id/withdraw',
-    { config: { rateLimit: RL_WRITE } },
+    {
+      config: { rateLimit: RL_WRITE },
+      schema: {
+        tags: ['applications'],
+        summary: 'Withdraw an application (service-shaped)',
+        params: {
+          type: 'object',
+          properties: {
+            id: { type: 'string' },
+          },
+        },
+        body: {
+          type: 'object',
+          properties: {
+            reason: { type: 'string' },
+          },
+          additionalProperties: true,
+        },
+      },
+    },
     async (req, reply) => {
       const b = (req.body ?? {}) as Record<string, unknown>;
       const grpcReq: WithdrawRequest = {
@@ -341,7 +562,19 @@ export const registerApplicationsRoutes = async (
 
   app.post<{ Params: { id: string } }>(
     '/api/v1/applications/:id/adopt',
-    { config: { rateLimit: RL_WRITE } },
+    {
+      config: { rateLimit: RL_WRITE },
+      schema: {
+        tags: ['applications'],
+        summary: 'Mark an application as adopted',
+        params: {
+          type: 'object',
+          properties: {
+            id: { type: 'string' },
+          },
+        },
+      },
+    },
     async (req, reply) => {
       try {
         const res = await client.markAdopted({ applicationId: req.params.id }, buildMetadata(req));
@@ -357,7 +590,21 @@ export const registerApplicationsRoutes = async (
   // Registered before /:id so the static `stats` segment wins over the
   // param route. Collapses the service's raw per-status counts to the
   // SPA's ApplicationStatsSchema, wrapped in `{ data }`.
-  app.get('/api/v1/applications/stats', { config: { rateLimit: RL_READ } }, async (req, reply) => {
+  app.get('/api/v1/applications/stats', {
+    config: { rateLimit: RL_READ },
+    schema: {
+      tags: ['applications'],
+      summary: 'Get application statistics',
+      querystring: {
+        type: 'object',
+        properties: {
+          rescue: { type: 'string' },
+          adopter: { type: 'string' },
+        },
+        additionalProperties: true,
+      },
+    },
+  }, async (req, reply) => {
     const q = req.query as Record<string, string | undefined>;
     try {
       const res = await client.getStats(
@@ -370,7 +617,24 @@ export const registerApplicationsRoutes = async (
     }
   });
 
-  app.get('/api/v1/applications', { config: { rateLimit: RL_READ } }, async (req, reply) => {
+  app.get('/api/v1/applications', {
+    config: { rateLimit: RL_READ },
+    schema: {
+      tags: ['applications'],
+      summary: 'List applications',
+      querystring: {
+        type: 'object',
+        properties: {
+          cursor: { type: 'string' },
+          limit: { type: 'string' },
+          status: { type: 'string' },
+          rescue: { type: 'string' },
+          adopter: { type: 'string' },
+        },
+        additionalProperties: true,
+      },
+    },
+  }, async (req, reply) => {
     const q = req.query as Record<string, string | undefined>;
     const pagination = parsePagination(q, { limit: 0 });
     if (!pagination.ok) {

--- a/services/gateway/src/routes/applications.ts
+++ b/services/gateway/src/routes/applications.ts
@@ -79,44 +79,48 @@ export const registerApplicationsRoutes = async (
   // and stores the frontend's data blob verbatim as answers so it
   // round-trips on read (applications-view.ts parses it back into `data`).
 
-  app.post('/api/v1/applications', {
-    config: { rateLimit: RL_WRITE },
-    schema: {
-      tags: ['applications'],
-      summary: 'Create and submit an adoption application',
-      body: {
-        type: 'object',
-        additionalProperties: true,
+  app.post(
+    '/api/v1/applications',
+    {
+      config: { rateLimit: RL_WRITE },
+      schema: {
+        tags: ['applications'],
+        summary: 'Create and submit an adoption application',
+        body: {
+          type: 'object',
+          additionalProperties: true,
+        },
       },
     },
-  }, async (req, reply) => {
-    const b = (req.body ?? {}) as Record<string, unknown>;
-    const adopterId = (b.userId as string) ?? (b.adopterId as string) ?? headerUserId(req) ?? '';
-    const petId = (b.petId as string) ?? '';
-    const meta = buildMetadata(req);
-    try {
-      const started = await client.startDraft({ adopterId, petId }, meta);
-      const draft = requireApplication(started.application);
+    async (req, reply) => {
+      const b = (req.body ?? {}) as Record<string, unknown>;
+      const adopterId = (b.userId as string) ?? (b.adopterId as string) ?? headerUserId(req) ?? '';
+      const petId = (b.petId as string) ?? '';
+      const meta = buildMetadata(req);
+      try {
+        const started = await client.startDraft({ adopterId, petId }, meta);
+        const draft = requireApplication(started.application);
 
-      const saved = await client.saveDraftAnswers(
-        {
-          applicationId: draft.applicationId,
-          expectedVersion: draft.version,
-          answersPatchJson: JSON.stringify(b),
-        },
-        meta
-      );
-      const withAnswers = requireApplication(saved.application);
+        const saved = await client.saveDraftAnswers(
+          {
+            applicationId: draft.applicationId,
+            expectedVersion: draft.version,
+            answersPatchJson: JSON.stringify(b),
+          },
+          meta
+        );
+        const withAnswers = requireApplication(saved.application);
 
-      const submitted = await client.submitDraft(
-        { applicationId: withAnswers.applicationId, expectedVersion: withAnswers.version },
-        meta
-      );
-      return sendView(reply, submitted.application, 201);
-    } catch (err) {
-      return handleGrpcError(err, reply);
+        const submitted = await client.submitDraft(
+          { applicationId: withAnswers.applicationId, expectedVersion: withAnswers.version },
+          meta
+        );
+        return sendView(reply, submitted.application, 201);
+      } catch (err) {
+        return handleGrpcError(err, reply);
+      }
     }
-  });
+  );
 
   // PATCH /:id/status — the SPA's updateApplicationStatus. The frontend's
   // 4-value status maps onto the service's decision commands.
@@ -590,75 +594,83 @@ export const registerApplicationsRoutes = async (
   // Registered before /:id so the static `stats` segment wins over the
   // param route. Collapses the service's raw per-status counts to the
   // SPA's ApplicationStatsSchema, wrapped in `{ data }`.
-  app.get('/api/v1/applications/stats', {
-    config: { rateLimit: RL_READ },
-    schema: {
-      tags: ['applications'],
-      summary: 'Get application statistics',
-      querystring: {
-        type: 'object',
-        properties: {
-          rescue: { type: 'string' },
-          adopter: { type: 'string' },
+  app.get(
+    '/api/v1/applications/stats',
+    {
+      config: { rateLimit: RL_READ },
+      schema: {
+        tags: ['applications'],
+        summary: 'Get application statistics',
+        querystring: {
+          type: 'object',
+          properties: {
+            rescue: { type: 'string' },
+            adopter: { type: 'string' },
+          },
+          additionalProperties: true,
         },
-        additionalProperties: true,
       },
     },
-  }, async (req, reply) => {
-    const q = req.query as Record<string, string | undefined>;
-    try {
-      const res = await client.getStats(
-        { rescueIdFilter: q.rescue, adopterIdFilter: q.adopter },
-        buildMetadata(req)
-      );
-      return reply.send({ data: statsToView(res) });
-    } catch (err) {
-      return handleGrpcError(err, reply);
+    async (req, reply) => {
+      const q = req.query as Record<string, string | undefined>;
+      try {
+        const res = await client.getStats(
+          { rescueIdFilter: q.rescue, adopterIdFilter: q.adopter },
+          buildMetadata(req)
+        );
+        return reply.send({ data: statsToView(res) });
+      } catch (err) {
+        return handleGrpcError(err, reply);
+      }
     }
-  });
+  );
 
-  app.get('/api/v1/applications', {
-    config: { rateLimit: RL_READ },
-    schema: {
-      tags: ['applications'],
-      summary: 'List applications',
-      querystring: {
-        type: 'object',
-        properties: {
-          cursor: { type: 'string' },
-          limit: { type: 'string' },
-          status: { type: 'string' },
-          rescue: { type: 'string' },
-          adopter: { type: 'string' },
+  app.get(
+    '/api/v1/applications',
+    {
+      config: { rateLimit: RL_READ },
+      schema: {
+        tags: ['applications'],
+        summary: 'List applications',
+        querystring: {
+          type: 'object',
+          properties: {
+            cursor: { type: 'string' },
+            limit: { type: 'string' },
+            status: { type: 'string' },
+            rescue: { type: 'string' },
+            adopter: { type: 'string' },
+          },
+          additionalProperties: true,
         },
-        additionalProperties: true,
       },
     },
-  }, async (req, reply) => {
-    const q = req.query as Record<string, string | undefined>;
-    const pagination = parsePagination(q, { limit: 0 });
-    if (!pagination.ok) {
-      return reply.code(400).send({ error: pagination.error });
+    async (req, reply) => {
+      const q = req.query as Record<string, string | undefined>;
+      const pagination = parsePagination(q, { limit: 0 });
+      if (!pagination.ok) {
+        return reply.code(400).send({ error: pagination.error });
+      }
+      const grpcReq: ListApplicationsRequest = {
+        cursor: q.cursor,
+        limit: pagination.limit,
+        statusFilter: parseStatus(q.status),
+        rescueIdFilter: q.rescue,
+        adopterIdFilter: q.adopter,
+      };
+      try {
+        const res = await client.list(grpcReq, buildMetadata(req));
+        // Stage B: map to the frontend view + drop draft/unspecified rows,
+        // and wrap in the `{ data }` envelope the SPA expects.
+        const data = res.applications
+          .map(applicationToView)
+          .filter((v): v is ApplicationView => v !== null);
+        return reply.send({ data });
+      } catch (err) {
+        return handleGrpcError(err, reply);
+      }
     }
-    const grpcReq: ListApplicationsRequest = {
-      cursor: q.cursor,
-      limit: pagination.limit,
-      statusFilter: parseStatus(q.status),
-      rescueIdFilter: q.rescue,
-      adopterIdFilter: q.adopter,
-    };
-    try {
-      const res = await client.list(grpcReq, buildMetadata(req));
-      // Stage B: map to the frontend view + drop draft/unspecified rows,
-      // and wrap in the `{ data }` envelope the SPA expects.
-      const data = res.applications
-        .map(applicationToView)
-        .filter((v): v is ApplicationView => v !== null);
-      return reply.send({ data });
-    } catch (err) {
-      return handleGrpcError(err, reply);
-    }
-  });
+  );
 
   app.get<{ Params: { id: string } }>(
     '/api/v1/applications/:id',

--- a/services/gateway/src/routes/audit.ts
+++ b/services/gateway/src/routes/audit.ts
@@ -58,20 +58,6 @@ export const registerAuditRoutes = async (
       schema: {
         tags: ['audit'],
         summary: 'Query audit log entries',
-        querystring: {
-          type: 'object',
-          properties: {
-            cursor: { type: 'string' },
-            limit: { type: 'string' },
-            service: { type: 'string' },
-            subject: { type: 'string' },
-            actor_user_id: { type: 'string' },
-            outcome: { type: 'string' },
-            from: { type: 'string' },
-            to: { type: 'string' },
-          },
-          additionalProperties: true,
-        },
       },
     },
     async (req, reply) => {
@@ -106,21 +92,6 @@ export const registerAuditRoutes = async (
       schema: {
         tags: ['audit'],
         summary: 'Get audit log entries for a specific target',
-        params: {
-          type: 'object',
-          properties: {
-            type: { type: 'string' },
-            id: { type: 'string' },
-          },
-        },
-        querystring: {
-          type: 'object',
-          properties: {
-            cursor: { type: 'string' },
-            limit: { type: 'string' },
-          },
-          additionalProperties: true,
-        },
       },
     },
     async (req, reply) => {

--- a/services/gateway/src/routes/audit.ts
+++ b/services/gateway/src/routes/audit.ts
@@ -53,7 +53,27 @@ export const registerAuditRoutes = async (
 
   app.get(
     '/api/v1/audit',
-    { config: { rateLimit: AUDIT_RATE_LIMITS.query } },
+    {
+      config: { rateLimit: AUDIT_RATE_LIMITS.query },
+      schema: {
+        tags: ['audit'],
+        summary: 'Query audit log entries',
+        querystring: {
+          type: 'object',
+          properties: {
+            cursor: { type: 'string' },
+            limit: { type: 'string' },
+            service: { type: 'string' },
+            subject: { type: 'string' },
+            actor_user_id: { type: 'string' },
+            outcome: { type: 'string' },
+            from: { type: 'string' },
+            to: { type: 'string' },
+          },
+          additionalProperties: true,
+        },
+      },
+    },
     async (req, reply) => {
       const query = req.query as Record<string, string | undefined>;
       const pagination = parsePagination(query, { limit: 0 });
@@ -81,7 +101,28 @@ export const registerAuditRoutes = async (
 
   app.get<{ Params: { type: string; id: string } }>(
     '/api/v1/audit/targets/:type/:id',
-    { config: { rateLimit: AUDIT_RATE_LIMITS.getByTarget } },
+    {
+      config: { rateLimit: AUDIT_RATE_LIMITS.getByTarget },
+      schema: {
+        tags: ['audit'],
+        summary: 'Get audit log entries for a specific target',
+        params: {
+          type: 'object',
+          properties: {
+            type: { type: 'string' },
+            id: { type: 'string' },
+          },
+        },
+        querystring: {
+          type: 'object',
+          properties: {
+            cursor: { type: 'string' },
+            limit: { type: 'string' },
+          },
+          additionalProperties: true,
+        },
+      },
+    },
     async (req, reply) => {
       const query = req.query as Record<string, string | undefined>;
       const pagination = parsePagination(query, { limit: 0 });

--- a/services/gateway/src/routes/auth.ts
+++ b/services/gateway/src/routes/auth.ts
@@ -188,7 +188,20 @@ export const registerAuthRoutes = async (
 
   app.post(
     '/api/v1/auth/logout',
-    { config: { rateLimit: AUTH_RATE_LIMITS.logout } },
+    {
+      config: { rateLimit: AUTH_RATE_LIMITS.logout },
+      schema: {
+        tags: ['auth'],
+        summary: 'Invalidate the current session and refresh token',
+        body: {
+          type: 'object',
+          properties: {
+            refreshToken: { type: 'string' },
+          },
+          additionalProperties: true,
+        },
+      },
+    },
     async (req, reply) => {
       const body = (req.body ?? {}) as LogoutBody;
       const grpcReq: LogoutRequest = { refreshToken: body.refreshToken ?? '' };
@@ -204,7 +217,20 @@ export const registerAuthRoutes = async (
 
   app.post(
     '/api/v1/auth/refresh-token',
-    { config: { rateLimit: AUTH_RATE_LIMITS.refreshToken } },
+    {
+      config: { rateLimit: AUTH_RATE_LIMITS.refreshToken },
+      schema: {
+        tags: ['auth'],
+        summary: 'Exchange a refresh token for a new access token',
+        body: {
+          type: 'object',
+          properties: {
+            refreshToken: { type: 'string' },
+          },
+          additionalProperties: true,
+        },
+      },
+    },
     async (req, reply) => {
       const body = (req.body ?? {}) as RefreshTokenBody;
       const grpcReq: RefreshTokenRequest = { refreshToken: body.refreshToken ?? '' };
@@ -240,7 +266,22 @@ export const registerAuthRoutes = async (
 
   app.post(
     '/api/v1/auth/assign-role',
-    { config: { rateLimit: AUTH_RATE_LIMITS.assignRole } },
+    {
+      config: { rateLimit: AUTH_RATE_LIMITS.assignRole },
+      schema: {
+        tags: ['auth', 'admin'],
+        summary: 'Assign a role to a target user (admin only)',
+        body: {
+          type: 'object',
+          properties: {
+            targetUserId: { type: 'string' },
+            role: { type: 'string' },
+            reason: { type: 'string' },
+          },
+          additionalProperties: true,
+        },
+      },
+    },
     async (req, reply) => {
       const body = (req.body ?? {}) as AssignRoleBody;
       const grpcReq: AssignRoleRequest = {
@@ -265,6 +306,24 @@ export const registerAuthRoutes = async (
     {
       config: { rateLimit: AUTH_RATE_LIMITS.register },
       preHandler: emailRateLimit(b => b.email ?? b.email_address),
+      schema: {
+        tags: ['auth'],
+        summary: 'Register a new user account',
+        security: [],
+        body: {
+          type: 'object',
+          properties: {
+            email: { type: 'string' },
+            password: { type: 'string' },
+            firstName: { type: 'string' },
+            lastName: { type: 'string' },
+            phoneNumber: { type: 'string' },
+            termsAccepted: { type: 'boolean' },
+            privacyPolicyAccepted: { type: 'boolean' },
+          },
+          additionalProperties: true,
+        },
+      },
     },
     async (req, reply) => {
       const b = (req.body ?? {}) as Record<string, unknown>;
@@ -300,7 +359,21 @@ export const registerAuthRoutes = async (
 
   app.post(
     '/api/v1/auth/verify-email',
-    { config: { rateLimit: AUTH_RATE_LIMITS.verifyEmail } },
+    {
+      config: { rateLimit: AUTH_RATE_LIMITS.verifyEmail },
+      schema: {
+        tags: ['auth'],
+        summary: 'Verify email address using a verification token',
+        security: [],
+        body: {
+          type: 'object',
+          properties: {
+            verificationToken: { type: 'string' },
+          },
+          additionalProperties: true,
+        },
+      },
+    },
     async (req, reply) => {
       const b = (req.body ?? {}) as Record<string, unknown>;
       try {
@@ -326,6 +399,18 @@ export const registerAuthRoutes = async (
     {
       config: { rateLimit: AUTH_RATE_LIMITS.resendVerification },
       preHandler: emailRateLimit(b => b.email),
+      schema: {
+        tags: ['auth'],
+        summary: 'Resend the email verification link',
+        security: [],
+        body: {
+          type: 'object',
+          properties: {
+            email: { type: 'string' },
+          },
+          additionalProperties: true,
+        },
+      },
     },
     async (req, reply) => {
       const b = (req.body ?? {}) as Record<string, unknown>;
@@ -349,6 +434,18 @@ export const registerAuthRoutes = async (
     {
       config: { rateLimit: AUTH_RATE_LIMITS.forgotPassword },
       preHandler: emailRateLimit(b => b.email),
+      schema: {
+        tags: ['auth'],
+        summary: 'Send a password reset link to the given email',
+        security: [],
+        body: {
+          type: 'object',
+          properties: {
+            email: { type: 'string' },
+          },
+          additionalProperties: true,
+        },
+      },
     },
     async (req, reply) => {
       const b = (req.body ?? {}) as Record<string, unknown>;
@@ -374,6 +471,19 @@ export const registerAuthRoutes = async (
       // reset-password carries no email — key the per-target cap on the reset
       // token instead, so a flood against one token (across IPs) is throttled.
       preHandler: emailRateLimit(b => b.resetToken ?? b.reset_token),
+      schema: {
+        tags: ['auth'],
+        summary: 'Reset password using a reset token',
+        security: [],
+        body: {
+          type: 'object',
+          properties: {
+            resetToken: { type: 'string' },
+            newPassword: { type: 'string' },
+          },
+          additionalProperties: true,
+        },
+      },
     },
     async (req, reply) => {
       const b = (req.body ?? {}) as Record<string, unknown>;
@@ -397,7 +507,21 @@ export const registerAuthRoutes = async (
 
   app.post(
     '/api/v1/auth/change-password',
-    { config: { rateLimit: AUTH_RATE_LIMITS.changePassword } },
+    {
+      config: { rateLimit: AUTH_RATE_LIMITS.changePassword },
+      schema: {
+        tags: ['auth'],
+        summary: 'Change password for the authenticated user',
+        body: {
+          type: 'object',
+          properties: {
+            currentPassword: { type: 'string' },
+            newPassword: { type: 'string' },
+          },
+          additionalProperties: true,
+        },
+      },
+    },
     async (req, reply) => {
       const b = (req.body ?? {}) as Record<string, unknown>;
       try {
@@ -424,7 +548,13 @@ export const registerAuthRoutes = async (
 
   app.post(
     '/api/v1/auth/2fa/setup',
-    { config: { rateLimit: AUTH_RATE_LIMITS.twoFactor } },
+    {
+      config: { rateLimit: AUTH_RATE_LIMITS.twoFactor },
+      schema: {
+        tags: ['auth'],
+        summary: 'Initiate two-factor authentication setup for the authenticated user',
+      },
+    },
     async (req, reply) => {
       try {
         const res = await client.setupTwoFactor({}, buildMetadata(req));
@@ -437,7 +567,21 @@ export const registerAuthRoutes = async (
 
   app.post(
     '/api/v1/auth/2fa/enable',
-    { config: { rateLimit: AUTH_RATE_LIMITS.twoFactor } },
+    {
+      config: { rateLimit: AUTH_RATE_LIMITS.twoFactor },
+      schema: {
+        tags: ['auth'],
+        summary: 'Enable two-factor authentication using a verified TOTP secret',
+        body: {
+          type: 'object',
+          properties: {
+            secret: { type: 'string' },
+            token: { type: 'string' },
+          },
+          additionalProperties: true,
+        },
+      },
+    },
     async (req, reply) => {
       const b = (req.body ?? {}) as { secret?: string; token?: string };
       try {
@@ -454,7 +598,20 @@ export const registerAuthRoutes = async (
 
   app.post(
     '/api/v1/auth/2fa/disable',
-    { config: { rateLimit: AUTH_RATE_LIMITS.twoFactor } },
+    {
+      config: { rateLimit: AUTH_RATE_LIMITS.twoFactor },
+      schema: {
+        tags: ['auth'],
+        summary: 'Disable two-factor authentication for the authenticated user',
+        body: {
+          type: 'object',
+          properties: {
+            token: { type: 'string' },
+          },
+          additionalProperties: true,
+        },
+      },
+    },
     async (req, reply) => {
       const b = (req.body ?? {}) as { token?: string };
       try {
@@ -468,7 +625,30 @@ export const registerAuthRoutes = async (
 
   app.patch(
     '/api/v1/users/account',
-    { config: { rateLimit: AUTH_RATE_LIMITS.updateAccount } },
+    {
+      config: { rateLimit: AUTH_RATE_LIMITS.updateAccount },
+      schema: {
+        tags: ['auth'],
+        summary: 'Update account profile fields for the authenticated user',
+        body: {
+          type: 'object',
+          properties: {
+            firstName: { type: 'string' },
+            lastName: { type: 'string' },
+            phoneNumber: { type: 'string' },
+            bio: { type: 'string' },
+            timezone: { type: 'string' },
+            language: { type: 'string' },
+            country: { type: 'string' },
+            city: { type: 'string' },
+            addressLine1: { type: 'string' },
+            addressLine2: { type: 'string' },
+            postalCode: { type: 'string' },
+          },
+          additionalProperties: true,
+        },
+      },
+    },
     async (req, reply) => {
       const b = (req.body ?? {}) as Record<string, unknown>;
       try {
@@ -502,7 +682,13 @@ export const registerAuthRoutes = async (
   // GET /api/v1/users/account — alias for /auth/me.
   app.get(
     '/api/v1/users/account',
-    { config: { rateLimit: AUTH_RATE_LIMITS.getMe } },
+    {
+      config: { rateLimit: AUTH_RATE_LIMITS.getMe },
+      schema: {
+        tags: ['auth'],
+        summary: 'Return the authenticated user account profile',
+      },
+    },
     async (req, reply) => {
       try {
         const res = await client.getMe({}, buildMetadata(req));

--- a/services/gateway/src/routes/auth.ts
+++ b/services/gateway/src/routes/auth.ts
@@ -156,14 +156,6 @@ export const registerAuthRoutes = async (
         // so the existing handler keeps full control of validation
         // (returns the gRPC INVALID_ARGUMENT → 400 the SPA already
         // expects). The OpenAPI doc still tells consumers what to send.
-        body: {
-          type: 'object',
-          properties: {
-            email: { type: 'string' },
-            password: { type: 'string' },
-          },
-          additionalProperties: true,
-        },
       },
     },
     async (req, reply) => {
@@ -193,13 +185,6 @@ export const registerAuthRoutes = async (
       schema: {
         tags: ['auth'],
         summary: 'Invalidate the current session and refresh token',
-        body: {
-          type: 'object',
-          properties: {
-            refreshToken: { type: 'string' },
-          },
-          additionalProperties: true,
-        },
       },
     },
     async (req, reply) => {
@@ -222,13 +207,6 @@ export const registerAuthRoutes = async (
       schema: {
         tags: ['auth'],
         summary: 'Exchange a refresh token for a new access token',
-        body: {
-          type: 'object',
-          properties: {
-            refreshToken: { type: 'string' },
-          },
-          additionalProperties: true,
-        },
       },
     },
     async (req, reply) => {
@@ -271,15 +249,6 @@ export const registerAuthRoutes = async (
       schema: {
         tags: ['auth', 'admin'],
         summary: 'Assign a role to a target user (admin only)',
-        body: {
-          type: 'object',
-          properties: {
-            targetUserId: { type: 'string' },
-            role: { type: 'string' },
-            reason: { type: 'string' },
-          },
-          additionalProperties: true,
-        },
       },
     },
     async (req, reply) => {
@@ -310,19 +279,6 @@ export const registerAuthRoutes = async (
         tags: ['auth'],
         summary: 'Register a new user account',
         security: [],
-        body: {
-          type: 'object',
-          properties: {
-            email: { type: 'string' },
-            password: { type: 'string' },
-            firstName: { type: 'string' },
-            lastName: { type: 'string' },
-            phoneNumber: { type: 'string' },
-            termsAccepted: { type: 'boolean' },
-            privacyPolicyAccepted: { type: 'boolean' },
-          },
-          additionalProperties: true,
-        },
       },
     },
     async (req, reply) => {
@@ -365,13 +321,6 @@ export const registerAuthRoutes = async (
         tags: ['auth'],
         summary: 'Verify email address using a verification token',
         security: [],
-        body: {
-          type: 'object',
-          properties: {
-            verificationToken: { type: 'string' },
-          },
-          additionalProperties: true,
-        },
       },
     },
     async (req, reply) => {
@@ -403,13 +352,6 @@ export const registerAuthRoutes = async (
         tags: ['auth'],
         summary: 'Resend the email verification link',
         security: [],
-        body: {
-          type: 'object',
-          properties: {
-            email: { type: 'string' },
-          },
-          additionalProperties: true,
-        },
       },
     },
     async (req, reply) => {
@@ -438,13 +380,6 @@ export const registerAuthRoutes = async (
         tags: ['auth'],
         summary: 'Send a password reset link to the given email',
         security: [],
-        body: {
-          type: 'object',
-          properties: {
-            email: { type: 'string' },
-          },
-          additionalProperties: true,
-        },
       },
     },
     async (req, reply) => {
@@ -475,14 +410,6 @@ export const registerAuthRoutes = async (
         tags: ['auth'],
         summary: 'Reset password using a reset token',
         security: [],
-        body: {
-          type: 'object',
-          properties: {
-            resetToken: { type: 'string' },
-            newPassword: { type: 'string' },
-          },
-          additionalProperties: true,
-        },
       },
     },
     async (req, reply) => {
@@ -512,14 +439,6 @@ export const registerAuthRoutes = async (
       schema: {
         tags: ['auth'],
         summary: 'Change password for the authenticated user',
-        body: {
-          type: 'object',
-          properties: {
-            currentPassword: { type: 'string' },
-            newPassword: { type: 'string' },
-          },
-          additionalProperties: true,
-        },
       },
     },
     async (req, reply) => {
@@ -572,14 +491,6 @@ export const registerAuthRoutes = async (
       schema: {
         tags: ['auth'],
         summary: 'Enable two-factor authentication using a verified TOTP secret',
-        body: {
-          type: 'object',
-          properties: {
-            secret: { type: 'string' },
-            token: { type: 'string' },
-          },
-          additionalProperties: true,
-        },
       },
     },
     async (req, reply) => {
@@ -603,13 +514,6 @@ export const registerAuthRoutes = async (
       schema: {
         tags: ['auth'],
         summary: 'Disable two-factor authentication for the authenticated user',
-        body: {
-          type: 'object',
-          properties: {
-            token: { type: 'string' },
-          },
-          additionalProperties: true,
-        },
       },
     },
     async (req, reply) => {
@@ -630,23 +534,6 @@ export const registerAuthRoutes = async (
       schema: {
         tags: ['auth'],
         summary: 'Update account profile fields for the authenticated user',
-        body: {
-          type: 'object',
-          properties: {
-            firstName: { type: 'string' },
-            lastName: { type: 'string' },
-            phoneNumber: { type: 'string' },
-            bio: { type: 'string' },
-            timezone: { type: 'string' },
-            language: { type: 'string' },
-            country: { type: 'string' },
-            city: { type: 'string' },
-            addressLine1: { type: 'string' },
-            addressLine2: { type: 'string' },
-            postalCode: { type: 'string' },
-          },
-          additionalProperties: true,
-        },
       },
     },
     async (req, reply) => {

--- a/services/gateway/src/routes/broadcast.ts
+++ b/services/gateway/src/routes/broadcast.ts
@@ -22,7 +22,31 @@ export const registerBroadcastRoutes = async (
 ): Promise<void> => {
   const { client } = opts;
 
-  app.post('/api/v1/notifications/broadcast', async (req, reply) => {
+  app.post(
+    '/api/v1/notifications/broadcast',
+    {
+      schema: {
+        tags: ['notifications', 'admin'],
+        summary: 'Broadcast a notification to a cohort of users',
+        body: {
+          type: 'object',
+          properties: {
+            cohort: { type: 'object' },
+            type: {},
+            title: { type: 'string' },
+            message: { type: 'string' },
+            actionUrl: { type: 'string' },
+            action_url: { type: 'string' },
+            data: { type: 'object' },
+            dataJson: { type: 'string' },
+            scheduledFor: { type: 'string' },
+            scheduled_for: { type: 'string' },
+          },
+          additionalProperties: true,
+        },
+      },
+    },
+    async (req, reply) => {
     const body = (req.body ?? {}) as Record<string, unknown>;
     const cohort = (body.cohort ?? {}) as Record<string, unknown>;
 

--- a/services/gateway/src/routes/broadcast.ts
+++ b/services/gateway/src/routes/broadcast.ts
@@ -28,22 +28,6 @@ export const registerBroadcastRoutes = async (
       schema: {
         tags: ['notifications', 'admin'],
         summary: 'Broadcast a notification to a cohort of users',
-        body: {
-          type: 'object',
-          properties: {
-            cohort: { type: 'object' },
-            type: {},
-            title: { type: 'string' },
-            message: { type: 'string' },
-            actionUrl: { type: 'string' },
-            action_url: { type: 'string' },
-            data: { type: 'object' },
-            dataJson: { type: 'string' },
-            scheduledFor: { type: 'string' },
-            scheduled_for: { type: 'string' },
-          },
-          additionalProperties: true,
-        },
       },
     },
     async (req, reply) => {

--- a/services/gateway/src/routes/broadcast.ts
+++ b/services/gateway/src/routes/broadcast.ts
@@ -47,60 +47,61 @@ export const registerBroadcastRoutes = async (
       },
     },
     async (req, reply) => {
-    const body = (req.body ?? {}) as Record<string, unknown>;
-    const cohort = (body.cohort ?? {}) as Record<string, unknown>;
+      const body = (req.body ?? {}) as Record<string, unknown>;
+      const cohort = (body.cohort ?? {}) as Record<string, unknown>;
 
-    const grpcReq: BroadcastRequest = {
-      cohort: {
-        userTypes: Array.isArray(cohort.userTypes)
-          ? (cohort.userTypes as string[])
-          : Array.isArray(cohort.user_types)
-            ? (cohort.user_types as string[])
-            : [],
-        statuses: Array.isArray(cohort.statuses) ? (cohort.statuses as string[]) : [],
-        emailVerified:
-          typeof cohort.emailVerified === 'boolean'
-            ? cohort.emailVerified
-            : typeof cohort.email_verified === 'boolean'
-              ? cohort.email_verified
+      const grpcReq: BroadcastRequest = {
+        cohort: {
+          userTypes: Array.isArray(cohort.userTypes)
+            ? (cohort.userTypes as string[])
+            : Array.isArray(cohort.user_types)
+              ? (cohort.user_types as string[])
+              : [],
+          statuses: Array.isArray(cohort.statuses) ? (cohort.statuses as string[]) : [],
+          emailVerified:
+            typeof cohort.emailVerified === 'boolean'
+              ? cohort.emailVerified
+              : typeof cohort.email_verified === 'boolean'
+                ? cohort.email_verified
+                : undefined,
+        },
+        type: parseBodyType(body.type),
+        title: typeof body.title === 'string' ? body.title : '',
+        message: typeof body.message === 'string' ? body.message : '',
+        actionUrl:
+          typeof body.actionUrl === 'string'
+            ? body.actionUrl
+            : typeof body.action_url === 'string'
+              ? body.action_url
               : undefined,
-      },
-      type: parseBodyType(body.type),
-      title: typeof body.title === 'string' ? body.title : '',
-      message: typeof body.message === 'string' ? body.message : '',
-      actionUrl:
-        typeof body.actionUrl === 'string'
-          ? body.actionUrl
-          : typeof body.action_url === 'string'
-            ? body.action_url
-            : undefined,
-      dataJson:
-        typeof body.data === 'object' && body.data !== null
-          ? JSON.stringify(body.data)
-          : typeof body.dataJson === 'string'
-            ? body.dataJson
-            : undefined,
-      scheduledFor:
-        typeof body.scheduledFor === 'string'
-          ? body.scheduledFor
-          : typeof body.scheduled_for === 'string'
-            ? body.scheduled_for
-            : undefined,
-    };
+        dataJson:
+          typeof body.data === 'object' && body.data !== null
+            ? JSON.stringify(body.data)
+            : typeof body.dataJson === 'string'
+              ? body.dataJson
+              : undefined,
+        scheduledFor:
+          typeof body.scheduledFor === 'string'
+            ? body.scheduledFor
+            : typeof body.scheduled_for === 'string'
+              ? body.scheduled_for
+              : undefined,
+      };
 
-    try {
-      const res = await client.broadcast(grpcReq, buildMetadata(req));
-      return reply.send({
-        success: true,
-        targeted: res.targeted,
-        delivered: res.delivered,
-        suppressed: res.suppressed,
-        failed: res.failed,
-      });
-    } catch (err) {
-      return handleGrpcError(err, reply);
+      try {
+        const res = await client.broadcast(grpcReq, buildMetadata(req));
+        return reply.send({
+          success: true,
+          targeted: res.targeted,
+          delivered: res.delivered,
+          suppressed: res.suppressed,
+          failed: res.failed,
+        });
+      } catch (err) {
+        return handleGrpcError(err, reply);
+      }
     }
-  });
+  );
 };
 
 // body.type arrives either as the REST string form ('pet_available') or a

--- a/services/gateway/src/routes/chat.ts
+++ b/services/gateway/src/routes/chat.ts
@@ -73,6 +73,26 @@ export const registerChatRoutes = async (
   // registers once. Same handler shape as the other six.
   app.post<{ Params: { messageId: string } }>(
     '/api/v1/messages/:messageId/reactions',
+    {
+      schema: {
+        tags: ['chat'],
+        summary: 'Add or remove a reaction on a message',
+        params: {
+          type: 'object',
+          properties: {
+            messageId: { type: 'string' },
+          },
+        },
+        body: {
+          type: 'object',
+          properties: {
+            emoji: { type: 'string' },
+            remove: { type: 'boolean' },
+          },
+          additionalProperties: true,
+        },
+      },
+    },
     async (req, reply) => {
       const metadata = buildMetadata(req);
       const body = (req.body ?? {}) as { emoji?: string; remove?: boolean };
@@ -98,7 +118,22 @@ const registerChatRoutesForPrefix = (
   prefix: string
 ): void => {
   // ---- GET <prefix> -------------------------------------------------
-  app.get(prefix, async (req, reply) => {
+  app.get(prefix, {
+    schema: {
+      tags: ['chat'],
+      summary: 'List chats for the calling user',
+      querystring: {
+        type: 'object',
+        properties: {
+          cursor: { type: 'string' },
+          limit: { type: 'string' },
+          unreadOnly: { type: 'string' },
+          unread_only: { type: 'string' },
+        },
+        additionalProperties: true,
+      },
+    },
+  }, async (req, reply) => {
     const metadata = buildMetadata(req);
     const query = req.query as Record<string, string | undefined>;
     const pagination = parsePagination(query, { limit: 0 });
@@ -120,7 +155,22 @@ const registerChatRoutesForPrefix = (
   });
 
   // ---- POST <prefix> -----------------------------------------------
-  app.post(prefix, async (req, reply) => {
+  app.post(prefix, {
+    schema: {
+      tags: ['chat'],
+      summary: 'Open or create a chat',
+      body: {
+        type: 'object',
+        properties: {
+          applicationId: { type: 'string' },
+          application_id: { type: 'string' },
+          otherUserId: { type: 'string' },
+          other_user_id: { type: 'string' },
+        },
+        additionalProperties: true,
+      },
+    },
+  }, async (req, reply) => {
     const metadata = buildMetadata(req);
     const body = (req.body ?? {}) as Partial<OpenChatRequest> & {
       application_id?: string;
@@ -148,7 +198,24 @@ const registerChatRoutesForPrefix = (
   // ---- GET <prefix>/search ----------------------------------------
   // Must register BEFORE the :chatId routes so the static segment
   // wins Fastify's first-registered-wins matcher.
-  app.get(`${prefix}/search`, async (req, reply) => {
+  app.get(`${prefix}/search`, {
+    schema: {
+      tags: ['chat'],
+      summary: 'Search chats',
+      querystring: {
+        type: 'object',
+        properties: {
+          query: { type: 'string' },
+          q: { type: 'string' },
+          cursor: { type: 'string' },
+          limit: { type: 'string' },
+          rescueId: { type: 'string' },
+          rescue_id: { type: 'string' },
+        },
+        additionalProperties: true,
+      },
+    },
+  }, async (req, reply) => {
     const metadata = buildMetadata(req);
     const query = req.query as Record<string, string | undefined>;
     const pagination = parsePagination(query, { limit: 0 });
@@ -194,7 +261,18 @@ const registerChatRoutesForPrefix = (
   // Single-chat unread count for the calling principal. Returns the
   // monolith envelope { success, data: { unreadCount } } so the SPA's
   // lib.chat consumer keeps working.
-  app.get<{ Params: { chatId: string } }>(`${prefix}/:chatId/unread-count`, async (req, reply) => {
+  app.get<{ Params: { chatId: string } }>(`${prefix}/:chatId/unread-count`, {
+    schema: {
+      tags: ['chat'],
+      summary: 'Get unread message count for a chat',
+      params: {
+        type: 'object',
+        properties: {
+          chatId: { type: 'string' },
+        },
+      },
+    },
+  }, async (req, reply) => {
     const metadata = buildMetadata(req);
     try {
       const res = await client.getChatUnreadCount({ chatId: req.params.chatId }, metadata);
@@ -212,7 +290,18 @@ const registerChatRoutesForPrefix = (
   // /:chatId/{unread-count,messages,read} routes above so they win
   // Fastify's first-registered-wins matcher. Returns the monolith
   // envelope { success, data: Chat } where Chat is the proto JSON.
-  app.get<{ Params: { chatId: string } }>(`${prefix}/:chatId`, async (req, reply) => {
+  app.get<{ Params: { chatId: string } }>(`${prefix}/:chatId`, {
+    schema: {
+      tags: ['chat'],
+      summary: 'Get a single chat by ID',
+      params: {
+        type: 'object',
+        properties: {
+          chatId: { type: 'string' },
+        },
+      },
+    },
+  }, async (req, reply) => {
     const metadata = buildMetadata(req);
     try {
       const res = await client.getChat({ chatId: req.params.chatId }, metadata);
@@ -232,6 +321,25 @@ const registerChatRoutesForPrefix = (
   // Soft-delete (archive) a chat. Participant-or-admin only.
   app.delete<{ Params: { chatId: string }; Body?: { reason?: string } }>(
     `${prefix}/:chatId`,
+    {
+      schema: {
+        tags: ['chat'],
+        summary: 'Delete (archive) a chat',
+        params: {
+          type: 'object',
+          properties: {
+            chatId: { type: 'string' },
+          },
+        },
+        body: {
+          type: 'object',
+          properties: {
+            reason: { type: 'string' },
+          },
+          additionalProperties: true,
+        },
+      },
+    },
     async (req, reply) => {
       const metadata = buildMetadata(req);
       const body = (req.body ?? {}) as { reason?: string };
@@ -252,7 +360,26 @@ const registerChatRoutesForPrefix = (
   );
 
   // ---- GET <prefix>/:chatId/messages -------------------------------
-  app.get<{ Params: { chatId: string } }>(`${prefix}/:chatId/messages`, async (req, reply) => {
+  app.get<{ Params: { chatId: string } }>(`${prefix}/:chatId/messages`, {
+    schema: {
+      tags: ['chat'],
+      summary: 'List messages in a chat',
+      params: {
+        type: 'object',
+        properties: {
+          chatId: { type: 'string' },
+        },
+      },
+      querystring: {
+        type: 'object',
+        properties: {
+          cursor: { type: 'string' },
+          limit: { type: 'string' },
+        },
+        additionalProperties: true,
+      },
+    },
+  }, async (req, reply) => {
     const metadata = buildMetadata(req);
     const query = req.query as Record<string, string | undefined>;
     const pagination = parsePagination(query, { limit: 0 });
@@ -280,6 +407,26 @@ const registerChatRoutesForPrefix = (
   // message by its own id and verifies the chat link itself.
   app.delete<{ Params: { chatId: string; messageId: string }; Body?: { reason?: string } }>(
     `${prefix}/:chatId/messages/:messageId`,
+    {
+      schema: {
+        tags: ['chat'],
+        summary: 'Delete a message',
+        params: {
+          type: 'object',
+          properties: {
+            chatId: { type: 'string' },
+            messageId: { type: 'string' },
+          },
+        },
+        body: {
+          type: 'object',
+          properties: {
+            reason: { type: 'string' },
+          },
+          additionalProperties: true,
+        },
+      },
+    },
     async (req, reply) => {
       const metadata = buildMetadata(req);
       const body = (req.body ?? {}) as { reason?: string };
@@ -300,7 +447,26 @@ const registerChatRoutesForPrefix = (
   );
 
   // ---- POST <prefix>/:chatId/messages ------------------------------
-  app.post<{ Params: { chatId: string } }>(`${prefix}/:chatId/messages`, async (req, reply) => {
+  app.post<{ Params: { chatId: string } }>(`${prefix}/:chatId/messages`, {
+    schema: {
+      tags: ['chat'],
+      summary: 'Send a message to a chat',
+      params: {
+        type: 'object',
+        properties: {
+          chatId: { type: 'string' },
+        },
+      },
+      body: {
+        type: 'object',
+        properties: {
+          body: { type: 'string' },
+          content: { type: 'string' },
+        },
+        additionalProperties: true,
+      },
+    },
+  }, async (req, reply) => {
     const metadata = buildMetadata(req);
     const body = (req.body ?? {}) as { body?: string; content?: string };
     const grpcReq: SendMessageRequest = {
@@ -320,7 +486,26 @@ const registerChatRoutesForPrefix = (
   });
 
   // ---- POST <prefix>/:chatId/read ----------------------------------
-  app.post<{ Params: { chatId: string } }>(`${prefix}/:chatId/read`, async (req, reply) => {
+  app.post<{ Params: { chatId: string } }>(`${prefix}/:chatId/read`, {
+    schema: {
+      tags: ['chat'],
+      summary: 'Mark messages in a chat as read',
+      params: {
+        type: 'object',
+        properties: {
+          chatId: { type: 'string' },
+        },
+      },
+      body: {
+        type: 'object',
+        properties: {
+          upToMessageId: { type: 'string' },
+          up_to_message_id: { type: 'string' },
+        },
+        additionalProperties: true,
+      },
+    },
+  }, async (req, reply) => {
     const metadata = buildMetadata(req);
     const body = (req.body ?? {}) as { upToMessageId?: string; up_to_message_id?: string };
     const grpcReq: MarkReadRequest = {

--- a/services/gateway/src/routes/chat.ts
+++ b/services/gateway/src/routes/chat.ts
@@ -118,204 +118,224 @@ const registerChatRoutesForPrefix = (
   prefix: string
 ): void => {
   // ---- GET <prefix> -------------------------------------------------
-  app.get(prefix, {
-    schema: {
-      tags: ['chat'],
-      summary: 'List chats for the calling user',
-      querystring: {
-        type: 'object',
-        properties: {
-          cursor: { type: 'string' },
-          limit: { type: 'string' },
-          unreadOnly: { type: 'string' },
-          unread_only: { type: 'string' },
+  app.get(
+    prefix,
+    {
+      schema: {
+        tags: ['chat'],
+        summary: 'List chats for the calling user',
+        querystring: {
+          type: 'object',
+          properties: {
+            cursor: { type: 'string' },
+            limit: { type: 'string' },
+            unreadOnly: { type: 'string' },
+            unread_only: { type: 'string' },
+          },
+          additionalProperties: true,
         },
-        additionalProperties: true,
       },
     },
-  }, async (req, reply) => {
-    const metadata = buildMetadata(req);
-    const query = req.query as Record<string, string | undefined>;
-    const pagination = parsePagination(query, { limit: 0 });
-    if (!pagination.ok) {
-      return reply.code(400).send({ error: pagination.error });
-    }
-    const grpcReq: ListChatsRequest = {
-      cursor: query.cursor,
-      limit: pagination.limit,
-      unreadOnly: query.unreadOnly === 'true' || query.unread_only === 'true',
-    };
+    async (req, reply) => {
+      const metadata = buildMetadata(req);
+      const query = req.query as Record<string, string | undefined>;
+      const pagination = parsePagination(query, { limit: 0 });
+      if (!pagination.ok) {
+        return reply.code(400).send({ error: pagination.error });
+      }
+      const grpcReq: ListChatsRequest = {
+        cursor: query.cursor,
+        limit: pagination.limit,
+        unreadOnly: query.unreadOnly === 'true' || query.unread_only === 'true',
+      };
 
-    try {
-      const res = await client.listChats(grpcReq, metadata);
-      return reply.send(ChatV1.ListChatsResponse.toJSON(res));
-    } catch (err) {
-      return handleGrpcError(err, reply);
+      try {
+        const res = await client.listChats(grpcReq, metadata);
+        return reply.send(ChatV1.ListChatsResponse.toJSON(res));
+      } catch (err) {
+        return handleGrpcError(err, reply);
+      }
     }
-  });
+  );
 
   // ---- POST <prefix> -----------------------------------------------
-  app.post(prefix, {
-    schema: {
-      tags: ['chat'],
-      summary: 'Open or create a chat',
-      body: {
-        type: 'object',
-        properties: {
-          applicationId: { type: 'string' },
-          application_id: { type: 'string' },
-          otherUserId: { type: 'string' },
-          other_user_id: { type: 'string' },
+  app.post(
+    prefix,
+    {
+      schema: {
+        tags: ['chat'],
+        summary: 'Open or create a chat',
+        body: {
+          type: 'object',
+          properties: {
+            applicationId: { type: 'string' },
+            application_id: { type: 'string' },
+            otherUserId: { type: 'string' },
+            other_user_id: { type: 'string' },
+          },
+          additionalProperties: true,
         },
-        additionalProperties: true,
       },
     },
-  }, async (req, reply) => {
-    const metadata = buildMetadata(req);
-    const body = (req.body ?? {}) as Partial<OpenChatRequest> & {
-      application_id?: string;
-      other_user_id?: string;
-    };
-    // rescueId is sourced from the principal's rescue context (the
-    // x-rescue-id header stamped by the authenticate middleware), not the
-    // request body — so the chat row records its owning rescue instead of
-    // the chat service's null-UUID placeholder.
-    const rescueIdHeader = req.headers['x-rescue-id'];
-    const grpcReq: OpenChatRequest = {
-      applicationId: body.applicationId ?? body.application_id ?? '',
-      otherUserId: body.otherUserId ?? body.other_user_id ?? '',
-      rescueId: typeof rescueIdHeader === 'string' ? rescueIdHeader : '',
-    };
+    async (req, reply) => {
+      const metadata = buildMetadata(req);
+      const body = (req.body ?? {}) as Partial<OpenChatRequest> & {
+        application_id?: string;
+        other_user_id?: string;
+      };
+      // rescueId is sourced from the principal's rescue context (the
+      // x-rescue-id header stamped by the authenticate middleware), not the
+      // request body — so the chat row records its owning rescue instead of
+      // the chat service's null-UUID placeholder.
+      const rescueIdHeader = req.headers['x-rescue-id'];
+      const grpcReq: OpenChatRequest = {
+        applicationId: body.applicationId ?? body.application_id ?? '',
+        otherUserId: body.otherUserId ?? body.other_user_id ?? '',
+        rescueId: typeof rescueIdHeader === 'string' ? rescueIdHeader : '',
+      };
 
-    try {
-      const res = await client.openChat(grpcReq, metadata);
-      return reply.code(res.created ? 201 : 200).send(ChatV1.OpenChatResponse.toJSON(res));
-    } catch (err) {
-      return handleGrpcError(err, reply);
+      try {
+        const res = await client.openChat(grpcReq, metadata);
+        return reply.code(res.created ? 201 : 200).send(ChatV1.OpenChatResponse.toJSON(res));
+      } catch (err) {
+        return handleGrpcError(err, reply);
+      }
     }
-  });
+  );
 
   // ---- GET <prefix>/search ----------------------------------------
   // Must register BEFORE the :chatId routes so the static segment
   // wins Fastify's first-registered-wins matcher.
-  app.get(`${prefix}/search`, {
-    schema: {
-      tags: ['chat'],
-      summary: 'Search chats',
-      querystring: {
-        type: 'object',
-        properties: {
-          query: { type: 'string' },
-          q: { type: 'string' },
-          cursor: { type: 'string' },
-          limit: { type: 'string' },
-          rescueId: { type: 'string' },
-          rescue_id: { type: 'string' },
+  app.get(
+    `${prefix}/search`,
+    {
+      schema: {
+        tags: ['chat'],
+        summary: 'Search chats',
+        querystring: {
+          type: 'object',
+          properties: {
+            query: { type: 'string' },
+            q: { type: 'string' },
+            cursor: { type: 'string' },
+            limit: { type: 'string' },
+            rescueId: { type: 'string' },
+            rescue_id: { type: 'string' },
+          },
+          additionalProperties: true,
         },
-        additionalProperties: true,
       },
     },
-  }, async (req, reply) => {
-    const metadata = buildMetadata(req);
-    const query = req.query as Record<string, string | undefined>;
-    const pagination = parsePagination(query, { limit: 0 });
-    if (!pagination.ok) {
-      return reply.code(400).send({ error: pagination.error });
-    }
-    const grpcReq: SearchChatsRequest = {
-      query: query.query ?? query.q ?? '',
-      page: pagination.page,
-      limit: pagination.limit,
-      rescueId: query.rescueId ?? query.rescue_id,
-    };
+    async (req, reply) => {
+      const metadata = buildMetadata(req);
+      const query = req.query as Record<string, string | undefined>;
+      const pagination = parsePagination(query, { limit: 0 });
+      if (!pagination.ok) {
+        return reply.code(400).send({ error: pagination.error });
+      }
+      const grpcReq: SearchChatsRequest = {
+        query: query.query ?? query.q ?? '',
+        page: pagination.page,
+        limit: pagination.limit,
+        rescueId: query.rescueId ?? query.rescue_id,
+      };
 
-    try {
-      const res = await client.searchChats(grpcReq, metadata);
-      // Match the monolith ConversationsController.searchConversations
-      // body shape: { chats, pagination } so the SPA's existing search
-      // handler keeps working unchanged.
-      const total = res.total;
-      const limit = res.limit;
-      const page = res.page;
-      return reply.send({
-        success: true,
-        data: {
-          chats: res.hits.map(h => ({
-            ...(ChatV1.Chat.toJSON(h.chat!) as Record<string, unknown>),
-            matched_message: h.match ? ChatV1.Message.toJSON(h.match) : null,
-          })),
-          pagination: {
-            page,
-            limit,
-            total,
-            totalPages: limit > 0 ? Math.ceil(total / limit) : 0,
+      try {
+        const res = await client.searchChats(grpcReq, metadata);
+        // Match the monolith ConversationsController.searchConversations
+        // body shape: { chats, pagination } so the SPA's existing search
+        // handler keeps working unchanged.
+        const total = res.total;
+        const limit = res.limit;
+        const page = res.page;
+        return reply.send({
+          success: true,
+          data: {
+            chats: res.hits.map(h => ({
+              ...(ChatV1.Chat.toJSON(h.chat!) as Record<string, unknown>),
+              matched_message: h.match ? ChatV1.Message.toJSON(h.match) : null,
+            })),
+            pagination: {
+              page,
+              limit,
+              total,
+              totalPages: limit > 0 ? Math.ceil(total / limit) : 0,
+            },
           },
-        },
-      });
-    } catch (err) {
-      return handleGrpcError(err, reply);
+        });
+      } catch (err) {
+        return handleGrpcError(err, reply);
+      }
     }
-  });
+  );
 
   // ---- GET <prefix>/:chatId/unread-count ---------------------------
   // Single-chat unread count for the calling principal. Returns the
   // monolith envelope { success, data: { unreadCount } } so the SPA's
   // lib.chat consumer keeps working.
-  app.get<{ Params: { chatId: string } }>(`${prefix}/:chatId/unread-count`, {
-    schema: {
-      tags: ['chat'],
-      summary: 'Get unread message count for a chat',
-      params: {
-        type: 'object',
-        properties: {
-          chatId: { type: 'string' },
+  app.get<{ Params: { chatId: string } }>(
+    `${prefix}/:chatId/unread-count`,
+    {
+      schema: {
+        tags: ['chat'],
+        summary: 'Get unread message count for a chat',
+        params: {
+          type: 'object',
+          properties: {
+            chatId: { type: 'string' },
+          },
         },
       },
     },
-  }, async (req, reply) => {
-    const metadata = buildMetadata(req);
-    try {
-      const res = await client.getChatUnreadCount({ chatId: req.params.chatId }, metadata);
-      return reply.send({
-        success: true,
-        data: { unreadCount: res.unreadCount },
-      });
-    } catch (err) {
-      return handleGrpcError(err, reply);
+    async (req, reply) => {
+      const metadata = buildMetadata(req);
+      try {
+        const res = await client.getChatUnreadCount({ chatId: req.params.chatId }, metadata);
+        return reply.send({
+          success: true,
+          data: { unreadCount: res.unreadCount },
+        });
+      } catch (err) {
+        return handleGrpcError(err, reply);
+      }
     }
-  });
+  );
 
   // ---- GET <prefix>/:chatId ----------------------------------------
   // Fetch single chat details. Registered AFTER the more-specific
   // /:chatId/{unread-count,messages,read} routes above so they win
   // Fastify's first-registered-wins matcher. Returns the monolith
   // envelope { success, data: Chat } where Chat is the proto JSON.
-  app.get<{ Params: { chatId: string } }>(`${prefix}/:chatId`, {
-    schema: {
-      tags: ['chat'],
-      summary: 'Get a single chat by ID',
-      params: {
-        type: 'object',
-        properties: {
-          chatId: { type: 'string' },
+  app.get<{ Params: { chatId: string } }>(
+    `${prefix}/:chatId`,
+    {
+      schema: {
+        tags: ['chat'],
+        summary: 'Get a single chat by ID',
+        params: {
+          type: 'object',
+          properties: {
+            chatId: { type: 'string' },
+          },
         },
       },
     },
-  }, async (req, reply) => {
-    const metadata = buildMetadata(req);
-    try {
-      const res = await client.getChat({ chatId: req.params.chatId }, metadata);
-      if (!res.chat) {
-        return reply.code(404).send({ success: false, error: 'Chat not found' });
+    async (req, reply) => {
+      const metadata = buildMetadata(req);
+      try {
+        const res = await client.getChat({ chatId: req.params.chatId }, metadata);
+        if (!res.chat) {
+          return reply.code(404).send({ success: false, error: 'Chat not found' });
+        }
+        return reply.send({
+          success: true,
+          data: ChatV1.Chat.toJSON(res.chat),
+        });
+      } catch (err) {
+        return handleGrpcError(err, reply);
       }
-      return reply.send({
-        success: true,
-        data: ChatV1.Chat.toJSON(res.chat),
-      });
-    } catch (err) {
-      return handleGrpcError(err, reply);
     }
-  });
+  );
 
   // ---- DELETE <prefix>/:chatId -------------------------------------
   // Soft-delete (archive) a chat. Participant-or-admin only.
@@ -360,45 +380,49 @@ const registerChatRoutesForPrefix = (
   );
 
   // ---- GET <prefix>/:chatId/messages -------------------------------
-  app.get<{ Params: { chatId: string } }>(`${prefix}/:chatId/messages`, {
-    schema: {
-      tags: ['chat'],
-      summary: 'List messages in a chat',
-      params: {
-        type: 'object',
-        properties: {
-          chatId: { type: 'string' },
+  app.get<{ Params: { chatId: string } }>(
+    `${prefix}/:chatId/messages`,
+    {
+      schema: {
+        tags: ['chat'],
+        summary: 'List messages in a chat',
+        params: {
+          type: 'object',
+          properties: {
+            chatId: { type: 'string' },
+          },
         },
-      },
-      querystring: {
-        type: 'object',
-        properties: {
-          cursor: { type: 'string' },
-          limit: { type: 'string' },
+        querystring: {
+          type: 'object',
+          properties: {
+            cursor: { type: 'string' },
+            limit: { type: 'string' },
+          },
+          additionalProperties: true,
         },
-        additionalProperties: true,
       },
     },
-  }, async (req, reply) => {
-    const metadata = buildMetadata(req);
-    const query = req.query as Record<string, string | undefined>;
-    const pagination = parsePagination(query, { limit: 0 });
-    if (!pagination.ok) {
-      return reply.code(400).send({ error: pagination.error });
-    }
-    const grpcReq: ListMessagesRequest = {
-      chatId: req.params.chatId,
-      cursor: query.cursor,
-      limit: pagination.limit,
-    };
+    async (req, reply) => {
+      const metadata = buildMetadata(req);
+      const query = req.query as Record<string, string | undefined>;
+      const pagination = parsePagination(query, { limit: 0 });
+      if (!pagination.ok) {
+        return reply.code(400).send({ error: pagination.error });
+      }
+      const grpcReq: ListMessagesRequest = {
+        chatId: req.params.chatId,
+        cursor: query.cursor,
+        limit: pagination.limit,
+      };
 
-    try {
-      const res = await client.listMessages(grpcReq, metadata);
-      return reply.send(normalizeMessages(ChatV1.ListMessagesResponse.toJSON(res)));
-    } catch (err) {
-      return handleGrpcError(err, reply);
+      try {
+        const res = await client.listMessages(grpcReq, metadata);
+        return reply.send(normalizeMessages(ChatV1.ListMessagesResponse.toJSON(res)));
+      } catch (err) {
+        return handleGrpcError(err, reply);
+      }
     }
-  });
+  );
 
   // ---- DELETE <prefix>/:chatId/messages/:messageId -----------------
   // Soft-deletes the message. Senders can delete their own; moderators
@@ -447,79 +471,89 @@ const registerChatRoutesForPrefix = (
   );
 
   // ---- POST <prefix>/:chatId/messages ------------------------------
-  app.post<{ Params: { chatId: string } }>(`${prefix}/:chatId/messages`, {
-    schema: {
-      tags: ['chat'],
-      summary: 'Send a message to a chat',
-      params: {
-        type: 'object',
-        properties: {
-          chatId: { type: 'string' },
+  app.post<{ Params: { chatId: string } }>(
+    `${prefix}/:chatId/messages`,
+    {
+      schema: {
+        tags: ['chat'],
+        summary: 'Send a message to a chat',
+        params: {
+          type: 'object',
+          properties: {
+            chatId: { type: 'string' },
+          },
         },
-      },
-      body: {
-        type: 'object',
-        properties: {
-          body: { type: 'string' },
-          content: { type: 'string' },
+        body: {
+          type: 'object',
+          properties: {
+            body: { type: 'string' },
+            content: { type: 'string' },
+          },
+          additionalProperties: true,
         },
-        additionalProperties: true,
       },
     },
-  }, async (req, reply) => {
-    const metadata = buildMetadata(req);
-    const body = (req.body ?? {}) as { body?: string; content?: string };
-    const grpcReq: SendMessageRequest = {
-      chatId: req.params.chatId,
-      body: body.body ?? body.content ?? '',
-    };
+    async (req, reply) => {
+      const metadata = buildMetadata(req);
+      const body = (req.body ?? {}) as { body?: string; content?: string };
+      const grpcReq: SendMessageRequest = {
+        chatId: req.params.chatId,
+        body: body.body ?? body.content ?? '',
+      };
 
-    try {
-      const res = await client.sendMessage(grpcReq, metadata);
-      const json = ChatV1.SendMessageResponse.toJSON(res) as { message?: Record<string, unknown> };
-      return reply
-        .code(201)
-        .send(json.message ? { ...json, message: withMessageContent(json.message) } : json);
-    } catch (err) {
-      return handleGrpcError(err, reply);
+      try {
+        const res = await client.sendMessage(grpcReq, metadata);
+        const json = ChatV1.SendMessageResponse.toJSON(res) as {
+          message?: Record<string, unknown>;
+        };
+        return reply
+          .code(201)
+          .send(json.message ? { ...json, message: withMessageContent(json.message) } : json);
+      } catch (err) {
+        return handleGrpcError(err, reply);
+      }
     }
-  });
+  );
 
   // ---- POST <prefix>/:chatId/read ----------------------------------
-  app.post<{ Params: { chatId: string } }>(`${prefix}/:chatId/read`, {
-    schema: {
-      tags: ['chat'],
-      summary: 'Mark messages in a chat as read',
-      params: {
-        type: 'object',
-        properties: {
-          chatId: { type: 'string' },
+  app.post<{ Params: { chatId: string } }>(
+    `${prefix}/:chatId/read`,
+    {
+      schema: {
+        tags: ['chat'],
+        summary: 'Mark messages in a chat as read',
+        params: {
+          type: 'object',
+          properties: {
+            chatId: { type: 'string' },
+          },
         },
-      },
-      body: {
-        type: 'object',
-        properties: {
-          upToMessageId: { type: 'string' },
-          up_to_message_id: { type: 'string' },
+        body: {
+          type: 'object',
+          properties: {
+            upToMessageId: { type: 'string' },
+            up_to_message_id: { type: 'string' },
+          },
+          additionalProperties: true,
         },
-        additionalProperties: true,
       },
     },
-  }, async (req, reply) => {
-    const metadata = buildMetadata(req);
-    const body = (req.body ?? {}) as { upToMessageId?: string; up_to_message_id?: string };
-    const grpcReq: MarkReadRequest = {
-      chatId: req.params.chatId,
-      upToMessageId: body.upToMessageId ?? body.up_to_message_id ?? '',
-    };
+    async (req, reply) => {
+      const metadata = buildMetadata(req);
+      const body = (req.body ?? {}) as { upToMessageId?: string; up_to_message_id?: string };
+      const grpcReq: MarkReadRequest = {
+        chatId: req.params.chatId,
+        upToMessageId: body.upToMessageId ?? body.up_to_message_id ?? '',
+      };
 
-    try {
-      const res = await client.markRead(grpcReq, metadata);
-      return reply.send(ChatV1.MarkReadResponse.toJSON(res));
-    } catch (err) {
-      return handleGrpcError(err, reply);
+      try {
+        const res = await client.markRead(grpcReq, metadata);
+        return reply.send(ChatV1.MarkReadResponse.toJSON(res));
+      } catch (err) {
+        return handleGrpcError(err, reply);
+      }
     }
-  });
+  );
 };
 
 // --- Helpers ---------------------------------------------------------

--- a/services/gateway/src/routes/chat.ts
+++ b/services/gateway/src/routes/chat.ts
@@ -77,20 +77,6 @@ export const registerChatRoutes = async (
       schema: {
         tags: ['chat'],
         summary: 'Add or remove a reaction on a message',
-        params: {
-          type: 'object',
-          properties: {
-            messageId: { type: 'string' },
-          },
-        },
-        body: {
-          type: 'object',
-          properties: {
-            emoji: { type: 'string' },
-            remove: { type: 'boolean' },
-          },
-          additionalProperties: true,
-        },
       },
     },
     async (req, reply) => {
@@ -124,16 +110,6 @@ const registerChatRoutesForPrefix = (
       schema: {
         tags: ['chat'],
         summary: 'List chats for the calling user',
-        querystring: {
-          type: 'object',
-          properties: {
-            cursor: { type: 'string' },
-            limit: { type: 'string' },
-            unreadOnly: { type: 'string' },
-            unread_only: { type: 'string' },
-          },
-          additionalProperties: true,
-        },
       },
     },
     async (req, reply) => {
@@ -165,16 +141,6 @@ const registerChatRoutesForPrefix = (
       schema: {
         tags: ['chat'],
         summary: 'Open or create a chat',
-        body: {
-          type: 'object',
-          properties: {
-            applicationId: { type: 'string' },
-            application_id: { type: 'string' },
-            otherUserId: { type: 'string' },
-            other_user_id: { type: 'string' },
-          },
-          additionalProperties: true,
-        },
       },
     },
     async (req, reply) => {
@@ -212,18 +178,6 @@ const registerChatRoutesForPrefix = (
       schema: {
         tags: ['chat'],
         summary: 'Search chats',
-        querystring: {
-          type: 'object',
-          properties: {
-            query: { type: 'string' },
-            q: { type: 'string' },
-            cursor: { type: 'string' },
-            limit: { type: 'string' },
-            rescueId: { type: 'string' },
-            rescue_id: { type: 'string' },
-          },
-          additionalProperties: true,
-        },
       },
     },
     async (req, reply) => {
@@ -279,12 +233,6 @@ const registerChatRoutesForPrefix = (
       schema: {
         tags: ['chat'],
         summary: 'Get unread message count for a chat',
-        params: {
-          type: 'object',
-          properties: {
-            chatId: { type: 'string' },
-          },
-        },
       },
     },
     async (req, reply) => {
@@ -312,12 +260,6 @@ const registerChatRoutesForPrefix = (
       schema: {
         tags: ['chat'],
         summary: 'Get a single chat by ID',
-        params: {
-          type: 'object',
-          properties: {
-            chatId: { type: 'string' },
-          },
-        },
       },
     },
     async (req, reply) => {
@@ -345,19 +287,6 @@ const registerChatRoutesForPrefix = (
       schema: {
         tags: ['chat'],
         summary: 'Delete (archive) a chat',
-        params: {
-          type: 'object',
-          properties: {
-            chatId: { type: 'string' },
-          },
-        },
-        body: {
-          type: 'object',
-          properties: {
-            reason: { type: 'string' },
-          },
-          additionalProperties: true,
-        },
       },
     },
     async (req, reply) => {
@@ -386,20 +315,6 @@ const registerChatRoutesForPrefix = (
       schema: {
         tags: ['chat'],
         summary: 'List messages in a chat',
-        params: {
-          type: 'object',
-          properties: {
-            chatId: { type: 'string' },
-          },
-        },
-        querystring: {
-          type: 'object',
-          properties: {
-            cursor: { type: 'string' },
-            limit: { type: 'string' },
-          },
-          additionalProperties: true,
-        },
       },
     },
     async (req, reply) => {
@@ -435,20 +350,6 @@ const registerChatRoutesForPrefix = (
       schema: {
         tags: ['chat'],
         summary: 'Delete a message',
-        params: {
-          type: 'object',
-          properties: {
-            chatId: { type: 'string' },
-            messageId: { type: 'string' },
-          },
-        },
-        body: {
-          type: 'object',
-          properties: {
-            reason: { type: 'string' },
-          },
-          additionalProperties: true,
-        },
       },
     },
     async (req, reply) => {
@@ -477,20 +378,6 @@ const registerChatRoutesForPrefix = (
       schema: {
         tags: ['chat'],
         summary: 'Send a message to a chat',
-        params: {
-          type: 'object',
-          properties: {
-            chatId: { type: 'string' },
-          },
-        },
-        body: {
-          type: 'object',
-          properties: {
-            body: { type: 'string' },
-            content: { type: 'string' },
-          },
-          additionalProperties: true,
-        },
       },
     },
     async (req, reply) => {
@@ -522,20 +409,6 @@ const registerChatRoutesForPrefix = (
       schema: {
         tags: ['chat'],
         summary: 'Mark messages in a chat as read',
-        params: {
-          type: 'object',
-          properties: {
-            chatId: { type: 'string' },
-          },
-        },
-        body: {
-          type: 'object',
-          properties: {
-            upToMessageId: { type: 'string' },
-            up_to_message_id: { type: 'string' },
-          },
-          additionalProperties: true,
-        },
       },
     },
     async (req, reply) => {

--- a/services/gateway/src/routes/cms.ts
+++ b/services/gateway/src/routes/cms.ts
@@ -153,7 +153,22 @@ export const registerCmsRoutes = async (
   const { client } = opts;
 
   // --- Public reads (no auth) ----------------------------------------
-  app.get('/api/v1/cms/public/content', async (req, reply) => {
+  app.get('/api/v1/cms/public/content', {
+    schema: {
+      tags: ['cms'],
+      summary: 'List public CMS content',
+      security: [],
+      querystring: {
+        type: 'object',
+        properties: {
+          type: { type: 'string' },
+          page: { type: 'string' },
+          limit: { type: 'string' },
+        },
+        additionalProperties: true,
+      },
+    },
+  }, async (req, reply) => {
     const q = req.query as Record<string, string | undefined>;
     const pagination = parsePagination(q);
     if (!pagination.ok) {
@@ -181,7 +196,19 @@ export const registerCmsRoutes = async (
     }
   });
 
-  app.get<{ Params: { slug: string } }>('/api/v1/cms/public/content/:slug', async (req, reply) => {
+  app.get<{ Params: { slug: string } }>('/api/v1/cms/public/content/:slug', {
+    schema: {
+      tags: ['cms'],
+      summary: 'Get public CMS content by slug',
+      security: [],
+      params: {
+        type: 'object',
+        properties: {
+          slug: { type: 'string' },
+        },
+      },
+    },
+  }, async (req, reply) => {
     try {
       const res = await client.getPublicContentBySlug(
         { slug: req.params.slug },
@@ -197,7 +224,23 @@ export const registerCmsRoutes = async (
   });
 
   // --- Admin content reads ------------------------------------------
-  app.get('/api/v1/cms/content', async (req, reply) => {
+  app.get('/api/v1/cms/content', {
+    schema: {
+      tags: ['cms'],
+      summary: 'List CMS content (admin)',
+      querystring: {
+        type: 'object',
+        properties: {
+          type: { type: 'string' },
+          status: { type: 'string' },
+          search: { type: 'string' },
+          page: { type: 'string' },
+          limit: { type: 'string' },
+        },
+        additionalProperties: true,
+      },
+    },
+  }, async (req, reply) => {
     const q = req.query as Record<string, string | undefined>;
     const pagination = parsePagination(q);
     if (!pagination.ok) {
@@ -228,7 +271,18 @@ export const registerCmsRoutes = async (
   });
 
   // Slug lookup BEFORE the dynamic :contentId so it isn't shadowed.
-  app.get<{ Params: { slug: string } }>('/api/v1/cms/content/slug/:slug', async (req, reply) => {
+  app.get<{ Params: { slug: string } }>('/api/v1/cms/content/slug/:slug', {
+    schema: {
+      tags: ['cms'],
+      summary: 'Get CMS content by slug (admin)',
+      params: {
+        type: 'object',
+        properties: {
+          slug: { type: 'string' },
+        },
+      },
+    },
+  }, async (req, reply) => {
     try {
       const res = await client.getContentBySlug({ slug: req.params.slug }, buildMetadata(req));
       if (!res.content) {
@@ -242,6 +296,18 @@ export const registerCmsRoutes = async (
 
   app.get<{ Params: { contentId: string } }>(
     '/api/v1/cms/content/:contentId',
+    {
+      schema: {
+        tags: ['cms'],
+        summary: 'Get a CMS content item by ID',
+        params: {
+          type: 'object',
+          properties: {
+            contentId: { type: 'string' },
+          },
+        },
+      },
+    },
     async (req, reply) => {
       try {
         const res = await client.getContent(
@@ -258,7 +324,34 @@ export const registerCmsRoutes = async (
     }
   );
 
-  app.post('/api/v1/cms/content', async (req, reply) => {
+  app.post('/api/v1/cms/content', {
+    schema: {
+      tags: ['cms'],
+      summary: 'Create a CMS content item',
+      body: {
+        type: 'object',
+        properties: {
+          title: { type: 'string' },
+          slug: { type: 'string' },
+          contentType: { type: 'string' },
+          content_type: { type: 'string' },
+          content: { type: 'string' },
+          excerpt: { type: 'string' },
+          metaTitle: { type: 'string' },
+          meta_title: { type: 'string' },
+          metaDescription: { type: 'string' },
+          meta_description: { type: 'string' },
+          metaKeywords: { type: 'array', items: { type: 'string' } },
+          meta_keywords: { type: 'array', items: { type: 'string' } },
+          featuredImageUrl: { type: 'string' },
+          featured_image_url: { type: 'string' },
+          scheduledPublishAt: { type: 'string' },
+          scheduledUnpublishAt: { type: 'string' },
+        },
+        additionalProperties: true,
+      },
+    },
+  }, async (req, reply) => {
     const body = (req.body ?? {}) as Record<string, unknown>;
     const grpcReq: CmsCreateContentRequest = {
       title: String(body.title ?? ''),
@@ -307,6 +400,35 @@ export const registerCmsRoutes = async (
 
   app.put<{ Params: { contentId: string } }>(
     '/api/v1/cms/content/:contentId',
+    {
+      schema: {
+        tags: ['cms'],
+        summary: 'Update a CMS content item',
+        params: {
+          type: 'object',
+          properties: {
+            contentId: { type: 'string' },
+          },
+        },
+        body: {
+          type: 'object',
+          properties: {
+            title: { type: 'string' },
+            slug: { type: 'string' },
+            content: { type: 'string' },
+            excerpt: { type: 'string' },
+            metaTitle: { type: 'string' },
+            metaDescription: { type: 'string' },
+            metaKeywords: { type: 'array', items: { type: 'string' } },
+            meta_keywords: { type: 'array', items: { type: 'string' } },
+            featuredImageUrl: { type: 'string' },
+            changeNote: { type: 'string' },
+            change_note: { type: 'string' },
+          },
+          additionalProperties: true,
+        },
+      },
+    },
     async (req, reply) => {
       const body = (req.body ?? {}) as Record<string, unknown>;
       const hasMetaKeywords = Array.isArray(body.metaKeywords) || Array.isArray(body.meta_keywords);
@@ -346,6 +468,18 @@ export const registerCmsRoutes = async (
 
   app.delete<{ Params: { contentId: string } }>(
     '/api/v1/cms/content/:contentId',
+    {
+      schema: {
+        tags: ['cms'],
+        summary: 'Delete a CMS content item',
+        params: {
+          type: 'object',
+          properties: {
+            contentId: { type: 'string' },
+          },
+        },
+      },
+    },
     async (req, reply) => {
       try {
         const res = await client.deleteContent(
@@ -365,33 +499,61 @@ export const registerCmsRoutes = async (
   // Workflow
   const workflow = (
     path: string,
-    fn: (id: string, m: Metadata) => Promise<{ content?: CmsContent }>
+    fn: (id: string, m: Metadata) => Promise<{ content?: CmsContent }>,
+    summary: string
   ): void => {
-    app.post<{ Params: { contentId: string } }>(path, async (req, reply) => {
-      try {
-        const res = await fn(req.params.contentId, buildMetadata(req));
-        if (!res.content) {
-          return reply.code(404).send({ success: false, error: 'not found' });
+    app.post<{ Params: { contentId: string } }>(
+      path,
+      {
+        schema: {
+          tags: ['cms'],
+          summary,
+          params: {
+            type: 'object',
+            properties: {
+              contentId: { type: 'string' },
+            },
+          },
+        },
+      },
+      async (req, reply) => {
+        try {
+          const res = await fn(req.params.contentId, buildMetadata(req));
+          if (!res.content) {
+            return reply.code(404).send({ success: false, error: 'not found' });
+          }
+          return reply.send({ success: true, content: contentToView(res.content) });
+        } catch (err) {
+          return handleGrpcError(err, reply);
         }
-        return reply.send({ success: true, content: contentToView(res.content) });
-      } catch (err) {
-        return handleGrpcError(err, reply);
       }
-    });
+    );
   };
   workflow('/api/v1/cms/content/:contentId/publish', (id, m) =>
-    client.publishContent({ contentId: id }, m)
+    client.publishContent({ contentId: id }, m), 'Publish a CMS content item'
   );
   workflow('/api/v1/cms/content/:contentId/unpublish', (id, m) =>
-    client.unpublishContent({ contentId: id }, m)
+    client.unpublishContent({ contentId: id }, m), 'Unpublish a CMS content item'
   );
   workflow('/api/v1/cms/content/:contentId/archive', (id, m) =>
-    client.archiveContent({ contentId: id }, m)
+    client.archiveContent({ contentId: id }, m), 'Archive a CMS content item'
   );
 
   // Versions
   app.get<{ Params: { contentId: string } }>(
     '/api/v1/cms/content/:contentId/versions',
+    {
+      schema: {
+        tags: ['cms'],
+        summary: 'Get version history for a CMS content item',
+        params: {
+          type: 'object',
+          properties: {
+            contentId: { type: 'string' },
+          },
+        },
+      },
+    },
     async (req, reply) => {
       try {
         const res = await client.getVersionHistory(
@@ -411,6 +573,19 @@ export const registerCmsRoutes = async (
 
   app.post<{ Params: { contentId: string; version: string } }>(
     '/api/v1/cms/content/:contentId/versions/:version/restore',
+    {
+      schema: {
+        tags: ['cms'],
+        summary: 'Restore a CMS content item to a previous version',
+        params: {
+          type: 'object',
+          properties: {
+            contentId: { type: 'string' },
+            version: { type: 'string' },
+          },
+        },
+      },
+    },
     async (req, reply) => {
       const version = Number.parseInt(req.params.version, 10);
       if (Number.isNaN(version) || version <= 0) {
@@ -432,7 +607,20 @@ export const registerCmsRoutes = async (
   );
 
   // --- Menus --------------------------------------------------------
-  app.get('/api/v1/cms/menus', async (req, reply) => {
+  app.get('/api/v1/cms/menus', {
+    schema: {
+      tags: ['cms'],
+      summary: 'List CMS menus',
+      querystring: {
+        type: 'object',
+        properties: {
+          location: { type: 'string' },
+          active: { type: 'string' },
+        },
+        additionalProperties: true,
+      },
+    },
+  }, async (req, reply) => {
     const q = req.query as Record<string, string | undefined>;
     const grpcReq = {
       location: q.location,
@@ -446,7 +634,18 @@ export const registerCmsRoutes = async (
     }
   });
 
-  app.get<{ Params: { menuId: string } }>('/api/v1/cms/menus/:menuId', async (req, reply) => {
+  app.get<{ Params: { menuId: string } }>('/api/v1/cms/menus/:menuId', {
+    schema: {
+      tags: ['cms'],
+      summary: 'Get a CMS menu by ID',
+      params: {
+        type: 'object',
+        properties: {
+          menuId: { type: 'string' },
+        },
+      },
+    },
+  }, async (req, reply) => {
     try {
       const res = await client.getMenu({ menuId: req.params.menuId }, buildMetadata(req));
       if (!res.menu) {
@@ -458,7 +657,22 @@ export const registerCmsRoutes = async (
     }
   });
 
-  app.post('/api/v1/cms/menus', async (req, reply) => {
+  app.post('/api/v1/cms/menus', {
+    schema: {
+      tags: ['cms'],
+      summary: 'Create a CMS menu',
+      body: {
+        type: 'object',
+        properties: {
+          name: { type: 'string' },
+          location: { type: 'string' },
+          items: {},
+          isActive: { type: 'boolean' },
+        },
+        additionalProperties: true,
+      },
+    },
+  }, async (req, reply) => {
     const body = (req.body ?? {}) as Record<string, unknown>;
     const itemsJson = Array.isArray(body.items)
       ? JSON.stringify(body.items)
@@ -484,7 +698,28 @@ export const registerCmsRoutes = async (
     }
   });
 
-  app.put<{ Params: { menuId: string } }>('/api/v1/cms/menus/:menuId', async (req, reply) => {
+  app.put<{ Params: { menuId: string } }>('/api/v1/cms/menus/:menuId', {
+    schema: {
+      tags: ['cms'],
+      summary: 'Update a CMS menu',
+      params: {
+        type: 'object',
+        properties: {
+          menuId: { type: 'string' },
+        },
+      },
+      body: {
+        type: 'object',
+        properties: {
+          name: { type: 'string' },
+          location: { type: 'string' },
+          items: {},
+          isActive: { type: 'boolean' },
+        },
+        additionalProperties: true,
+      },
+    },
+  }, async (req, reply) => {
     const body = (req.body ?? {}) as Record<string, unknown>;
     const itemsJson = Array.isArray(body.items)
       ? JSON.stringify(body.items)
@@ -511,7 +746,18 @@ export const registerCmsRoutes = async (
     }
   });
 
-  app.delete<{ Params: { menuId: string } }>('/api/v1/cms/menus/:menuId', async (req, reply) => {
+  app.delete<{ Params: { menuId: string } }>('/api/v1/cms/menus/:menuId', {
+    schema: {
+      tags: ['cms'],
+      summary: 'Delete a CMS menu',
+      params: {
+        type: 'object',
+        properties: {
+          menuId: { type: 'string' },
+        },
+      },
+    },
+  }, async (req, reply) => {
     try {
       const res = await client.deleteMenu({ menuId: req.params.menuId }, buildMetadata(req));
       if (!res.deleted) {

--- a/services/gateway/src/routes/cms.ts
+++ b/services/gateway/src/routes/cms.ts
@@ -153,146 +153,162 @@ export const registerCmsRoutes = async (
   const { client } = opts;
 
   // --- Public reads (no auth) ----------------------------------------
-  app.get('/api/v1/cms/public/content', {
-    schema: {
-      tags: ['cms'],
-      summary: 'List public CMS content',
-      security: [],
-      querystring: {
-        type: 'object',
-        properties: {
-          type: { type: 'string' },
-          page: { type: 'string' },
-          limit: { type: 'string' },
-        },
-        additionalProperties: true,
-      },
-    },
-  }, async (req, reply) => {
-    const q = req.query as Record<string, string | undefined>;
-    const pagination = parsePagination(q);
-    if (!pagination.ok) {
-      return reply.code(400).send({ success: false, error: pagination.error });
-    }
-    const grpcReq: CmsListPublicContentRequest = {
-      contentType: contentTypeFromString(q.type),
-      page: pagination.page,
-      limit: pagination.limit,
-    };
-    try {
-      const res = await client.listPublicContent(grpcReq, buildMetadata(req));
-      return reply.send({
-        success: true,
-        data: res.items.map(contentToView),
-        pagination: {
-          page: res.page,
-          limit: grpcReq.limit || 20,
-          total: res.total,
-          totalPages: res.totalPages,
-        },
-      });
-    } catch (err) {
-      return handleGrpcError(err, reply);
-    }
-  });
-
-  app.get<{ Params: { slug: string } }>('/api/v1/cms/public/content/:slug', {
-    schema: {
-      tags: ['cms'],
-      summary: 'Get public CMS content by slug',
-      security: [],
-      params: {
-        type: 'object',
-        properties: {
-          slug: { type: 'string' },
+  app.get(
+    '/api/v1/cms/public/content',
+    {
+      schema: {
+        tags: ['cms'],
+        summary: 'List public CMS content',
+        security: [],
+        querystring: {
+          type: 'object',
+          properties: {
+            type: { type: 'string' },
+            page: { type: 'string' },
+            limit: { type: 'string' },
+          },
+          additionalProperties: true,
         },
       },
     },
-  }, async (req, reply) => {
-    try {
-      const res = await client.getPublicContentBySlug(
-        { slug: req.params.slug },
-        buildMetadata(req)
-      );
-      if (!res.content) {
-        return reply.code(404).send({ success: false, error: 'not found' });
+    async (req, reply) => {
+      const q = req.query as Record<string, string | undefined>;
+      const pagination = parsePagination(q);
+      if (!pagination.ok) {
+        return reply.code(400).send({ success: false, error: pagination.error });
       }
-      return reply.send({ success: true, content: contentToView(res.content) });
-    } catch (err) {
-      return handleGrpcError(err, reply);
+      const grpcReq: CmsListPublicContentRequest = {
+        contentType: contentTypeFromString(q.type),
+        page: pagination.page,
+        limit: pagination.limit,
+      };
+      try {
+        const res = await client.listPublicContent(grpcReq, buildMetadata(req));
+        return reply.send({
+          success: true,
+          data: res.items.map(contentToView),
+          pagination: {
+            page: res.page,
+            limit: grpcReq.limit || 20,
+            total: res.total,
+            totalPages: res.totalPages,
+          },
+        });
+      } catch (err) {
+        return handleGrpcError(err, reply);
+      }
     }
-  });
+  );
+
+  app.get<{ Params: { slug: string } }>(
+    '/api/v1/cms/public/content/:slug',
+    {
+      schema: {
+        tags: ['cms'],
+        summary: 'Get public CMS content by slug',
+        security: [],
+        params: {
+          type: 'object',
+          properties: {
+            slug: { type: 'string' },
+          },
+        },
+      },
+    },
+    async (req, reply) => {
+      try {
+        const res = await client.getPublicContentBySlug(
+          { slug: req.params.slug },
+          buildMetadata(req)
+        );
+        if (!res.content) {
+          return reply.code(404).send({ success: false, error: 'not found' });
+        }
+        return reply.send({ success: true, content: contentToView(res.content) });
+      } catch (err) {
+        return handleGrpcError(err, reply);
+      }
+    }
+  );
 
   // --- Admin content reads ------------------------------------------
-  app.get('/api/v1/cms/content', {
-    schema: {
-      tags: ['cms'],
-      summary: 'List CMS content (admin)',
-      querystring: {
-        type: 'object',
-        properties: {
-          type: { type: 'string' },
-          status: { type: 'string' },
-          search: { type: 'string' },
-          page: { type: 'string' },
-          limit: { type: 'string' },
+  app.get(
+    '/api/v1/cms/content',
+    {
+      schema: {
+        tags: ['cms'],
+        summary: 'List CMS content (admin)',
+        querystring: {
+          type: 'object',
+          properties: {
+            type: { type: 'string' },
+            status: { type: 'string' },
+            search: { type: 'string' },
+            page: { type: 'string' },
+            limit: { type: 'string' },
+          },
+          additionalProperties: true,
         },
-        additionalProperties: true,
       },
     },
-  }, async (req, reply) => {
-    const q = req.query as Record<string, string | undefined>;
-    const pagination = parsePagination(q);
-    if (!pagination.ok) {
-      return reply.code(400).send({ success: false, error: pagination.error });
+    async (req, reply) => {
+      const q = req.query as Record<string, string | undefined>;
+      const pagination = parsePagination(q);
+      if (!pagination.ok) {
+        return reply.code(400).send({ success: false, error: pagination.error });
+      }
+      const grpcReq: CmsListContentRequest = {
+        contentType: contentTypeFromString(q.type),
+        status: contentStatusFromString(q.status),
+        search: q.search,
+        page: pagination.page,
+        limit: pagination.limit,
+      };
+      try {
+        const res = await client.listContent(grpcReq, buildMetadata(req));
+        return reply.send({
+          success: true,
+          data: res.items.map(contentToView),
+          pagination: {
+            page: res.page,
+            limit: grpcReq.limit || 20,
+            total: res.total,
+            totalPages: res.totalPages,
+          },
+        });
+      } catch (err) {
+        return handleGrpcError(err, reply);
+      }
     }
-    const grpcReq: CmsListContentRequest = {
-      contentType: contentTypeFromString(q.type),
-      status: contentStatusFromString(q.status),
-      search: q.search,
-      page: pagination.page,
-      limit: pagination.limit,
-    };
-    try {
-      const res = await client.listContent(grpcReq, buildMetadata(req));
-      return reply.send({
-        success: true,
-        data: res.items.map(contentToView),
-        pagination: {
-          page: res.page,
-          limit: grpcReq.limit || 20,
-          total: res.total,
-          totalPages: res.totalPages,
-        },
-      });
-    } catch (err) {
-      return handleGrpcError(err, reply);
-    }
-  });
+  );
 
   // Slug lookup BEFORE the dynamic :contentId so it isn't shadowed.
-  app.get<{ Params: { slug: string } }>('/api/v1/cms/content/slug/:slug', {
-    schema: {
-      tags: ['cms'],
-      summary: 'Get CMS content by slug (admin)',
-      params: {
-        type: 'object',
-        properties: {
-          slug: { type: 'string' },
+  app.get<{ Params: { slug: string } }>(
+    '/api/v1/cms/content/slug/:slug',
+    {
+      schema: {
+        tags: ['cms'],
+        summary: 'Get CMS content by slug (admin)',
+        params: {
+          type: 'object',
+          properties: {
+            slug: { type: 'string' },
+          },
         },
       },
     },
-  }, async (req, reply) => {
-    try {
-      const res = await client.getContentBySlug({ slug: req.params.slug }, buildMetadata(req));
-      if (!res.content) {
-        return reply.code(404).send({ success: false, error: 'not found' });
+    async (req, reply) => {
+      try {
+        const res = await client.getContentBySlug({ slug: req.params.slug }, buildMetadata(req));
+        if (!res.content) {
+          return reply.code(404).send({ success: false, error: 'not found' });
+        }
+        return reply.send({ success: true, content: contentToView(res.content) });
+      } catch (err) {
+        return handleGrpcError(err, reply);
       }
-      return reply.send({ success: true, content: contentToView(res.content) });
-    } catch (err) {
-      return handleGrpcError(err, reply);
     }
-  });
+  );
 
   app.get<{ Params: { contentId: string } }>(
     '/api/v1/cms/content/:contentId',
@@ -324,79 +340,83 @@ export const registerCmsRoutes = async (
     }
   );
 
-  app.post('/api/v1/cms/content', {
-    schema: {
-      tags: ['cms'],
-      summary: 'Create a CMS content item',
-      body: {
-        type: 'object',
-        properties: {
-          title: { type: 'string' },
-          slug: { type: 'string' },
-          contentType: { type: 'string' },
-          content_type: { type: 'string' },
-          content: { type: 'string' },
-          excerpt: { type: 'string' },
-          metaTitle: { type: 'string' },
-          meta_title: { type: 'string' },
-          metaDescription: { type: 'string' },
-          meta_description: { type: 'string' },
-          metaKeywords: { type: 'array', items: { type: 'string' } },
-          meta_keywords: { type: 'array', items: { type: 'string' } },
-          featuredImageUrl: { type: 'string' },
-          featured_image_url: { type: 'string' },
-          scheduledPublishAt: { type: 'string' },
-          scheduledUnpublishAt: { type: 'string' },
+  app.post(
+    '/api/v1/cms/content',
+    {
+      schema: {
+        tags: ['cms'],
+        summary: 'Create a CMS content item',
+        body: {
+          type: 'object',
+          properties: {
+            title: { type: 'string' },
+            slug: { type: 'string' },
+            contentType: { type: 'string' },
+            content_type: { type: 'string' },
+            content: { type: 'string' },
+            excerpt: { type: 'string' },
+            metaTitle: { type: 'string' },
+            meta_title: { type: 'string' },
+            metaDescription: { type: 'string' },
+            meta_description: { type: 'string' },
+            metaKeywords: { type: 'array', items: { type: 'string' } },
+            meta_keywords: { type: 'array', items: { type: 'string' } },
+            featuredImageUrl: { type: 'string' },
+            featured_image_url: { type: 'string' },
+            scheduledPublishAt: { type: 'string' },
+            scheduledUnpublishAt: { type: 'string' },
+          },
+          additionalProperties: true,
         },
-        additionalProperties: true,
       },
     },
-  }, async (req, reply) => {
-    const body = (req.body ?? {}) as Record<string, unknown>;
-    const grpcReq: CmsCreateContentRequest = {
-      title: String(body.title ?? ''),
-      slug: String(body.slug ?? ''),
-      contentType: contentTypeFromString(String(body.contentType ?? body.content_type ?? '')),
-      content: String(body.content ?? ''),
-      excerpt: typeof body.excerpt === 'string' ? body.excerpt : undefined,
-      metaTitle:
-        typeof body.metaTitle === 'string'
-          ? body.metaTitle
-          : typeof body.meta_title === 'string'
-            ? body.meta_title
-            : undefined,
-      metaDescription:
-        typeof body.metaDescription === 'string'
-          ? body.metaDescription
-          : typeof body.meta_description === 'string'
-            ? body.meta_description
-            : undefined,
-      metaKeywords: Array.isArray(body.metaKeywords)
-        ? (body.metaKeywords as string[])
-        : Array.isArray(body.meta_keywords)
-          ? (body.meta_keywords as string[])
-          : [],
-      featuredImageUrl:
-        typeof body.featuredImageUrl === 'string'
-          ? body.featuredImageUrl
-          : typeof body.featured_image_url === 'string'
-            ? body.featured_image_url
-            : undefined,
-      scheduledPublishAt:
-        typeof body.scheduledPublishAt === 'string' ? body.scheduledPublishAt : undefined,
-      scheduledUnpublishAt:
-        typeof body.scheduledUnpublishAt === 'string' ? body.scheduledUnpublishAt : undefined,
-    };
-    try {
-      const res = await client.createContent(grpcReq, buildMetadata(req));
-      if (!res.content) {
-        return reply.code(500).send({ success: false, error: 'no content' });
+    async (req, reply) => {
+      const body = (req.body ?? {}) as Record<string, unknown>;
+      const grpcReq: CmsCreateContentRequest = {
+        title: String(body.title ?? ''),
+        slug: String(body.slug ?? ''),
+        contentType: contentTypeFromString(String(body.contentType ?? body.content_type ?? '')),
+        content: String(body.content ?? ''),
+        excerpt: typeof body.excerpt === 'string' ? body.excerpt : undefined,
+        metaTitle:
+          typeof body.metaTitle === 'string'
+            ? body.metaTitle
+            : typeof body.meta_title === 'string'
+              ? body.meta_title
+              : undefined,
+        metaDescription:
+          typeof body.metaDescription === 'string'
+            ? body.metaDescription
+            : typeof body.meta_description === 'string'
+              ? body.meta_description
+              : undefined,
+        metaKeywords: Array.isArray(body.metaKeywords)
+          ? (body.metaKeywords as string[])
+          : Array.isArray(body.meta_keywords)
+            ? (body.meta_keywords as string[])
+            : [],
+        featuredImageUrl:
+          typeof body.featuredImageUrl === 'string'
+            ? body.featuredImageUrl
+            : typeof body.featured_image_url === 'string'
+              ? body.featured_image_url
+              : undefined,
+        scheduledPublishAt:
+          typeof body.scheduledPublishAt === 'string' ? body.scheduledPublishAt : undefined,
+        scheduledUnpublishAt:
+          typeof body.scheduledUnpublishAt === 'string' ? body.scheduledUnpublishAt : undefined,
+      };
+      try {
+        const res = await client.createContent(grpcReq, buildMetadata(req));
+        if (!res.content) {
+          return reply.code(500).send({ success: false, error: 'no content' });
+        }
+        return reply.code(201).send({ success: true, content: contentToView(res.content) });
+      } catch (err) {
+        return handleGrpcError(err, reply);
       }
-      return reply.code(201).send({ success: true, content: contentToView(res.content) });
-    } catch (err) {
-      return handleGrpcError(err, reply);
     }
-  });
+  );
 
   app.put<{ Params: { contentId: string } }>(
     '/api/v1/cms/content/:contentId',
@@ -529,14 +549,20 @@ export const registerCmsRoutes = async (
       }
     );
   };
-  workflow('/api/v1/cms/content/:contentId/publish', (id, m) =>
-    client.publishContent({ contentId: id }, m), 'Publish a CMS content item'
+  workflow(
+    '/api/v1/cms/content/:contentId/publish',
+    (id, m) => client.publishContent({ contentId: id }, m),
+    'Publish a CMS content item'
   );
-  workflow('/api/v1/cms/content/:contentId/unpublish', (id, m) =>
-    client.unpublishContent({ contentId: id }, m), 'Unpublish a CMS content item'
+  workflow(
+    '/api/v1/cms/content/:contentId/unpublish',
+    (id, m) => client.unpublishContent({ contentId: id }, m),
+    'Unpublish a CMS content item'
   );
-  workflow('/api/v1/cms/content/:contentId/archive', (id, m) =>
-    client.archiveContent({ contentId: id }, m), 'Archive a CMS content item'
+  workflow(
+    '/api/v1/cms/content/:contentId/archive',
+    (id, m) => client.archiveContent({ contentId: id }, m),
+    'Archive a CMS content item'
   );
 
   // Versions
@@ -607,167 +633,187 @@ export const registerCmsRoutes = async (
   );
 
   // --- Menus --------------------------------------------------------
-  app.get('/api/v1/cms/menus', {
-    schema: {
-      tags: ['cms'],
-      summary: 'List CMS menus',
-      querystring: {
-        type: 'object',
-        properties: {
-          location: { type: 'string' },
-          active: { type: 'string' },
-        },
-        additionalProperties: true,
-      },
-    },
-  }, async (req, reply) => {
-    const q = req.query as Record<string, string | undefined>;
-    const grpcReq = {
-      location: q.location,
-      isActive: q.active === 'true' ? true : q.active === 'false' ? false : undefined,
-    };
-    try {
-      const res = await client.listMenus(grpcReq, buildMetadata(req));
-      return reply.send({ success: true, data: res.menus.map(menuToView) });
-    } catch (err) {
-      return handleGrpcError(err, reply);
-    }
-  });
-
-  app.get<{ Params: { menuId: string } }>('/api/v1/cms/menus/:menuId', {
-    schema: {
-      tags: ['cms'],
-      summary: 'Get a CMS menu by ID',
-      params: {
-        type: 'object',
-        properties: {
-          menuId: { type: 'string' },
+  app.get(
+    '/api/v1/cms/menus',
+    {
+      schema: {
+        tags: ['cms'],
+        summary: 'List CMS menus',
+        querystring: {
+          type: 'object',
+          properties: {
+            location: { type: 'string' },
+            active: { type: 'string' },
+          },
+          additionalProperties: true,
         },
       },
     },
-  }, async (req, reply) => {
-    try {
-      const res = await client.getMenu({ menuId: req.params.menuId }, buildMetadata(req));
-      if (!res.menu) {
-        return reply.code(404).send({ success: false, error: 'not found' });
+    async (req, reply) => {
+      const q = req.query as Record<string, string | undefined>;
+      const grpcReq = {
+        location: q.location,
+        isActive: q.active === 'true' ? true : q.active === 'false' ? false : undefined,
+      };
+      try {
+        const res = await client.listMenus(grpcReq, buildMetadata(req));
+        return reply.send({ success: true, data: res.menus.map(menuToView) });
+      } catch (err) {
+        return handleGrpcError(err, reply);
       }
-      return reply.send({ success: true, menu: menuToView(res.menu) });
-    } catch (err) {
-      return handleGrpcError(err, reply);
     }
-  });
+  );
 
-  app.post('/api/v1/cms/menus', {
-    schema: {
-      tags: ['cms'],
-      summary: 'Create a CMS menu',
-      body: {
-        type: 'object',
-        properties: {
-          name: { type: 'string' },
-          location: { type: 'string' },
-          items: {},
-          isActive: { type: 'boolean' },
-        },
-        additionalProperties: true,
-      },
-    },
-  }, async (req, reply) => {
-    const body = (req.body ?? {}) as Record<string, unknown>;
-    const itemsJson = Array.isArray(body.items)
-      ? JSON.stringify(body.items)
-      : typeof body.items === 'string'
-        ? body.items
-        : '[]';
-    try {
-      const res = await client.createMenu(
-        {
-          name: String(body.name ?? ''),
-          location: String(body.location ?? ''),
-          itemsJson,
-          isActive: typeof body.isActive === 'boolean' ? body.isActive : undefined,
-        },
-        buildMetadata(req)
-      );
-      if (!res.menu) {
-        return reply.code(500).send({ success: false, error: 'no menu' });
-      }
-      return reply.code(201).send({ success: true, menu: menuToView(res.menu) });
-    } catch (err) {
-      return handleGrpcError(err, reply);
-    }
-  });
-
-  app.put<{ Params: { menuId: string } }>('/api/v1/cms/menus/:menuId', {
-    schema: {
-      tags: ['cms'],
-      summary: 'Update a CMS menu',
-      params: {
-        type: 'object',
-        properties: {
-          menuId: { type: 'string' },
-        },
-      },
-      body: {
-        type: 'object',
-        properties: {
-          name: { type: 'string' },
-          location: { type: 'string' },
-          items: {},
-          isActive: { type: 'boolean' },
-        },
-        additionalProperties: true,
-      },
-    },
-  }, async (req, reply) => {
-    const body = (req.body ?? {}) as Record<string, unknown>;
-    const itemsJson = Array.isArray(body.items)
-      ? JSON.stringify(body.items)
-      : typeof body.items === 'string'
-        ? body.items
-        : undefined;
-    try {
-      const res = await client.updateMenu(
-        {
-          menuId: req.params.menuId,
-          name: typeof body.name === 'string' ? body.name : undefined,
-          location: typeof body.location === 'string' ? body.location : undefined,
-          itemsJson,
-          isActive: typeof body.isActive === 'boolean' ? body.isActive : undefined,
-        },
-        buildMetadata(req)
-      );
-      if (!res.menu) {
-        return reply.code(404).send({ success: false, error: 'not found' });
-      }
-      return reply.send({ success: true, menu: menuToView(res.menu) });
-    } catch (err) {
-      return handleGrpcError(err, reply);
-    }
-  });
-
-  app.delete<{ Params: { menuId: string } }>('/api/v1/cms/menus/:menuId', {
-    schema: {
-      tags: ['cms'],
-      summary: 'Delete a CMS menu',
-      params: {
-        type: 'object',
-        properties: {
-          menuId: { type: 'string' },
+  app.get<{ Params: { menuId: string } }>(
+    '/api/v1/cms/menus/:menuId',
+    {
+      schema: {
+        tags: ['cms'],
+        summary: 'Get a CMS menu by ID',
+        params: {
+          type: 'object',
+          properties: {
+            menuId: { type: 'string' },
+          },
         },
       },
     },
-  }, async (req, reply) => {
-    try {
-      const res = await client.deleteMenu({ menuId: req.params.menuId }, buildMetadata(req));
-      if (!res.deleted) {
-        return reply.code(404).send({ success: false, error: 'not found' });
+    async (req, reply) => {
+      try {
+        const res = await client.getMenu({ menuId: req.params.menuId }, buildMetadata(req));
+        if (!res.menu) {
+          return reply.code(404).send({ success: false, error: 'not found' });
+        }
+        return reply.send({ success: true, menu: menuToView(res.menu) });
+      } catch (err) {
+        return handleGrpcError(err, reply);
       }
-      return reply.send({ success: true });
-    } catch (err) {
-      return handleGrpcError(err, reply);
     }
-  });
+  );
+
+  app.post(
+    '/api/v1/cms/menus',
+    {
+      schema: {
+        tags: ['cms'],
+        summary: 'Create a CMS menu',
+        body: {
+          type: 'object',
+          properties: {
+            name: { type: 'string' },
+            location: { type: 'string' },
+            items: {},
+            isActive: { type: 'boolean' },
+          },
+          additionalProperties: true,
+        },
+      },
+    },
+    async (req, reply) => {
+      const body = (req.body ?? {}) as Record<string, unknown>;
+      const itemsJson = Array.isArray(body.items)
+        ? JSON.stringify(body.items)
+        : typeof body.items === 'string'
+          ? body.items
+          : '[]';
+      try {
+        const res = await client.createMenu(
+          {
+            name: String(body.name ?? ''),
+            location: String(body.location ?? ''),
+            itemsJson,
+            isActive: typeof body.isActive === 'boolean' ? body.isActive : undefined,
+          },
+          buildMetadata(req)
+        );
+        if (!res.menu) {
+          return reply.code(500).send({ success: false, error: 'no menu' });
+        }
+        return reply.code(201).send({ success: true, menu: menuToView(res.menu) });
+      } catch (err) {
+        return handleGrpcError(err, reply);
+      }
+    }
+  );
+
+  app.put<{ Params: { menuId: string } }>(
+    '/api/v1/cms/menus/:menuId',
+    {
+      schema: {
+        tags: ['cms'],
+        summary: 'Update a CMS menu',
+        params: {
+          type: 'object',
+          properties: {
+            menuId: { type: 'string' },
+          },
+        },
+        body: {
+          type: 'object',
+          properties: {
+            name: { type: 'string' },
+            location: { type: 'string' },
+            items: {},
+            isActive: { type: 'boolean' },
+          },
+          additionalProperties: true,
+        },
+      },
+    },
+    async (req, reply) => {
+      const body = (req.body ?? {}) as Record<string, unknown>;
+      const itemsJson = Array.isArray(body.items)
+        ? JSON.stringify(body.items)
+        : typeof body.items === 'string'
+          ? body.items
+          : undefined;
+      try {
+        const res = await client.updateMenu(
+          {
+            menuId: req.params.menuId,
+            name: typeof body.name === 'string' ? body.name : undefined,
+            location: typeof body.location === 'string' ? body.location : undefined,
+            itemsJson,
+            isActive: typeof body.isActive === 'boolean' ? body.isActive : undefined,
+          },
+          buildMetadata(req)
+        );
+        if (!res.menu) {
+          return reply.code(404).send({ success: false, error: 'not found' });
+        }
+        return reply.send({ success: true, menu: menuToView(res.menu) });
+      } catch (err) {
+        return handleGrpcError(err, reply);
+      }
+    }
+  );
+
+  app.delete<{ Params: { menuId: string } }>(
+    '/api/v1/cms/menus/:menuId',
+    {
+      schema: {
+        tags: ['cms'],
+        summary: 'Delete a CMS menu',
+        params: {
+          type: 'object',
+          properties: {
+            menuId: { type: 'string' },
+          },
+        },
+      },
+    },
+    async (req, reply) => {
+      try {
+        const res = await client.deleteMenu({ menuId: req.params.menuId }, buildMetadata(req));
+        if (!res.deleted) {
+          return reply.code(404).send({ success: false, error: 'not found' });
+        }
+        return reply.send({ success: true });
+      } catch (err) {
+        return handleGrpcError(err, reply);
+      }
+    }
+  );
 };
 
 // --- Helpers --------------------------------------------------------

--- a/services/gateway/src/routes/cms.ts
+++ b/services/gateway/src/routes/cms.ts
@@ -160,15 +160,6 @@ export const registerCmsRoutes = async (
         tags: ['cms'],
         summary: 'List public CMS content',
         security: [],
-        querystring: {
-          type: 'object',
-          properties: {
-            type: { type: 'string' },
-            page: { type: 'string' },
-            limit: { type: 'string' },
-          },
-          additionalProperties: true,
-        },
       },
     },
     async (req, reply) => {
@@ -207,12 +198,6 @@ export const registerCmsRoutes = async (
         tags: ['cms'],
         summary: 'Get public CMS content by slug',
         security: [],
-        params: {
-          type: 'object',
-          properties: {
-            slug: { type: 'string' },
-          },
-        },
       },
     },
     async (req, reply) => {
@@ -238,17 +223,6 @@ export const registerCmsRoutes = async (
       schema: {
         tags: ['cms'],
         summary: 'List CMS content (admin)',
-        querystring: {
-          type: 'object',
-          properties: {
-            type: { type: 'string' },
-            status: { type: 'string' },
-            search: { type: 'string' },
-            page: { type: 'string' },
-            limit: { type: 'string' },
-          },
-          additionalProperties: true,
-        },
       },
     },
     async (req, reply) => {
@@ -289,12 +263,6 @@ export const registerCmsRoutes = async (
       schema: {
         tags: ['cms'],
         summary: 'Get CMS content by slug (admin)',
-        params: {
-          type: 'object',
-          properties: {
-            slug: { type: 'string' },
-          },
-        },
       },
     },
     async (req, reply) => {
@@ -316,12 +284,6 @@ export const registerCmsRoutes = async (
       schema: {
         tags: ['cms'],
         summary: 'Get a CMS content item by ID',
-        params: {
-          type: 'object',
-          properties: {
-            contentId: { type: 'string' },
-          },
-        },
       },
     },
     async (req, reply) => {
@@ -346,28 +308,6 @@ export const registerCmsRoutes = async (
       schema: {
         tags: ['cms'],
         summary: 'Create a CMS content item',
-        body: {
-          type: 'object',
-          properties: {
-            title: { type: 'string' },
-            slug: { type: 'string' },
-            contentType: { type: 'string' },
-            content_type: { type: 'string' },
-            content: { type: 'string' },
-            excerpt: { type: 'string' },
-            metaTitle: { type: 'string' },
-            meta_title: { type: 'string' },
-            metaDescription: { type: 'string' },
-            meta_description: { type: 'string' },
-            metaKeywords: { type: 'array', items: { type: 'string' } },
-            meta_keywords: { type: 'array', items: { type: 'string' } },
-            featuredImageUrl: { type: 'string' },
-            featured_image_url: { type: 'string' },
-            scheduledPublishAt: { type: 'string' },
-            scheduledUnpublishAt: { type: 'string' },
-          },
-          additionalProperties: true,
-        },
       },
     },
     async (req, reply) => {
@@ -424,29 +364,6 @@ export const registerCmsRoutes = async (
       schema: {
         tags: ['cms'],
         summary: 'Update a CMS content item',
-        params: {
-          type: 'object',
-          properties: {
-            contentId: { type: 'string' },
-          },
-        },
-        body: {
-          type: 'object',
-          properties: {
-            title: { type: 'string' },
-            slug: { type: 'string' },
-            content: { type: 'string' },
-            excerpt: { type: 'string' },
-            metaTitle: { type: 'string' },
-            metaDescription: { type: 'string' },
-            metaKeywords: { type: 'array', items: { type: 'string' } },
-            meta_keywords: { type: 'array', items: { type: 'string' } },
-            featuredImageUrl: { type: 'string' },
-            changeNote: { type: 'string' },
-            change_note: { type: 'string' },
-          },
-          additionalProperties: true,
-        },
       },
     },
     async (req, reply) => {
@@ -492,12 +409,6 @@ export const registerCmsRoutes = async (
       schema: {
         tags: ['cms'],
         summary: 'Delete a CMS content item',
-        params: {
-          type: 'object',
-          properties: {
-            contentId: { type: 'string' },
-          },
-        },
       },
     },
     async (req, reply) => {
@@ -528,12 +439,6 @@ export const registerCmsRoutes = async (
         schema: {
           tags: ['cms'],
           summary,
-          params: {
-            type: 'object',
-            properties: {
-              contentId: { type: 'string' },
-            },
-          },
         },
       },
       async (req, reply) => {
@@ -572,12 +477,6 @@ export const registerCmsRoutes = async (
       schema: {
         tags: ['cms'],
         summary: 'Get version history for a CMS content item',
-        params: {
-          type: 'object',
-          properties: {
-            contentId: { type: 'string' },
-          },
-        },
       },
     },
     async (req, reply) => {
@@ -603,13 +502,6 @@ export const registerCmsRoutes = async (
       schema: {
         tags: ['cms'],
         summary: 'Restore a CMS content item to a previous version',
-        params: {
-          type: 'object',
-          properties: {
-            contentId: { type: 'string' },
-            version: { type: 'string' },
-          },
-        },
       },
     },
     async (req, reply) => {
@@ -639,14 +531,6 @@ export const registerCmsRoutes = async (
       schema: {
         tags: ['cms'],
         summary: 'List CMS menus',
-        querystring: {
-          type: 'object',
-          properties: {
-            location: { type: 'string' },
-            active: { type: 'string' },
-          },
-          additionalProperties: true,
-        },
       },
     },
     async (req, reply) => {
@@ -670,12 +554,6 @@ export const registerCmsRoutes = async (
       schema: {
         tags: ['cms'],
         summary: 'Get a CMS menu by ID',
-        params: {
-          type: 'object',
-          properties: {
-            menuId: { type: 'string' },
-          },
-        },
       },
     },
     async (req, reply) => {
@@ -697,16 +575,6 @@ export const registerCmsRoutes = async (
       schema: {
         tags: ['cms'],
         summary: 'Create a CMS menu',
-        body: {
-          type: 'object',
-          properties: {
-            name: { type: 'string' },
-            location: { type: 'string' },
-            items: {},
-            isActive: { type: 'boolean' },
-          },
-          additionalProperties: true,
-        },
       },
     },
     async (req, reply) => {
@@ -742,22 +610,6 @@ export const registerCmsRoutes = async (
       schema: {
         tags: ['cms'],
         summary: 'Update a CMS menu',
-        params: {
-          type: 'object',
-          properties: {
-            menuId: { type: 'string' },
-          },
-        },
-        body: {
-          type: 'object',
-          properties: {
-            name: { type: 'string' },
-            location: { type: 'string' },
-            items: {},
-            isActive: { type: 'boolean' },
-          },
-          additionalProperties: true,
-        },
       },
     },
     async (req, reply) => {
@@ -794,12 +646,6 @@ export const registerCmsRoutes = async (
       schema: {
         tags: ['cms'],
         summary: 'Delete a CMS menu',
-        params: {
-          type: 'object',
-          properties: {
-            menuId: { type: 'string' },
-          },
-        },
       },
     },
     async (req, reply) => {

--- a/services/gateway/src/routes/config.ts
+++ b/services/gateway/src/routes/config.ts
@@ -25,5 +25,15 @@ const DEFAULT_PUBLIC_CONFIG: Record<string, string | number | boolean> = {
 };
 
 export const registerConfigRoutes = async (app: FastifyInstance): Promise<void> => {
-  app.get('/api/v1/config', async (_req, reply) => reply.send(DEFAULT_PUBLIC_CONFIG));
+  app.get(
+    '/api/v1/config',
+    {
+      schema: {
+        tags: ['config'],
+        summary: 'Return public application configuration values',
+        security: [],
+      },
+    },
+    async (_req, reply) => reply.send(DEFAULT_PUBLIC_CONFIG)
+  );
 };

--- a/services/gateway/src/routes/dashboard.ts
+++ b/services/gateway/src/routes/dashboard.ts
@@ -137,149 +137,157 @@ export const registerDashboardRoutes = async (
   const { petsClient, applicationsClient, rescueClient } = opts;
 
   // --- GET /api/v1/dashboard/rescue --------------------------------
-  app.get('/api/v1/dashboard/rescue', {
-    schema: {
-      tags: ['dashboard'],
-      summary: 'Get rescue dashboard statistics',
-      querystring: {
-        type: 'object',
-        properties: {
-          rescueId: { type: 'string' },
+  app.get(
+    '/api/v1/dashboard/rescue',
+    {
+      schema: {
+        tags: ['dashboard'],
+        summary: 'Get rescue dashboard statistics',
+        querystring: {
+          type: 'object',
+          properties: {
+            rescueId: { type: 'string' },
+          },
+          additionalProperties: true,
         },
-        additionalProperties: true,
       },
     },
-  }, async (req, reply) => {
-    const metadata = buildMetadata(req);
-    const rescueId = resolveRescueScope(req);
+    async (req, reply) => {
+      const metadata = buildMetadata(req);
+      const rescueId = resolveRescueScope(req);
 
-    if (!rescueId) {
-      // Mirrors monolith behaviour: no staff association → 400.
-      return reply.code(400).send({
-        success: false,
-        message: 'User is not associated with a rescue organization',
-      });
+      if (!rescueId) {
+        // Mirrors monolith behaviour: no staff association → 400.
+        return reply.code(400).send({
+          success: false,
+          message: 'User is not associated with a rescue organization',
+        });
+      }
+
+      try {
+        // Four parallel upstream calls. The pets recent-listing reuses
+        // pets.List with limit=10; the applications recent-listing reuses
+        // apps.List the same way. We could ask for fewer fields, but the
+        // ListPets / ListApplications shapes are already lean, and one
+        // round trip per upstream beats six.
+        const petStatsReq: GetPetStatsRequest = { rescueIdFilter: rescueId };
+        const appStatsReq: ApplicationsGetStatsRequest = { rescueIdFilter: rescueId };
+        const petListReq: ListPetsRequest = {
+          rescueIdFilter: rescueId,
+          limit: DEFAULT_ACTIVITY_LIMIT,
+          statusFilter: PetsV1.PetStatus.PET_STATUS_UNSPECIFIED,
+          typeFilter: PetsV1.PetType.PET_TYPE_UNSPECIFIED,
+          sizeFilter: PetsV1.PetSize.PET_SIZE_UNSPECIFIED,
+        };
+        const appListReq: ListApplicationsRequest = {
+          rescueIdFilter: rescueId,
+          limit: DEFAULT_ACTIVITY_LIMIT,
+          statusFilter: ApplicationsV1.ApplicationStatus.APPLICATION_STATUS_UNSPECIFIED,
+        };
+        const staffReq: ListStaffMembersRequest = {
+          rescueId,
+        };
+
+        const [petStats, appStats, petList, appList, staffList] = await Promise.all([
+          petsClient.getStats(petStatsReq, metadata),
+          applicationsClient.getStats(appStatsReq, metadata),
+          petsClient.list(petListReq, metadata),
+          applicationsClient.list(appListReq, metadata),
+          rescueClient.listStaffMembers(staffReq, metadata),
+        ]);
+
+        const recentActivity = mergeAndSort(
+          petList.pets.map(buildPetActivity),
+          appList.applications.map(buildApplicationActivity),
+          DEFAULT_ACTIVITY_LIMIT
+        );
+
+        return reply.send({
+          success: true,
+          message: 'Dashboard statistics retrieved successfully',
+          data: {
+            totalAnimals: petStats.total,
+            availableForAdoption: petStats.available,
+            pendingApplications: appStats.submitted,
+            recentAdoptions: petStats.monthlyAdoptions,
+            totalApplications: appStats.total,
+            adoptedPets: petStats.adopted,
+            staffCount: staffList.staffMembers?.length ?? 0,
+            averageTimeToAdoption: petStats.averageDaysToAdoption,
+            recentActivity,
+          },
+        });
+      } catch (err) {
+        return handleGrpcError(err, reply);
+      }
     }
-
-    try {
-      // Four parallel upstream calls. The pets recent-listing reuses
-      // pets.List with limit=10; the applications recent-listing reuses
-      // apps.List the same way. We could ask for fewer fields, but the
-      // ListPets / ListApplications shapes are already lean, and one
-      // round trip per upstream beats six.
-      const petStatsReq: GetPetStatsRequest = { rescueIdFilter: rescueId };
-      const appStatsReq: ApplicationsGetStatsRequest = { rescueIdFilter: rescueId };
-      const petListReq: ListPetsRequest = {
-        rescueIdFilter: rescueId,
-        limit: DEFAULT_ACTIVITY_LIMIT,
-        statusFilter: PetsV1.PetStatus.PET_STATUS_UNSPECIFIED,
-        typeFilter: PetsV1.PetType.PET_TYPE_UNSPECIFIED,
-        sizeFilter: PetsV1.PetSize.PET_SIZE_UNSPECIFIED,
-      };
-      const appListReq: ListApplicationsRequest = {
-        rescueIdFilter: rescueId,
-        limit: DEFAULT_ACTIVITY_LIMIT,
-        statusFilter: ApplicationsV1.ApplicationStatus.APPLICATION_STATUS_UNSPECIFIED,
-      };
-      const staffReq: ListStaffMembersRequest = {
-        rescueId,
-      };
-
-      const [petStats, appStats, petList, appList, staffList] = await Promise.all([
-        petsClient.getStats(petStatsReq, metadata),
-        applicationsClient.getStats(appStatsReq, metadata),
-        petsClient.list(petListReq, metadata),
-        applicationsClient.list(appListReq, metadata),
-        rescueClient.listStaffMembers(staffReq, metadata),
-      ]);
-
-      const recentActivity = mergeAndSort(
-        petList.pets.map(buildPetActivity),
-        appList.applications.map(buildApplicationActivity),
-        DEFAULT_ACTIVITY_LIMIT
-      );
-
-      return reply.send({
-        success: true,
-        message: 'Dashboard statistics retrieved successfully',
-        data: {
-          totalAnimals: petStats.total,
-          availableForAdoption: petStats.available,
-          pendingApplications: appStats.submitted,
-          recentAdoptions: petStats.monthlyAdoptions,
-          totalApplications: appStats.total,
-          adoptedPets: petStats.adopted,
-          staffCount: staffList.staffMembers?.length ?? 0,
-          averageTimeToAdoption: petStats.averageDaysToAdoption,
-          recentActivity,
-        },
-      });
-    } catch (err) {
-      return handleGrpcError(err, reply);
-    }
-  });
+  );
 
   // --- GET /api/v1/dashboard/activity ------------------------------
-  app.get('/api/v1/dashboard/activity', {
-    schema: {
-      tags: ['dashboard'],
-      summary: 'Get recent activity for a rescue',
-      querystring: {
-        type: 'object',
-        properties: {
-          rescueId: { type: 'string' },
-          limit: { type: 'string' },
+  app.get(
+    '/api/v1/dashboard/activity',
+    {
+      schema: {
+        tags: ['dashboard'],
+        summary: 'Get recent activity for a rescue',
+        querystring: {
+          type: 'object',
+          properties: {
+            rescueId: { type: 'string' },
+            limit: { type: 'string' },
+          },
+          additionalProperties: true,
         },
-        additionalProperties: true,
       },
     },
-  }, async (req, reply) => {
-    const metadata = buildMetadata(req);
-    const rescueId = resolveRescueScope(req);
-    if (!rescueId) {
-      return reply.code(400).send({
-        success: false,
-        message: 'User is not associated with a rescue organization',
-      });
+    async (req, reply) => {
+      const metadata = buildMetadata(req);
+      const rescueId = resolveRescueScope(req);
+      if (!rescueId) {
+        return reply.code(400).send({
+          success: false,
+          message: 'User is not associated with a rescue organization',
+        });
+      }
+
+      const query = req.query as Record<string, string | undefined>;
+      const limit = parseLimit(query.limit);
+
+      try {
+        const petListReq: ListPetsRequest = {
+          rescueIdFilter: rescueId,
+          limit,
+          statusFilter: PetsV1.PetStatus.PET_STATUS_UNSPECIFIED,
+          typeFilter: PetsV1.PetType.PET_TYPE_UNSPECIFIED,
+          sizeFilter: PetsV1.PetSize.PET_SIZE_UNSPECIFIED,
+        };
+        const appListReq: ListApplicationsRequest = {
+          rescueIdFilter: rescueId,
+          limit,
+          statusFilter: ApplicationsV1.ApplicationStatus.APPLICATION_STATUS_UNSPECIFIED,
+        };
+
+        const [petList, appList] = await Promise.all([
+          petsClient.list(petListReq, metadata),
+          applicationsClient.list(appListReq, metadata),
+        ]);
+
+        const activity = mergeAndSort(
+          petList.pets.map(buildPetActivity),
+          appList.applications.map(buildApplicationActivity),
+          limit
+        );
+
+        return reply.send({
+          success: true,
+          message: 'Activity retrieved successfully',
+          data: activity,
+        });
+      } catch (err) {
+        return handleGrpcError(err, reply);
+      }
     }
-
-    const query = req.query as Record<string, string | undefined>;
-    const limit = parseLimit(query.limit);
-
-    try {
-      const petListReq: ListPetsRequest = {
-        rescueIdFilter: rescueId,
-        limit,
-        statusFilter: PetsV1.PetStatus.PET_STATUS_UNSPECIFIED,
-        typeFilter: PetsV1.PetType.PET_TYPE_UNSPECIFIED,
-        sizeFilter: PetsV1.PetSize.PET_SIZE_UNSPECIFIED,
-      };
-      const appListReq: ListApplicationsRequest = {
-        rescueIdFilter: rescueId,
-        limit,
-        statusFilter: ApplicationsV1.ApplicationStatus.APPLICATION_STATUS_UNSPECIFIED,
-      };
-
-      const [petList, appList] = await Promise.all([
-        petsClient.list(petListReq, metadata),
-        applicationsClient.list(appListReq, metadata),
-      ]);
-
-      const activity = mergeAndSort(
-        petList.pets.map(buildPetActivity),
-        appList.applications.map(buildApplicationActivity),
-        limit
-      );
-
-      return reply.send({
-        success: true,
-        message: 'Activity retrieved successfully',
-        data: activity,
-      });
-    } catch (err) {
-      return handleGrpcError(err, reply);
-    }
-  });
+  );
 };
 
 // --- Helpers ---------------------------------------------------------

--- a/services/gateway/src/routes/dashboard.ts
+++ b/services/gateway/src/routes/dashboard.ts
@@ -143,13 +143,6 @@ export const registerDashboardRoutes = async (
       schema: {
         tags: ['dashboard'],
         summary: 'Get rescue dashboard statistics',
-        querystring: {
-          type: 'object',
-          properties: {
-            rescueId: { type: 'string' },
-          },
-          additionalProperties: true,
-        },
       },
     },
     async (req, reply) => {
@@ -230,14 +223,6 @@ export const registerDashboardRoutes = async (
       schema: {
         tags: ['dashboard'],
         summary: 'Get recent activity for a rescue',
-        querystring: {
-          type: 'object',
-          properties: {
-            rescueId: { type: 'string' },
-            limit: { type: 'string' },
-          },
-          additionalProperties: true,
-        },
       },
     },
     async (req, reply) => {

--- a/services/gateway/src/routes/dashboard.ts
+++ b/services/gateway/src/routes/dashboard.ts
@@ -137,7 +137,19 @@ export const registerDashboardRoutes = async (
   const { petsClient, applicationsClient, rescueClient } = opts;
 
   // --- GET /api/v1/dashboard/rescue --------------------------------
-  app.get('/api/v1/dashboard/rescue', async (req, reply) => {
+  app.get('/api/v1/dashboard/rescue', {
+    schema: {
+      tags: ['dashboard'],
+      summary: 'Get rescue dashboard statistics',
+      querystring: {
+        type: 'object',
+        properties: {
+          rescueId: { type: 'string' },
+        },
+        additionalProperties: true,
+      },
+    },
+  }, async (req, reply) => {
     const metadata = buildMetadata(req);
     const rescueId = resolveRescueScope(req);
 
@@ -208,7 +220,20 @@ export const registerDashboardRoutes = async (
   });
 
   // --- GET /api/v1/dashboard/activity ------------------------------
-  app.get('/api/v1/dashboard/activity', async (req, reply) => {
+  app.get('/api/v1/dashboard/activity', {
+    schema: {
+      tags: ['dashboard'],
+      summary: 'Get recent activity for a rescue',
+      querystring: {
+        type: 'object',
+        properties: {
+          rescueId: { type: 'string' },
+          limit: { type: 'string' },
+        },
+        additionalProperties: true,
+      },
+    },
+  }, async (req, reply) => {
     const metadata = buildMetadata(req);
     const rescueId = resolveRescueScope(req);
     if (!rescueId) {

--- a/services/gateway/src/routes/devices.ts
+++ b/services/gateway/src/routes/devices.ts
@@ -51,7 +51,26 @@ export const registerDevicesRoutes = async (
   const { client } = opts;
 
   // POST /api/v1/devices — register / refresh a device token.
-  app.post('/api/v1/devices', async (req, reply) => {
+  app.post('/api/v1/devices', {
+    schema: {
+      tags: ['devices'],
+      summary: 'Register or refresh a device token',
+      body: {
+        type: 'object',
+        properties: {
+          token: { type: 'string' },
+          deviceToken: { type: 'string' },
+          device_token: { type: 'string' },
+          platform: { type: 'string' },
+          appVersion: { type: 'string' },
+          app_version: { type: 'string' },
+          deviceInfo: { type: 'object' },
+          device_info: { type: 'object' },
+        },
+        additionalProperties: true,
+      },
+    },
+  }, async (req, reply) => {
     const metadata = buildMetadata(req);
     const body = (req.body ?? {}) as {
       // Monolith accepts `token`; the proto field is `device_token`.
@@ -93,7 +112,20 @@ export const registerDevicesRoutes = async (
   });
 
   // GET /api/v1/devices — list the calling principal's device tokens.
-  app.get('/api/v1/devices', async (req, reply) => {
+  app.get('/api/v1/devices', {
+    schema: {
+      tags: ['devices'],
+      summary: 'List device tokens for the calling user',
+      querystring: {
+        type: 'object',
+        properties: {
+          includeInactive: { type: 'string' },
+          include_inactive: { type: 'string' },
+        },
+        additionalProperties: true,
+      },
+    },
+  }, async (req, reply) => {
     const metadata = buildMetadata(req);
     const query = req.query as Record<string, string | undefined>;
     const grpcReq: ListDeviceTokensRequest = {
@@ -109,7 +141,18 @@ export const registerDevicesRoutes = async (
   });
 
   // DELETE /api/v1/devices/:tokenId — soft-delete + revoke.
-  app.delete<{ Params: { tokenId: string } }>('/api/v1/devices/:tokenId', async (req, reply) => {
+  app.delete<{ Params: { tokenId: string } }>('/api/v1/devices/:tokenId', {
+    schema: {
+      tags: ['devices'],
+      summary: 'Unregister a device token',
+      params: {
+        type: 'object',
+        properties: {
+          tokenId: { type: 'string' },
+        },
+      },
+    },
+  }, async (req, reply) => {
     const metadata = buildMetadata(req);
     const grpcReq: UnregisterDeviceTokenRequest = { tokenId: req.params.tokenId };
 

--- a/services/gateway/src/routes/devices.ts
+++ b/services/gateway/src/routes/devices.ts
@@ -51,118 +51,130 @@ export const registerDevicesRoutes = async (
   const { client } = opts;
 
   // POST /api/v1/devices — register / refresh a device token.
-  app.post('/api/v1/devices', {
-    schema: {
-      tags: ['devices'],
-      summary: 'Register or refresh a device token',
-      body: {
-        type: 'object',
-        properties: {
-          token: { type: 'string' },
-          deviceToken: { type: 'string' },
-          device_token: { type: 'string' },
-          platform: { type: 'string' },
-          appVersion: { type: 'string' },
-          app_version: { type: 'string' },
-          deviceInfo: { type: 'object' },
-          device_info: { type: 'object' },
+  app.post(
+    '/api/v1/devices',
+    {
+      schema: {
+        tags: ['devices'],
+        summary: 'Register or refresh a device token',
+        body: {
+          type: 'object',
+          properties: {
+            token: { type: 'string' },
+            deviceToken: { type: 'string' },
+            device_token: { type: 'string' },
+            platform: { type: 'string' },
+            appVersion: { type: 'string' },
+            app_version: { type: 'string' },
+            deviceInfo: { type: 'object' },
+            device_info: { type: 'object' },
+          },
+          additionalProperties: true,
         },
-        additionalProperties: true,
       },
     },
-  }, async (req, reply) => {
-    const metadata = buildMetadata(req);
-    const body = (req.body ?? {}) as {
-      // Monolith accepts `token`; the proto field is `device_token`.
-      // Accept both so the SPA can transition without coordinated
-      // rename.
-      token?: string;
-      deviceToken?: string;
-      device_token?: string;
-      platform?: string;
-      appVersion?: string;
-      app_version?: string;
-      deviceInfo?: Record<string, unknown>;
-      device_info?: Record<string, unknown>;
-    };
+    async (req, reply) => {
+      const metadata = buildMetadata(req);
+      const body = (req.body ?? {}) as {
+        // Monolith accepts `token`; the proto field is `device_token`.
+        // Accept both so the SPA can transition without coordinated
+        // rename.
+        token?: string;
+        deviceToken?: string;
+        device_token?: string;
+        platform?: string;
+        appVersion?: string;
+        app_version?: string;
+        deviceInfo?: Record<string, unknown>;
+        device_info?: Record<string, unknown>;
+      };
 
-    const grpcReq: RegisterDeviceTokenRequest = {
-      deviceToken: body.deviceToken ?? body.device_token ?? body.token ?? '',
-      platform: platformFromString(body.platform),
-      appVersion: body.appVersion ?? body.app_version,
-      // Proto field carries the JSON-stringified payload; the chat /
-      // notifications handler parses it back.
-      deviceInfoJson: body.deviceInfo
-        ? JSON.stringify(body.deviceInfo)
-        : body.device_info
-          ? JSON.stringify(body.device_info)
-          : '',
-    };
+      const grpcReq: RegisterDeviceTokenRequest = {
+        deviceToken: body.deviceToken ?? body.device_token ?? body.token ?? '',
+        platform: platformFromString(body.platform),
+        appVersion: body.appVersion ?? body.app_version,
+        // Proto field carries the JSON-stringified payload; the chat /
+        // notifications handler parses it back.
+        deviceInfoJson: body.deviceInfo
+          ? JSON.stringify(body.deviceInfo)
+          : body.device_info
+            ? JSON.stringify(body.device_info)
+            : '',
+      };
 
-    try {
-      const res = await client.registerDeviceToken(grpcReq, metadata);
-      // 201 on fresh registration, 200 when an existing token was
-      // refreshed — same convention chat.openChat uses.
-      return reply
-        .code(res.alreadyRegistered ? 200 : 201)
-        .send(NotificationsV1.RegisterDeviceTokenResponse.toJSON(res));
-    } catch (err) {
-      return handleGrpcError(err, reply);
+      try {
+        const res = await client.registerDeviceToken(grpcReq, metadata);
+        // 201 on fresh registration, 200 when an existing token was
+        // refreshed — same convention chat.openChat uses.
+        return reply
+          .code(res.alreadyRegistered ? 200 : 201)
+          .send(NotificationsV1.RegisterDeviceTokenResponse.toJSON(res));
+      } catch (err) {
+        return handleGrpcError(err, reply);
+      }
     }
-  });
+  );
 
   // GET /api/v1/devices — list the calling principal's device tokens.
-  app.get('/api/v1/devices', {
-    schema: {
-      tags: ['devices'],
-      summary: 'List device tokens for the calling user',
-      querystring: {
-        type: 'object',
-        properties: {
-          includeInactive: { type: 'string' },
-          include_inactive: { type: 'string' },
+  app.get(
+    '/api/v1/devices',
+    {
+      schema: {
+        tags: ['devices'],
+        summary: 'List device tokens for the calling user',
+        querystring: {
+          type: 'object',
+          properties: {
+            includeInactive: { type: 'string' },
+            include_inactive: { type: 'string' },
+          },
+          additionalProperties: true,
         },
-        additionalProperties: true,
       },
     },
-  }, async (req, reply) => {
-    const metadata = buildMetadata(req);
-    const query = req.query as Record<string, string | undefined>;
-    const grpcReq: ListDeviceTokensRequest = {
-      includeInactive: query.includeInactive === 'true' || query.include_inactive === 'true',
-    } as ListDeviceTokensRequest;
+    async (req, reply) => {
+      const metadata = buildMetadata(req);
+      const query = req.query as Record<string, string | undefined>;
+      const grpcReq: ListDeviceTokensRequest = {
+        includeInactive: query.includeInactive === 'true' || query.include_inactive === 'true',
+      } as ListDeviceTokensRequest;
 
-    try {
-      const res = await client.listDeviceTokens(grpcReq, metadata);
-      return reply.send(NotificationsV1.ListDeviceTokensResponse.toJSON(res));
-    } catch (err) {
-      return handleGrpcError(err, reply);
+      try {
+        const res = await client.listDeviceTokens(grpcReq, metadata);
+        return reply.send(NotificationsV1.ListDeviceTokensResponse.toJSON(res));
+      } catch (err) {
+        return handleGrpcError(err, reply);
+      }
     }
-  });
+  );
 
   // DELETE /api/v1/devices/:tokenId — soft-delete + revoke.
-  app.delete<{ Params: { tokenId: string } }>('/api/v1/devices/:tokenId', {
-    schema: {
-      tags: ['devices'],
-      summary: 'Unregister a device token',
-      params: {
-        type: 'object',
-        properties: {
-          tokenId: { type: 'string' },
+  app.delete<{ Params: { tokenId: string } }>(
+    '/api/v1/devices/:tokenId',
+    {
+      schema: {
+        tags: ['devices'],
+        summary: 'Unregister a device token',
+        params: {
+          type: 'object',
+          properties: {
+            tokenId: { type: 'string' },
+          },
         },
       },
     },
-  }, async (req, reply) => {
-    const metadata = buildMetadata(req);
-    const grpcReq: UnregisterDeviceTokenRequest = { tokenId: req.params.tokenId };
+    async (req, reply) => {
+      const metadata = buildMetadata(req);
+      const grpcReq: UnregisterDeviceTokenRequest = { tokenId: req.params.tokenId };
 
-    try {
-      const res = await client.unregisterDeviceToken(grpcReq, metadata);
-      return reply.send(NotificationsV1.UnregisterDeviceTokenResponse.toJSON(res));
-    } catch (err) {
-      return handleGrpcError(err, reply);
+      try {
+        const res = await client.unregisterDeviceToken(grpcReq, metadata);
+        return reply.send(NotificationsV1.UnregisterDeviceTokenResponse.toJSON(res));
+      } catch (err) {
+        return handleGrpcError(err, reply);
+      }
     }
-  });
+  );
 };
 
 // --- Helpers ---------------------------------------------------------

--- a/services/gateway/src/routes/devices.ts
+++ b/services/gateway/src/routes/devices.ts
@@ -57,20 +57,6 @@ export const registerDevicesRoutes = async (
       schema: {
         tags: ['devices'],
         summary: 'Register or refresh a device token',
-        body: {
-          type: 'object',
-          properties: {
-            token: { type: 'string' },
-            deviceToken: { type: 'string' },
-            device_token: { type: 'string' },
-            platform: { type: 'string' },
-            appVersion: { type: 'string' },
-            app_version: { type: 'string' },
-            deviceInfo: { type: 'object' },
-            device_info: { type: 'object' },
-          },
-          additionalProperties: true,
-        },
       },
     },
     async (req, reply) => {
@@ -122,14 +108,6 @@ export const registerDevicesRoutes = async (
       schema: {
         tags: ['devices'],
         summary: 'List device tokens for the calling user',
-        querystring: {
-          type: 'object',
-          properties: {
-            includeInactive: { type: 'string' },
-            include_inactive: { type: 'string' },
-          },
-          additionalProperties: true,
-        },
       },
     },
     async (req, reply) => {
@@ -155,12 +133,6 @@ export const registerDevicesRoutes = async (
       schema: {
         tags: ['devices'],
         summary: 'Unregister a device token',
-        params: {
-          type: 'object',
-          properties: {
-            tokenId: { type: 'string' },
-          },
-        },
       },
     },
     async (req, reply) => {

--- a/services/gateway/src/routes/email.ts
+++ b/services/gateway/src/routes/email.ts
@@ -72,114 +72,122 @@ export const registerEmailRoutes = async (
   const { client } = opts;
 
   // GET /api/v1/email/templates
-  app.get('/api/v1/email/templates', {
-    schema: {
-      tags: ['email'],
-      summary: 'List email templates',
-      querystring: {
-        type: 'object',
-        properties: {
-          type: { type: 'string' },
-          status: { type: 'string' },
-          category: { type: 'string' },
-          search: { type: 'string' },
-          page: { type: 'string' },
-          limit: { type: 'string' },
+  app.get(
+    '/api/v1/email/templates',
+    {
+      schema: {
+        tags: ['email'],
+        summary: 'List email templates',
+        querystring: {
+          type: 'object',
+          properties: {
+            type: { type: 'string' },
+            status: { type: 'string' },
+            category: { type: 'string' },
+            search: { type: 'string' },
+            page: { type: 'string' },
+            limit: { type: 'string' },
+          },
+          additionalProperties: true,
         },
-        additionalProperties: true,
       },
     },
-  }, async (req, reply) => {
-    const metadata = buildMetadata(req);
-    const q = req.query as Record<string, string | undefined>;
-    const pagination = parsePagination(q, { limit: 0 });
-    if (!pagination.ok) {
-      return reply.code(400).send({ success: false, error: pagination.error });
+    async (req, reply) => {
+      const metadata = buildMetadata(req);
+      const q = req.query as Record<string, string | undefined>;
+      const pagination = parsePagination(q, { limit: 0 });
+      if (!pagination.ok) {
+        return reply.code(400).send({ success: false, error: pagination.error });
+      }
+      const grpcReq: ListEmailTemplatesRequest = {
+        typeFilter: typeFromString(q.type),
+        statusFilter: statusFromString(q.status),
+        categoryFilter: q.category,
+        search: q.search,
+        page: pagination.page,
+        limit: pagination.limit,
+      };
+      try {
+        const res = await client.listEmailTemplates(grpcReq, metadata);
+        return reply.send({
+          success: true,
+          data: res.templates.map(t => NotificationsV1.EmailTemplate.toJSON(t)),
+          pagination: {
+            page: res.page,
+            limit: grpcReq.limit || 20,
+            total: res.total,
+            totalPages: res.totalPages,
+          },
+        });
+      } catch (err) {
+        return handleGrpcError(err, reply);
+      }
     }
-    const grpcReq: ListEmailTemplatesRequest = {
-      typeFilter: typeFromString(q.type),
-      statusFilter: statusFromString(q.status),
-      categoryFilter: q.category,
-      search: q.search,
-      page: pagination.page,
-      limit: pagination.limit,
-    };
-    try {
-      const res = await client.listEmailTemplates(grpcReq, metadata);
-      return reply.send({
-        success: true,
-        data: res.templates.map(t => NotificationsV1.EmailTemplate.toJSON(t)),
-        pagination: {
-          page: res.page,
-          limit: grpcReq.limit || 20,
-          total: res.total,
-          totalPages: res.totalPages,
-        },
-      });
-    } catch (err) {
-      return handleGrpcError(err, reply);
-    }
-  });
+  );
 
   // POST /api/v1/email/templates
-  app.post('/api/v1/email/templates', {
-    schema: {
-      tags: ['email'],
-      summary: 'Create an email template',
-      body: {
-        type: 'object',
-        properties: {
-          name: { type: 'string' },
-          description: { type: 'string' },
-          type: { type: 'string' },
-          category: { type: 'string' },
-          status: { type: 'string' },
-          subject: { type: 'string' },
-          htmlContent: { type: 'string' },
-          html_content: { type: 'string' },
-          textContent: { type: 'string' },
-          text_content: { type: 'string' },
-          variables: {},
-          locale: { type: 'string' },
+  app.post(
+    '/api/v1/email/templates',
+    {
+      schema: {
+        tags: ['email'],
+        summary: 'Create an email template',
+        body: {
+          type: 'object',
+          properties: {
+            name: { type: 'string' },
+            description: { type: 'string' },
+            type: { type: 'string' },
+            category: { type: 'string' },
+            status: { type: 'string' },
+            subject: { type: 'string' },
+            htmlContent: { type: 'string' },
+            html_content: { type: 'string' },
+            textContent: { type: 'string' },
+            text_content: { type: 'string' },
+            variables: {},
+            locale: { type: 'string' },
+          },
+          additionalProperties: true,
         },
-        additionalProperties: true,
       },
     },
-  }, async (req, reply) => {
-    const metadata = buildMetadata(req);
-    const body = (req.body ?? {}) as Record<string, unknown>;
-    const grpcReq: CreateEmailTemplateRequest = {
-      name: typeof body.name === 'string' ? body.name : '',
-      description: typeof body.description === 'string' ? body.description : undefined,
-      type: typeFromString(typeof body.type === 'string' ? body.type : undefined),
-      category: typeof body.category === 'string' ? body.category : '',
-      status: statusFromString(typeof body.status === 'string' ? body.status : undefined),
-      subject: typeof body.subject === 'string' ? body.subject : '',
-      htmlContent:
-        typeof body.htmlContent === 'string'
-          ? body.htmlContent
-          : typeof body.html_content === 'string'
-            ? body.html_content
-            : '',
-      textContent:
-        typeof body.textContent === 'string'
-          ? body.textContent
-          : typeof body.text_content === 'string'
-            ? body.text_content
-            : undefined,
-      variablesJson: variablesJson(body.variables) ?? '[]',
-      locale: typeof body.locale === 'string' ? body.locale : undefined,
-    };
-    try {
-      const res = await client.createEmailTemplate(grpcReq, metadata);
-      return reply.code(201).send({
-        success: true,
-        data: NotificationsV1.EmailTemplate.toJSON(res.template!),
-      });
-    } catch (err) {
-      return handleGrpcError(err, reply);
+    async (req, reply) => {
+      const metadata = buildMetadata(req);
+      const body = (req.body ?? {}) as Record<string, unknown>;
+      const grpcReq: CreateEmailTemplateRequest = {
+        name: typeof body.name === 'string' ? body.name : '',
+        description: typeof body.description === 'string' ? body.description : undefined,
+        type: typeFromString(typeof body.type === 'string' ? body.type : undefined),
+        category: typeof body.category === 'string' ? body.category : '',
+        status: statusFromString(typeof body.status === 'string' ? body.status : undefined),
+        subject: typeof body.subject === 'string' ? body.subject : '',
+        htmlContent:
+          typeof body.htmlContent === 'string'
+            ? body.htmlContent
+            : typeof body.html_content === 'string'
+              ? body.html_content
+              : '',
+        textContent:
+          typeof body.textContent === 'string'
+            ? body.textContent
+            : typeof body.text_content === 'string'
+              ? body.text_content
+              : undefined,
+        variablesJson: variablesJson(body.variables) ?? '[]',
+        locale: typeof body.locale === 'string' ? body.locale : undefined,
+      };
+      try {
+        const res = await client.createEmailTemplate(grpcReq, metadata);
+        return reply.code(201).send({
+          success: true,
+          data: NotificationsV1.EmailTemplate.toJSON(res.template!),
+        });
+      } catch (err) {
+        return handleGrpcError(err, reply);
+      }
     }
-  });
+  );
 
   // GET /api/v1/email/templates/:templateId
   app.get<{ Params: { templateId: string } }>(

--- a/services/gateway/src/routes/email.ts
+++ b/services/gateway/src/routes/email.ts
@@ -78,18 +78,6 @@ export const registerEmailRoutes = async (
       schema: {
         tags: ['email'],
         summary: 'List email templates',
-        querystring: {
-          type: 'object',
-          properties: {
-            type: { type: 'string' },
-            status: { type: 'string' },
-            category: { type: 'string' },
-            search: { type: 'string' },
-            page: { type: 'string' },
-            limit: { type: 'string' },
-          },
-          additionalProperties: true,
-        },
       },
     },
     async (req, reply) => {
@@ -132,24 +120,6 @@ export const registerEmailRoutes = async (
       schema: {
         tags: ['email'],
         summary: 'Create an email template',
-        body: {
-          type: 'object',
-          properties: {
-            name: { type: 'string' },
-            description: { type: 'string' },
-            type: { type: 'string' },
-            category: { type: 'string' },
-            status: { type: 'string' },
-            subject: { type: 'string' },
-            htmlContent: { type: 'string' },
-            html_content: { type: 'string' },
-            textContent: { type: 'string' },
-            text_content: { type: 'string' },
-            variables: {},
-            locale: { type: 'string' },
-          },
-          additionalProperties: true,
-        },
       },
     },
     async (req, reply) => {
@@ -196,12 +166,6 @@ export const registerEmailRoutes = async (
       schema: {
         tags: ['email'],
         summary: 'Get an email template by ID',
-        params: {
-          type: 'object',
-          properties: {
-            templateId: { type: 'string' },
-          },
-        },
       },
     },
     async (req, reply) => {
@@ -225,29 +189,6 @@ export const registerEmailRoutes = async (
       schema: {
         tags: ['email'],
         summary: 'Update an email template',
-        params: {
-          type: 'object',
-          properties: {
-            templateId: { type: 'string' },
-          },
-        },
-        body: {
-          type: 'object',
-          properties: {
-            name: { type: 'string' },
-            description: { type: 'string' },
-            type: { type: 'string' },
-            category: { type: 'string' },
-            status: { type: 'string' },
-            subject: { type: 'string' },
-            htmlContent: { type: 'string' },
-            html_content: { type: 'string' },
-            textContent: { type: 'string' },
-            text_content: { type: 'string' },
-            variables: {},
-          },
-          additionalProperties: true,
-        },
       },
     },
     async (req, reply) => {
@@ -294,12 +235,6 @@ export const registerEmailRoutes = async (
       schema: {
         tags: ['email'],
         summary: 'Delete an email template',
-        params: {
-          type: 'object',
-          properties: {
-            templateId: { type: 'string' },
-          },
-        },
       },
     },
     async (req, reply) => {
@@ -320,19 +255,6 @@ export const registerEmailRoutes = async (
       schema: {
         tags: ['email'],
         summary: 'Preview a rendered email template',
-        params: {
-          type: 'object',
-          properties: {
-            templateId: { type: 'string' },
-          },
-        },
-        body: {
-          type: 'object',
-          properties: {
-            variables: {},
-          },
-          additionalProperties: true,
-        },
       },
     },
     async (req, reply) => {

--- a/services/gateway/src/routes/email.ts
+++ b/services/gateway/src/routes/email.ts
@@ -72,7 +72,24 @@ export const registerEmailRoutes = async (
   const { client } = opts;
 
   // GET /api/v1/email/templates
-  app.get('/api/v1/email/templates', async (req, reply) => {
+  app.get('/api/v1/email/templates', {
+    schema: {
+      tags: ['email'],
+      summary: 'List email templates',
+      querystring: {
+        type: 'object',
+        properties: {
+          type: { type: 'string' },
+          status: { type: 'string' },
+          category: { type: 'string' },
+          search: { type: 'string' },
+          page: { type: 'string' },
+          limit: { type: 'string' },
+        },
+        additionalProperties: true,
+      },
+    },
+  }, async (req, reply) => {
     const metadata = buildMetadata(req);
     const q = req.query as Record<string, string | undefined>;
     const pagination = parsePagination(q, { limit: 0 });
@@ -105,7 +122,30 @@ export const registerEmailRoutes = async (
   });
 
   // POST /api/v1/email/templates
-  app.post('/api/v1/email/templates', async (req, reply) => {
+  app.post('/api/v1/email/templates', {
+    schema: {
+      tags: ['email'],
+      summary: 'Create an email template',
+      body: {
+        type: 'object',
+        properties: {
+          name: { type: 'string' },
+          description: { type: 'string' },
+          type: { type: 'string' },
+          category: { type: 'string' },
+          status: { type: 'string' },
+          subject: { type: 'string' },
+          htmlContent: { type: 'string' },
+          html_content: { type: 'string' },
+          textContent: { type: 'string' },
+          text_content: { type: 'string' },
+          variables: {},
+          locale: { type: 'string' },
+        },
+        additionalProperties: true,
+      },
+    },
+  }, async (req, reply) => {
     const metadata = buildMetadata(req);
     const body = (req.body ?? {}) as Record<string, unknown>;
     const grpcReq: CreateEmailTemplateRequest = {
@@ -144,6 +184,18 @@ export const registerEmailRoutes = async (
   // GET /api/v1/email/templates/:templateId
   app.get<{ Params: { templateId: string } }>(
     '/api/v1/email/templates/:templateId',
+    {
+      schema: {
+        tags: ['email'],
+        summary: 'Get an email template by ID',
+        params: {
+          type: 'object',
+          properties: {
+            templateId: { type: 'string' },
+          },
+        },
+      },
+    },
     async (req, reply) => {
       const metadata = buildMetadata(req);
       try {
@@ -161,6 +213,35 @@ export const registerEmailRoutes = async (
   // PUT /api/v1/email/templates/:templateId
   app.put<{ Params: { templateId: string } }>(
     '/api/v1/email/templates/:templateId',
+    {
+      schema: {
+        tags: ['email'],
+        summary: 'Update an email template',
+        params: {
+          type: 'object',
+          properties: {
+            templateId: { type: 'string' },
+          },
+        },
+        body: {
+          type: 'object',
+          properties: {
+            name: { type: 'string' },
+            description: { type: 'string' },
+            type: { type: 'string' },
+            category: { type: 'string' },
+            status: { type: 'string' },
+            subject: { type: 'string' },
+            htmlContent: { type: 'string' },
+            html_content: { type: 'string' },
+            textContent: { type: 'string' },
+            text_content: { type: 'string' },
+            variables: {},
+          },
+          additionalProperties: true,
+        },
+      },
+    },
     async (req, reply) => {
       const metadata = buildMetadata(req);
       const body = (req.body ?? {}) as Record<string, unknown>;
@@ -201,6 +282,18 @@ export const registerEmailRoutes = async (
   // DELETE /api/v1/email/templates/:templateId
   app.delete<{ Params: { templateId: string } }>(
     '/api/v1/email/templates/:templateId',
+    {
+      schema: {
+        tags: ['email'],
+        summary: 'Delete an email template',
+        params: {
+          type: 'object',
+          properties: {
+            templateId: { type: 'string' },
+          },
+        },
+      },
+    },
     async (req, reply) => {
       const metadata = buildMetadata(req);
       try {
@@ -215,6 +308,25 @@ export const registerEmailRoutes = async (
   // POST /api/v1/email/templates/:templateId/preview
   app.post<{ Params: { templateId: string } }>(
     '/api/v1/email/templates/:templateId/preview',
+    {
+      schema: {
+        tags: ['email'],
+        summary: 'Preview a rendered email template',
+        params: {
+          type: 'object',
+          properties: {
+            templateId: { type: 'string' },
+          },
+        },
+        body: {
+          type: 'object',
+          properties: {
+            variables: {},
+          },
+          additionalProperties: true,
+        },
+      },
+    },
     async (req, reply) => {
       const metadata = buildMetadata(req);
       const body = (req.body ?? {}) as { variables?: unknown };

--- a/services/gateway/src/routes/field-permissions.ts
+++ b/services/gateway/src/routes/field-permissions.ts
@@ -86,16 +86,20 @@ export const registerFieldPermissionsRoutes = async (
   const { client } = opts;
 
   // GET /api/v1/field-permissions/defaults — full defaults blob.
-  app.get('/api/v1/field-permissions/defaults', { schema: { tags: ['field-permissions'] } }, async (req, reply) => {
-    try {
-      const res = await client.getFieldPermissionDefaults({}, buildMetadata(req));
-      // The handler JSON-encodes the defaults blob; parse here so the
-      // gateway response stays a normal object the SPA can consume.
-      return reply.send({ success: true, data: JSON.parse(res.defaultsJson) });
-    } catch (err) {
-      return handleGrpcError(err, reply);
+  app.get(
+    '/api/v1/field-permissions/defaults',
+    { schema: { tags: ['field-permissions'] } },
+    async (req, reply) => {
+      try {
+        const res = await client.getFieldPermissionDefaults({}, buildMetadata(req));
+        // The handler JSON-encodes the defaults blob; parse here so the
+        // gateway response stays a normal object the SPA can consume.
+        return reply.send({ success: true, data: JSON.parse(res.defaultsJson) });
+      } catch (err) {
+        return handleGrpcError(err, reply);
+      }
     }
-  });
+  );
 
   // GET /api/v1/field-permissions/defaults/:resource/:role
   app.get<{ Params: { resource: string; role: string } }>(
@@ -103,7 +107,11 @@ export const registerFieldPermissionsRoutes = async (
     {
       schema: {
         tags: ['field-permissions'],
-        params: { type: 'object', properties: { resource: { type: 'string' }, role: { type: 'string' } }, required: ['resource', 'role'] },
+        params: {
+          type: 'object',
+          properties: { resource: { type: 'string' }, role: { type: 'string' } },
+          required: ['resource', 'role'],
+        },
       },
     },
     async (req, reply) => {
@@ -126,85 +134,97 @@ export const registerFieldPermissionsRoutes = async (
   // POST /api/v1/field-permissions/bulk — keep before the dynamic
   // /:resource handlers so Fastify's first-match-wins router picks the
   // static segment.
-  app.post('/api/v1/field-permissions/bulk', {
-    schema: {
-      tags: ['field-permissions'],
-      body: {
-        type: 'object',
-        additionalProperties: true,
-        properties: {
-          overrides: { type: 'array', items: { type: 'object', additionalProperties: true } },
+  app.post(
+    '/api/v1/field-permissions/bulk',
+    {
+      schema: {
+        tags: ['field-permissions'],
+        body: {
+          type: 'object',
+          additionalProperties: true,
+          properties: {
+            overrides: { type: 'array', items: { type: 'object', additionalProperties: true } },
+          },
         },
       },
     },
-  }, async (req, reply) => {
-    const body = (req.body ?? {}) as { overrides?: Array<Record<string, unknown>> };
-    const overridesRaw = body.overrides ?? [];
-    if (!Array.isArray(overridesRaw) || overridesRaw.length === 0) {
-      return reply.code(400).send({ success: false, error: 'overrides must be a non-empty array' });
+    async (req, reply) => {
+      const body = (req.body ?? {}) as { overrides?: Array<Record<string, unknown>> };
+      const overridesRaw = body.overrides ?? [];
+      if (!Array.isArray(overridesRaw) || overridesRaw.length === 0) {
+        return reply
+          .code(400)
+          .send({ success: false, error: 'overrides must be a non-empty array' });
+      }
+      const overrides: FieldPermissionOverrideInput[] = [];
+      for (const o of overridesRaw) {
+        const resource = resourceToProto(String(o.resource ?? ''));
+        const accessLevel = accessLevelToProto(String(o.access_level ?? o.accessLevel ?? ''));
+        if (resource === null || accessLevel === null) {
+          return reply
+            .code(400)
+            .send({ success: false, error: 'invalid resource or access_level' });
+        }
+        overrides.push({
+          resource,
+          fieldName: String(o.field_name ?? o.fieldName ?? ''),
+          role: String(o.role ?? ''),
+          accessLevel,
+        });
+      }
+      try {
+        const res = await client.bulkUpsertFieldPermissions({ overrides }, buildMetadata(req));
+        return reply.send({ success: true, data: res.overrides.map(toView) });
+      } catch (err) {
+        return handleGrpcError(err, reply);
+      }
     }
-    const overrides: FieldPermissionOverrideInput[] = [];
-    for (const o of overridesRaw) {
-      const resource = resourceToProto(String(o.resource ?? ''));
-      const accessLevel = accessLevelToProto(String(o.access_level ?? o.accessLevel ?? ''));
+  );
+
+  // POST /api/v1/field-permissions — single upsert.
+  app.post(
+    '/api/v1/field-permissions',
+    {
+      schema: {
+        tags: ['field-permissions'],
+        body: {
+          type: 'object',
+          additionalProperties: true,
+          properties: {
+            resource: { type: 'string' },
+            field_name: { type: 'string' },
+            role: { type: 'string' },
+            access_level: { type: 'string' },
+          },
+        },
+      },
+    },
+    async (req, reply) => {
+      const body = (req.body ?? {}) as Record<string, unknown>;
+      const resource = resourceToProto(String(body.resource ?? ''));
+      const accessLevel = accessLevelToProto(String(body.access_level ?? body.accessLevel ?? ''));
       if (resource === null || accessLevel === null) {
         return reply.code(400).send({ success: false, error: 'invalid resource or access_level' });
       }
-      overrides.push({
-        resource,
-        fieldName: String(o.field_name ?? o.fieldName ?? ''),
-        role: String(o.role ?? ''),
-        accessLevel,
-      });
-    }
-    try {
-      const res = await client.bulkUpsertFieldPermissions({ overrides }, buildMetadata(req));
-      return reply.send({ success: true, data: res.overrides.map(toView) });
-    } catch (err) {
-      return handleGrpcError(err, reply);
-    }
-  });
-
-  // POST /api/v1/field-permissions — single upsert.
-  app.post('/api/v1/field-permissions', {
-    schema: {
-      tags: ['field-permissions'],
-      body: {
-        type: 'object',
-        additionalProperties: true,
-        properties: {
-          resource: { type: 'string' },
-          field_name: { type: 'string' },
-          role: { type: 'string' },
-          access_level: { type: 'string' },
-        },
-      },
-    },
-  }, async (req, reply) => {
-    const body = (req.body ?? {}) as Record<string, unknown>;
-    const resource = resourceToProto(String(body.resource ?? ''));
-    const accessLevel = accessLevelToProto(String(body.access_level ?? body.accessLevel ?? ''));
-    if (resource === null || accessLevel === null) {
-      return reply.code(400).send({ success: false, error: 'invalid resource or access_level' });
-    }
-    try {
-      const res = await client.upsertFieldPermission(
-        {
-          resource,
-          fieldName: String(body.field_name ?? body.fieldName ?? ''),
-          role: String(body.role ?? ''),
-          accessLevel,
-        },
-        buildMetadata(req)
-      );
-      if (res.override === undefined) {
-        return reply.code(500).send({ success: false, error: 'no override returned' });
+      try {
+        const res = await client.upsertFieldPermission(
+          {
+            resource,
+            fieldName: String(body.field_name ?? body.fieldName ?? ''),
+            role: String(body.role ?? ''),
+            accessLevel,
+          },
+          buildMetadata(req)
+        );
+        if (res.override === undefined) {
+          return reply.code(500).send({ success: false, error: 'no override returned' });
+        }
+        return reply.send({ success: true, data: toView(res.override) });
+      } catch (err) {
+        return handleGrpcError(err, reply);
       }
-      return reply.send({ success: true, data: toView(res.override) });
-    } catch (err) {
-      return handleGrpcError(err, reply);
     }
-  });
+  );
 
   // GET /api/v1/field-permissions/:resource/:role — order matters,
   // must register BEFORE the bare /:resource route so the 3-segment
@@ -214,7 +234,11 @@ export const registerFieldPermissionsRoutes = async (
     {
       schema: {
         tags: ['field-permissions'],
-        params: { type: 'object', properties: { resource: { type: 'string' }, role: { type: 'string' } }, required: ['resource', 'role'] },
+        params: {
+          type: 'object',
+          properties: { resource: { type: 'string' }, role: { type: 'string' } },
+          required: ['resource', 'role'],
+        },
       },
     },
     async (req, reply) => {
@@ -240,7 +264,15 @@ export const registerFieldPermissionsRoutes = async (
     {
       schema: {
         tags: ['field-permissions'],
-        params: { type: 'object', properties: { resource: { type: 'string' }, role: { type: 'string' }, field_name: { type: 'string' } }, required: ['resource', 'role', 'field_name'] },
+        params: {
+          type: 'object',
+          properties: {
+            resource: { type: 'string' },
+            role: { type: 'string' },
+            field_name: { type: 'string' },
+          },
+          required: ['resource', 'role', 'field_name'],
+        },
       },
     },
     async (req, reply) => {
@@ -271,7 +303,11 @@ export const registerFieldPermissionsRoutes = async (
     {
       schema: {
         tags: ['field-permissions'],
-        params: { type: 'object', properties: { resource: { type: 'string' } }, required: ['resource'] },
+        params: {
+          type: 'object',
+          properties: { resource: { type: 'string' } },
+          required: ['resource'],
+        },
       },
     },
     async (req, reply) => {

--- a/services/gateway/src/routes/field-permissions.ts
+++ b/services/gateway/src/routes/field-permissions.ts
@@ -107,11 +107,6 @@ export const registerFieldPermissionsRoutes = async (
     {
       schema: {
         tags: ['field-permissions'],
-        params: {
-          type: 'object',
-          properties: { resource: { type: 'string' }, role: { type: 'string' } },
-          required: ['resource', 'role'],
-        },
       },
     },
     async (req, reply) => {
@@ -139,13 +134,6 @@ export const registerFieldPermissionsRoutes = async (
     {
       schema: {
         tags: ['field-permissions'],
-        body: {
-          type: 'object',
-          additionalProperties: true,
-          properties: {
-            overrides: { type: 'array', items: { type: 'object', additionalProperties: true } },
-          },
-        },
       },
     },
     async (req, reply) => {
@@ -187,16 +175,6 @@ export const registerFieldPermissionsRoutes = async (
     {
       schema: {
         tags: ['field-permissions'],
-        body: {
-          type: 'object',
-          additionalProperties: true,
-          properties: {
-            resource: { type: 'string' },
-            field_name: { type: 'string' },
-            role: { type: 'string' },
-            access_level: { type: 'string' },
-          },
-        },
       },
     },
     async (req, reply) => {
@@ -234,11 +212,6 @@ export const registerFieldPermissionsRoutes = async (
     {
       schema: {
         tags: ['field-permissions'],
-        params: {
-          type: 'object',
-          properties: { resource: { type: 'string' }, role: { type: 'string' } },
-          required: ['resource', 'role'],
-        },
       },
     },
     async (req, reply) => {
@@ -264,15 +237,6 @@ export const registerFieldPermissionsRoutes = async (
     {
       schema: {
         tags: ['field-permissions'],
-        params: {
-          type: 'object',
-          properties: {
-            resource: { type: 'string' },
-            role: { type: 'string' },
-            field_name: { type: 'string' },
-          },
-          required: ['resource', 'role', 'field_name'],
-        },
       },
     },
     async (req, reply) => {
@@ -303,11 +267,6 @@ export const registerFieldPermissionsRoutes = async (
     {
       schema: {
         tags: ['field-permissions'],
-        params: {
-          type: 'object',
-          properties: { resource: { type: 'string' } },
-          required: ['resource'],
-        },
       },
     },
     async (req, reply) => {

--- a/services/gateway/src/routes/field-permissions.ts
+++ b/services/gateway/src/routes/field-permissions.ts
@@ -86,7 +86,7 @@ export const registerFieldPermissionsRoutes = async (
   const { client } = opts;
 
   // GET /api/v1/field-permissions/defaults — full defaults blob.
-  app.get('/api/v1/field-permissions/defaults', async (req, reply) => {
+  app.get('/api/v1/field-permissions/defaults', { schema: { tags: ['field-permissions'] } }, async (req, reply) => {
     try {
       const res = await client.getFieldPermissionDefaults({}, buildMetadata(req));
       // The handler JSON-encodes the defaults blob; parse here so the
@@ -100,6 +100,12 @@ export const registerFieldPermissionsRoutes = async (
   // GET /api/v1/field-permissions/defaults/:resource/:role
   app.get<{ Params: { resource: string; role: string } }>(
     '/api/v1/field-permissions/defaults/:resource/:role',
+    {
+      schema: {
+        tags: ['field-permissions'],
+        params: { type: 'object', properties: { resource: { type: 'string' }, role: { type: 'string' } }, required: ['resource', 'role'] },
+      },
+    },
     async (req, reply) => {
       const resource = resourceToProto(req.params.resource);
       if (resource === null) {
@@ -120,7 +126,18 @@ export const registerFieldPermissionsRoutes = async (
   // POST /api/v1/field-permissions/bulk — keep before the dynamic
   // /:resource handlers so Fastify's first-match-wins router picks the
   // static segment.
-  app.post('/api/v1/field-permissions/bulk', async (req, reply) => {
+  app.post('/api/v1/field-permissions/bulk', {
+    schema: {
+      tags: ['field-permissions'],
+      body: {
+        type: 'object',
+        additionalProperties: true,
+        properties: {
+          overrides: { type: 'array', items: { type: 'object', additionalProperties: true } },
+        },
+      },
+    },
+  }, async (req, reply) => {
     const body = (req.body ?? {}) as { overrides?: Array<Record<string, unknown>> };
     const overridesRaw = body.overrides ?? [];
     if (!Array.isArray(overridesRaw) || overridesRaw.length === 0) {
@@ -149,7 +166,21 @@ export const registerFieldPermissionsRoutes = async (
   });
 
   // POST /api/v1/field-permissions — single upsert.
-  app.post('/api/v1/field-permissions', async (req, reply) => {
+  app.post('/api/v1/field-permissions', {
+    schema: {
+      tags: ['field-permissions'],
+      body: {
+        type: 'object',
+        additionalProperties: true,
+        properties: {
+          resource: { type: 'string' },
+          field_name: { type: 'string' },
+          role: { type: 'string' },
+          access_level: { type: 'string' },
+        },
+      },
+    },
+  }, async (req, reply) => {
     const body = (req.body ?? {}) as Record<string, unknown>;
     const resource = resourceToProto(String(body.resource ?? ''));
     const accessLevel = accessLevelToProto(String(body.access_level ?? body.accessLevel ?? ''));
@@ -180,6 +211,12 @@ export const registerFieldPermissionsRoutes = async (
   // form wins.
   app.get<{ Params: { resource: string; role: string } }>(
     '/api/v1/field-permissions/:resource/:role',
+    {
+      schema: {
+        tags: ['field-permissions'],
+        params: { type: 'object', properties: { resource: { type: 'string' }, role: { type: 'string' } }, required: ['resource', 'role'] },
+      },
+    },
     async (req, reply) => {
       const resource = resourceToProto(req.params.resource);
       if (resource === null) {
@@ -200,6 +237,12 @@ export const registerFieldPermissionsRoutes = async (
   // DELETE /api/v1/field-permissions/:resource/:role/:field_name
   app.delete<{ Params: { resource: string; role: string; field_name: string } }>(
     '/api/v1/field-permissions/:resource/:role/:field_name',
+    {
+      schema: {
+        tags: ['field-permissions'],
+        params: { type: 'object', properties: { resource: { type: 'string' }, role: { type: 'string' }, field_name: { type: 'string' } }, required: ['resource', 'role', 'field_name'] },
+      },
+    },
     async (req, reply) => {
       const resource = resourceToProto(req.params.resource);
       if (resource === null) {
@@ -225,6 +268,12 @@ export const registerFieldPermissionsRoutes = async (
   // GET /api/v1/field-permissions/:resource
   app.get<{ Params: { resource: string } }>(
     '/api/v1/field-permissions/:resource',
+    {
+      schema: {
+        tags: ['field-permissions'],
+        params: { type: 'object', properties: { resource: { type: 'string' } }, required: ['resource'] },
+      },
+    },
     async (req, reply) => {
       const resource = resourceToProto(req.params.resource);
       if (resource === null) {

--- a/services/gateway/src/routes/gdpr.ts
+++ b/services/gateway/src/routes/gdpr.ts
@@ -68,7 +68,21 @@ export const registerGdprRoutes = async (
 
   app.post(
     '/api/v1/users/me/erasure-request',
-    { config: { rateLimit: ERASURE_RATE_LIMIT } },
+    {
+      config: { rateLimit: ERASURE_RATE_LIMIT },
+      schema: {
+        tags: ['gdpr'],
+        summary: 'Submit a GDPR erasure request for the authenticated user',
+        security: [],
+        body: {
+          type: 'object',
+          properties: {
+            reason: { type: 'string' },
+          },
+          additionalProperties: true,
+        },
+      },
+    },
     async (req, reply) => {
       const userId = principalUserId(req);
       if (!userId) {
@@ -158,6 +172,18 @@ export const registerGdprRoutes = async (
   if (auditClient) {
     app.get<{ Params: { correlationId: string } }>(
       '/api/v1/users/me/erasure-request/:correlationId',
+      {
+        schema: {
+          tags: ['gdpr'],
+          summary: 'Get the status of a GDPR erasure request by correlation ID',
+          params: {
+            type: 'object',
+            properties: {
+              correlationId: { type: 'string' },
+            },
+          },
+        },
+      },
       async (req, reply) => {
         try {
           const res = await auditClient.getGdprErasureRequest(

--- a/services/gateway/src/routes/gdpr.ts
+++ b/services/gateway/src/routes/gdpr.ts
@@ -74,13 +74,6 @@ export const registerGdprRoutes = async (
         tags: ['gdpr'],
         summary: 'Submit a GDPR erasure request for the authenticated user',
         security: [],
-        body: {
-          type: 'object',
-          properties: {
-            reason: { type: 'string' },
-          },
-          additionalProperties: true,
-        },
       },
     },
     async (req, reply) => {
@@ -176,12 +169,6 @@ export const registerGdprRoutes = async (
         schema: {
           tags: ['gdpr'],
           summary: 'Get the status of a GDPR erasure request by correlation ID',
-          params: {
-            type: 'object',
-            properties: {
-              correlationId: { type: 'string' },
-            },
-          },
         },
       },
       async (req, reply) => {

--- a/services/gateway/src/routes/invitation-accept.ts
+++ b/services/gateway/src/routes/invitation-accept.ts
@@ -50,16 +50,6 @@ export const registerInvitationAcceptRoutes = async (
         tags: ['invitations'],
         summary: 'Accept a rescue staff invitation and provision the user account',
         security: [],
-        body: {
-          type: 'object',
-          properties: {
-            token: { type: 'string' },
-            password: { type: 'string' },
-            firstName: { type: 'string' },
-            lastName: { type: 'string' },
-          },
-          additionalProperties: true,
-        },
       },
     },
     async (req, reply) => {

--- a/services/gateway/src/routes/invitation-accept.ts
+++ b/services/gateway/src/routes/invitation-accept.ts
@@ -63,54 +63,55 @@ export const registerInvitationAcceptRoutes = async (
       },
     },
     async (req, reply) => {
-    const body = (req.body ?? {}) as AcceptBody;
-    const token = body.token ?? '';
-    const password = body.password ?? '';
-    const firstName = body.firstName ?? body.first_name ?? '';
-    const lastName = body.lastName ?? body.last_name ?? '';
+      const body = (req.body ?? {}) as AcceptBody;
+      const token = body.token ?? '';
+      const password = body.password ?? '';
+      const firstName = body.firstName ?? body.first_name ?? '';
+      const lastName = body.lastName ?? body.last_name ?? '';
 
-    if (!token) {
-      return reply.code(400).send({ error: 'token is required' });
-    }
-    if (!password) {
-      return reply.code(400).send({ error: 'password is required' });
-    }
-    if (!firstName || !lastName) {
-      return reply.code(400).send({ error: 'firstName and lastName are required' });
-    }
-
-    const metadata = buildMetadata(req);
-
-    try {
-      // 1. Validate the invitation + read the invitee's email. NOT_FOUND
-      //    (unknown / used / expired) surfaces as 404.
-      const details = await rescueClient.getInvitationByToken({ token }, metadata);
-      const email = details.invitation?.email;
-      if (!email) {
-        return reply.code(404).send({ error: 'invitation not found or no longer valid' });
+      if (!token) {
+        return reply.code(400).send({ error: 'token is required' });
+      }
+      if (!password) {
+        return reply.code(400).send({ error: 'password is required' });
+      }
+      if (!firstName || !lastName) {
+        return reply.code(400).send({ error: 'firstName and lastName are required' });
       }
 
-      // 2. Create-or-find the auth user with the invitee's trusted email.
-      const provisioned = await authClient.provisionInvitedUser(
-        { email, password, firstName, lastName },
-        metadata
-      );
-      const userId = provisioned.user?.userId;
-      if (!userId) {
-        return reply.code(500).send({ error: 'internal_error' });
+      const metadata = buildMetadata(req);
+
+      try {
+        // 1. Validate the invitation + read the invitee's email. NOT_FOUND
+        //    (unknown / used / expired) surfaces as 404.
+        const details = await rescueClient.getInvitationByToken({ token }, metadata);
+        const email = details.invitation?.email;
+        if (!email) {
+          return reply.code(404).send({ error: 'invitation not found or no longer valid' });
+        }
+
+        // 2. Create-or-find the auth user with the invitee's trusted email.
+        const provisioned = await authClient.provisionInvitedUser(
+          { email, password, firstName, lastName },
+          metadata
+        );
+        const userId = provisioned.user?.userId;
+        if (!userId) {
+          return reply.code(500).send({ error: 'internal_error' });
+        }
+
+        // 3. Consume the invitation + attach staff membership.
+        const accepted = await rescueClient.acceptInvitation({ token, userId }, metadata);
+
+        return reply.code(201).send({
+          success: true,
+          message: 'Invitation accepted',
+          userId,
+          data: accepted.staffMember,
+        });
+      } catch (err) {
+        return handleGrpcError(err, reply);
       }
-
-      // 3. Consume the invitation + attach staff membership.
-      const accepted = await rescueClient.acceptInvitation({ token, userId }, metadata);
-
-      return reply.code(201).send({
-        success: true,
-        message: 'Invitation accepted',
-        userId,
-        data: accepted.staffMember,
-      });
-    } catch (err) {
-      return handleGrpcError(err, reply);
     }
-  });
+  );
 };

--- a/services/gateway/src/routes/invitation-accept.ts
+++ b/services/gateway/src/routes/invitation-accept.ts
@@ -43,7 +43,26 @@ export const registerInvitationAcceptRoutes = async (
 ): Promise<void> => {
   const { authClient, rescueClient } = opts;
 
-  app.post('/api/v1/invitations/accept', async (req, reply) => {
+  app.post(
+    '/api/v1/invitations/accept',
+    {
+      schema: {
+        tags: ['invitations'],
+        summary: 'Accept a rescue staff invitation and provision the user account',
+        security: [],
+        body: {
+          type: 'object',
+          properties: {
+            token: { type: 'string' },
+            password: { type: 'string' },
+            firstName: { type: 'string' },
+            lastName: { type: 'string' },
+          },
+          additionalProperties: true,
+        },
+      },
+    },
+    async (req, reply) => {
     const body = (req.body ?? {}) as AcceptBody;
     const token = body.token ?? '';
     const password = body.password ?? '';

--- a/services/gateway/src/routes/legal.ts
+++ b/services/gateway/src/routes/legal.ts
@@ -83,7 +83,16 @@ export const registerLegalRoutes = async (
 ): Promise<void> => {
   const { docsDir } = opts;
 
-  app.get('/api/v1/legal/terms', async (_req, reply) => {
+  app.get(
+    '/api/v1/legal/terms',
+    {
+      schema: {
+        tags: ['legal'],
+        summary: 'Return the current terms of service document',
+        security: [],
+      },
+    },
+    async (_req, reply) => {
     try {
       const doc = await getTermsDocument(docsDir);
       return reply.send({ data: doc });
@@ -92,7 +101,16 @@ export const registerLegalRoutes = async (
     }
   });
 
-  app.get('/api/v1/legal/privacy', async (_req, reply) => {
+  app.get(
+    '/api/v1/legal/privacy',
+    {
+      schema: {
+        tags: ['legal'],
+        summary: 'Return the current privacy policy document',
+        security: [],
+      },
+    },
+    async (_req, reply) => {
     try {
       const doc = await getPrivacyDocument(docsDir);
       return reply.send({ data: doc });
@@ -101,7 +119,16 @@ export const registerLegalRoutes = async (
     }
   });
 
-  app.get('/api/v1/legal/cookies', async (_req, reply) => {
+  app.get(
+    '/api/v1/legal/cookies',
+    {
+      schema: {
+        tags: ['legal'],
+        summary: 'Return the current cookie policy document',
+        security: [],
+      },
+    },
+    async (_req, reply) => {
     try {
       const doc = await getCookiesDocument(docsDir);
       return reply.send({ data: doc });

--- a/services/gateway/src/routes/legal.ts
+++ b/services/gateway/src/routes/legal.ts
@@ -93,13 +93,14 @@ export const registerLegalRoutes = async (
       },
     },
     async (_req, reply) => {
-    try {
-      const doc = await getTermsDocument(docsDir);
-      return reply.send({ data: doc });
-    } catch {
-      return reply.code(500).send({ error: 'legal content unavailable' });
+      try {
+        const doc = await getTermsDocument(docsDir);
+        return reply.send({ data: doc });
+      } catch {
+        return reply.code(500).send({ error: 'legal content unavailable' });
+      }
     }
-  });
+  );
 
   app.get(
     '/api/v1/legal/privacy',
@@ -111,13 +112,14 @@ export const registerLegalRoutes = async (
       },
     },
     async (_req, reply) => {
-    try {
-      const doc = await getPrivacyDocument(docsDir);
-      return reply.send({ data: doc });
-    } catch {
-      return reply.code(500).send({ error: 'legal content unavailable' });
+      try {
+        const doc = await getPrivacyDocument(docsDir);
+        return reply.send({ data: doc });
+      } catch {
+        return reply.code(500).send({ error: 'legal content unavailable' });
+      }
     }
-  });
+  );
 
   app.get(
     '/api/v1/legal/cookies',
@@ -129,13 +131,14 @@ export const registerLegalRoutes = async (
       },
     },
     async (_req, reply) => {
-    try {
-      const doc = await getCookiesDocument(docsDir);
-      return reply.send({ data: doc });
-    } catch {
-      return reply.code(500).send({ error: 'legal content unavailable' });
+      try {
+        const doc = await getCookiesDocument(docsDir);
+        return reply.send({ data: doc });
+      } catch {
+        return reply.code(500).send({ error: 'legal content unavailable' });
+      }
     }
-  });
+  );
 };
 
 // Exposed for tests so they can clear cached fixture reads between

--- a/services/gateway/src/routes/matching.ts
+++ b/services/gateway/src/routes/matching.ts
@@ -87,7 +87,22 @@ export const registerMatchingRoutes = async (
 
   app.post(
     '/api/v1/matching/sessions',
-    { config: { rateLimit: MATCHING_RATE_LIMITS.startSession } },
+    {
+      config: { rateLimit: MATCHING_RATE_LIMITS.startSession },
+      schema: {
+        tags: ['matching'],
+        body: {
+          type: 'object',
+          additionalProperties: true,
+          properties: {
+            filtersJson: { type: 'string' },
+            deviceType: { type: 'string' },
+            userAgent: { type: 'string' },
+            ipAddress: { type: 'string' },
+          },
+        },
+      },
+    },
     async (req, reply) => {
       const body = (req.body ?? {}) as StartSessionBody;
       const grpcReq: StartSessionRequest = {
@@ -109,7 +124,13 @@ export const registerMatchingRoutes = async (
 
   app.post<{ Params: { id: string } }>(
     '/api/v1/matching/sessions/:id/end',
-    { config: { rateLimit: MATCHING_RATE_LIMITS.endSession } },
+    {
+      config: { rateLimit: MATCHING_RATE_LIMITS.endSession },
+      schema: {
+        tags: ['matching'],
+        params: { type: 'object', properties: { id: { type: 'string' } }, required: ['id'] },
+      },
+    },
     async (req, reply) => {
       const grpcReq: EndSessionRequest = { sessionId: req.params.id };
       try {
@@ -123,7 +144,23 @@ export const registerMatchingRoutes = async (
 
   app.post<{ Params: { id: string } }>(
     '/api/v1/matching/sessions/:id/swipes',
-    { config: { rateLimit: MATCHING_RATE_LIMITS.recordSwipe } },
+    {
+      config: { rateLimit: MATCHING_RATE_LIMITS.recordSwipe },
+      schema: {
+        tags: ['matching'],
+        params: { type: 'object', properties: { id: { type: 'string' } }, required: ['id'] },
+        body: {
+          type: 'object',
+          additionalProperties: true,
+          properties: {
+            petId: { type: 'string' },
+            action: { type: 'string' },
+            responseTime: { type: 'number' },
+            deviceType: { type: 'string' },
+          },
+        },
+      },
+    },
     async (req, reply) => {
       const body = (req.body ?? {}) as RecordSwipeBody;
       const grpcReq: RecordSwipeRequest = {
@@ -148,7 +185,23 @@ export const registerMatchingRoutes = async (
   // ({ success, message }) so the SPA doesn't notice the cutover.
   app.post(
     '/api/v1/discovery/swipe/action',
-    { config: { rateLimit: MATCHING_RATE_LIMITS.recordSwipe } },
+    {
+      config: { rateLimit: MATCHING_RATE_LIMITS.recordSwipe },
+      schema: {
+        tags: ['discovery'],
+        body: {
+          type: 'object',
+          additionalProperties: true,
+          properties: {
+            sessionId: { type: 'string' },
+            petId: { type: 'string' },
+            action: { type: 'string' },
+            responseTime: { type: 'number' },
+            deviceType: { type: 'string' },
+          },
+        },
+      },
+    },
     async (req, reply) => {
       const body = (req.body ?? {}) as RecordSwipeBody & { sessionId?: string };
       if (!body.sessionId) {
@@ -175,7 +228,21 @@ export const registerMatchingRoutes = async (
 
   app.get(
     '/api/v1/matching/swipes',
-    { config: { rateLimit: MATCHING_RATE_LIMITS.listSwipeHistory } },
+    {
+      config: { rateLimit: MATCHING_RATE_LIMITS.listSwipeHistory },
+      schema: {
+        tags: ['matching'],
+        querystring: {
+          type: 'object',
+          additionalProperties: true,
+          properties: {
+            cursor: { type: 'string' },
+            limit: { type: 'string' },
+            action: { type: 'string' },
+          },
+        },
+      },
+    },
     async (req, reply) => {
       const query = req.query as Record<string, string | undefined>;
       const pagination = parsePagination(query, { limit: 0 });
@@ -202,7 +269,22 @@ export const registerMatchingRoutes = async (
   // start a session implicitly using the filters as the session filters.
   app.post(
     '/api/v1/discovery/queue',
-    { config: { rateLimit: MATCHING_RATE_LIMITS.recommend } },
+    {
+      config: { rateLimit: MATCHING_RATE_LIMITS.recommend },
+      schema: {
+        tags: ['discovery'],
+        body: {
+          type: 'object',
+          additionalProperties: true,
+          properties: {
+            sessionId: { type: 'string' },
+            filters: { type: 'object', additionalProperties: true },
+            userId: { type: 'string' },
+            limit: { type: 'number' },
+          },
+        },
+      },
+    },
     async (req, reply) => {
       const body = (req.body ?? {}) as DiscoveryQueueBody;
       const filtersJson = body.filters !== undefined ? JSON.stringify(body.filters) : '';
@@ -225,7 +307,22 @@ export const registerMatchingRoutes = async (
   // an active session.
   app.post(
     '/api/v1/discovery/pets/more',
-    { config: { rateLimit: MATCHING_RATE_LIMITS.recommend } },
+    {
+      config: { rateLimit: MATCHING_RATE_LIMITS.recommend },
+      schema: {
+        tags: ['discovery'],
+        body: {
+          type: 'object',
+          additionalProperties: true,
+          properties: {
+            sessionId: { type: 'string' },
+            filters: { type: 'object', additionalProperties: true },
+            userId: { type: 'string' },
+            limit: { type: 'number' },
+          },
+        },
+      },
+    },
     async (req, reply) => {
       const body = (req.body ?? {}) as DiscoveryQueueBody;
       if (body.sessionId === undefined || body.sessionId === '') {
@@ -248,7 +345,23 @@ export const registerMatchingRoutes = async (
   // GET /api/v1/search/pets — lib.search free-text + filters search.
   app.get(
     '/api/v1/search/pets',
-    { config: { rateLimit: MATCHING_RATE_LIMITS.search } },
+    {
+      config: { rateLimit: MATCHING_RATE_LIMITS.search },
+      schema: {
+        tags: ['discovery'],
+        querystring: {
+          type: 'object',
+          additionalProperties: true,
+          properties: {
+            q: { type: 'string' },
+            query: { type: 'string' },
+            filters: { type: 'string' },
+            cursor: { type: 'string' },
+            limit: { type: 'string' },
+          },
+        },
+      },
+    },
     async (req, reply) => {
       const query = req.query as Record<string, string | undefined>;
       const pagination = parsePagination(query, { limit: 0 });
@@ -272,7 +385,7 @@ export const registerMatchingRoutes = async (
 
   // ---- Match profile -----------------------------------------------
   // GET /api/v1/match/profile — read the adopter's preferences.
-  app.get('/api/v1/match/profile', async (req, reply) => {
+  app.get('/api/v1/match/profile', { schema: { tags: ['matching'] } }, async (req, reply) => {
     try {
       const res = await client.getMatchProfile({}, buildMetadata(req));
       return reply.send({ success: true, data: matchProfileToView(res.profile) });
@@ -283,7 +396,12 @@ export const registerMatchingRoutes = async (
 
   // PUT /api/v1/match/profile — upsert. The SPA sends snake_case
   // preference fields; map each to the proto's set_* + *_json pair.
-  app.put('/api/v1/match/profile', async (req, reply) => {
+  app.put('/api/v1/match/profile', {
+    schema: {
+      tags: ['matching'],
+      body: { type: 'object', additionalProperties: true },
+    },
+  }, async (req, reply) => {
     const body = (req.body ?? {}) as Record<string, unknown>;
     try {
       const grpcReq = buildUpsertRequest(body);
@@ -298,6 +416,12 @@ export const registerMatchingRoutes = async (
   // GET /api/v1/discovery/swipe/stats/:userId
   app.get<{ Params: { userId: string } }>(
     '/api/v1/discovery/swipe/stats/:userId',
+    {
+      schema: {
+        tags: ['discovery'],
+        params: { type: 'object', properties: { userId: { type: 'string' } }, required: ['userId'] },
+      },
+    },
     async (req, reply) => {
       try {
         const res = await client.getUserSwipeStats(
@@ -318,6 +442,12 @@ export const registerMatchingRoutes = async (
   // GET /api/v1/discovery/swipe/session/:sessionId
   app.get<{ Params: { sessionId: string } }>(
     '/api/v1/discovery/swipe/session/:sessionId',
+    {
+      schema: {
+        tags: ['discovery'],
+        params: { type: 'object', properties: { sessionId: { type: 'string' } }, required: ['sessionId'] },
+      },
+    },
     async (req, reply) => {
       try {
         const res = await client.getSessionStats(

--- a/services/gateway/src/routes/matching.ts
+++ b/services/gateway/src/routes/matching.ts
@@ -396,21 +396,25 @@ export const registerMatchingRoutes = async (
 
   // PUT /api/v1/match/profile — upsert. The SPA sends snake_case
   // preference fields; map each to the proto's set_* + *_json pair.
-  app.put('/api/v1/match/profile', {
-    schema: {
-      tags: ['matching'],
-      body: { type: 'object', additionalProperties: true },
+  app.put(
+    '/api/v1/match/profile',
+    {
+      schema: {
+        tags: ['matching'],
+        body: { type: 'object', additionalProperties: true },
+      },
     },
-  }, async (req, reply) => {
-    const body = (req.body ?? {}) as Record<string, unknown>;
-    try {
-      const grpcReq = buildUpsertRequest(body);
-      const res = await client.upsertMatchProfile(grpcReq, buildMetadata(req));
-      return reply.send({ success: true, data: matchProfileToView(res.profile) });
-    } catch (err) {
-      return handleGrpcError(err, reply);
+    async (req, reply) => {
+      const body = (req.body ?? {}) as Record<string, unknown>;
+      try {
+        const grpcReq = buildUpsertRequest(body);
+        const res = await client.upsertMatchProfile(grpcReq, buildMetadata(req));
+        return reply.send({ success: true, data: matchProfileToView(res.profile) });
+      } catch (err) {
+        return handleGrpcError(err, reply);
+      }
     }
-  });
+  );
 
   // ---- Swipe statistics --------------------------------------------
   // GET /api/v1/discovery/swipe/stats/:userId
@@ -419,7 +423,11 @@ export const registerMatchingRoutes = async (
     {
       schema: {
         tags: ['discovery'],
-        params: { type: 'object', properties: { userId: { type: 'string' } }, required: ['userId'] },
+        params: {
+          type: 'object',
+          properties: { userId: { type: 'string' } },
+          required: ['userId'],
+        },
       },
     },
     async (req, reply) => {
@@ -445,7 +453,11 @@ export const registerMatchingRoutes = async (
     {
       schema: {
         tags: ['discovery'],
-        params: { type: 'object', properties: { sessionId: { type: 'string' } }, required: ['sessionId'] },
+        params: {
+          type: 'object',
+          properties: { sessionId: { type: 'string' } },
+          required: ['sessionId'],
+        },
       },
     },
     async (req, reply) => {

--- a/services/gateway/src/routes/matching.ts
+++ b/services/gateway/src/routes/matching.ts
@@ -91,16 +91,6 @@ export const registerMatchingRoutes = async (
       config: { rateLimit: MATCHING_RATE_LIMITS.startSession },
       schema: {
         tags: ['matching'],
-        body: {
-          type: 'object',
-          additionalProperties: true,
-          properties: {
-            filtersJson: { type: 'string' },
-            deviceType: { type: 'string' },
-            userAgent: { type: 'string' },
-            ipAddress: { type: 'string' },
-          },
-        },
       },
     },
     async (req, reply) => {
@@ -149,16 +139,6 @@ export const registerMatchingRoutes = async (
       schema: {
         tags: ['matching'],
         params: { type: 'object', properties: { id: { type: 'string' } }, required: ['id'] },
-        body: {
-          type: 'object',
-          additionalProperties: true,
-          properties: {
-            petId: { type: 'string' },
-            action: { type: 'string' },
-            responseTime: { type: 'number' },
-            deviceType: { type: 'string' },
-          },
-        },
       },
     },
     async (req, reply) => {
@@ -189,17 +169,6 @@ export const registerMatchingRoutes = async (
       config: { rateLimit: MATCHING_RATE_LIMITS.recordSwipe },
       schema: {
         tags: ['discovery'],
-        body: {
-          type: 'object',
-          additionalProperties: true,
-          properties: {
-            sessionId: { type: 'string' },
-            petId: { type: 'string' },
-            action: { type: 'string' },
-            responseTime: { type: 'number' },
-            deviceType: { type: 'string' },
-          },
-        },
       },
     },
     async (req, reply) => {
@@ -232,15 +201,6 @@ export const registerMatchingRoutes = async (
       config: { rateLimit: MATCHING_RATE_LIMITS.listSwipeHistory },
       schema: {
         tags: ['matching'],
-        querystring: {
-          type: 'object',
-          additionalProperties: true,
-          properties: {
-            cursor: { type: 'string' },
-            limit: { type: 'string' },
-            action: { type: 'string' },
-          },
-        },
       },
     },
     async (req, reply) => {
@@ -273,16 +233,6 @@ export const registerMatchingRoutes = async (
       config: { rateLimit: MATCHING_RATE_LIMITS.recommend },
       schema: {
         tags: ['discovery'],
-        body: {
-          type: 'object',
-          additionalProperties: true,
-          properties: {
-            sessionId: { type: 'string' },
-            filters: { type: 'object', additionalProperties: true },
-            userId: { type: 'string' },
-            limit: { type: 'number' },
-          },
-        },
       },
     },
     async (req, reply) => {
@@ -311,16 +261,6 @@ export const registerMatchingRoutes = async (
       config: { rateLimit: MATCHING_RATE_LIMITS.recommend },
       schema: {
         tags: ['discovery'],
-        body: {
-          type: 'object',
-          additionalProperties: true,
-          properties: {
-            sessionId: { type: 'string' },
-            filters: { type: 'object', additionalProperties: true },
-            userId: { type: 'string' },
-            limit: { type: 'number' },
-          },
-        },
       },
     },
     async (req, reply) => {
@@ -349,17 +289,6 @@ export const registerMatchingRoutes = async (
       config: { rateLimit: MATCHING_RATE_LIMITS.search },
       schema: {
         tags: ['discovery'],
-        querystring: {
-          type: 'object',
-          additionalProperties: true,
-          properties: {
-            q: { type: 'string' },
-            query: { type: 'string' },
-            filters: { type: 'string' },
-            cursor: { type: 'string' },
-            limit: { type: 'string' },
-          },
-        },
       },
     },
     async (req, reply) => {
@@ -423,11 +352,6 @@ export const registerMatchingRoutes = async (
     {
       schema: {
         tags: ['discovery'],
-        params: {
-          type: 'object',
-          properties: { userId: { type: 'string' } },
-          required: ['userId'],
-        },
       },
     },
     async (req, reply) => {
@@ -453,11 +377,6 @@ export const registerMatchingRoutes = async (
     {
       schema: {
         tags: ['discovery'],
-        params: {
-          type: 'object',
-          properties: { sessionId: { type: 'string' } },
-          required: ['sessionId'],
-        },
       },
     },
     async (req, reply) => {

--- a/services/gateway/src/routes/moderation-admin.ts
+++ b/services/gateway/src/routes/moderation-admin.ts
@@ -62,7 +62,24 @@ export const registerModerationAdminRoutes = async (
 
   app.get(
     '/api/v1/admin/moderation/reports',
-    { config: { rateLimit: RL_READ } },
+    {
+      config: { rateLimit: RL_READ },
+      schema: {
+        tags: ['moderation', 'admin'],
+        querystring: {
+          type: 'object',
+          additionalProperties: true,
+          properties: {
+            cursor: { type: 'string' },
+            limit: { type: 'string' },
+            status: { type: 'string' },
+            severity: { type: 'string' },
+            category: { type: 'string' },
+            assigned: { type: 'string' },
+          },
+        },
+      },
+    },
     async (req, reply) => {
       const q = req.query as Record<string, string | undefined>;
       const pagination = parsePagination(q, { limit: 0 });
@@ -111,7 +128,13 @@ export const registerModerationAdminRoutes = async (
 
   app.get<{ Params: { id: string } }>(
     '/api/v1/admin/moderation/reports/:id',
-    { config: { rateLimit: RL_READ } },
+    {
+      config: { rateLimit: RL_READ },
+      schema: {
+        tags: ['moderation', 'admin'],
+        params: { type: 'object', properties: { id: { type: 'string' } }, required: ['id'] },
+      },
+    },
     async (req, reply) => {
       try {
         const res = await client.getReport(
@@ -130,7 +153,26 @@ export const registerModerationAdminRoutes = async (
 
   app.post(
     '/api/v1/admin/moderation/reports',
-    { config: { rateLimit: RL_WRITE } },
+    {
+      config: { rateLimit: RL_WRITE },
+      schema: {
+        tags: ['moderation', 'admin'],
+        body: {
+          type: 'object',
+          additionalProperties: true,
+          properties: {
+            reportedEntityType: { type: 'string' },
+            reportedEntityId: { type: 'string' },
+            reportedUserId: { type: 'string' },
+            category: { type: 'string' },
+            severity: { type: 'string' },
+            title: { type: 'string' },
+            description: { type: 'string' },
+            metadata: { type: 'object', additionalProperties: true },
+          },
+        },
+      },
+    },
     async (req, reply) => {
       const b = (req.body ?? {}) as Record<string, unknown>;
       const grpcReq: FileReportRequest = {
@@ -184,7 +226,22 @@ export const registerModerationAdminRoutes = async (
   // resolution). Assignment is a separate route.
   app.patch<{ Params: { id: string } }>(
     '/api/v1/admin/moderation/reports/:id/status',
-    { config: { rateLimit: RL_WRITE } },
+    {
+      config: { rateLimit: RL_WRITE },
+      schema: {
+        tags: ['moderation', 'admin'],
+        params: { type: 'object', properties: { id: { type: 'string' } }, required: ['id'] },
+        body: {
+          type: 'object',
+          additionalProperties: true,
+          properties: {
+            status: { type: 'string' },
+            resolution: { type: 'string' },
+            resolutionNotes: { type: 'string' },
+          },
+        },
+      },
+    },
     async (req, reply) => {
       const b = (req.body ?? {}) as Record<string, unknown>;
       const target = b.status as string | undefined;
@@ -210,7 +267,21 @@ export const registerModerationAdminRoutes = async (
 
   app.post<{ Params: { id: string } }>(
     '/api/v1/admin/moderation/reports/:id/assign',
-    { config: { rateLimit: RL_WRITE } },
+    {
+      config: { rateLimit: RL_WRITE },
+      schema: {
+        tags: ['moderation', 'admin'],
+        params: { type: 'object', properties: { id: { type: 'string' } }, required: ['id'] },
+        body: {
+          type: 'object',
+          additionalProperties: true,
+          properties: {
+            moderatorId: { type: 'string' },
+            reason: { type: 'string' },
+          },
+        },
+      },
+    },
     async (req, reply) => {
       const b = (req.body ?? {}) as Record<string, unknown>;
       const grpcReq: AssignReportRequest = {
@@ -236,7 +307,24 @@ export const registerModerationAdminRoutes = async (
   // failure short-circuits the loop and surfaces the first error.
   app.post(
     '/api/v1/admin/moderation/reports/bulk-update',
-    { config: { rateLimit: RL_WRITE } },
+    {
+      config: { rateLimit: RL_WRITE },
+      schema: {
+        tags: ['moderation', 'admin'],
+        body: {
+          type: 'object',
+          additionalProperties: true,
+          properties: {
+            reportIds: { type: 'array', items: { type: 'string' } },
+            action: { type: 'string' },
+            moderatorId: { type: 'string' },
+            reason: { type: 'string' },
+            resolution: { type: 'string' },
+            resolutionNotes: { type: 'string' },
+          },
+        },
+      },
+    },
     async (req, reply) => {
       const b = (req.body ?? {}) as {
         reportIds?: string[];
@@ -296,7 +384,23 @@ export const registerModerationAdminRoutes = async (
 
   app.get(
     '/api/v1/admin/moderation/actions',
-    { config: { rateLimit: RL_READ } },
+    {
+      config: { rateLimit: RL_READ },
+      schema: {
+        tags: ['moderation', 'admin'],
+        querystring: {
+          type: 'object',
+          additionalProperties: true,
+          properties: {
+            cursor: { type: 'string' },
+            limit: { type: 'string' },
+            user: { type: 'string' },
+            report: { type: 'string' },
+            action: { type: 'string' },
+          },
+        },
+      },
+    },
     async (req, reply) => {
       const q = req.query as Record<string, string | undefined>;
       const pagination = parsePagination(q, { limit: 0 });
@@ -330,7 +434,28 @@ export const registerModerationAdminRoutes = async (
 
   app.post(
     '/api/v1/admin/moderation/actions',
-    { config: { rateLimit: RL_WRITE } },
+    {
+      config: { rateLimit: RL_WRITE },
+      schema: {
+        tags: ['moderation', 'admin'],
+        body: {
+          type: 'object',
+          additionalProperties: true,
+          properties: {
+            reportId: { type: 'string' },
+            targetEntityType: { type: 'string' },
+            targetEntityId: { type: 'string' },
+            targetUserId: { type: 'string' },
+            actionType: { type: 'string' },
+            severity: { type: 'string' },
+            reason: { type: 'string' },
+            description: { type: 'string' },
+            metadata: { type: 'object', additionalProperties: true },
+            duration: { type: 'number' },
+          },
+        },
+      },
+    },
     async (req, reply) => {
       const b = (req.body ?? {}) as Record<string, unknown>;
       const grpcReq: LogModeratorActionRequest = {
@@ -385,7 +510,25 @@ export const registerModerationAdminRoutes = async (
 
   app.get(
     '/api/v1/admin/support/tickets',
-    { config: { rateLimit: RL_READ } },
+    {
+      config: { rateLimit: RL_READ },
+      schema: {
+        tags: ['moderation', 'admin'],
+        querystring: {
+          type: 'object',
+          additionalProperties: true,
+          properties: {
+            cursor: { type: 'string' },
+            limit: { type: 'string' },
+            status: { type: 'string' },
+            priority: { type: 'string' },
+            category: { type: 'string' },
+            assigned: { type: 'string' },
+            user: { type: 'string' },
+          },
+        },
+      },
+    },
     async (req, reply) => {
       const q = req.query as Record<string, string | undefined>;
       const pagination = parsePagination(q, { limit: 0 });
@@ -435,7 +578,13 @@ export const registerModerationAdminRoutes = async (
 
   app.get<{ Params: { id: string } }>(
     '/api/v1/admin/support/tickets/:id',
-    { config: { rateLimit: RL_READ } },
+    {
+      config: { rateLimit: RL_READ },
+      schema: {
+        tags: ['moderation', 'admin'],
+        params: { type: 'object', properties: { id: { type: 'string' } }, required: ['id'] },
+      },
+    },
     async (req, reply) => {
       try {
         const res = await client.getSupportTicket(
@@ -457,7 +606,26 @@ export const registerModerationAdminRoutes = async (
 
   app.post(
     '/api/v1/admin/support/tickets',
-    { config: { rateLimit: RL_WRITE } },
+    {
+      config: { rateLimit: RL_WRITE },
+      schema: {
+        tags: ['moderation', 'admin'],
+        body: {
+          type: 'object',
+          additionalProperties: true,
+          properties: {
+            userId: { type: 'string' },
+            userEmail: { type: 'string' },
+            userName: { type: 'string' },
+            priority: { type: 'string' },
+            category: { type: 'string' },
+            subject: { type: 'string' },
+            description: { type: 'string' },
+            tags: { type: 'array', items: { type: 'string' } },
+          },
+        },
+      },
+    },
     async (req, reply) => {
       const b = (req.body ?? {}) as Record<string, unknown>;
       const grpcReq: OpenSupportTicketRequest = {
@@ -498,7 +666,21 @@ export const registerModerationAdminRoutes = async (
 
   app.post<{ Params: { id: string } }>(
     '/api/v1/admin/support/tickets/:id/responses',
-    { config: { rateLimit: RL_WRITE } },
+    {
+      config: { rateLimit: RL_WRITE },
+      schema: {
+        tags: ['moderation', 'admin'],
+        params: { type: 'object', properties: { id: { type: 'string' } }, required: ['id'] },
+        body: {
+          type: 'object',
+          additionalProperties: true,
+          properties: {
+            content: { type: 'string' },
+            isInternal: { type: 'boolean' },
+          },
+        },
+      },
+    },
     async (req, reply) => {
       const b = (req.body ?? {}) as Record<string, unknown>;
       const grpcReq: RespondToTicketRequest = {

--- a/services/gateway/src/routes/moderation-admin.ts
+++ b/services/gateway/src/routes/moderation-admin.ts
@@ -66,18 +66,6 @@ export const registerModerationAdminRoutes = async (
       config: { rateLimit: RL_READ },
       schema: {
         tags: ['moderation', 'admin'],
-        querystring: {
-          type: 'object',
-          additionalProperties: true,
-          properties: {
-            cursor: { type: 'string' },
-            limit: { type: 'string' },
-            status: { type: 'string' },
-            severity: { type: 'string' },
-            category: { type: 'string' },
-            assigned: { type: 'string' },
-          },
-        },
       },
     },
     async (req, reply) => {
@@ -157,20 +145,6 @@ export const registerModerationAdminRoutes = async (
       config: { rateLimit: RL_WRITE },
       schema: {
         tags: ['moderation', 'admin'],
-        body: {
-          type: 'object',
-          additionalProperties: true,
-          properties: {
-            reportedEntityType: { type: 'string' },
-            reportedEntityId: { type: 'string' },
-            reportedUserId: { type: 'string' },
-            category: { type: 'string' },
-            severity: { type: 'string' },
-            title: { type: 'string' },
-            description: { type: 'string' },
-            metadata: { type: 'object', additionalProperties: true },
-          },
-        },
       },
     },
     async (req, reply) => {
@@ -231,15 +205,6 @@ export const registerModerationAdminRoutes = async (
       schema: {
         tags: ['moderation', 'admin'],
         params: { type: 'object', properties: { id: { type: 'string' } }, required: ['id'] },
-        body: {
-          type: 'object',
-          additionalProperties: true,
-          properties: {
-            status: { type: 'string' },
-            resolution: { type: 'string' },
-            resolutionNotes: { type: 'string' },
-          },
-        },
       },
     },
     async (req, reply) => {
@@ -272,14 +237,6 @@ export const registerModerationAdminRoutes = async (
       schema: {
         tags: ['moderation', 'admin'],
         params: { type: 'object', properties: { id: { type: 'string' } }, required: ['id'] },
-        body: {
-          type: 'object',
-          additionalProperties: true,
-          properties: {
-            moderatorId: { type: 'string' },
-            reason: { type: 'string' },
-          },
-        },
       },
     },
     async (req, reply) => {
@@ -311,18 +268,6 @@ export const registerModerationAdminRoutes = async (
       config: { rateLimit: RL_WRITE },
       schema: {
         tags: ['moderation', 'admin'],
-        body: {
-          type: 'object',
-          additionalProperties: true,
-          properties: {
-            reportIds: { type: 'array', items: { type: 'string' } },
-            action: { type: 'string' },
-            moderatorId: { type: 'string' },
-            reason: { type: 'string' },
-            resolution: { type: 'string' },
-            resolutionNotes: { type: 'string' },
-          },
-        },
       },
     },
     async (req, reply) => {
@@ -388,17 +333,6 @@ export const registerModerationAdminRoutes = async (
       config: { rateLimit: RL_READ },
       schema: {
         tags: ['moderation', 'admin'],
-        querystring: {
-          type: 'object',
-          additionalProperties: true,
-          properties: {
-            cursor: { type: 'string' },
-            limit: { type: 'string' },
-            user: { type: 'string' },
-            report: { type: 'string' },
-            action: { type: 'string' },
-          },
-        },
       },
     },
     async (req, reply) => {
@@ -438,22 +372,6 @@ export const registerModerationAdminRoutes = async (
       config: { rateLimit: RL_WRITE },
       schema: {
         tags: ['moderation', 'admin'],
-        body: {
-          type: 'object',
-          additionalProperties: true,
-          properties: {
-            reportId: { type: 'string' },
-            targetEntityType: { type: 'string' },
-            targetEntityId: { type: 'string' },
-            targetUserId: { type: 'string' },
-            actionType: { type: 'string' },
-            severity: { type: 'string' },
-            reason: { type: 'string' },
-            description: { type: 'string' },
-            metadata: { type: 'object', additionalProperties: true },
-            duration: { type: 'number' },
-          },
-        },
       },
     },
     async (req, reply) => {
@@ -514,19 +432,6 @@ export const registerModerationAdminRoutes = async (
       config: { rateLimit: RL_READ },
       schema: {
         tags: ['moderation', 'admin'],
-        querystring: {
-          type: 'object',
-          additionalProperties: true,
-          properties: {
-            cursor: { type: 'string' },
-            limit: { type: 'string' },
-            status: { type: 'string' },
-            priority: { type: 'string' },
-            category: { type: 'string' },
-            assigned: { type: 'string' },
-            user: { type: 'string' },
-          },
-        },
       },
     },
     async (req, reply) => {
@@ -610,20 +515,6 @@ export const registerModerationAdminRoutes = async (
       config: { rateLimit: RL_WRITE },
       schema: {
         tags: ['moderation', 'admin'],
-        body: {
-          type: 'object',
-          additionalProperties: true,
-          properties: {
-            userId: { type: 'string' },
-            userEmail: { type: 'string' },
-            userName: { type: 'string' },
-            priority: { type: 'string' },
-            category: { type: 'string' },
-            subject: { type: 'string' },
-            description: { type: 'string' },
-            tags: { type: 'array', items: { type: 'string' } },
-          },
-        },
       },
     },
     async (req, reply) => {
@@ -671,14 +562,6 @@ export const registerModerationAdminRoutes = async (
       schema: {
         tags: ['moderation', 'admin'],
         params: { type: 'object', properties: { id: { type: 'string' } }, required: ['id'] },
-        body: {
-          type: 'object',
-          additionalProperties: true,
-          properties: {
-            content: { type: 'string' },
-            isInternal: { type: 'boolean' },
-          },
-        },
       },
     },
     async (req, reply) => {

--- a/services/gateway/src/routes/moderation.ts
+++ b/services/gateway/src/routes/moderation.ts
@@ -77,7 +77,26 @@ export const registerModerationRoutes = async (
 
   app.post(
     '/api/v1/moderation/reports',
-    { config: { rateLimit: RL_WRITE } },
+    {
+      config: { rateLimit: RL_WRITE },
+      schema: {
+        tags: ['moderation'],
+        body: {
+          type: 'object',
+          additionalProperties: true,
+          properties: {
+            reportedEntityType: { type: 'string' },
+            reportedEntityId: { type: 'string' },
+            reportedUserId: { type: 'string' },
+            category: { type: 'string' },
+            severity: { type: 'string' },
+            title: { type: 'string' },
+            description: { type: 'string' },
+            metadataJson: { type: 'string' },
+          },
+        },
+      },
+    },
     async (req, reply) => {
       const b = (req.body ?? {}) as Record<string, unknown>;
       const grpcReq: FileReportRequest = {
@@ -99,7 +118,24 @@ export const registerModerationRoutes = async (
     }
   );
 
-  app.get('/api/v1/moderation/reports', { config: { rateLimit: RL_READ } }, async (req, reply) => {
+  app.get('/api/v1/moderation/reports', {
+    config: { rateLimit: RL_READ },
+    schema: {
+      tags: ['moderation'],
+      querystring: {
+        type: 'object',
+        additionalProperties: true,
+        properties: {
+          cursor: { type: 'string' },
+          limit: { type: 'string' },
+          status: { type: 'string' },
+          severity: { type: 'string' },
+          category: { type: 'string' },
+          assigned: { type: 'string' },
+        },
+      },
+    },
+  }, async (req, reply) => {
     const q = req.query as Record<string, string | undefined>;
     const pagination = parsePagination(q, { limit: 0 });
     if (!pagination.ok) {
@@ -123,7 +159,13 @@ export const registerModerationRoutes = async (
 
   app.get<{ Params: { id: string } }>(
     '/api/v1/moderation/reports/:id',
-    { config: { rateLimit: RL_READ } },
+    {
+      config: { rateLimit: RL_READ },
+      schema: {
+        tags: ['moderation'],
+        params: { type: 'object', properties: { id: { type: 'string' } }, required: ['id'] },
+      },
+    },
     async (req, reply) => {
       const q = req.query as Record<string, string | undefined>;
       try {
@@ -140,7 +182,21 @@ export const registerModerationRoutes = async (
 
   app.post<{ Params: { id: string } }>(
     '/api/v1/moderation/reports/:id/assign',
-    { config: { rateLimit: RL_WRITE } },
+    {
+      config: { rateLimit: RL_WRITE },
+      schema: {
+        tags: ['moderation'],
+        params: { type: 'object', properties: { id: { type: 'string' } }, required: ['id'] },
+        body: {
+          type: 'object',
+          additionalProperties: true,
+          properties: {
+            moderatorId: { type: 'string' },
+            reason: { type: 'string' },
+          },
+        },
+      },
+    },
     async (req, reply) => {
       const b = (req.body ?? {}) as Record<string, unknown>;
       const grpcReq: AssignReportRequest = {
@@ -159,7 +215,21 @@ export const registerModerationRoutes = async (
 
   app.post<{ Params: { id: string } }>(
     '/api/v1/moderation/reports/:id/resolve',
-    { config: { rateLimit: RL_WRITE } },
+    {
+      config: { rateLimit: RL_WRITE },
+      schema: {
+        tags: ['moderation'],
+        params: { type: 'object', properties: { id: { type: 'string' } }, required: ['id'] },
+        body: {
+          type: 'object',
+          additionalProperties: true,
+          properties: {
+            resolution: { type: 'string' },
+            resolutionNotes: { type: 'string' },
+          },
+        },
+      },
+    },
     async (req, reply) => {
       const b = (req.body ?? {}) as Record<string, unknown>;
       const grpcReq: ResolveReportRequest = {
@@ -180,7 +250,28 @@ export const registerModerationRoutes = async (
 
   app.post(
     '/api/v1/moderation/actions',
-    { config: { rateLimit: RL_WRITE } },
+    {
+      config: { rateLimit: RL_WRITE },
+      schema: {
+        tags: ['moderation'],
+        body: {
+          type: 'object',
+          additionalProperties: true,
+          properties: {
+            reportId: { type: 'string' },
+            targetEntityType: { type: 'string' },
+            targetEntityId: { type: 'string' },
+            targetUserId: { type: 'string' },
+            actionType: { type: 'string' },
+            severity: { type: 'string' },
+            reason: { type: 'string' },
+            description: { type: 'string' },
+            metadataJson: { type: 'string' },
+            duration: { type: 'number' },
+          },
+        },
+      },
+    },
     async (req, reply) => {
       const b = (req.body ?? {}) as Record<string, unknown>;
       const grpcReq: LogModeratorActionRequest = {
@@ -204,7 +295,23 @@ export const registerModerationRoutes = async (
     }
   );
 
-  app.get('/api/v1/moderation/actions', { config: { rateLimit: RL_READ } }, async (req, reply) => {
+  app.get('/api/v1/moderation/actions', {
+    config: { rateLimit: RL_READ },
+    schema: {
+      tags: ['moderation'],
+      querystring: {
+        type: 'object',
+        additionalProperties: true,
+        properties: {
+          cursor: { type: 'string' },
+          limit: { type: 'string' },
+          user: { type: 'string' },
+          report: { type: 'string' },
+          action: { type: 'string' },
+        },
+      },
+    },
+  }, async (req, reply) => {
     const q = req.query as Record<string, string | undefined>;
     const pagination = parsePagination(q, { limit: 0 });
     if (!pagination.ok) {
@@ -229,7 +336,23 @@ export const registerModerationRoutes = async (
 
   app.post(
     '/api/v1/moderation/evidence',
-    { config: { rateLimit: RL_WRITE } },
+    {
+      config: { rateLimit: RL_WRITE },
+      schema: {
+        tags: ['moderation'],
+        body: {
+          type: 'object',
+          additionalProperties: true,
+          properties: {
+            parentType: { type: 'string' },
+            parentId: { type: 'string' },
+            type: { type: 'string' },
+            content: { type: 'string' },
+            description: { type: 'string' },
+          },
+        },
+      },
+    },
     async (req, reply) => {
       const b = (req.body ?? {}) as Record<string, unknown>;
       const grpcReq: AddEvidenceRequest = {
@@ -252,7 +375,25 @@ export const registerModerationRoutes = async (
 
   app.post(
     '/api/v1/moderation/sanctions',
-    { config: { rateLimit: RL_WRITE } },
+    {
+      config: { rateLimit: RL_WRITE },
+      schema: {
+        tags: ['moderation'],
+        body: {
+          type: 'object',
+          additionalProperties: true,
+          properties: {
+            userId: { type: 'string' },
+            sanctionType: { type: 'string' },
+            reason: { type: 'string' },
+            description: { type: 'string' },
+            duration: { type: 'number' },
+            reportId: { type: 'string' },
+            moderatorActionId: { type: 'string' },
+          },
+        },
+      },
+    },
     async (req, reply) => {
       const b = (req.body ?? {}) as Record<string, unknown>;
       const grpcReq: IssueSanctionRequest = {
@@ -275,7 +416,18 @@ export const registerModerationRoutes = async (
 
   app.get<{ Params: { userId: string } }>(
     '/api/v1/moderation/users/:userId/sanctions',
-    { config: { rateLimit: RL_READ } },
+    {
+      config: { rateLimit: RL_READ },
+      schema: {
+        tags: ['moderation'],
+        params: { type: 'object', properties: { userId: { type: 'string' } }, required: ['userId'] },
+        querystring: {
+          type: 'object',
+          additionalProperties: true,
+          properties: { includeInactive: { type: 'string' } },
+        },
+      },
+    },
     async (req, reply) => {
       const q = req.query as Record<string, string | undefined>;
       try {
@@ -292,7 +444,18 @@ export const registerModerationRoutes = async (
 
   app.post<{ Params: { id: string } }>(
     '/api/v1/moderation/sanctions/:id/appeal',
-    { config: { rateLimit: RL_WRITE } },
+    {
+      config: { rateLimit: RL_WRITE },
+      schema: {
+        tags: ['moderation'],
+        params: { type: 'object', properties: { id: { type: 'string' } }, required: ['id'] },
+        body: {
+          type: 'object',
+          additionalProperties: true,
+          properties: { appealReason: { type: 'string' } },
+        },
+      },
+    },
     async (req, reply) => {
       const b = (req.body ?? {}) as Record<string, unknown>;
       const grpcReq: AppealSanctionRequest = {
@@ -312,7 +475,26 @@ export const registerModerationRoutes = async (
 
   app.post(
     '/api/v1/moderation/tickets',
-    { config: { rateLimit: RL_WRITE } },
+    {
+      config: { rateLimit: RL_WRITE },
+      schema: {
+        tags: ['moderation'],
+        body: {
+          type: 'object',
+          additionalProperties: true,
+          properties: {
+            userId: { type: 'string' },
+            userEmail: { type: 'string' },
+            userName: { type: 'string' },
+            priority: { type: 'string' },
+            category: { type: 'string' },
+            subject: { type: 'string' },
+            description: { type: 'string' },
+            tags: { type: 'array', items: { type: 'string' } },
+          },
+        },
+      },
+    },
     async (req, reply) => {
       const b = (req.body ?? {}) as Record<string, unknown>;
       const grpcReq: OpenSupportTicketRequest = {
@@ -334,7 +516,25 @@ export const registerModerationRoutes = async (
     }
   );
 
-  app.get('/api/v1/moderation/tickets', { config: { rateLimit: RL_READ } }, async (req, reply) => {
+  app.get('/api/v1/moderation/tickets', {
+    config: { rateLimit: RL_READ },
+    schema: {
+      tags: ['moderation'],
+      querystring: {
+        type: 'object',
+        additionalProperties: true,
+        properties: {
+          cursor: { type: 'string' },
+          limit: { type: 'string' },
+          status: { type: 'string' },
+          priority: { type: 'string' },
+          category: { type: 'string' },
+          assigned: { type: 'string' },
+          user: { type: 'string' },
+        },
+      },
+    },
+  }, async (req, reply) => {
     const q = req.query as Record<string, string | undefined>;
     const pagination = parsePagination(q, { limit: 0 });
     if (!pagination.ok) {
@@ -359,7 +559,18 @@ export const registerModerationRoutes = async (
 
   app.get<{ Params: { id: string } }>(
     '/api/v1/moderation/tickets/:id',
-    { config: { rateLimit: RL_READ } },
+    {
+      config: { rateLimit: RL_READ },
+      schema: {
+        tags: ['moderation'],
+        params: { type: 'object', properties: { id: { type: 'string' } }, required: ['id'] },
+        querystring: {
+          type: 'object',
+          additionalProperties: true,
+          properties: { responses: { type: 'string' } },
+        },
+      },
+    },
     async (req, reply) => {
       const q = req.query as Record<string, string | undefined>;
       try {
@@ -376,7 +587,21 @@ export const registerModerationRoutes = async (
 
   app.post<{ Params: { id: string } }>(
     '/api/v1/moderation/tickets/:id/responses',
-    { config: { rateLimit: RL_WRITE } },
+    {
+      config: { rateLimit: RL_WRITE },
+      schema: {
+        tags: ['moderation'],
+        params: { type: 'object', properties: { id: { type: 'string' } }, required: ['id'] },
+        body: {
+          type: 'object',
+          additionalProperties: true,
+          properties: {
+            content: { type: 'string' },
+            isInternal: { type: 'boolean' },
+          },
+        },
+      },
+    },
     async (req, reply) => {
       const b = (req.body ?? {}) as Record<string, unknown>;
       const grpcReq: RespondToTicketRequest = {

--- a/services/gateway/src/routes/moderation.ts
+++ b/services/gateway/src/routes/moderation.ts
@@ -81,20 +81,6 @@ export const registerModerationRoutes = async (
       config: { rateLimit: RL_WRITE },
       schema: {
         tags: ['moderation'],
-        body: {
-          type: 'object',
-          additionalProperties: true,
-          properties: {
-            reportedEntityType: { type: 'string' },
-            reportedEntityId: { type: 'string' },
-            reportedUserId: { type: 'string' },
-            category: { type: 'string' },
-            severity: { type: 'string' },
-            title: { type: 'string' },
-            description: { type: 'string' },
-            metadataJson: { type: 'string' },
-          },
-        },
       },
     },
     async (req, reply) => {
@@ -124,18 +110,6 @@ export const registerModerationRoutes = async (
       config: { rateLimit: RL_READ },
       schema: {
         tags: ['moderation'],
-        querystring: {
-          type: 'object',
-          additionalProperties: true,
-          properties: {
-            cursor: { type: 'string' },
-            limit: { type: 'string' },
-            status: { type: 'string' },
-            severity: { type: 'string' },
-            category: { type: 'string' },
-            assigned: { type: 'string' },
-          },
-        },
       },
     },
     async (req, reply) => {
@@ -191,14 +165,6 @@ export const registerModerationRoutes = async (
       schema: {
         tags: ['moderation'],
         params: { type: 'object', properties: { id: { type: 'string' } }, required: ['id'] },
-        body: {
-          type: 'object',
-          additionalProperties: true,
-          properties: {
-            moderatorId: { type: 'string' },
-            reason: { type: 'string' },
-          },
-        },
       },
     },
     async (req, reply) => {
@@ -224,14 +190,6 @@ export const registerModerationRoutes = async (
       schema: {
         tags: ['moderation'],
         params: { type: 'object', properties: { id: { type: 'string' } }, required: ['id'] },
-        body: {
-          type: 'object',
-          additionalProperties: true,
-          properties: {
-            resolution: { type: 'string' },
-            resolutionNotes: { type: 'string' },
-          },
-        },
       },
     },
     async (req, reply) => {
@@ -258,22 +216,6 @@ export const registerModerationRoutes = async (
       config: { rateLimit: RL_WRITE },
       schema: {
         tags: ['moderation'],
-        body: {
-          type: 'object',
-          additionalProperties: true,
-          properties: {
-            reportId: { type: 'string' },
-            targetEntityType: { type: 'string' },
-            targetEntityId: { type: 'string' },
-            targetUserId: { type: 'string' },
-            actionType: { type: 'string' },
-            severity: { type: 'string' },
-            reason: { type: 'string' },
-            description: { type: 'string' },
-            metadataJson: { type: 'string' },
-            duration: { type: 'number' },
-          },
-        },
       },
     },
     async (req, reply) => {
@@ -305,17 +247,6 @@ export const registerModerationRoutes = async (
       config: { rateLimit: RL_READ },
       schema: {
         tags: ['moderation'],
-        querystring: {
-          type: 'object',
-          additionalProperties: true,
-          properties: {
-            cursor: { type: 'string' },
-            limit: { type: 'string' },
-            user: { type: 'string' },
-            report: { type: 'string' },
-            action: { type: 'string' },
-          },
-        },
       },
     },
     async (req, reply) => {
@@ -348,17 +279,6 @@ export const registerModerationRoutes = async (
       config: { rateLimit: RL_WRITE },
       schema: {
         tags: ['moderation'],
-        body: {
-          type: 'object',
-          additionalProperties: true,
-          properties: {
-            parentType: { type: 'string' },
-            parentId: { type: 'string' },
-            type: { type: 'string' },
-            content: { type: 'string' },
-            description: { type: 'string' },
-          },
-        },
       },
     },
     async (req, reply) => {
@@ -387,19 +307,6 @@ export const registerModerationRoutes = async (
       config: { rateLimit: RL_WRITE },
       schema: {
         tags: ['moderation'],
-        body: {
-          type: 'object',
-          additionalProperties: true,
-          properties: {
-            userId: { type: 'string' },
-            sanctionType: { type: 'string' },
-            reason: { type: 'string' },
-            description: { type: 'string' },
-            duration: { type: 'number' },
-            reportId: { type: 'string' },
-            moderatorActionId: { type: 'string' },
-          },
-        },
       },
     },
     async (req, reply) => {
@@ -428,16 +335,6 @@ export const registerModerationRoutes = async (
       config: { rateLimit: RL_READ },
       schema: {
         tags: ['moderation'],
-        params: {
-          type: 'object',
-          properties: { userId: { type: 'string' } },
-          required: ['userId'],
-        },
-        querystring: {
-          type: 'object',
-          additionalProperties: true,
-          properties: { includeInactive: { type: 'string' } },
-        },
       },
     },
     async (req, reply) => {
@@ -461,11 +358,6 @@ export const registerModerationRoutes = async (
       schema: {
         tags: ['moderation'],
         params: { type: 'object', properties: { id: { type: 'string' } }, required: ['id'] },
-        body: {
-          type: 'object',
-          additionalProperties: true,
-          properties: { appealReason: { type: 'string' } },
-        },
       },
     },
     async (req, reply) => {
@@ -491,20 +383,6 @@ export const registerModerationRoutes = async (
       config: { rateLimit: RL_WRITE },
       schema: {
         tags: ['moderation'],
-        body: {
-          type: 'object',
-          additionalProperties: true,
-          properties: {
-            userId: { type: 'string' },
-            userEmail: { type: 'string' },
-            userName: { type: 'string' },
-            priority: { type: 'string' },
-            category: { type: 'string' },
-            subject: { type: 'string' },
-            description: { type: 'string' },
-            tags: { type: 'array', items: { type: 'string' } },
-          },
-        },
       },
     },
     async (req, reply) => {
@@ -534,19 +412,6 @@ export const registerModerationRoutes = async (
       config: { rateLimit: RL_READ },
       schema: {
         tags: ['moderation'],
-        querystring: {
-          type: 'object',
-          additionalProperties: true,
-          properties: {
-            cursor: { type: 'string' },
-            limit: { type: 'string' },
-            status: { type: 'string' },
-            priority: { type: 'string' },
-            category: { type: 'string' },
-            assigned: { type: 'string' },
-            user: { type: 'string' },
-          },
-        },
       },
     },
     async (req, reply) => {
@@ -580,11 +445,6 @@ export const registerModerationRoutes = async (
       schema: {
         tags: ['moderation'],
         params: { type: 'object', properties: { id: { type: 'string' } }, required: ['id'] },
-        querystring: {
-          type: 'object',
-          additionalProperties: true,
-          properties: { responses: { type: 'string' } },
-        },
       },
     },
     async (req, reply) => {
@@ -608,14 +468,6 @@ export const registerModerationRoutes = async (
       schema: {
         tags: ['moderation'],
         params: { type: 'object', properties: { id: { type: 'string' } }, required: ['id'] },
-        body: {
-          type: 'object',
-          additionalProperties: true,
-          properties: {
-            content: { type: 'string' },
-            isInternal: { type: 'boolean' },
-          },
-        },
       },
     },
     async (req, reply) => {

--- a/services/gateway/src/routes/moderation.ts
+++ b/services/gateway/src/routes/moderation.ts
@@ -118,44 +118,48 @@ export const registerModerationRoutes = async (
     }
   );
 
-  app.get('/api/v1/moderation/reports', {
-    config: { rateLimit: RL_READ },
-    schema: {
-      tags: ['moderation'],
-      querystring: {
-        type: 'object',
-        additionalProperties: true,
-        properties: {
-          cursor: { type: 'string' },
-          limit: { type: 'string' },
-          status: { type: 'string' },
-          severity: { type: 'string' },
-          category: { type: 'string' },
-          assigned: { type: 'string' },
+  app.get(
+    '/api/v1/moderation/reports',
+    {
+      config: { rateLimit: RL_READ },
+      schema: {
+        tags: ['moderation'],
+        querystring: {
+          type: 'object',
+          additionalProperties: true,
+          properties: {
+            cursor: { type: 'string' },
+            limit: { type: 'string' },
+            status: { type: 'string' },
+            severity: { type: 'string' },
+            category: { type: 'string' },
+            assigned: { type: 'string' },
+          },
         },
       },
     },
-  }, async (req, reply) => {
-    const q = req.query as Record<string, string | undefined>;
-    const pagination = parsePagination(q, { limit: 0 });
-    if (!pagination.ok) {
-      return reply.code(400).send({ error: pagination.error });
+    async (req, reply) => {
+      const q = req.query as Record<string, string | undefined>;
+      const pagination = parsePagination(q, { limit: 0 });
+      if (!pagination.ok) {
+        return reply.code(400).send({ error: pagination.error });
+      }
+      const grpcReq: ListReportsRequest = {
+        cursor: q.cursor,
+        limit: pagination.limit,
+        status: parseReportStatus(q.status),
+        severity: parseSeverity(q.severity),
+        category: parseCategory(q.category),
+        assignedModerator: q.assigned,
+      };
+      try {
+        const res = await client.listReports(grpcReq, buildMetadata(req));
+        return reply.send(ModerationV1.ListReportsResponse.toJSON(res));
+      } catch (err) {
+        return handleGrpcError(err, reply);
+      }
     }
-    const grpcReq: ListReportsRequest = {
-      cursor: q.cursor,
-      limit: pagination.limit,
-      status: parseReportStatus(q.status),
-      severity: parseSeverity(q.severity),
-      category: parseCategory(q.category),
-      assignedModerator: q.assigned,
-    };
-    try {
-      const res = await client.listReports(grpcReq, buildMetadata(req));
-      return reply.send(ModerationV1.ListReportsResponse.toJSON(res));
-    } catch (err) {
-      return handleGrpcError(err, reply);
-    }
-  });
+  );
 
   app.get<{ Params: { id: string } }>(
     '/api/v1/moderation/reports/:id',
@@ -295,42 +299,46 @@ export const registerModerationRoutes = async (
     }
   );
 
-  app.get('/api/v1/moderation/actions', {
-    config: { rateLimit: RL_READ },
-    schema: {
-      tags: ['moderation'],
-      querystring: {
-        type: 'object',
-        additionalProperties: true,
-        properties: {
-          cursor: { type: 'string' },
-          limit: { type: 'string' },
-          user: { type: 'string' },
-          report: { type: 'string' },
-          action: { type: 'string' },
+  app.get(
+    '/api/v1/moderation/actions',
+    {
+      config: { rateLimit: RL_READ },
+      schema: {
+        tags: ['moderation'],
+        querystring: {
+          type: 'object',
+          additionalProperties: true,
+          properties: {
+            cursor: { type: 'string' },
+            limit: { type: 'string' },
+            user: { type: 'string' },
+            report: { type: 'string' },
+            action: { type: 'string' },
+          },
         },
       },
     },
-  }, async (req, reply) => {
-    const q = req.query as Record<string, string | undefined>;
-    const pagination = parsePagination(q, { limit: 0 });
-    if (!pagination.ok) {
-      return reply.code(400).send({ error: pagination.error });
+    async (req, reply) => {
+      const q = req.query as Record<string, string | undefined>;
+      const pagination = parsePagination(q, { limit: 0 });
+      if (!pagination.ok) {
+        return reply.code(400).send({ error: pagination.error });
+      }
+      const grpcReq: ListModeratorActionsRequest = {
+        cursor: q.cursor,
+        limit: pagination.limit,
+        targetUserId: q.user,
+        reportId: q.report,
+        actionType: parseActionType(q.action),
+      };
+      try {
+        const res = await client.listModeratorActions(grpcReq, buildMetadata(req));
+        return reply.send(ModerationV1.ListModeratorActionsResponse.toJSON(res));
+      } catch (err) {
+        return handleGrpcError(err, reply);
+      }
     }
-    const grpcReq: ListModeratorActionsRequest = {
-      cursor: q.cursor,
-      limit: pagination.limit,
-      targetUserId: q.user,
-      reportId: q.report,
-      actionType: parseActionType(q.action),
-    };
-    try {
-      const res = await client.listModeratorActions(grpcReq, buildMetadata(req));
-      return reply.send(ModerationV1.ListModeratorActionsResponse.toJSON(res));
-    } catch (err) {
-      return handleGrpcError(err, reply);
-    }
-  });
+  );
 
   // ---------- Evidence ----------
 
@@ -420,7 +428,11 @@ export const registerModerationRoutes = async (
       config: { rateLimit: RL_READ },
       schema: {
         tags: ['moderation'],
-        params: { type: 'object', properties: { userId: { type: 'string' } }, required: ['userId'] },
+        params: {
+          type: 'object',
+          properties: { userId: { type: 'string' } },
+          required: ['userId'],
+        },
         querystring: {
           type: 'object',
           additionalProperties: true,
@@ -516,46 +528,50 @@ export const registerModerationRoutes = async (
     }
   );
 
-  app.get('/api/v1/moderation/tickets', {
-    config: { rateLimit: RL_READ },
-    schema: {
-      tags: ['moderation'],
-      querystring: {
-        type: 'object',
-        additionalProperties: true,
-        properties: {
-          cursor: { type: 'string' },
-          limit: { type: 'string' },
-          status: { type: 'string' },
-          priority: { type: 'string' },
-          category: { type: 'string' },
-          assigned: { type: 'string' },
-          user: { type: 'string' },
+  app.get(
+    '/api/v1/moderation/tickets',
+    {
+      config: { rateLimit: RL_READ },
+      schema: {
+        tags: ['moderation'],
+        querystring: {
+          type: 'object',
+          additionalProperties: true,
+          properties: {
+            cursor: { type: 'string' },
+            limit: { type: 'string' },
+            status: { type: 'string' },
+            priority: { type: 'string' },
+            category: { type: 'string' },
+            assigned: { type: 'string' },
+            user: { type: 'string' },
+          },
         },
       },
     },
-  }, async (req, reply) => {
-    const q = req.query as Record<string, string | undefined>;
-    const pagination = parsePagination(q, { limit: 0 });
-    if (!pagination.ok) {
-      return reply.code(400).send({ error: pagination.error });
+    async (req, reply) => {
+      const q = req.query as Record<string, string | undefined>;
+      const pagination = parsePagination(q, { limit: 0 });
+      if (!pagination.ok) {
+        return reply.code(400).send({ error: pagination.error });
+      }
+      const grpcReq: ListSupportTicketsRequest = {
+        cursor: q.cursor,
+        limit: pagination.limit,
+        status: parseTicketStatus(q.status),
+        priority: parseTicketPriority(q.priority),
+        category: parseTicketCategory(q.category),
+        assignedTo: q.assigned,
+        userId: q.user,
+      };
+      try {
+        const res = await client.listSupportTickets(grpcReq, buildMetadata(req));
+        return reply.send(ModerationV1.ListSupportTicketsResponse.toJSON(res));
+      } catch (err) {
+        return handleGrpcError(err, reply);
+      }
     }
-    const grpcReq: ListSupportTicketsRequest = {
-      cursor: q.cursor,
-      limit: pagination.limit,
-      status: parseTicketStatus(q.status),
-      priority: parseTicketPriority(q.priority),
-      category: parseTicketCategory(q.category),
-      assignedTo: q.assigned,
-      userId: q.user,
-    };
-    try {
-      const res = await client.listSupportTickets(grpcReq, buildMetadata(req));
-      return reply.send(ModerationV1.ListSupportTicketsResponse.toJSON(res));
-    } catch (err) {
-      return handleGrpcError(err, reply);
-    }
-  });
+  );
 
   app.get<{ Params: { id: string } }>(
     '/api/v1/moderation/tickets/:id',

--- a/services/gateway/src/routes/notifications.ts
+++ b/services/gateway/src/routes/notifications.ts
@@ -41,250 +41,291 @@ export const registerNotificationsRoutes = async (
 ): Promise<void> => {
   const { client } = opts;
 
-  app.get('/api/v1/notifications', {
-    schema: {
-      tags: ['notifications'],
-      querystring: {
-        type: 'object',
-        additionalProperties: true,
-        properties: {
-          cursor: { type: 'string' },
-          limit: { type: 'string' },
-          status: { type: 'string' },
-          channel: { type: 'string' },
-          type: { type: 'string' },
+  app.get(
+    '/api/v1/notifications',
+    {
+      schema: {
+        tags: ['notifications'],
+        querystring: {
+          type: 'object',
+          additionalProperties: true,
+          properties: {
+            cursor: { type: 'string' },
+            limit: { type: 'string' },
+            status: { type: 'string' },
+            channel: { type: 'string' },
+            type: { type: 'string' },
+          },
         },
       },
     },
-  }, async (req, reply) => {
-    const metadata = buildMetadata(req);
-    const query = req.query as Record<string, string | undefined>;
-    const pagination = parsePagination(query, { limit: 0 });
-    if (!pagination.ok) {
-      return reply.code(400).send({ error: pagination.error });
+    async (req, reply) => {
+      const metadata = buildMetadata(req);
+      const query = req.query as Record<string, string | undefined>;
+      const pagination = parsePagination(query, { limit: 0 });
+      if (!pagination.ok) {
+        return reply.code(400).send({ error: pagination.error });
+      }
+
+      const grpcReq: ListNotificationsRequest = {
+        cursor: query.cursor,
+        // Default 0 → handler clamps to the canonical default. Same shape
+        // service.notifications.handlers.listNotifications expects.
+        limit: pagination.limit,
+        statusFilter: parseStatus(query.status),
+        channelFilter: parseChannel(query.channel),
+        typeFilter: parseType(query.type),
+      };
+
+      try {
+        const res = await client.list(grpcReq, metadata);
+        return reply.send(NotificationsV1.ListNotificationsResponse.toJSON(res));
+      } catch (err) {
+        return handleGrpcError(err, reply);
+      }
     }
+  );
 
-    const grpcReq: ListNotificationsRequest = {
-      cursor: query.cursor,
-      // Default 0 → handler clamps to the canonical default. Same shape
-      // service.notifications.handlers.listNotifications expects.
-      limit: pagination.limit,
-      statusFilter: parseStatus(query.status),
-      channelFilter: parseChannel(query.channel),
-      typeFilter: parseType(query.type),
-    };
-
-    try {
-      const res = await client.list(grpcReq, metadata);
-      return reply.send(NotificationsV1.ListNotificationsResponse.toJSON(res));
-    } catch (err) {
-      return handleGrpcError(err, reply);
-    }
-  });
-
-  app.post('/api/v1/notifications', {
-    schema: {
-      tags: ['notifications'],
-      body: {
-        type: 'object',
-        additionalProperties: true,
-        properties: {
-          userId: { type: 'string' },
-          type: { type: 'string' },
-          title: { type: 'string' },
-          message: { type: 'string' },
+  app.post(
+    '/api/v1/notifications',
+    {
+      schema: {
+        tags: ['notifications'],
+        body: {
+          type: 'object',
+          additionalProperties: true,
+          properties: {
+            userId: { type: 'string' },
+            type: { type: 'string' },
+            title: { type: 'string' },
+            message: { type: 'string' },
+          },
         },
       },
     },
-  }, async (req, reply) => {
-    const metadata = buildMetadata(req);
-    const body = (req.body ?? {}) as Partial<CreateNotificationRequest>;
+    async (req, reply) => {
+      const metadata = buildMetadata(req);
+      const body = (req.body ?? {}) as Partial<CreateNotificationRequest>;
 
-    // We accept the JSON shape that mirrors the proto fields directly.
-    // fromJSON would also work, but proto3 oneof JSON encoding rules
-    // change the structure; keeping a direct map is more predictable
-    // for the small set of fields the gateway needs to accept.
-    const grpcReq: CreateNotificationRequest = {
-      userId: body.userId ?? '',
-      type: body.type ?? NotificationsV1.NotificationType.NOTIFICATION_TYPE_UNSPECIFIED,
-      channel: body.channel ?? NotificationsV1.NotificationChannel.NOTIFICATION_CHANNEL_UNSPECIFIED,
-      priority:
-        body.priority ?? NotificationsV1.NotificationPriority.NOTIFICATION_PRIORITY_UNSPECIFIED,
-      title: body.title ?? '',
-      message: body.message ?? '',
-      dataJson: body.dataJson ?? '{}',
-      templateId: body.templateId,
-      templateVariablesJson: body.templateVariablesJson ?? '{}',
-      relatedEntityType: body.relatedEntityType,
-      relatedEntityId: body.relatedEntityId,
-      scheduledFor: body.scheduledFor,
-      expiresAt: body.expiresAt,
-      externalId: body.externalId,
-    };
+      // We accept the JSON shape that mirrors the proto fields directly.
+      // fromJSON would also work, but proto3 oneof JSON encoding rules
+      // change the structure; keeping a direct map is more predictable
+      // for the small set of fields the gateway needs to accept.
+      const grpcReq: CreateNotificationRequest = {
+        userId: body.userId ?? '',
+        type: body.type ?? NotificationsV1.NotificationType.NOTIFICATION_TYPE_UNSPECIFIED,
+        channel:
+          body.channel ?? NotificationsV1.NotificationChannel.NOTIFICATION_CHANNEL_UNSPECIFIED,
+        priority:
+          body.priority ?? NotificationsV1.NotificationPriority.NOTIFICATION_PRIORITY_UNSPECIFIED,
+        title: body.title ?? '',
+        message: body.message ?? '',
+        dataJson: body.dataJson ?? '{}',
+        templateId: body.templateId,
+        templateVariablesJson: body.templateVariablesJson ?? '{}',
+        relatedEntityType: body.relatedEntityType,
+        relatedEntityId: body.relatedEntityId,
+        scheduledFor: body.scheduledFor,
+        expiresAt: body.expiresAt,
+        externalId: body.externalId,
+      };
 
-    try {
-      const res = await client.create(grpcReq, metadata);
-      return reply.code(201).send(NotificationsV1.CreateNotificationResponse.toJSON(res));
-    } catch (err) {
-      return handleGrpcError(err, reply);
+      try {
+        const res = await client.create(grpcReq, metadata);
+        return reply.code(201).send(NotificationsV1.CreateNotificationResponse.toJSON(res));
+      } catch (err) {
+        return handleGrpcError(err, reply);
+      }
     }
-  });
+  );
 
   // Unread count — must register before /:id so the static segment wins.
-  app.get('/api/v1/notifications/unread/count', { schema: { tags: ['notifications'] } }, async (req, reply) => {
-    const metadata = buildMetadata(req);
-    try {
-      const res = await client.getUnreadCount({}, metadata);
-      return reply.send({ success: true, data: { count: res.count } });
-    } catch (err) {
-      return handleGrpcError(err, reply);
+  app.get(
+    '/api/v1/notifications/unread/count',
+    { schema: { tags: ['notifications'] } },
+    async (req, reply) => {
+      const metadata = buildMetadata(req);
+      try {
+        const res = await client.getUnreadCount({}, metadata);
+        return reply.send({ success: true, data: { count: res.count } });
+      } catch (err) {
+        return handleGrpcError(err, reply);
+      }
     }
-  });
+  );
 
   // Admin cleanup — soft-delete notifications older than N days.
-  app.post('/api/v1/notifications/cleanup', {
-    schema: {
-      tags: ['notifications'],
-      body: {
-        type: 'object',
-        additionalProperties: true,
-        properties: {
-          daysToKeep: { type: 'number' },
-          days_to_keep: { type: 'number' },
+  app.post(
+    '/api/v1/notifications/cleanup',
+    {
+      schema: {
+        tags: ['notifications'],
+        body: {
+          type: 'object',
+          additionalProperties: true,
+          properties: {
+            daysToKeep: { type: 'number' },
+            days_to_keep: { type: 'number' },
+          },
         },
       },
     },
-  }, async (req, reply) => {
-    const metadata = buildMetadata(req);
-    const body = (req.body ?? {}) as { daysToKeep?: number; days_to_keep?: number };
-    const daysToKeep = body.daysToKeep ?? body.days_to_keep ?? 0;
-    try {
-      const res = await client.cleanupExpiredNotifications({ daysToKeep }, metadata);
-      return reply.send({
-        success: true,
-        message: `Cleaned up ${res.deletedCount} expired notifications`,
-        data: { deletedCount: res.deletedCount },
-      });
-    } catch (err) {
-      return handleGrpcError(err, reply);
+    async (req, reply) => {
+      const metadata = buildMetadata(req);
+      const body = (req.body ?? {}) as { daysToKeep?: number; days_to_keep?: number };
+      const daysToKeep = body.daysToKeep ?? body.days_to_keep ?? 0;
+      try {
+        const res = await client.cleanupExpiredNotifications({ daysToKeep }, metadata);
+        return reply.send({
+          success: true,
+          message: `Cleaned up ${res.deletedCount} expired notifications`,
+          data: { deletedCount: res.deletedCount },
+        });
+      } catch (err) {
+        return handleGrpcError(err, reply);
+      }
     }
-  });
+  );
 
   // Mark all unread as read.
-  app.post('/api/v1/notifications/read-all', { schema: { tags: ['notifications'] } }, async (req, reply) => {
-    const metadata = buildMetadata(req);
-    try {
-      const res = await client.markAllRead({}, metadata);
-      return reply.send({
-        success: true,
-        message: `Marked ${res.affectedCount} notifications as read`,
-        data: { affectedCount: res.affectedCount },
-      });
-    } catch (err) {
-      return handleGrpcError(err, reply);
+  app.post(
+    '/api/v1/notifications/read-all',
+    { schema: { tags: ['notifications'] } },
+    async (req, reply) => {
+      const metadata = buildMetadata(req);
+      try {
+        const res = await client.markAllRead({}, metadata);
+        return reply.send({
+          success: true,
+          message: `Marked ${res.affectedCount} notifications as read`,
+          data: { affectedCount: res.affectedCount },
+        });
+      } catch (err) {
+        return handleGrpcError(err, reply);
+      }
     }
-  });
+  );
 
   // In-app notification preferences (user_notification_prefs).
-  app.get('/api/v1/notifications/preferences', { schema: { tags: ['notifications'] } }, async (req, reply) => {
-    const metadata = buildMetadata(req);
-    try {
-      const res = await client.getNotificationPreferences({}, metadata);
-      return reply.send({
-        success: true,
-        data: NotificationsV1.NotificationPreferences.toJSON(res.preferences!),
-      });
-    } catch (err) {
-      return handleGrpcError(err, reply);
+  app.get(
+    '/api/v1/notifications/preferences',
+    { schema: { tags: ['notifications'] } },
+    async (req, reply) => {
+      const metadata = buildMetadata(req);
+      try {
+        const res = await client.getNotificationPreferences({}, metadata);
+        return reply.send({
+          success: true,
+          data: NotificationsV1.NotificationPreferences.toJSON(res.preferences!),
+        });
+      } catch (err) {
+        return handleGrpcError(err, reply);
+      }
     }
-  });
+  );
 
-  app.put('/api/v1/notifications/preferences', {
-    schema: {
-      tags: ['notifications'],
-      body: { type: 'object', additionalProperties: true },
+  app.put(
+    '/api/v1/notifications/preferences',
+    {
+      schema: {
+        tags: ['notifications'],
+        body: { type: 'object', additionalProperties: true },
+      },
     },
-  }, async (req, reply) => {
-    const metadata = buildMetadata(req);
-    const body = (req.body ?? {}) as Record<string, unknown>;
-    const grpcReq: UpdateNotificationPreferencesRequest = buildPrefsPatch(body);
+    async (req, reply) => {
+      const metadata = buildMetadata(req);
+      const body = (req.body ?? {}) as Record<string, unknown>;
+      const grpcReq: UpdateNotificationPreferencesRequest = buildPrefsPatch(body);
 
-    try {
-      const res = await client.updateNotificationPreferences(grpcReq, metadata);
-      return reply.send({
-        success: true,
-        message: 'Notification preferences updated successfully',
-        data: NotificationsV1.NotificationPreferences.toJSON(res.preferences!),
-      });
-    } catch (err) {
-      return handleGrpcError(err, reply);
+      try {
+        const res = await client.updateNotificationPreferences(grpcReq, metadata);
+        return reply.send({
+          success: true,
+          message: 'Notification preferences updated successfully',
+          data: NotificationsV1.NotificationPreferences.toJSON(res.preferences!),
+        });
+      } catch (err) {
+        return handleGrpcError(err, reply);
+      }
     }
-  });
+  );
 
   // Single notification fetch.
-  app.get<{ Params: { id: string } }>('/api/v1/notifications/:id', {
-    schema: {
-      tags: ['notifications'],
-      params: { type: 'object', properties: { id: { type: 'string' } }, required: ['id'] },
+  app.get<{ Params: { id: string } }>(
+    '/api/v1/notifications/:id',
+    {
+      schema: {
+        tags: ['notifications'],
+        params: { type: 'object', properties: { id: { type: 'string' } }, required: ['id'] },
+      },
     },
-  }, async (req, reply) => {
-    const metadata = buildMetadata(req);
-    try {
-      const res = await client.getNotification({ notificationId: req.params.id }, metadata);
-      return reply.send({
-        success: true,
-        data: NotificationsV1.Notification.toJSON(res.notification!),
-      });
-    } catch (err) {
-      return handleGrpcError(err, reply);
+    async (req, reply) => {
+      const metadata = buildMetadata(req);
+      try {
+        const res = await client.getNotification({ notificationId: req.params.id }, metadata);
+        return reply.send({
+          success: true,
+          data: NotificationsV1.Notification.toJSON(res.notification!),
+        });
+      } catch (err) {
+        return handleGrpcError(err, reply);
+      }
     }
-  });
+  );
 
   // Mark single notification as read — matches the monolith path
   // /api/v1/notifications/:notificationId/read.
-  app.patch<{ Params: { id: string } }>('/api/v1/notifications/:id/read', {
-    schema: {
-      tags: ['notifications'],
-      params: { type: 'object', properties: { id: { type: 'string' } }, required: ['id'] },
+  app.patch<{ Params: { id: string } }>(
+    '/api/v1/notifications/:id/read',
+    {
+      schema: {
+        tags: ['notifications'],
+        params: { type: 'object', properties: { id: { type: 'string' } }, required: ['id'] },
+      },
     },
-  }, async (req, reply) => {
-    const metadata = buildMetadata(req);
-    try {
-      await client.dismiss({ notificationId: req.params.id }, metadata);
-      return reply.send({
-        success: true,
-        message: 'Notification marked as read',
-      });
-    } catch (err) {
-      return handleGrpcError(err, reply);
+    async (req, reply) => {
+      const metadata = buildMetadata(req);
+      try {
+        await client.dismiss({ notificationId: req.params.id }, metadata);
+        return reply.send({
+          success: true,
+          message: 'Notification marked as read',
+        });
+      } catch (err) {
+        return handleGrpcError(err, reply);
+      }
     }
-  });
+  );
 
-  app.delete<{ Params: { id: string } }>('/api/v1/notifications/:id', {
-    schema: {
-      tags: ['notifications'],
-      params: { type: 'object', properties: { id: { type: 'string' } }, required: ['id'] },
+  app.delete<{ Params: { id: string } }>(
+    '/api/v1/notifications/:id',
+    {
+      schema: {
+        tags: ['notifications'],
+        params: { type: 'object', properties: { id: { type: 'string' } }, required: ['id'] },
+      },
     },
-  }, async (req, reply) => {
-    const metadata = buildMetadata(req);
-    const grpcReq: DismissNotificationRequest = { notificationId: req.params.id };
+    async (req, reply) => {
+      const metadata = buildMetadata(req);
+      const grpcReq: DismissNotificationRequest = { notificationId: req.params.id };
 
-    try {
-      // The monolith DELETE soft-deletes via deleted_at. We call the
-      // dedicated deleteNotification RPC (status untouched) for parity —
-      // the old proto contract used Dismiss(status='read') under DELETE,
-      // which would have lost the distinction between read-but-kept and
-      // deleted. Preserve the monolith semantics here.
-      const res = await client.deleteNotification(grpcReq, metadata);
-      return reply.send({
-        success: true,
-        message: 'Notification deleted successfully',
-        data: NotificationsV1.Notification.toJSON(res.notification!),
-      });
-    } catch (err) {
-      return handleGrpcError(err, reply);
+      try {
+        // The monolith DELETE soft-deletes via deleted_at. We call the
+        // dedicated deleteNotification RPC (status untouched) for parity —
+        // the old proto contract used Dismiss(status='read') under DELETE,
+        // which would have lost the distinction between read-but-kept and
+        // deleted. Preserve the monolith semantics here.
+        const res = await client.deleteNotification(grpcReq, metadata);
+        return reply.send({
+          success: true,
+          message: 'Notification deleted successfully',
+          data: NotificationsV1.Notification.toJSON(res.notification!),
+        });
+      } catch (err) {
+        return handleGrpcError(err, reply);
+      }
     }
-  });
+  );
 };
 
 // --- Body parsing for prefs PUT --------------------------------------

--- a/services/gateway/src/routes/notifications.ts
+++ b/services/gateway/src/routes/notifications.ts
@@ -41,7 +41,22 @@ export const registerNotificationsRoutes = async (
 ): Promise<void> => {
   const { client } = opts;
 
-  app.get('/api/v1/notifications', async (req, reply) => {
+  app.get('/api/v1/notifications', {
+    schema: {
+      tags: ['notifications'],
+      querystring: {
+        type: 'object',
+        additionalProperties: true,
+        properties: {
+          cursor: { type: 'string' },
+          limit: { type: 'string' },
+          status: { type: 'string' },
+          channel: { type: 'string' },
+          type: { type: 'string' },
+        },
+      },
+    },
+  }, async (req, reply) => {
     const metadata = buildMetadata(req);
     const query = req.query as Record<string, string | undefined>;
     const pagination = parsePagination(query, { limit: 0 });
@@ -67,7 +82,21 @@ export const registerNotificationsRoutes = async (
     }
   });
 
-  app.post('/api/v1/notifications', async (req, reply) => {
+  app.post('/api/v1/notifications', {
+    schema: {
+      tags: ['notifications'],
+      body: {
+        type: 'object',
+        additionalProperties: true,
+        properties: {
+          userId: { type: 'string' },
+          type: { type: 'string' },
+          title: { type: 'string' },
+          message: { type: 'string' },
+        },
+      },
+    },
+  }, async (req, reply) => {
     const metadata = buildMetadata(req);
     const body = (req.body ?? {}) as Partial<CreateNotificationRequest>;
 
@@ -102,7 +131,7 @@ export const registerNotificationsRoutes = async (
   });
 
   // Unread count — must register before /:id so the static segment wins.
-  app.get('/api/v1/notifications/unread/count', async (req, reply) => {
+  app.get('/api/v1/notifications/unread/count', { schema: { tags: ['notifications'] } }, async (req, reply) => {
     const metadata = buildMetadata(req);
     try {
       const res = await client.getUnreadCount({}, metadata);
@@ -113,7 +142,19 @@ export const registerNotificationsRoutes = async (
   });
 
   // Admin cleanup — soft-delete notifications older than N days.
-  app.post('/api/v1/notifications/cleanup', async (req, reply) => {
+  app.post('/api/v1/notifications/cleanup', {
+    schema: {
+      tags: ['notifications'],
+      body: {
+        type: 'object',
+        additionalProperties: true,
+        properties: {
+          daysToKeep: { type: 'number' },
+          days_to_keep: { type: 'number' },
+        },
+      },
+    },
+  }, async (req, reply) => {
     const metadata = buildMetadata(req);
     const body = (req.body ?? {}) as { daysToKeep?: number; days_to_keep?: number };
     const daysToKeep = body.daysToKeep ?? body.days_to_keep ?? 0;
@@ -130,7 +171,7 @@ export const registerNotificationsRoutes = async (
   });
 
   // Mark all unread as read.
-  app.post('/api/v1/notifications/read-all', async (req, reply) => {
+  app.post('/api/v1/notifications/read-all', { schema: { tags: ['notifications'] } }, async (req, reply) => {
     const metadata = buildMetadata(req);
     try {
       const res = await client.markAllRead({}, metadata);
@@ -145,7 +186,7 @@ export const registerNotificationsRoutes = async (
   });
 
   // In-app notification preferences (user_notification_prefs).
-  app.get('/api/v1/notifications/preferences', async (req, reply) => {
+  app.get('/api/v1/notifications/preferences', { schema: { tags: ['notifications'] } }, async (req, reply) => {
     const metadata = buildMetadata(req);
     try {
       const res = await client.getNotificationPreferences({}, metadata);
@@ -158,7 +199,12 @@ export const registerNotificationsRoutes = async (
     }
   });
 
-  app.put('/api/v1/notifications/preferences', async (req, reply) => {
+  app.put('/api/v1/notifications/preferences', {
+    schema: {
+      tags: ['notifications'],
+      body: { type: 'object', additionalProperties: true },
+    },
+  }, async (req, reply) => {
     const metadata = buildMetadata(req);
     const body = (req.body ?? {}) as Record<string, unknown>;
     const grpcReq: UpdateNotificationPreferencesRequest = buildPrefsPatch(body);
@@ -176,7 +222,12 @@ export const registerNotificationsRoutes = async (
   });
 
   // Single notification fetch.
-  app.get<{ Params: { id: string } }>('/api/v1/notifications/:id', async (req, reply) => {
+  app.get<{ Params: { id: string } }>('/api/v1/notifications/:id', {
+    schema: {
+      tags: ['notifications'],
+      params: { type: 'object', properties: { id: { type: 'string' } }, required: ['id'] },
+    },
+  }, async (req, reply) => {
     const metadata = buildMetadata(req);
     try {
       const res = await client.getNotification({ notificationId: req.params.id }, metadata);
@@ -191,7 +242,12 @@ export const registerNotificationsRoutes = async (
 
   // Mark single notification as read — matches the monolith path
   // /api/v1/notifications/:notificationId/read.
-  app.patch<{ Params: { id: string } }>('/api/v1/notifications/:id/read', async (req, reply) => {
+  app.patch<{ Params: { id: string } }>('/api/v1/notifications/:id/read', {
+    schema: {
+      tags: ['notifications'],
+      params: { type: 'object', properties: { id: { type: 'string' } }, required: ['id'] },
+    },
+  }, async (req, reply) => {
     const metadata = buildMetadata(req);
     try {
       await client.dismiss({ notificationId: req.params.id }, metadata);
@@ -204,7 +260,12 @@ export const registerNotificationsRoutes = async (
     }
   });
 
-  app.delete<{ Params: { id: string } }>('/api/v1/notifications/:id', async (req, reply) => {
+  app.delete<{ Params: { id: string } }>('/api/v1/notifications/:id', {
+    schema: {
+      tags: ['notifications'],
+      params: { type: 'object', properties: { id: { type: 'string' } }, required: ['id'] },
+    },
+  }, async (req, reply) => {
     const metadata = buildMetadata(req);
     const grpcReq: DismissNotificationRequest = { notificationId: req.params.id };
 

--- a/services/gateway/src/routes/notifications.ts
+++ b/services/gateway/src/routes/notifications.ts
@@ -46,17 +46,6 @@ export const registerNotificationsRoutes = async (
     {
       schema: {
         tags: ['notifications'],
-        querystring: {
-          type: 'object',
-          additionalProperties: true,
-          properties: {
-            cursor: { type: 'string' },
-            limit: { type: 'string' },
-            status: { type: 'string' },
-            channel: { type: 'string' },
-            type: { type: 'string' },
-          },
-        },
       },
     },
     async (req, reply) => {
@@ -91,16 +80,6 @@ export const registerNotificationsRoutes = async (
     {
       schema: {
         tags: ['notifications'],
-        body: {
-          type: 'object',
-          additionalProperties: true,
-          properties: {
-            userId: { type: 'string' },
-            type: { type: 'string' },
-            title: { type: 'string' },
-            message: { type: 'string' },
-          },
-        },
       },
     },
     async (req, reply) => {
@@ -160,14 +139,6 @@ export const registerNotificationsRoutes = async (
     {
       schema: {
         tags: ['notifications'],
-        body: {
-          type: 'object',
-          additionalProperties: true,
-          properties: {
-            daysToKeep: { type: 'number' },
-            days_to_keep: { type: 'number' },
-          },
-        },
       },
     },
     async (req, reply) => {

--- a/services/gateway/src/routes/pets.ts
+++ b/services/gateway/src/routes/pets.ts
@@ -134,14 +134,15 @@ export const registerPetsRoutes = async (
       },
     },
     async (req, reply) => {
-    const query = req.query as Record<string, string | undefined>;
-    try {
-      const res = await client.getStats({ rescueIdFilter: query.rescueId }, buildMetadata(req));
-      return reply.send({ success: true, data: res });
-    } catch (err) {
-      return handleGrpcError(err, reply);
+      const query = req.query as Record<string, string | undefined>;
+      try {
+        const res = await client.getStats({ rescueIdFilter: query.rescueId }, buildMetadata(req));
+        return reply.send({ success: true, data: res });
+      } catch (err) {
+        return handleGrpcError(err, reply);
+      }
     }
-  });
+  );
 
   // GET /api/v1/pets/favorites/user — the caller's own favourites. Static
   // path, so it must register BEFORE the dynamic /:id route. Returns the
@@ -155,17 +156,18 @@ export const registerPetsRoutes = async (
       },
     },
     async (req, reply) => {
-    try {
-      const res = await client.listUserFavorites({}, buildMetadata(req));
-      const pets = res.pets.map(petToView);
-      return reply.send({
-        success: true,
-        data: { pets, total: pets.length, page: 1, totalPages: 1 },
-      });
-    } catch (err) {
-      return handleGrpcError(err, reply);
+      try {
+        const res = await client.listUserFavorites({}, buildMetadata(req));
+        const pets = res.pets.map(petToView);
+        return reply.send({
+          success: true,
+          data: { pets, total: pets.length, page: 1, totalPages: 1 },
+        });
+      } catch (err) {
+        return handleGrpcError(err, reply);
+      }
     }
-  });
+  );
 
   app.get<{ Params: { id: string } }>(
     '/api/v1/pets/:id',
@@ -340,13 +342,14 @@ export const registerPetsRoutes = async (
       },
     },
     async (req, reply) => {
-    try {
-      const res = await client.getFavoriteStatus({ petId: req.params.id }, buildMetadata(req));
-      return reply.send({ success: true, data: { isFavorite: res.isFavorite } });
-    } catch (err) {
-      return handleGrpcError(err, reply);
+      try {
+        const res = await client.getFavoriteStatus({ petId: req.params.id }, buildMetadata(req));
+        return reply.send({ success: true, data: { isFavorite: res.isFavorite } });
+      } catch (err) {
+        return handleGrpcError(err, reply);
+      }
     }
-  });
+  );
 
   app.post<{ Params: { id: string } }>(
     '/api/v1/pets/:id/favorite',
@@ -363,13 +366,14 @@ export const registerPetsRoutes = async (
       },
     },
     async (req, reply) => {
-    try {
-      const res = await client.addFavorite({ petId: req.params.id }, buildMetadata(req));
-      return reply.code(201).send({ success: true, data: { favorited: res.favorited } });
-    } catch (err) {
-      return handleGrpcError(err, reply);
+      try {
+        const res = await client.addFavorite({ petId: req.params.id }, buildMetadata(req));
+        return reply.code(201).send({ success: true, data: { favorited: res.favorited } });
+      } catch (err) {
+        return handleGrpcError(err, reply);
+      }
     }
-  });
+  );
 
   app.delete<{ Params: { id: string } }>(
     '/api/v1/pets/:id/favorite',
@@ -386,13 +390,14 @@ export const registerPetsRoutes = async (
       },
     },
     async (req, reply) => {
-    try {
-      const res = await client.removeFavorite({ petId: req.params.id }, buildMetadata(req));
-      return reply.send({ success: true, data: { removed: res.removed } });
-    } catch (err) {
-      return handleGrpcError(err, reply);
+      try {
+        const res = await client.removeFavorite({ petId: req.params.id }, buildMetadata(req));
+        return reply.send({ success: true, data: { removed: res.removed } });
+      } catch (err) {
+        return handleGrpcError(err, reply);
+      }
     }
-  });
+  );
 };
 
 // --- Helpers ---------------------------------------------------------

--- a/services/gateway/src/routes/pets.ts
+++ b/services/gateway/src/routes/pets.ts
@@ -118,7 +118,22 @@ export const registerPetsRoutes = async (
 
   // /stats must register BEFORE the dynamic /:id route so the literal
   // segment wins Fastify's first-registered-wins matcher.
-  app.get('/api/v1/pets/stats', async (req, reply) => {
+  app.get(
+    '/api/v1/pets/stats',
+    {
+      schema: {
+        tags: ['pets'],
+        summary: 'Get pet statistics, optionally filtered by rescue',
+        querystring: {
+          type: 'object',
+          properties: {
+            rescueId: { type: 'string' },
+          },
+          additionalProperties: true,
+        },
+      },
+    },
+    async (req, reply) => {
     const query = req.query as Record<string, string | undefined>;
     try {
       const res = await client.getStats({ rescueIdFilter: query.rescueId }, buildMetadata(req));
@@ -131,7 +146,15 @@ export const registerPetsRoutes = async (
   // GET /api/v1/pets/favorites/user — the caller's own favourites. Static
   // path, so it must register BEFORE the dynamic /:id route. Returns the
   // monolith shape { success, data: { pets, total, ... } } the SPA reads.
-  app.get('/api/v1/pets/favorites/user', async (req, reply) => {
+  app.get(
+    '/api/v1/pets/favorites/user',
+    {
+      schema: {
+        tags: ['pets'],
+        summary: "List the authenticated user's favourite pets",
+      },
+    },
+    async (req, reply) => {
     try {
       const res = await client.listUserFavorites({}, buildMetadata(req));
       const pets = res.pets.map(petToView);
@@ -146,7 +169,19 @@ export const registerPetsRoutes = async (
 
   app.get<{ Params: { id: string } }>(
     '/api/v1/pets/:id',
-    { config: { rateLimit: PETS_RATE_LIMITS.get } },
+    {
+      config: { rateLimit: PETS_RATE_LIMITS.get },
+      schema: {
+        tags: ['pets'],
+        summary: 'Get a single pet by ID',
+        params: {
+          type: 'object',
+          properties: {
+            id: { type: 'string' },
+          },
+        },
+      },
+    },
     async (req, reply) => {
       try {
         const res = await client.get({ petId: req.params.id }, buildMetadata(req));
@@ -162,7 +197,17 @@ export const registerPetsRoutes = async (
 
   app.post(
     '/api/v1/pets',
-    { config: { rateLimit: PETS_RATE_LIMITS.create } },
+    {
+      config: { rateLimit: PETS_RATE_LIMITS.create },
+      schema: {
+        tags: ['pets'],
+        summary: 'Create a new pet listing',
+        body: {
+          type: 'object',
+          additionalProperties: true,
+        },
+      },
+    },
     async (req, reply) => {
       // Stage B: adapt the frontend snake_case/token payload → proto.
       const grpcReq = viewToCreateRequest(req.body);
@@ -180,7 +225,23 @@ export const registerPetsRoutes = async (
 
   app.patch<{ Params: { id: string } }>(
     '/api/v1/pets/:id',
-    { config: { rateLimit: PETS_RATE_LIMITS.update } },
+    {
+      config: { rateLimit: PETS_RATE_LIMITS.update },
+      schema: {
+        tags: ['pets'],
+        summary: 'Update an existing pet listing',
+        params: {
+          type: 'object',
+          properties: {
+            id: { type: 'string' },
+          },
+        },
+        body: {
+          type: 'object',
+          additionalProperties: true,
+        },
+      },
+    },
     async (req, reply) => {
       const grpcReq = viewToUpdateRequest(req.params.id, req.body);
       try {
@@ -197,7 +258,27 @@ export const registerPetsRoutes = async (
 
   app.post<{ Params: { id: string } }>(
     '/api/v1/pets/:id/status',
-    { config: { rateLimit: PETS_RATE_LIMITS.updateStatus } },
+    {
+      config: { rateLimit: PETS_RATE_LIMITS.updateStatus },
+      schema: {
+        tags: ['pets'],
+        summary: 'Update the adoption status of a pet',
+        params: {
+          type: 'object',
+          properties: {
+            id: { type: 'string' },
+          },
+        },
+        body: {
+          type: 'object',
+          properties: {
+            toStatus: { type: 'string' },
+            reason: { type: 'string' },
+          },
+          additionalProperties: true,
+        },
+      },
+    },
     async (req, reply) => {
       const body = (req.body ?? {}) as UpdateStatusBody;
       const grpcReq: UpdatePetStatusRequest = {
@@ -219,7 +300,19 @@ export const registerPetsRoutes = async (
 
   app.delete<{ Params: { id: string } }>(
     '/api/v1/pets/:id',
-    { config: { rateLimit: PETS_RATE_LIMITS.delete } },
+    {
+      config: { rateLimit: PETS_RATE_LIMITS.delete },
+      schema: {
+        tags: ['pets'],
+        summary: 'Delete a pet listing',
+        params: {
+          type: 'object',
+          properties: {
+            id: { type: 'string' },
+          },
+        },
+      },
+    },
     async (req, reply) => {
       try {
         await client.delete({ petId: req.params.id }, buildMetadata(req));
@@ -232,7 +325,21 @@ export const registerPetsRoutes = async (
 
   // --- Per-user favourites: /api/v1/pets/:id/favorite[/status] --------
 
-  app.get<{ Params: { id: string } }>('/api/v1/pets/:id/favorite/status', async (req, reply) => {
+  app.get<{ Params: { id: string } }>(
+    '/api/v1/pets/:id/favorite/status',
+    {
+      schema: {
+        tags: ['pets'],
+        summary: 'Check whether the authenticated user has favourited a pet',
+        params: {
+          type: 'object',
+          properties: {
+            id: { type: 'string' },
+          },
+        },
+      },
+    },
+    async (req, reply) => {
     try {
       const res = await client.getFavoriteStatus({ petId: req.params.id }, buildMetadata(req));
       return reply.send({ success: true, data: { isFavorite: res.isFavorite } });
@@ -241,7 +348,21 @@ export const registerPetsRoutes = async (
     }
   });
 
-  app.post<{ Params: { id: string } }>('/api/v1/pets/:id/favorite', async (req, reply) => {
+  app.post<{ Params: { id: string } }>(
+    '/api/v1/pets/:id/favorite',
+    {
+      schema: {
+        tags: ['pets'],
+        summary: 'Add a pet to the authenticated user favourites',
+        params: {
+          type: 'object',
+          properties: {
+            id: { type: 'string' },
+          },
+        },
+      },
+    },
+    async (req, reply) => {
     try {
       const res = await client.addFavorite({ petId: req.params.id }, buildMetadata(req));
       return reply.code(201).send({ success: true, data: { favorited: res.favorited } });
@@ -250,7 +371,21 @@ export const registerPetsRoutes = async (
     }
   });
 
-  app.delete<{ Params: { id: string } }>('/api/v1/pets/:id/favorite', async (req, reply) => {
+  app.delete<{ Params: { id: string } }>(
+    '/api/v1/pets/:id/favorite',
+    {
+      schema: {
+        tags: ['pets'],
+        summary: 'Remove a pet from the authenticated user favourites',
+        params: {
+          type: 'object',
+          properties: {
+            id: { type: 'string' },
+          },
+        },
+      },
+    },
+    async (req, reply) => {
     try {
       const res = await client.removeFavorite({ petId: req.params.id }, buildMetadata(req));
       return reply.send({ success: true, data: { removed: res.removed } });

--- a/services/gateway/src/routes/pets.ts
+++ b/services/gateway/src/routes/pets.ts
@@ -78,18 +78,6 @@ export const registerPetsRoutes = async (
         // coercion (the existing handler does its own parseInt). Keeps
         // OpenAPI useful for SDK generation without changing runtime
         // validation behaviour.
-        querystring: {
-          type: 'object',
-          properties: {
-            cursor: { type: 'string' },
-            limit: { type: 'string' },
-            status: { type: 'string' },
-            type: { type: 'string' },
-            size: { type: 'string' },
-            rescueId: { type: 'string' },
-          },
-          additionalProperties: true,
-        },
       },
     },
     async (req, reply) => {
@@ -124,13 +112,6 @@ export const registerPetsRoutes = async (
       schema: {
         tags: ['pets'],
         summary: 'Get pet statistics, optionally filtered by rescue',
-        querystring: {
-          type: 'object',
-          properties: {
-            rescueId: { type: 'string' },
-          },
-          additionalProperties: true,
-        },
       },
     },
     async (req, reply) => {
@@ -176,12 +157,6 @@ export const registerPetsRoutes = async (
       schema: {
         tags: ['pets'],
         summary: 'Get a single pet by ID',
-        params: {
-          type: 'object',
-          properties: {
-            id: { type: 'string' },
-          },
-        },
       },
     },
     async (req, reply) => {
@@ -204,10 +179,6 @@ export const registerPetsRoutes = async (
       schema: {
         tags: ['pets'],
         summary: 'Create a new pet listing',
-        body: {
-          type: 'object',
-          additionalProperties: true,
-        },
       },
     },
     async (req, reply) => {
@@ -232,16 +203,6 @@ export const registerPetsRoutes = async (
       schema: {
         tags: ['pets'],
         summary: 'Update an existing pet listing',
-        params: {
-          type: 'object',
-          properties: {
-            id: { type: 'string' },
-          },
-        },
-        body: {
-          type: 'object',
-          additionalProperties: true,
-        },
       },
     },
     async (req, reply) => {
@@ -265,20 +226,6 @@ export const registerPetsRoutes = async (
       schema: {
         tags: ['pets'],
         summary: 'Update the adoption status of a pet',
-        params: {
-          type: 'object',
-          properties: {
-            id: { type: 'string' },
-          },
-        },
-        body: {
-          type: 'object',
-          properties: {
-            toStatus: { type: 'string' },
-            reason: { type: 'string' },
-          },
-          additionalProperties: true,
-        },
       },
     },
     async (req, reply) => {
@@ -307,12 +254,6 @@ export const registerPetsRoutes = async (
       schema: {
         tags: ['pets'],
         summary: 'Delete a pet listing',
-        params: {
-          type: 'object',
-          properties: {
-            id: { type: 'string' },
-          },
-        },
       },
     },
     async (req, reply) => {
@@ -333,12 +274,6 @@ export const registerPetsRoutes = async (
       schema: {
         tags: ['pets'],
         summary: 'Check whether the authenticated user has favourited a pet',
-        params: {
-          type: 'object',
-          properties: {
-            id: { type: 'string' },
-          },
-        },
       },
     },
     async (req, reply) => {
@@ -357,12 +292,6 @@ export const registerPetsRoutes = async (
       schema: {
         tags: ['pets'],
         summary: 'Add a pet to the authenticated user favourites',
-        params: {
-          type: 'object',
-          properties: {
-            id: { type: 'string' },
-          },
-        },
       },
     },
     async (req, reply) => {
@@ -381,12 +310,6 @@ export const registerPetsRoutes = async (
       schema: {
         tags: ['pets'],
         summary: 'Remove a pet from the authenticated user favourites',
-        params: {
-          type: 'object',
-          properties: {
-            id: { type: 'string' },
-          },
-        },
       },
     },
     async (req, reply) => {

--- a/services/gateway/src/routes/reports.ts
+++ b/services/gateway/src/routes/reports.ts
@@ -95,18 +95,6 @@ export const registerReportsRoutes = async (
       schema: {
         tags: ['reports'],
         summary: 'List saved reports',
-        querystring: {
-          type: 'object',
-          properties: {
-            rescue_id: { type: 'string' },
-            rescueId: { type: 'string' },
-            is_archived: { type: 'string' },
-            archived: { type: 'string' },
-            page: { type: 'string' },
-            limit: { type: 'string' },
-          },
-          additionalProperties: true,
-        },
       },
     },
     async (req, reply) => {
@@ -152,17 +140,6 @@ export const registerReportsRoutes = async (
       schema: {
         tags: ['reports'],
         summary: 'List report templates',
-        querystring: {
-          type: 'object',
-          properties: {
-            category: { type: 'string' },
-            rescue_id: { type: 'string' },
-            rescueId: { type: 'string' },
-            system: { type: 'string' },
-            system_only: { type: 'string' },
-          },
-          additionalProperties: true,
-        },
       },
     },
     async (req, reply) => {
@@ -191,12 +168,6 @@ export const registerReportsRoutes = async (
       schema: {
         tags: ['reports'],
         summary: 'Get a saved report by ID',
-        params: {
-          type: 'object',
-          properties: {
-            id: { type: 'string' },
-          },
-        },
       },
     },
     async (req, reply) => {
@@ -221,21 +192,6 @@ export const registerReportsRoutes = async (
       schema: {
         tags: ['reports'],
         summary: 'Create a saved report',
-        body: {
-          type: 'object',
-          properties: {
-            name: { type: 'string' },
-            description: { type: 'string' },
-            rescue_id: { type: 'string' },
-            rescueId: { type: 'string' },
-            template_id: { type: 'string' },
-            templateId: { type: 'string' },
-            config: { type: 'object' },
-            configJson: { type: 'string' },
-            config_json: { type: 'string' },
-          },
-          additionalProperties: true,
-        },
       },
     },
     async (req, reply) => {
@@ -276,25 +232,6 @@ export const registerReportsRoutes = async (
       schema: {
         tags: ['reports'],
         summary: 'Update a saved report',
-        params: {
-          type: 'object',
-          properties: {
-            id: { type: 'string' },
-          },
-        },
-        body: {
-          type: 'object',
-          properties: {
-            name: { type: 'string' },
-            description: { type: 'string' },
-            config: { type: 'object' },
-            configJson: { type: 'string' },
-            config_json: { type: 'string' },
-            is_archived: { type: 'boolean' },
-            isArchived: { type: 'boolean' },
-          },
-          additionalProperties: true,
-        },
       },
     },
     async (req, reply) => {
@@ -334,12 +271,6 @@ export const registerReportsRoutes = async (
       schema: {
         tags: ['reports'],
         summary: 'Delete a saved report',
-        params: {
-          type: 'object',
-          properties: {
-            id: { type: 'string' },
-          },
-        },
       },
     },
     async (req, reply) => {

--- a/services/gateway/src/routes/reports.ts
+++ b/services/gateway/src/routes/reports.ts
@@ -89,7 +89,24 @@ export const registerReportsRoutes = async (
   const { client } = opts;
 
   // GET /api/v1/reports — paginated list. Self-scoped at the service.
-  app.get('/api/v1/reports', async (req, reply) => {
+  app.get('/api/v1/reports', {
+    schema: {
+      tags: ['reports'],
+      summary: 'List saved reports',
+      querystring: {
+        type: 'object',
+        properties: {
+          rescue_id: { type: 'string' },
+          rescueId: { type: 'string' },
+          is_archived: { type: 'string' },
+          archived: { type: 'string' },
+          page: { type: 'string' },
+          limit: { type: 'string' },
+        },
+        additionalProperties: true,
+      },
+    },
+  }, async (req, reply) => {
     const q = req.query as Record<string, string | undefined>;
     const pagination = parsePagination(q);
     if (!pagination.ok) {
@@ -125,7 +142,23 @@ export const registerReportsRoutes = async (
 
   // GET /api/v1/reports/templates — register BEFORE /:id so the
   // static path wins.
-  app.get('/api/v1/reports/templates', async (req, reply) => {
+  app.get('/api/v1/reports/templates', {
+    schema: {
+      tags: ['reports'],
+      summary: 'List report templates',
+      querystring: {
+        type: 'object',
+        properties: {
+          category: { type: 'string' },
+          rescue_id: { type: 'string' },
+          rescueId: { type: 'string' },
+          system: { type: 'string' },
+          system_only: { type: 'string' },
+        },
+        additionalProperties: true,
+      },
+    },
+  }, async (req, reply) => {
     const q = req.query as Record<string, string | undefined>;
     const cat = CATEGORY_FROM_STRING[(q.category ?? '').toLowerCase()];
     const grpcReq: AuditListReportTemplatesRequest = {
@@ -144,7 +177,18 @@ export const registerReportsRoutes = async (
     }
   });
 
-  app.get<{ Params: { id: string } }>('/api/v1/reports/:id', async (req, reply) => {
+  app.get<{ Params: { id: string } }>('/api/v1/reports/:id', {
+    schema: {
+      tags: ['reports'],
+      summary: 'Get a saved report by ID',
+      params: {
+        type: 'object',
+        properties: {
+          id: { type: 'string' },
+        },
+      },
+    },
+  }, async (req, reply) => {
     try {
       const res = await client.getSavedReport({ savedReportId: req.params.id }, buildMetadata(req));
       if (!res.report) {
@@ -156,7 +200,27 @@ export const registerReportsRoutes = async (
     }
   });
 
-  app.post('/api/v1/reports', async (req, reply) => {
+  app.post('/api/v1/reports', {
+    schema: {
+      tags: ['reports'],
+      summary: 'Create a saved report',
+      body: {
+        type: 'object',
+        properties: {
+          name: { type: 'string' },
+          description: { type: 'string' },
+          rescue_id: { type: 'string' },
+          rescueId: { type: 'string' },
+          template_id: { type: 'string' },
+          templateId: { type: 'string' },
+          config: { type: 'object' },
+          configJson: { type: 'string' },
+          config_json: { type: 'string' },
+        },
+        additionalProperties: true,
+      },
+    },
+  }, async (req, reply) => {
     const body = (req.body ?? {}) as Record<string, unknown>;
     const configJson = encodeConfig(body.config, body.configJson, body.config_json);
     const grpcReq: AuditCreateSavedReportRequest = {
@@ -187,7 +251,31 @@ export const registerReportsRoutes = async (
     }
   });
 
-  app.put<{ Params: { id: string } }>('/api/v1/reports/:id', async (req, reply) => {
+  app.put<{ Params: { id: string } }>('/api/v1/reports/:id', {
+    schema: {
+      tags: ['reports'],
+      summary: 'Update a saved report',
+      params: {
+        type: 'object',
+        properties: {
+          id: { type: 'string' },
+        },
+      },
+      body: {
+        type: 'object',
+        properties: {
+          name: { type: 'string' },
+          description: { type: 'string' },
+          config: { type: 'object' },
+          configJson: { type: 'string' },
+          config_json: { type: 'string' },
+          is_archived: { type: 'boolean' },
+          isArchived: { type: 'boolean' },
+        },
+        additionalProperties: true,
+      },
+    },
+  }, async (req, reply) => {
     const body = (req.body ?? {}) as Record<string, unknown>;
     const grpcReq: AuditUpdateSavedReportRequest = {
       savedReportId: req.params.id,
@@ -215,7 +303,18 @@ export const registerReportsRoutes = async (
     }
   });
 
-  app.delete<{ Params: { id: string } }>('/api/v1/reports/:id', async (req, reply) => {
+  app.delete<{ Params: { id: string } }>('/api/v1/reports/:id', {
+    schema: {
+      tags: ['reports'],
+      summary: 'Delete a saved report',
+      params: {
+        type: 'object',
+        properties: {
+          id: { type: 'string' },
+        },
+      },
+    },
+  }, async (req, reply) => {
     try {
       const res = await client.deleteSavedReport(
         { savedReportId: req.params.id },

--- a/services/gateway/src/routes/reports.ts
+++ b/services/gateway/src/routes/reports.ts
@@ -89,245 +89,274 @@ export const registerReportsRoutes = async (
   const { client } = opts;
 
   // GET /api/v1/reports — paginated list. Self-scoped at the service.
-  app.get('/api/v1/reports', {
-    schema: {
-      tags: ['reports'],
-      summary: 'List saved reports',
-      querystring: {
-        type: 'object',
-        properties: {
-          rescue_id: { type: 'string' },
-          rescueId: { type: 'string' },
-          is_archived: { type: 'string' },
-          archived: { type: 'string' },
-          page: { type: 'string' },
-          limit: { type: 'string' },
+  app.get(
+    '/api/v1/reports',
+    {
+      schema: {
+        tags: ['reports'],
+        summary: 'List saved reports',
+        querystring: {
+          type: 'object',
+          properties: {
+            rescue_id: { type: 'string' },
+            rescueId: { type: 'string' },
+            is_archived: { type: 'string' },
+            archived: { type: 'string' },
+            page: { type: 'string' },
+            limit: { type: 'string' },
+          },
+          additionalProperties: true,
         },
-        additionalProperties: true,
       },
     },
-  }, async (req, reply) => {
-    const q = req.query as Record<string, string | undefined>;
-    const pagination = parsePagination(q);
-    if (!pagination.ok) {
-      return reply.code(400).send({ success: false, error: pagination.error });
+    async (req, reply) => {
+      const q = req.query as Record<string, string | undefined>;
+      const pagination = parsePagination(q);
+      if (!pagination.ok) {
+        return reply.code(400).send({ success: false, error: pagination.error });
+      }
+      const grpcReq: AuditListSavedReportsRequest = {
+        rescueId: q.rescue_id || q.rescueId,
+        isArchived:
+          q.is_archived === 'true' || q.archived === 'true'
+            ? true
+            : q.is_archived === 'false' || q.archived === 'false'
+              ? false
+              : undefined,
+        page: pagination.page,
+        limit: pagination.limit,
+      };
+      try {
+        const res = await client.listSavedReports(grpcReq, buildMetadata(req));
+        return reply.send({
+          success: true,
+          data: res.reports.map(reportToView),
+          pagination: {
+            page: res.page,
+            limit: grpcReq.limit || 20,
+            total: res.total,
+            totalPages: res.totalPages,
+          },
+        });
+      } catch (err) {
+        return handleGrpcError(err, reply);
+      }
     }
-    const grpcReq: AuditListSavedReportsRequest = {
-      rescueId: q.rescue_id || q.rescueId,
-      isArchived:
-        q.is_archived === 'true' || q.archived === 'true'
-          ? true
-          : q.is_archived === 'false' || q.archived === 'false'
-            ? false
-            : undefined,
-      page: pagination.page,
-      limit: pagination.limit,
-    };
-    try {
-      const res = await client.listSavedReports(grpcReq, buildMetadata(req));
-      return reply.send({
-        success: true,
-        data: res.reports.map(reportToView),
-        pagination: {
-          page: res.page,
-          limit: grpcReq.limit || 20,
-          total: res.total,
-          totalPages: res.totalPages,
-        },
-      });
-    } catch (err) {
-      return handleGrpcError(err, reply);
-    }
-  });
+  );
 
   // GET /api/v1/reports/templates — register BEFORE /:id so the
   // static path wins.
-  app.get('/api/v1/reports/templates', {
-    schema: {
-      tags: ['reports'],
-      summary: 'List report templates',
-      querystring: {
-        type: 'object',
-        properties: {
-          category: { type: 'string' },
-          rescue_id: { type: 'string' },
-          rescueId: { type: 'string' },
-          system: { type: 'string' },
-          system_only: { type: 'string' },
-        },
-        additionalProperties: true,
-      },
-    },
-  }, async (req, reply) => {
-    const q = req.query as Record<string, string | undefined>;
-    const cat = CATEGORY_FROM_STRING[(q.category ?? '').toLowerCase()];
-    const grpcReq: AuditListReportTemplatesRequest = {
-      category: cat ?? AuditV1.ReportTemplateCategory.REPORT_TEMPLATE_CATEGORY_UNSPECIFIED,
-      rescueId: q.rescue_id || q.rescueId,
-      systemOnly: q.system === 'true' || q.system_only === 'true' ? true : undefined,
-    };
-    try {
-      const res = await client.listReportTemplates(grpcReq, buildMetadata(req));
-      return reply.send({
-        success: true,
-        data: res.templates.map(templateToView),
-      });
-    } catch (err) {
-      return handleGrpcError(err, reply);
-    }
-  });
-
-  app.get<{ Params: { id: string } }>('/api/v1/reports/:id', {
-    schema: {
-      tags: ['reports'],
-      summary: 'Get a saved report by ID',
-      params: {
-        type: 'object',
-        properties: {
-          id: { type: 'string' },
+  app.get(
+    '/api/v1/reports/templates',
+    {
+      schema: {
+        tags: ['reports'],
+        summary: 'List report templates',
+        querystring: {
+          type: 'object',
+          properties: {
+            category: { type: 'string' },
+            rescue_id: { type: 'string' },
+            rescueId: { type: 'string' },
+            system: { type: 'string' },
+            system_only: { type: 'string' },
+          },
+          additionalProperties: true,
         },
       },
     },
-  }, async (req, reply) => {
-    try {
-      const res = await client.getSavedReport({ savedReportId: req.params.id }, buildMetadata(req));
-      if (!res.report) {
-        return reply.code(404).send({ success: false, error: 'not found' });
+    async (req, reply) => {
+      const q = req.query as Record<string, string | undefined>;
+      const cat = CATEGORY_FROM_STRING[(q.category ?? '').toLowerCase()];
+      const grpcReq: AuditListReportTemplatesRequest = {
+        category: cat ?? AuditV1.ReportTemplateCategory.REPORT_TEMPLATE_CATEGORY_UNSPECIFIED,
+        rescueId: q.rescue_id || q.rescueId,
+        systemOnly: q.system === 'true' || q.system_only === 'true' ? true : undefined,
+      };
+      try {
+        const res = await client.listReportTemplates(grpcReq, buildMetadata(req));
+        return reply.send({
+          success: true,
+          data: res.templates.map(templateToView),
+        });
+      } catch (err) {
+        return handleGrpcError(err, reply);
       }
-      return reply.send({ success: true, data: reportToView(res.report) });
-    } catch (err) {
-      return handleGrpcError(err, reply);
     }
-  });
+  );
 
-  app.post('/api/v1/reports', {
-    schema: {
-      tags: ['reports'],
-      summary: 'Create a saved report',
-      body: {
-        type: 'object',
-        properties: {
-          name: { type: 'string' },
-          description: { type: 'string' },
-          rescue_id: { type: 'string' },
-          rescueId: { type: 'string' },
-          template_id: { type: 'string' },
-          templateId: { type: 'string' },
-          config: { type: 'object' },
-          configJson: { type: 'string' },
-          config_json: { type: 'string' },
+  app.get<{ Params: { id: string } }>(
+    '/api/v1/reports/:id',
+    {
+      schema: {
+        tags: ['reports'],
+        summary: 'Get a saved report by ID',
+        params: {
+          type: 'object',
+          properties: {
+            id: { type: 'string' },
+          },
         },
-        additionalProperties: true,
       },
     },
-  }, async (req, reply) => {
-    const body = (req.body ?? {}) as Record<string, unknown>;
-    const configJson = encodeConfig(body.config, body.configJson, body.config_json);
-    const grpcReq: AuditCreateSavedReportRequest = {
-      name: String(body.name ?? ''),
-      description: typeof body.description === 'string' ? body.description : undefined,
-      rescueId:
-        typeof body.rescue_id === 'string'
-          ? body.rescue_id
-          : typeof body.rescueId === 'string'
-            ? body.rescueId
+    async (req, reply) => {
+      try {
+        const res = await client.getSavedReport(
+          { savedReportId: req.params.id },
+          buildMetadata(req)
+        );
+        if (!res.report) {
+          return reply.code(404).send({ success: false, error: 'not found' });
+        }
+        return reply.send({ success: true, data: reportToView(res.report) });
+      } catch (err) {
+        return handleGrpcError(err, reply);
+      }
+    }
+  );
+
+  app.post(
+    '/api/v1/reports',
+    {
+      schema: {
+        tags: ['reports'],
+        summary: 'Create a saved report',
+        body: {
+          type: 'object',
+          properties: {
+            name: { type: 'string' },
+            description: { type: 'string' },
+            rescue_id: { type: 'string' },
+            rescueId: { type: 'string' },
+            template_id: { type: 'string' },
+            templateId: { type: 'string' },
+            config: { type: 'object' },
+            configJson: { type: 'string' },
+            config_json: { type: 'string' },
+          },
+          additionalProperties: true,
+        },
+      },
+    },
+    async (req, reply) => {
+      const body = (req.body ?? {}) as Record<string, unknown>;
+      const configJson = encodeConfig(body.config, body.configJson, body.config_json);
+      const grpcReq: AuditCreateSavedReportRequest = {
+        name: String(body.name ?? ''),
+        description: typeof body.description === 'string' ? body.description : undefined,
+        rescueId:
+          typeof body.rescue_id === 'string'
+            ? body.rescue_id
+            : typeof body.rescueId === 'string'
+              ? body.rescueId
+              : undefined,
+        templateId:
+          typeof body.template_id === 'string'
+            ? body.template_id
+            : typeof body.templateId === 'string'
+              ? body.templateId
+              : undefined,
+        configJson,
+      };
+      try {
+        const res = await client.createSavedReport(grpcReq, buildMetadata(req));
+        if (!res.report) {
+          return reply.code(500).send({ success: false, error: 'no row returned' });
+        }
+        return reply.code(201).send({ success: true, data: reportToView(res.report) });
+      } catch (err) {
+        return handleGrpcError(err, reply);
+      }
+    }
+  );
+
+  app.put<{ Params: { id: string } }>(
+    '/api/v1/reports/:id',
+    {
+      schema: {
+        tags: ['reports'],
+        summary: 'Update a saved report',
+        params: {
+          type: 'object',
+          properties: {
+            id: { type: 'string' },
+          },
+        },
+        body: {
+          type: 'object',
+          properties: {
+            name: { type: 'string' },
+            description: { type: 'string' },
+            config: { type: 'object' },
+            configJson: { type: 'string' },
+            config_json: { type: 'string' },
+            is_archived: { type: 'boolean' },
+            isArchived: { type: 'boolean' },
+          },
+          additionalProperties: true,
+        },
+      },
+    },
+    async (req, reply) => {
+      const body = (req.body ?? {}) as Record<string, unknown>;
+      const grpcReq: AuditUpdateSavedReportRequest = {
+        savedReportId: req.params.id,
+        name: typeof body.name === 'string' ? body.name : undefined,
+        description: typeof body.description === 'string' ? body.description : undefined,
+        configJson:
+          body.config !== undefined ||
+          body.configJson !== undefined ||
+          body.config_json !== undefined
+            ? encodeConfig(body.config, body.configJson, body.config_json)
             : undefined,
-      templateId:
-        typeof body.template_id === 'string'
-          ? body.template_id
-          : typeof body.templateId === 'string'
-            ? body.templateId
-            : undefined,
-      configJson,
-    };
-    try {
-      const res = await client.createSavedReport(grpcReq, buildMetadata(req));
-      if (!res.report) {
-        return reply.code(500).send({ success: false, error: 'no row returned' });
+        isArchived:
+          typeof body.is_archived === 'boolean'
+            ? body.is_archived
+            : typeof body.isArchived === 'boolean'
+              ? body.isArchived
+              : undefined,
+      };
+      try {
+        const res = await client.updateSavedReport(grpcReq, buildMetadata(req));
+        if (!res.report) {
+          return reply.code(404).send({ success: false, error: 'not found' });
+        }
+        return reply.send({ success: true, data: reportToView(res.report) });
+      } catch (err) {
+        return handleGrpcError(err, reply);
       }
-      return reply.code(201).send({ success: true, data: reportToView(res.report) });
-    } catch (err) {
-      return handleGrpcError(err, reply);
     }
-  });
+  );
 
-  app.put<{ Params: { id: string } }>('/api/v1/reports/:id', {
-    schema: {
-      tags: ['reports'],
-      summary: 'Update a saved report',
-      params: {
-        type: 'object',
-        properties: {
-          id: { type: 'string' },
-        },
-      },
-      body: {
-        type: 'object',
-        properties: {
-          name: { type: 'string' },
-          description: { type: 'string' },
-          config: { type: 'object' },
-          configJson: { type: 'string' },
-          config_json: { type: 'string' },
-          is_archived: { type: 'boolean' },
-          isArchived: { type: 'boolean' },
-        },
-        additionalProperties: true,
-      },
-    },
-  }, async (req, reply) => {
-    const body = (req.body ?? {}) as Record<string, unknown>;
-    const grpcReq: AuditUpdateSavedReportRequest = {
-      savedReportId: req.params.id,
-      name: typeof body.name === 'string' ? body.name : undefined,
-      description: typeof body.description === 'string' ? body.description : undefined,
-      configJson:
-        body.config !== undefined || body.configJson !== undefined || body.config_json !== undefined
-          ? encodeConfig(body.config, body.configJson, body.config_json)
-          : undefined,
-      isArchived:
-        typeof body.is_archived === 'boolean'
-          ? body.is_archived
-          : typeof body.isArchived === 'boolean'
-            ? body.isArchived
-            : undefined,
-    };
-    try {
-      const res = await client.updateSavedReport(grpcReq, buildMetadata(req));
-      if (!res.report) {
-        return reply.code(404).send({ success: false, error: 'not found' });
-      }
-      return reply.send({ success: true, data: reportToView(res.report) });
-    } catch (err) {
-      return handleGrpcError(err, reply);
-    }
-  });
-
-  app.delete<{ Params: { id: string } }>('/api/v1/reports/:id', {
-    schema: {
-      tags: ['reports'],
-      summary: 'Delete a saved report',
-      params: {
-        type: 'object',
-        properties: {
-          id: { type: 'string' },
+  app.delete<{ Params: { id: string } }>(
+    '/api/v1/reports/:id',
+    {
+      schema: {
+        tags: ['reports'],
+        summary: 'Delete a saved report',
+        params: {
+          type: 'object',
+          properties: {
+            id: { type: 'string' },
+          },
         },
       },
     },
-  }, async (req, reply) => {
-    try {
-      const res = await client.deleteSavedReport(
-        { savedReportId: req.params.id },
-        buildMetadata(req)
-      );
-      if (!res.deleted) {
-        return reply.code(404).send({ success: false, error: 'not found' });
+    async (req, reply) => {
+      try {
+        const res = await client.deleteSavedReport(
+          { savedReportId: req.params.id },
+          buildMetadata(req)
+        );
+        if (!res.deleted) {
+          return reply.code(404).send({ success: false, error: 'not found' });
+        }
+        return reply.send({ success: true });
+      } catch (err) {
+        return handleGrpcError(err, reply);
       }
-      return reply.send({ success: true });
-    } catch (err) {
-      return handleGrpcError(err, reply);
     }
-  });
+  );
 };
 
 function encodeConfig(configObj: unknown, configJson: unknown, configSnake: unknown): string {

--- a/services/gateway/src/routes/rescue.ts
+++ b/services/gateway/src/routes/rescue.ts
@@ -91,7 +91,22 @@ export const registerRescueRoutes = async (
 
   app.get(
     '/api/v1/rescue',
-    { config: { rateLimit: RESCUE_RATE_LIMITS.list } },
+    {
+      config: { rateLimit: RESCUE_RATE_LIMITS.list },
+      schema: {
+        tags: ['rescue'],
+        summary: 'List rescues',
+        querystring: {
+          type: 'object',
+          properties: {
+            cursor: { type: 'string' },
+            limit: { type: 'string' },
+            status: { type: 'string' },
+          },
+          additionalProperties: true,
+        },
+      },
+    },
     async (req, reply) => {
       const query = req.query as Record<string, string | undefined>;
       const pagination = parsePagination(query, { limit: 0 });
@@ -114,7 +129,19 @@ export const registerRescueRoutes = async (
 
   app.get<{ Params: { id: string } }>(
     '/api/v1/rescue/:id',
-    { config: { rateLimit: RESCUE_RATE_LIMITS.get } },
+    {
+      config: { rateLimit: RESCUE_RATE_LIMITS.get },
+      schema: {
+        tags: ['rescue'],
+        summary: 'Get a rescue by ID',
+        params: {
+          type: 'object',
+          properties: {
+            id: { type: 'string' },
+          },
+        },
+      },
+    },
     async (req, reply) => {
       try {
         const res = await client.get({ rescueId: req.params.id }, buildMetadata(req));
@@ -127,7 +154,36 @@ export const registerRescueRoutes = async (
 
   app.post(
     '/api/v1/rescue',
-    { config: { rateLimit: RESCUE_RATE_LIMITS.create } },
+    {
+      config: { rateLimit: RESCUE_RATE_LIMITS.create },
+      schema: {
+        tags: ['rescue'],
+        summary: 'Create a rescue',
+        body: {
+          type: 'object',
+          properties: {
+            name: { type: 'string' },
+            email: { type: 'string' },
+            phone: { type: 'string' },
+            address: { type: 'string' },
+            city: { type: 'string' },
+            county: { type: 'string' },
+            postcode: { type: 'string' },
+            country: { type: 'string' },
+            website: { type: 'string' },
+            description: { type: 'string' },
+            mission: { type: 'string' },
+            companiesHouseNumber: { type: 'string' },
+            charityRegistrationNumber: { type: 'string' },
+            contactPerson: { type: 'string' },
+            contactTitle: { type: 'string' },
+            contactEmail: { type: 'string' },
+            contactPhone: { type: 'string' },
+          },
+          additionalProperties: true,
+        },
+      },
+    },
     async (req, reply) => {
       const body = (req.body ?? {}) as CreateRescueBody;
       const grpcReq: CreateRescueRequest = {
@@ -160,7 +216,23 @@ export const registerRescueRoutes = async (
 
   app.patch<{ Params: { id: string } }>(
     '/api/v1/rescue/:id',
-    { config: { rateLimit: RESCUE_RATE_LIMITS.update } },
+    {
+      config: { rateLimit: RESCUE_RATE_LIMITS.update },
+      schema: {
+        tags: ['rescue'],
+        summary: 'Update a rescue',
+        params: {
+          type: 'object',
+          properties: {
+            id: { type: 'string' },
+          },
+        },
+        body: {
+          type: 'object',
+          additionalProperties: true,
+        },
+      },
+    },
     async (req, reply) => {
       const body = (req.body ?? {}) as UpdateRescueBody;
       const grpcReq: UpdateRescueRequest = { rescueId: req.params.id, ...body };
@@ -175,7 +247,28 @@ export const registerRescueRoutes = async (
 
   app.post<{ Params: { id: string } }>(
     '/api/v1/rescue/:id/verify',
-    { config: { rateLimit: RESCUE_RATE_LIMITS.verify } },
+    {
+      config: { rateLimit: RESCUE_RATE_LIMITS.verify },
+      schema: {
+        tags: ['rescue'],
+        summary: 'Verify a rescue',
+        params: {
+          type: 'object',
+          properties: {
+            id: { type: 'string' },
+          },
+        },
+        body: {
+          type: 'object',
+          properties: {
+            toStatus: { type: 'string' },
+            verificationSource: { type: 'string' },
+            failureReason: { type: 'string' },
+          },
+          additionalProperties: true,
+        },
+      },
+    },
     async (req, reply) => {
       const body = (req.body ?? {}) as VerifyBody;
       const grpcReq: VerifyRescueRequest = {
@@ -195,7 +288,28 @@ export const registerRescueRoutes = async (
 
   app.post<{ Params: { id: string } }>(
     '/api/v1/rescue/:id/invitations',
-    { config: { rateLimit: RESCUE_RATE_LIMITS.inviteStaff } },
+    {
+      config: { rateLimit: RESCUE_RATE_LIMITS.inviteStaff },
+      schema: {
+        tags: ['rescue'],
+        summary: 'Invite staff to a rescue',
+        params: {
+          type: 'object',
+          properties: {
+            id: { type: 'string' },
+          },
+        },
+        body: {
+          type: 'object',
+          properties: {
+            email: { type: 'string' },
+            title: { type: 'string' },
+            expiresInSeconds: { type: 'number' },
+          },
+          additionalProperties: true,
+        },
+      },
+    },
     async (req, reply) => {
       const body = (req.body ?? {}) as InviteStaffBody;
       const grpcReq: InviteStaffRequest = {
@@ -221,7 +335,19 @@ export const registerRescueRoutes = async (
 
   app.get<{ Params: { rescueId: string } }>(
     '/api/v1/rescues/:rescueId/questions',
-    { config: { rateLimit: RESCUE_RATE_LIMITS.get } },
+    {
+      config: { rateLimit: RESCUE_RATE_LIMITS.get },
+      schema: {
+        tags: ['rescue'],
+        summary: 'List application questions for a rescue',
+        params: {
+          type: 'object',
+          properties: {
+            rescueId: { type: 'string' },
+          },
+        },
+      },
+    },
     async (req, reply) => {
       try {
         const res = await client.listApplicationQuestions(
@@ -240,7 +366,40 @@ export const registerRescueRoutes = async (
 
   app.post<{ Params: { rescueId: string } }>(
     '/api/v1/rescues/:rescueId/questions',
-    { config: { rateLimit: RESCUE_RATE_LIMITS.update } },
+    {
+      config: { rateLimit: RESCUE_RATE_LIMITS.update },
+      schema: {
+        tags: ['rescue'],
+        summary: 'Create an application question for a rescue',
+        params: {
+          type: 'object',
+          properties: {
+            rescueId: { type: 'string' },
+          },
+        },
+        body: {
+          type: 'object',
+          properties: {
+            questionKey: { type: 'string' },
+            question_key: { type: 'string' },
+            category: { type: 'string' },
+            questionType: { type: 'string' },
+            question_type: { type: 'string' },
+            questionText: { type: 'string' },
+            question_text: { type: 'string' },
+            helpText: { type: 'string' },
+            help_text: { type: 'string' },
+            placeholder: { type: 'string' },
+            options: { type: 'array', items: { type: 'string' } },
+            sortOrder: { type: 'number' },
+            displayOrder: { type: 'number' },
+            isRequired: { type: 'boolean' },
+            is_required: { type: 'boolean' },
+          },
+          additionalProperties: true,
+        },
+      },
+    },
     async (req, reply) => {
       const body = (req.body ?? {}) as QuestionBody;
       const grpcReq: CreateApplicationQuestionRequest = {
@@ -274,7 +433,20 @@ export const registerRescueRoutes = async (
 
   app.delete<{ Params: { rescueId: string; questionId: string } }>(
     '/api/v1/rescues/:rescueId/questions/:questionId',
-    { config: { rateLimit: RESCUE_RATE_LIMITS.update } },
+    {
+      config: { rateLimit: RESCUE_RATE_LIMITS.update },
+      schema: {
+        tags: ['rescue'],
+        summary: 'Delete an application question',
+        params: {
+          type: 'object',
+          properties: {
+            rescueId: { type: 'string' },
+            questionId: { type: 'string' },
+          },
+        },
+      },
+    },
     async (req, reply) => {
       try {
         const res = await client.deleteApplicationQuestion(

--- a/services/gateway/src/routes/rescue.ts
+++ b/services/gateway/src/routes/rescue.ts
@@ -96,15 +96,6 @@ export const registerRescueRoutes = async (
       schema: {
         tags: ['rescue'],
         summary: 'List rescues',
-        querystring: {
-          type: 'object',
-          properties: {
-            cursor: { type: 'string' },
-            limit: { type: 'string' },
-            status: { type: 'string' },
-          },
-          additionalProperties: true,
-        },
       },
     },
     async (req, reply) => {
@@ -134,12 +125,6 @@ export const registerRescueRoutes = async (
       schema: {
         tags: ['rescue'],
         summary: 'Get a rescue by ID',
-        params: {
-          type: 'object',
-          properties: {
-            id: { type: 'string' },
-          },
-        },
       },
     },
     async (req, reply) => {
@@ -159,29 +144,6 @@ export const registerRescueRoutes = async (
       schema: {
         tags: ['rescue'],
         summary: 'Create a rescue',
-        body: {
-          type: 'object',
-          properties: {
-            name: { type: 'string' },
-            email: { type: 'string' },
-            phone: { type: 'string' },
-            address: { type: 'string' },
-            city: { type: 'string' },
-            county: { type: 'string' },
-            postcode: { type: 'string' },
-            country: { type: 'string' },
-            website: { type: 'string' },
-            description: { type: 'string' },
-            mission: { type: 'string' },
-            companiesHouseNumber: { type: 'string' },
-            charityRegistrationNumber: { type: 'string' },
-            contactPerson: { type: 'string' },
-            contactTitle: { type: 'string' },
-            contactEmail: { type: 'string' },
-            contactPhone: { type: 'string' },
-          },
-          additionalProperties: true,
-        },
       },
     },
     async (req, reply) => {
@@ -221,16 +183,6 @@ export const registerRescueRoutes = async (
       schema: {
         tags: ['rescue'],
         summary: 'Update a rescue',
-        params: {
-          type: 'object',
-          properties: {
-            id: { type: 'string' },
-          },
-        },
-        body: {
-          type: 'object',
-          additionalProperties: true,
-        },
       },
     },
     async (req, reply) => {
@@ -252,21 +204,6 @@ export const registerRescueRoutes = async (
       schema: {
         tags: ['rescue'],
         summary: 'Verify a rescue',
-        params: {
-          type: 'object',
-          properties: {
-            id: { type: 'string' },
-          },
-        },
-        body: {
-          type: 'object',
-          properties: {
-            toStatus: { type: 'string' },
-            verificationSource: { type: 'string' },
-            failureReason: { type: 'string' },
-          },
-          additionalProperties: true,
-        },
       },
     },
     async (req, reply) => {
@@ -293,21 +230,6 @@ export const registerRescueRoutes = async (
       schema: {
         tags: ['rescue'],
         summary: 'Invite staff to a rescue',
-        params: {
-          type: 'object',
-          properties: {
-            id: { type: 'string' },
-          },
-        },
-        body: {
-          type: 'object',
-          properties: {
-            email: { type: 'string' },
-            title: { type: 'string' },
-            expiresInSeconds: { type: 'number' },
-          },
-          additionalProperties: true,
-        },
       },
     },
     async (req, reply) => {
@@ -340,12 +262,6 @@ export const registerRescueRoutes = async (
       schema: {
         tags: ['rescue'],
         summary: 'List application questions for a rescue',
-        params: {
-          type: 'object',
-          properties: {
-            rescueId: { type: 'string' },
-          },
-        },
       },
     },
     async (req, reply) => {
@@ -371,33 +287,6 @@ export const registerRescueRoutes = async (
       schema: {
         tags: ['rescue'],
         summary: 'Create an application question for a rescue',
-        params: {
-          type: 'object',
-          properties: {
-            rescueId: { type: 'string' },
-          },
-        },
-        body: {
-          type: 'object',
-          properties: {
-            questionKey: { type: 'string' },
-            question_key: { type: 'string' },
-            category: { type: 'string' },
-            questionType: { type: 'string' },
-            question_type: { type: 'string' },
-            questionText: { type: 'string' },
-            question_text: { type: 'string' },
-            helpText: { type: 'string' },
-            help_text: { type: 'string' },
-            placeholder: { type: 'string' },
-            options: { type: 'array', items: { type: 'string' } },
-            sortOrder: { type: 'number' },
-            displayOrder: { type: 'number' },
-            isRequired: { type: 'boolean' },
-            is_required: { type: 'boolean' },
-          },
-          additionalProperties: true,
-        },
       },
     },
     async (req, reply) => {
@@ -438,13 +327,6 @@ export const registerRescueRoutes = async (
       schema: {
         tags: ['rescue'],
         summary: 'Delete an application question',
-        params: {
-          type: 'object',
-          properties: {
-            rescueId: { type: 'string' },
-            questionId: { type: 'string' },
-          },
-        },
       },
     },
     async (req, reply) => {

--- a/services/gateway/src/routes/rescues-public.ts
+++ b/services/gateway/src/routes/rescues-public.ts
@@ -48,16 +48,6 @@ export const registerRescuesPublicRoutes = async (
       schema: {
         tags: ['rescues'],
         summary: 'List rescues',
-        querystring: {
-          type: 'object',
-          properties: {
-            cursor: { type: 'string' },
-            limit: { type: 'string' },
-            status: { type: 'string' },
-            search: { type: 'string' },
-          },
-          additionalProperties: true,
-        },
       },
     },
     async (req, reply) => {
@@ -85,13 +75,6 @@ export const registerRescuesPublicRoutes = async (
       schema: {
         tags: ['rescues'],
         summary: 'List featured rescues',
-        querystring: {
-          type: 'object',
-          properties: {
-            limit: { type: 'string' },
-          },
-          additionalProperties: true,
-        },
       },
     },
     async (req, reply) => {
@@ -123,17 +106,6 @@ export const registerRescuesPublicRoutes = async (
       schema: {
         tags: ['rescues'],
         summary: 'Search rescues',
-        querystring: {
-          type: 'object',
-          properties: {
-            search: { type: 'string' },
-            q: { type: 'string' },
-            status: { type: 'string' },
-            cursor: { type: 'string' },
-            limit: { type: 'string' },
-          },
-          additionalProperties: true,
-        },
       },
     },
     async (req, reply) => {
@@ -163,16 +135,6 @@ export const registerRescuesPublicRoutes = async (
       schema: {
         tags: ['rescues'],
         summary: 'List nearby rescues by location',
-        querystring: {
-          type: 'object',
-          properties: {
-            lat: { type: 'string' },
-            lng: { type: 'string' },
-            radiusKm: { type: 'string' },
-            limit: { type: 'string' },
-          },
-          additionalProperties: true,
-        },
       },
     },
     async (req, reply) => {
@@ -230,10 +192,6 @@ export const registerRescuesPublicRoutes = async (
       schema: {
         tags: ['rescues'],
         summary: 'Register a new rescue organisation',
-        body: {
-          type: 'object',
-          additionalProperties: true,
-        },
       },
     },
     async (req, reply) => createRescue(client, req, reply)
@@ -248,10 +206,6 @@ export const registerRescuesPublicRoutes = async (
       schema: {
         tags: ['rescues'],
         summary: 'Create a rescue organisation',
-        body: {
-          type: 'object',
-          additionalProperties: true,
-        },
       },
     },
     async (req, reply) => createRescue(client, req, reply)
@@ -266,12 +220,6 @@ export const registerRescuesPublicRoutes = async (
       schema: {
         tags: ['rescues'],
         summary: 'Get a rescue by ID',
-        params: {
-          type: 'object',
-          properties: {
-            id: { type: 'string' },
-          },
-        },
       },
     },
     async (req, reply) => {

--- a/services/gateway/src/routes/rescues-public.ts
+++ b/services/gateway/src/routes/rescues-public.ts
@@ -41,7 +41,23 @@ export const registerRescuesPublicRoutes = async (
   // GET /api/v1/rescues — list with optional status filter, name search,
   // and keyset pagination. lib.rescue.searchRescues / followedRescues
   // hit this with `search=` / cursor params.
-  app.get('/api/v1/rescues', { config: { rateLimit: RL_READ } }, async (req, reply) => {
+  app.get('/api/v1/rescues', {
+    config: { rateLimit: RL_READ },
+    schema: {
+      tags: ['rescues'],
+      summary: 'List rescues',
+      querystring: {
+        type: 'object',
+        properties: {
+          cursor: { type: 'string' },
+          limit: { type: 'string' },
+          status: { type: 'string' },
+          search: { type: 'string' },
+        },
+        additionalProperties: true,
+      },
+    },
+  }, async (req, reply) => {
     const q = req.query as Record<string, string | undefined>;
     const pagination = parsePagination(q, { limit: 0 });
     if (!pagination.ok) {
@@ -58,7 +74,20 @@ export const registerRescuesPublicRoutes = async (
 
   // GET /api/v1/rescues/featured — randomized verified picks. Limit
   // defaults to 8 since the SPA renders a small carousel.
-  app.get('/api/v1/rescues/featured', { config: { rateLimit: RL_READ } }, async (req, reply) => {
+  app.get('/api/v1/rescues/featured', {
+    config: { rateLimit: RL_READ },
+    schema: {
+      tags: ['rescues'],
+      summary: 'List featured rescues',
+      querystring: {
+        type: 'object',
+        properties: {
+          limit: { type: 'string' },
+        },
+        additionalProperties: true,
+      },
+    },
+  }, async (req, reply) => {
     const q = req.query as Record<string, string | undefined>;
     const pagination = parsePagination(q, { limit: 8 });
     if (!pagination.ok) {
@@ -79,7 +108,24 @@ export const registerRescuesPublicRoutes = async (
 
   // GET /api/v1/rescues/search?search=…&status=… — alias for List with
   // name_search wired in.
-  app.get('/api/v1/rescues/search', { config: { rateLimit: RL_READ } }, async (req, reply) => {
+  app.get('/api/v1/rescues/search', {
+    config: { rateLimit: RL_READ },
+    schema: {
+      tags: ['rescues'],
+      summary: 'Search rescues',
+      querystring: {
+        type: 'object',
+        properties: {
+          search: { type: 'string' },
+          q: { type: 'string' },
+          status: { type: 'string' },
+          cursor: { type: 'string' },
+          limit: { type: 'string' },
+        },
+        additionalProperties: true,
+      },
+    },
+  }, async (req, reply) => {
     const q = req.query as Record<string, string | undefined>;
     const pagination = parsePagination(q, { limit: 0 });
     if (!pagination.ok) {
@@ -98,7 +144,23 @@ export const registerRescuesPublicRoutes = async (
   // service stub returns empty until lat/lng columns land in the schema;
   // the SPA's UX falls back to a "no nearby rescues" empty state
   // cleanly when that happens.
-  app.get('/api/v1/rescues/nearby', { config: { rateLimit: RL_READ } }, async (req, reply) => {
+  app.get('/api/v1/rescues/nearby', {
+    config: { rateLimit: RL_READ },
+    schema: {
+      tags: ['rescues'],
+      summary: 'List nearby rescues by location',
+      querystring: {
+        type: 'object',
+        properties: {
+          lat: { type: 'string' },
+          lng: { type: 'string' },
+          radiusKm: { type: 'string' },
+          limit: { type: 'string' },
+        },
+        additionalProperties: true,
+      },
+    },
+  }, async (req, reply) => {
     const q = req.query as Record<string, string | undefined>;
     const pagination = parsePagination(q, { limit: 20 });
     if (!pagination.ok) {
@@ -125,7 +187,13 @@ export const registerRescuesPublicRoutes = async (
   // GET /api/v1/rescues/followed — per-user follows. No follows table yet;
   // return an empty page so the SPA's "rescues you follow" surface renders
   // cleanly. A future PR adds a user_rescue_follows table + the join.
-  app.get('/api/v1/rescues/followed', { config: { rateLimit: RL_READ } }, async (_req, reply) => {
+  app.get('/api/v1/rescues/followed', {
+    config: { rateLimit: RL_READ },
+    schema: {
+      tags: ['rescues'],
+      summary: 'List rescues followed by the current user',
+    },
+  }, async (_req, reply) => {
     return reply.send({
       success: true,
       data: [],
@@ -135,13 +203,33 @@ export const registerRescuesPublicRoutes = async (
 
   // POST /api/v1/rescues/register — alias for Create. The SPA's
   // registration flow posts here.
-  app.post('/api/v1/rescues/register', { config: { rateLimit: RL_WRITE } }, async (req, reply) =>
+  app.post('/api/v1/rescues/register', {
+    config: { rateLimit: RL_WRITE },
+    schema: {
+      tags: ['rescues'],
+      summary: 'Register a new rescue organisation',
+      body: {
+        type: 'object',
+        additionalProperties: true,
+      },
+    },
+  }, async (req, reply) =>
     createRescue(client, req, reply)
   );
 
   // POST /api/v1/rescues — also Create (for admin tooling that hits the
   // canonical path).
-  app.post('/api/v1/rescues', { config: { rateLimit: RL_WRITE } }, async (req, reply) =>
+  app.post('/api/v1/rescues', {
+    config: { rateLimit: RL_WRITE },
+    schema: {
+      tags: ['rescues'],
+      summary: 'Create a rescue organisation',
+      body: {
+        type: 'object',
+        additionalProperties: true,
+      },
+    },
+  }, async (req, reply) =>
     createRescue(client, req, reply)
   );
 
@@ -149,7 +237,19 @@ export const registerRescuesPublicRoutes = async (
   // getRescueById hits this and parses with RescueAPIResponseSchema.
   app.get<{ Params: { id: string } }>(
     '/api/v1/rescues/:id',
-    { config: { rateLimit: RL_READ } },
+    {
+      config: { rateLimit: RL_READ },
+      schema: {
+        tags: ['rescues'],
+        summary: 'Get a rescue by ID',
+        params: {
+          type: 'object',
+          properties: {
+            id: { type: 'string' },
+          },
+        },
+      },
+    },
     async (req, reply) => {
       try {
         const res = await client.get({ rescueId: req.params.id }, buildMetadata(req));

--- a/services/gateway/src/routes/rescues-public.ts
+++ b/services/gateway/src/routes/rescues-public.ts
@@ -41,196 +41,220 @@ export const registerRescuesPublicRoutes = async (
   // GET /api/v1/rescues — list with optional status filter, name search,
   // and keyset pagination. lib.rescue.searchRescues / followedRescues
   // hit this with `search=` / cursor params.
-  app.get('/api/v1/rescues', {
-    config: { rateLimit: RL_READ },
-    schema: {
-      tags: ['rescues'],
-      summary: 'List rescues',
-      querystring: {
-        type: 'object',
-        properties: {
-          cursor: { type: 'string' },
-          limit: { type: 'string' },
-          status: { type: 'string' },
-          search: { type: 'string' },
+  app.get(
+    '/api/v1/rescues',
+    {
+      config: { rateLimit: RL_READ },
+      schema: {
+        tags: ['rescues'],
+        summary: 'List rescues',
+        querystring: {
+          type: 'object',
+          properties: {
+            cursor: { type: 'string' },
+            limit: { type: 'string' },
+            status: { type: 'string' },
+            search: { type: 'string' },
+          },
+          additionalProperties: true,
         },
-        additionalProperties: true,
       },
     },
-  }, async (req, reply) => {
-    const q = req.query as Record<string, string | undefined>;
-    const pagination = parsePagination(q, { limit: 0 });
-    if (!pagination.ok) {
-      return reply.code(400).send({ success: false, error: pagination.error });
+    async (req, reply) => {
+      const q = req.query as Record<string, string | undefined>;
+      const pagination = parsePagination(q, { limit: 0 });
+      if (!pagination.ok) {
+        return reply.code(400).send({ success: false, error: pagination.error });
+      }
+      const grpcReq = buildListRequest(q, pagination.limit);
+      try {
+        const res = await client.list(grpcReq, buildMetadata(req));
+        return reply.send(rescueListEnvelope(res));
+      } catch (err) {
+        return handleGrpcError(err, reply);
+      }
     }
-    const grpcReq = buildListRequest(q, pagination.limit);
-    try {
-      const res = await client.list(grpcReq, buildMetadata(req));
-      return reply.send(rescueListEnvelope(res));
-    } catch (err) {
-      return handleGrpcError(err, reply);
-    }
-  });
+  );
 
   // GET /api/v1/rescues/featured — randomized verified picks. Limit
   // defaults to 8 since the SPA renders a small carousel.
-  app.get('/api/v1/rescues/featured', {
-    config: { rateLimit: RL_READ },
-    schema: {
-      tags: ['rescues'],
-      summary: 'List featured rescues',
-      querystring: {
-        type: 'object',
-        properties: {
-          limit: { type: 'string' },
+  app.get(
+    '/api/v1/rescues/featured',
+    {
+      config: { rateLimit: RL_READ },
+      schema: {
+        tags: ['rescues'],
+        summary: 'List featured rescues',
+        querystring: {
+          type: 'object',
+          properties: {
+            limit: { type: 'string' },
+          },
+          additionalProperties: true,
         },
-        additionalProperties: true,
       },
     },
-  }, async (req, reply) => {
-    const q = req.query as Record<string, string | undefined>;
-    const pagination = parsePagination(q, { limit: 8 });
-    if (!pagination.ok) {
-      return reply.code(400).send({ success: false, error: pagination.error });
+    async (req, reply) => {
+      const q = req.query as Record<string, string | undefined>;
+      const pagination = parsePagination(q, { limit: 8 });
+      if (!pagination.ok) {
+        return reply.code(400).send({ success: false, error: pagination.error });
+      }
+      const grpcReq: ListRescuesRequest = {
+        limit: pagination.limit,
+        statusFilter: RescueV1.RescueStatus.RESCUE_STATUS_UNSPECIFIED,
+        randomize: true,
+      };
+      try {
+        const res = await client.list(grpcReq, buildMetadata(req));
+        return reply.send(rescueListEnvelope(res));
+      } catch (err) {
+        return handleGrpcError(err, reply);
+      }
     }
-    const grpcReq: ListRescuesRequest = {
-      limit: pagination.limit,
-      statusFilter: RescueV1.RescueStatus.RESCUE_STATUS_UNSPECIFIED,
-      randomize: true,
-    };
-    try {
-      const res = await client.list(grpcReq, buildMetadata(req));
-      return reply.send(rescueListEnvelope(res));
-    } catch (err) {
-      return handleGrpcError(err, reply);
-    }
-  });
+  );
 
   // GET /api/v1/rescues/search?search=…&status=… — alias for List with
   // name_search wired in.
-  app.get('/api/v1/rescues/search', {
-    config: { rateLimit: RL_READ },
-    schema: {
-      tags: ['rescues'],
-      summary: 'Search rescues',
-      querystring: {
-        type: 'object',
-        properties: {
-          search: { type: 'string' },
-          q: { type: 'string' },
-          status: { type: 'string' },
-          cursor: { type: 'string' },
-          limit: { type: 'string' },
+  app.get(
+    '/api/v1/rescues/search',
+    {
+      config: { rateLimit: RL_READ },
+      schema: {
+        tags: ['rescues'],
+        summary: 'Search rescues',
+        querystring: {
+          type: 'object',
+          properties: {
+            search: { type: 'string' },
+            q: { type: 'string' },
+            status: { type: 'string' },
+            cursor: { type: 'string' },
+            limit: { type: 'string' },
+          },
+          additionalProperties: true,
         },
-        additionalProperties: true,
       },
     },
-  }, async (req, reply) => {
-    const q = req.query as Record<string, string | undefined>;
-    const pagination = parsePagination(q, { limit: 0 });
-    if (!pagination.ok) {
-      return reply.code(400).send({ success: false, error: pagination.error });
+    async (req, reply) => {
+      const q = req.query as Record<string, string | undefined>;
+      const pagination = parsePagination(q, { limit: 0 });
+      if (!pagination.ok) {
+        return reply.code(400).send({ success: false, error: pagination.error });
+      }
+      const grpcReq = buildListRequest({ ...q, search: q.search ?? q.q }, pagination.limit);
+      try {
+        const res = await client.list(grpcReq, buildMetadata(req));
+        return reply.send(rescueListEnvelope(res));
+      } catch (err) {
+        return handleGrpcError(err, reply);
+      }
     }
-    const grpcReq = buildListRequest({ ...q, search: q.search ?? q.q }, pagination.limit);
-    try {
-      const res = await client.list(grpcReq, buildMetadata(req));
-      return reply.send(rescueListEnvelope(res));
-    } catch (err) {
-      return handleGrpcError(err, reply);
-    }
-  });
+  );
 
   // GET /api/v1/rescues/nearby?lat&lng&radiusKm=… — geo filter. The
   // service stub returns empty until lat/lng columns land in the schema;
   // the SPA's UX falls back to a "no nearby rescues" empty state
   // cleanly when that happens.
-  app.get('/api/v1/rescues/nearby', {
-    config: { rateLimit: RL_READ },
-    schema: {
-      tags: ['rescues'],
-      summary: 'List nearby rescues by location',
-      querystring: {
-        type: 'object',
-        properties: {
-          lat: { type: 'string' },
-          lng: { type: 'string' },
-          radiusKm: { type: 'string' },
-          limit: { type: 'string' },
+  app.get(
+    '/api/v1/rescues/nearby',
+    {
+      config: { rateLimit: RL_READ },
+      schema: {
+        tags: ['rescues'],
+        summary: 'List nearby rescues by location',
+        querystring: {
+          type: 'object',
+          properties: {
+            lat: { type: 'string' },
+            lng: { type: 'string' },
+            radiusKm: { type: 'string' },
+            limit: { type: 'string' },
+          },
+          additionalProperties: true,
         },
-        additionalProperties: true,
       },
     },
-  }, async (req, reply) => {
-    const q = req.query as Record<string, string | undefined>;
-    const pagination = parsePagination(q, { limit: 20 });
-    if (!pagination.ok) {
-      return reply.code(400).send({ success: false, error: pagination.error });
+    async (req, reply) => {
+      const q = req.query as Record<string, string | undefined>;
+      const pagination = parsePagination(q, { limit: 20 });
+      if (!pagination.ok) {
+        return reply.code(400).send({ success: false, error: pagination.error });
+      }
+      const lat = q.lat ? Number.parseFloat(q.lat) : undefined;
+      const lng = q.lng ? Number.parseFloat(q.lng) : undefined;
+      const radius = q.radiusKm ? Number.parseFloat(q.radiusKm) : undefined;
+      const grpcReq: ListRescuesRequest = {
+        limit: pagination.limit,
+        statusFilter: RescueV1.RescueStatus.RESCUE_STATUS_UNSPECIFIED,
+        latitude: lat,
+        longitude: lng,
+        radiusKm: radius,
+      };
+      try {
+        const res = await client.list(grpcReq, buildMetadata(req));
+        return reply.send(rescueListEnvelope(res));
+      } catch (err) {
+        return handleGrpcError(err, reply);
+      }
     }
-    const lat = q.lat ? Number.parseFloat(q.lat) : undefined;
-    const lng = q.lng ? Number.parseFloat(q.lng) : undefined;
-    const radius = q.radiusKm ? Number.parseFloat(q.radiusKm) : undefined;
-    const grpcReq: ListRescuesRequest = {
-      limit: pagination.limit,
-      statusFilter: RescueV1.RescueStatus.RESCUE_STATUS_UNSPECIFIED,
-      latitude: lat,
-      longitude: lng,
-      radiusKm: radius,
-    };
-    try {
-      const res = await client.list(grpcReq, buildMetadata(req));
-      return reply.send(rescueListEnvelope(res));
-    } catch (err) {
-      return handleGrpcError(err, reply);
-    }
-  });
+  );
 
   // GET /api/v1/rescues/followed — per-user follows. No follows table yet;
   // return an empty page so the SPA's "rescues you follow" surface renders
   // cleanly. A future PR adds a user_rescue_follows table + the join.
-  app.get('/api/v1/rescues/followed', {
-    config: { rateLimit: RL_READ },
-    schema: {
-      tags: ['rescues'],
-      summary: 'List rescues followed by the current user',
+  app.get(
+    '/api/v1/rescues/followed',
+    {
+      config: { rateLimit: RL_READ },
+      schema: {
+        tags: ['rescues'],
+        summary: 'List rescues followed by the current user',
+      },
     },
-  }, async (_req, reply) => {
-    return reply.send({
-      success: true,
-      data: [],
-      meta: { hasNext: false },
-    });
-  });
+    async (_req, reply) => {
+      return reply.send({
+        success: true,
+        data: [],
+        meta: { hasNext: false },
+      });
+    }
+  );
 
   // POST /api/v1/rescues/register — alias for Create. The SPA's
   // registration flow posts here.
-  app.post('/api/v1/rescues/register', {
-    config: { rateLimit: RL_WRITE },
-    schema: {
-      tags: ['rescues'],
-      summary: 'Register a new rescue organisation',
-      body: {
-        type: 'object',
-        additionalProperties: true,
+  app.post(
+    '/api/v1/rescues/register',
+    {
+      config: { rateLimit: RL_WRITE },
+      schema: {
+        tags: ['rescues'],
+        summary: 'Register a new rescue organisation',
+        body: {
+          type: 'object',
+          additionalProperties: true,
+        },
       },
     },
-  }, async (req, reply) =>
-    createRescue(client, req, reply)
+    async (req, reply) => createRescue(client, req, reply)
   );
 
   // POST /api/v1/rescues — also Create (for admin tooling that hits the
   // canonical path).
-  app.post('/api/v1/rescues', {
-    config: { rateLimit: RL_WRITE },
-    schema: {
-      tags: ['rescues'],
-      summary: 'Create a rescue organisation',
-      body: {
-        type: 'object',
-        additionalProperties: true,
+  app.post(
+    '/api/v1/rescues',
+    {
+      config: { rateLimit: RL_WRITE },
+      schema: {
+        tags: ['rescues'],
+        summary: 'Create a rescue organisation',
+        body: {
+          type: 'object',
+          additionalProperties: true,
+        },
       },
     },
-  }, async (req, reply) =>
-    createRescue(client, req, reply)
+    async (req, reply) => createRescue(client, req, reply)
   );
 
   // GET /api/v1/rescues/:id — single rescue read. lib.rescue's

--- a/services/gateway/src/routes/sessions.ts
+++ b/services/gateway/src/routes/sessions.ts
@@ -32,7 +32,15 @@ export const registerSessionsRoutes = async (
   // GET /api/v1/sessions — list active sessions for the calling user.
   // Monolith response shape: { data: [{sessionId, familyId, expiresAt,
   // createdAt}, ...] }. We mirror it.
-  app.get('/api/v1/sessions', async (req, reply) => {
+  app.get(
+    '/api/v1/sessions',
+    {
+      schema: {
+        tags: ['sessions'],
+        summary: 'List active sessions for the calling user',
+      },
+    },
+    async (req, reply) => {
     const metadata = buildMetadata(req);
     try {
       const res = await client.listSessions({}, metadata);
@@ -55,6 +63,18 @@ export const registerSessionsRoutes = async (
   // monolith parity. The gRPC response payload is discarded.
   app.delete<{ Params: { sessionId: string } }>(
     '/api/v1/sessions/:sessionId',
+    {
+      schema: {
+        tags: ['sessions'],
+        summary: 'Revoke a specific session',
+        params: {
+          type: 'object',
+          properties: {
+            sessionId: { type: 'string' },
+          },
+        },
+      },
+    },
     async (req, reply) => {
       const metadata = buildMetadata(req);
       const grpcReq: RevokeSessionRequest = { sessionId: req.params.sessionId };

--- a/services/gateway/src/routes/sessions.ts
+++ b/services/gateway/src/routes/sessions.ts
@@ -68,12 +68,6 @@ export const registerSessionsRoutes = async (
       schema: {
         tags: ['sessions'],
         summary: 'Revoke a specific session',
-        params: {
-          type: 'object',
-          properties: {
-            sessionId: { type: 'string' },
-          },
-        },
       },
     },
     async (req, reply) => {

--- a/services/gateway/src/routes/sessions.ts
+++ b/services/gateway/src/routes/sessions.ts
@@ -41,23 +41,24 @@ export const registerSessionsRoutes = async (
       },
     },
     async (req, reply) => {
-    const metadata = buildMetadata(req);
-    try {
-      const res = await client.listSessions({}, metadata);
-      // toJSON would yield `{ sessions: [...] }` (proto field name);
-      // the monolith uses `data: [...]`. Reshape here.
-      return reply.send({
-        data: (res.sessions ?? []).map(s => ({
-          sessionId: s.sessionId,
-          familyId: s.familyId,
-          expiresAt: s.expiresAt,
-          createdAt: s.createdAt,
-        })),
-      });
-    } catch (err) {
-      return handleGrpcError(err, reply);
+      const metadata = buildMetadata(req);
+      try {
+        const res = await client.listSessions({}, metadata);
+        // toJSON would yield `{ sessions: [...] }` (proto field name);
+        // the monolith uses `data: [...]`. Reshape here.
+        return reply.send({
+          data: (res.sessions ?? []).map(s => ({
+            sessionId: s.sessionId,
+            familyId: s.familyId,
+            expiresAt: s.expiresAt,
+            createdAt: s.createdAt,
+          })),
+        });
+      } catch (err) {
+        return handleGrpcError(err, reply);
+      }
     }
-  });
+  );
 
   // DELETE /api/v1/sessions/:sessionId — revoke. Returns 204 to match
   // monolith parity. The gRPC response payload is discarded.

--- a/services/gateway/src/routes/staff-foster.ts
+++ b/services/gateway/src/routes/staff-foster.ts
@@ -56,170 +56,194 @@ export const registerStaffFosterRoutes = async (
   const { client } = opts;
 
   // ---- GET /api/v1/staff/me ----------------------------------------
-  app.get('/api/v1/staff/me', {
-    schema: {
-      tags: ['staff'],
-      summary: 'Get current user staff membership',
+  app.get(
+    '/api/v1/staff/me',
+    {
+      schema: {
+        tags: ['staff'],
+        summary: 'Get current user staff membership',
+      },
     },
-  }, async (req, reply) => {
-    try {
-      const res = await client.getMyStaffMembership({}, buildMetadata(req));
-      return reply.send({ success: true, data: res.staffMember });
-    } catch (err) {
-      return handleGrpcError(err, reply);
+    async (req, reply) => {
+      try {
+        const res = await client.getMyStaffMembership({}, buildMetadata(req));
+        return reply.send({ success: true, data: res.staffMember });
+      } catch (err) {
+        return handleGrpcError(err, reply);
+      }
     }
-  });
+  );
 
   // ---- GET /api/v1/staff/colleagues --------------------------------
-  app.get('/api/v1/staff/colleagues', {
-    schema: {
-      tags: ['staff'],
-      summary: 'List staff colleagues within the current rescue',
+  app.get(
+    '/api/v1/staff/colleagues',
+    {
+      schema: {
+        tags: ['staff'],
+        summary: 'List staff colleagues within the current rescue',
+      },
     },
-  }, async (req, reply) => {
-    try {
-      // Empty rescue_id → service resolves the caller's own rescue.
-      const res = await client.listStaffMembers({ rescueId: undefined }, buildMetadata(req));
-      return reply.send({ success: true, data: res.staffMembers ?? [] });
-    } catch (err) {
-      return handleGrpcError(err, reply);
+    async (req, reply) => {
+      try {
+        // Empty rescue_id → service resolves the caller's own rescue.
+        const res = await client.listStaffMembers({ rescueId: undefined }, buildMetadata(req));
+        return reply.send({ success: true, data: res.staffMembers ?? [] });
+      } catch (err) {
+        return handleGrpcError(err, reply);
+      }
     }
-  });
+  );
 
   // ---- POST /api/v1/foster/placements ------------------------------
-  app.post('/api/v1/foster/placements', {
-    schema: {
-      tags: ['foster'],
-      summary: 'Create a foster placement',
-      body: {
-        type: 'object',
-        properties: {
-          rescueId: { type: 'string' },
-          petId: { type: 'string' },
-          fosterUserId: { type: 'string' },
-          startDate: { type: 'string' },
-          notes: { type: 'string' },
+  app.post(
+    '/api/v1/foster/placements',
+    {
+      schema: {
+        tags: ['foster'],
+        summary: 'Create a foster placement',
+        body: {
+          type: 'object',
+          properties: {
+            rescueId: { type: 'string' },
+            petId: { type: 'string' },
+            fosterUserId: { type: 'string' },
+            startDate: { type: 'string' },
+            notes: { type: 'string' },
+          },
+          additionalProperties: true,
         },
-        additionalProperties: true,
       },
     },
-  }, async (req, reply) => {
-    const body = (req.body ?? {}) as {
-      rescueId?: string;
-      petId?: string;
-      fosterUserId?: string;
-      startDate?: string;
-      notes?: string;
-    };
-    const grpcReq: CreateFosterPlacementRequest = {
-      rescueId: body.rescueId ?? '',
-      petId: body.petId ?? '',
-      fosterUserId: body.fosterUserId ?? '',
-      startDate: body.startDate ?? '',
-      notes: body.notes,
-    };
-    try {
-      const res = await client.createFosterPlacement(grpcReq, buildMetadata(req));
-      return reply.code(201).send({ success: true, data: res.placement });
-    } catch (err) {
-      return handleGrpcError(err, reply);
+    async (req, reply) => {
+      const body = (req.body ?? {}) as {
+        rescueId?: string;
+        petId?: string;
+        fosterUserId?: string;
+        startDate?: string;
+        notes?: string;
+      };
+      const grpcReq: CreateFosterPlacementRequest = {
+        rescueId: body.rescueId ?? '',
+        petId: body.petId ?? '',
+        fosterUserId: body.fosterUserId ?? '',
+        startDate: body.startDate ?? '',
+        notes: body.notes,
+      };
+      try {
+        const res = await client.createFosterPlacement(grpcReq, buildMetadata(req));
+        return reply.code(201).send({ success: true, data: res.placement });
+      } catch (err) {
+        return handleGrpcError(err, reply);
+      }
     }
-  });
+  );
 
   // ---- GET /api/v1/foster/placements -------------------------------
-  app.get('/api/v1/foster/placements', {
-    schema: {
-      tags: ['foster'],
-      summary: 'List foster placements',
-      querystring: {
-        type: 'object',
-        properties: {
-          rescueId: { type: 'string' },
-          fosterUserId: { type: 'string' },
-          status: { type: 'string' },
+  app.get(
+    '/api/v1/foster/placements',
+    {
+      schema: {
+        tags: ['foster'],
+        summary: 'List foster placements',
+        querystring: {
+          type: 'object',
+          properties: {
+            rescueId: { type: 'string' },
+            fosterUserId: { type: 'string' },
+            status: { type: 'string' },
+          },
+          additionalProperties: true,
         },
-        additionalProperties: true,
       },
     },
-  }, async (req, reply) => {
-    const query = req.query as Record<string, string | undefined>;
-    const grpcReq: ListFosterPlacementsRequest = {
-      rescueId: query.rescueId,
-      fosterUserId: query.fosterUserId,
-      statusFilter: fosterStatusFromString(query.status),
-    };
-    try {
-      const res = await client.listFosterPlacements(grpcReq, buildMetadata(req));
-      return reply.send({ success: true, data: res.placements ?? [] });
-    } catch (err) {
-      return handleGrpcError(err, reply);
+    async (req, reply) => {
+      const query = req.query as Record<string, string | undefined>;
+      const grpcReq: ListFosterPlacementsRequest = {
+        rescueId: query.rescueId,
+        fosterUserId: query.fosterUserId,
+        statusFilter: fosterStatusFromString(query.status),
+      };
+      try {
+        const res = await client.listFosterPlacements(grpcReq, buildMetadata(req));
+        return reply.send({ success: true, data: res.placements ?? [] });
+      } catch (err) {
+        return handleGrpcError(err, reply);
+      }
     }
-  });
+  );
 
   // ---- GET /api/v1/foster/placements/:id ---------------------------
-  app.get<{ Params: { id: string } }>('/api/v1/foster/placements/:id', {
-    schema: {
-      tags: ['foster'],
-      summary: 'Get a foster placement by ID',
-      params: {
-        type: 'object',
-        properties: {
-          id: { type: 'string' },
+  app.get<{ Params: { id: string } }>(
+    '/api/v1/foster/placements/:id',
+    {
+      schema: {
+        tags: ['foster'],
+        summary: 'Get a foster placement by ID',
+        params: {
+          type: 'object',
+          properties: {
+            id: { type: 'string' },
+          },
         },
       },
     },
-  }, async (req, reply) => {
-    try {
-      const res = await client.getFosterPlacement(
-        { placementId: req.params.id },
-        buildMetadata(req)
-      );
-      return reply.send({ success: true, data: res.placement });
-    } catch (err) {
-      return handleGrpcError(err, reply);
+    async (req, reply) => {
+      try {
+        const res = await client.getFosterPlacement(
+          { placementId: req.params.id },
+          buildMetadata(req)
+        );
+        return reply.send({ success: true, data: res.placement });
+      } catch (err) {
+        return handleGrpcError(err, reply);
+      }
     }
-  });
+  );
 
   // ---- POST /api/v1/foster/placements/:id/end ----------------------
-  app.post<{ Params: { id: string } }>('/api/v1/foster/placements/:id/end', {
-    schema: {
-      tags: ['foster'],
-      summary: 'End a foster placement',
-      params: {
-        type: 'object',
-        properties: {
-          id: { type: 'string' },
+  app.post<{ Params: { id: string } }>(
+    '/api/v1/foster/placements/:id/end',
+    {
+      schema: {
+        tags: ['foster'],
+        summary: 'End a foster placement',
+        params: {
+          type: 'object',
+          properties: {
+            id: { type: 'string' },
+          },
         },
-      },
-      body: {
-        type: 'object',
-        properties: {
-          outcome: { type: 'string' },
-          endDate: { type: 'string' },
-          notes: { type: 'string' },
+        body: {
+          type: 'object',
+          properties: {
+            outcome: { type: 'string' },
+            endDate: { type: 'string' },
+            notes: { type: 'string' },
+          },
+          additionalProperties: true,
         },
-        additionalProperties: true,
       },
     },
-  }, async (req, reply) => {
-    const body = (req.body ?? {}) as {
-      outcome?: string;
-      endDate?: string;
-      notes?: string;
-    };
-    const grpcReq: EndFosterPlacementRequest = {
-      placementId: req.params.id,
-      outcome: endOutcomeFromString(body.outcome),
-      endDate: body.endDate,
-      notes: body.notes,
-    };
-    try {
-      const res = await client.endFosterPlacement(grpcReq, buildMetadata(req));
-      return reply.send({ success: true, data: res.placement });
-    } catch (err) {
-      return handleGrpcError(err, reply);
+    async (req, reply) => {
+      const body = (req.body ?? {}) as {
+        outcome?: string;
+        endDate?: string;
+        notes?: string;
+      };
+      const grpcReq: EndFosterPlacementRequest = {
+        placementId: req.params.id,
+        outcome: endOutcomeFromString(body.outcome),
+        endDate: body.endDate,
+        notes: body.notes,
+      };
+      try {
+        const res = await client.endFosterPlacement(grpcReq, buildMetadata(req));
+        return reply.send({ success: true, data: res.placement });
+      } catch (err) {
+        return handleGrpcError(err, reply);
+      }
     }
-  });
+  );
 
   // ---- GET /api/v1/invitations/details/:token ----------------------
   // Public — reachable from the email link before the invitee has an

--- a/services/gateway/src/routes/staff-foster.ts
+++ b/services/gateway/src/routes/staff-foster.ts
@@ -56,7 +56,12 @@ export const registerStaffFosterRoutes = async (
   const { client } = opts;
 
   // ---- GET /api/v1/staff/me ----------------------------------------
-  app.get('/api/v1/staff/me', async (req, reply) => {
+  app.get('/api/v1/staff/me', {
+    schema: {
+      tags: ['staff'],
+      summary: 'Get current user staff membership',
+    },
+  }, async (req, reply) => {
     try {
       const res = await client.getMyStaffMembership({}, buildMetadata(req));
       return reply.send({ success: true, data: res.staffMember });
@@ -66,7 +71,12 @@ export const registerStaffFosterRoutes = async (
   });
 
   // ---- GET /api/v1/staff/colleagues --------------------------------
-  app.get('/api/v1/staff/colleagues', async (req, reply) => {
+  app.get('/api/v1/staff/colleagues', {
+    schema: {
+      tags: ['staff'],
+      summary: 'List staff colleagues within the current rescue',
+    },
+  }, async (req, reply) => {
     try {
       // Empty rescue_id → service resolves the caller's own rescue.
       const res = await client.listStaffMembers({ rescueId: undefined }, buildMetadata(req));
@@ -77,7 +87,23 @@ export const registerStaffFosterRoutes = async (
   });
 
   // ---- POST /api/v1/foster/placements ------------------------------
-  app.post('/api/v1/foster/placements', async (req, reply) => {
+  app.post('/api/v1/foster/placements', {
+    schema: {
+      tags: ['foster'],
+      summary: 'Create a foster placement',
+      body: {
+        type: 'object',
+        properties: {
+          rescueId: { type: 'string' },
+          petId: { type: 'string' },
+          fosterUserId: { type: 'string' },
+          startDate: { type: 'string' },
+          notes: { type: 'string' },
+        },
+        additionalProperties: true,
+      },
+    },
+  }, async (req, reply) => {
     const body = (req.body ?? {}) as {
       rescueId?: string;
       petId?: string;
@@ -101,7 +127,21 @@ export const registerStaffFosterRoutes = async (
   });
 
   // ---- GET /api/v1/foster/placements -------------------------------
-  app.get('/api/v1/foster/placements', async (req, reply) => {
+  app.get('/api/v1/foster/placements', {
+    schema: {
+      tags: ['foster'],
+      summary: 'List foster placements',
+      querystring: {
+        type: 'object',
+        properties: {
+          rescueId: { type: 'string' },
+          fosterUserId: { type: 'string' },
+          status: { type: 'string' },
+        },
+        additionalProperties: true,
+      },
+    },
+  }, async (req, reply) => {
     const query = req.query as Record<string, string | undefined>;
     const grpcReq: ListFosterPlacementsRequest = {
       rescueId: query.rescueId,
@@ -117,7 +157,18 @@ export const registerStaffFosterRoutes = async (
   });
 
   // ---- GET /api/v1/foster/placements/:id ---------------------------
-  app.get<{ Params: { id: string } }>('/api/v1/foster/placements/:id', async (req, reply) => {
+  app.get<{ Params: { id: string } }>('/api/v1/foster/placements/:id', {
+    schema: {
+      tags: ['foster'],
+      summary: 'Get a foster placement by ID',
+      params: {
+        type: 'object',
+        properties: {
+          id: { type: 'string' },
+        },
+      },
+    },
+  }, async (req, reply) => {
     try {
       const res = await client.getFosterPlacement(
         { placementId: req.params.id },
@@ -130,7 +181,27 @@ export const registerStaffFosterRoutes = async (
   });
 
   // ---- POST /api/v1/foster/placements/:id/end ----------------------
-  app.post<{ Params: { id: string } }>('/api/v1/foster/placements/:id/end', async (req, reply) => {
+  app.post<{ Params: { id: string } }>('/api/v1/foster/placements/:id/end', {
+    schema: {
+      tags: ['foster'],
+      summary: 'End a foster placement',
+      params: {
+        type: 'object',
+        properties: {
+          id: { type: 'string' },
+        },
+      },
+      body: {
+        type: 'object',
+        properties: {
+          outcome: { type: 'string' },
+          endDate: { type: 'string' },
+          notes: { type: 'string' },
+        },
+        additionalProperties: true,
+      },
+    },
+  }, async (req, reply) => {
     const body = (req.body ?? {}) as {
       outcome?: string;
       endDate?: string;
@@ -155,6 +226,19 @@ export const registerStaffFosterRoutes = async (
   // account. The token IS the credential.
   app.get<{ Params: { token: string } }>(
     '/api/v1/invitations/details/:token',
+    {
+      schema: {
+        tags: ['staff'],
+        summary: 'Get invitation details by token',
+        security: [],
+        params: {
+          type: 'object',
+          properties: {
+            token: { type: 'string' },
+          },
+        },
+      },
+    },
     async (req, reply) => {
       try {
         const res = await client.getInvitationByToken(

--- a/services/gateway/src/routes/staff-foster.ts
+++ b/services/gateway/src/routes/staff-foster.ts
@@ -101,17 +101,6 @@ export const registerStaffFosterRoutes = async (
       schema: {
         tags: ['foster'],
         summary: 'Create a foster placement',
-        body: {
-          type: 'object',
-          properties: {
-            rescueId: { type: 'string' },
-            petId: { type: 'string' },
-            fosterUserId: { type: 'string' },
-            startDate: { type: 'string' },
-            notes: { type: 'string' },
-          },
-          additionalProperties: true,
-        },
       },
     },
     async (req, reply) => {
@@ -145,15 +134,6 @@ export const registerStaffFosterRoutes = async (
       schema: {
         tags: ['foster'],
         summary: 'List foster placements',
-        querystring: {
-          type: 'object',
-          properties: {
-            rescueId: { type: 'string' },
-            fosterUserId: { type: 'string' },
-            status: { type: 'string' },
-          },
-          additionalProperties: true,
-        },
       },
     },
     async (req, reply) => {
@@ -179,12 +159,6 @@ export const registerStaffFosterRoutes = async (
       schema: {
         tags: ['foster'],
         summary: 'Get a foster placement by ID',
-        params: {
-          type: 'object',
-          properties: {
-            id: { type: 'string' },
-          },
-        },
       },
     },
     async (req, reply) => {
@@ -207,21 +181,6 @@ export const registerStaffFosterRoutes = async (
       schema: {
         tags: ['foster'],
         summary: 'End a foster placement',
-        params: {
-          type: 'object',
-          properties: {
-            id: { type: 'string' },
-          },
-        },
-        body: {
-          type: 'object',
-          properties: {
-            outcome: { type: 'string' },
-            endDate: { type: 'string' },
-            notes: { type: 'string' },
-          },
-          additionalProperties: true,
-        },
       },
     },
     async (req, reply) => {
@@ -255,12 +214,6 @@ export const registerStaffFosterRoutes = async (
         tags: ['staff'],
         summary: 'Get invitation details by token',
         security: [],
-        params: {
-          type: 'object',
-          properties: {
-            token: { type: 'string' },
-          },
-        },
       },
     },
     async (req, reply) => {

--- a/services/gateway/src/routes/support.ts
+++ b/services/gateway/src/routes/support.ts
@@ -85,21 +85,6 @@ export const registerSupportRoutes = async (
       schema: {
         tags: ['support'],
         summary: 'Open a support ticket',
-        body: {
-          type: 'object',
-          properties: {
-            subject: { type: 'string' },
-            description: { type: 'string' },
-            category: { type: 'string' },
-            priority: { type: 'string' },
-            userEmail: { type: 'string' },
-            user_email: { type: 'string' },
-            userName: { type: 'string' },
-            user_name: { type: 'string' },
-            tags: { type: 'array', items: { type: 'string' } },
-          },
-          additionalProperties: true,
-        },
       },
     },
     async (req, reply) => {
@@ -141,15 +126,6 @@ export const registerSupportRoutes = async (
       schema: {
         tags: ['support'],
         summary: 'List support tickets for the current user',
-        querystring: {
-          type: 'object',
-          properties: {
-            status: { type: 'string' },
-            cursor: { type: 'string' },
-            limit: { type: 'string' },
-          },
-          additionalProperties: true,
-        },
       },
     },
     async (req, reply) => {
@@ -186,12 +162,6 @@ export const registerSupportRoutes = async (
       schema: {
         tags: ['support'],
         summary: 'Get a support ticket by ID',
-        params: {
-          type: 'object',
-          properties: {
-            ticketId: { type: 'string' },
-          },
-        },
       },
     },
     async (req, reply) => {
@@ -215,19 +185,6 @@ export const registerSupportRoutes = async (
       schema: {
         tags: ['support'],
         summary: 'Reply to a support ticket',
-        params: {
-          type: 'object',
-          properties: {
-            ticketId: { type: 'string' },
-          },
-        },
-        body: {
-          type: 'object',
-          properties: {
-            content: { type: 'string' },
-          },
-          additionalProperties: true,
-        },
       },
     },
     async (req, reply) => {
@@ -257,12 +214,6 @@ export const registerSupportRoutes = async (
       schema: {
         tags: ['support'],
         summary: 'Get support ticket messages',
-        params: {
-          type: 'object',
-          properties: {
-            ticketId: { type: 'string' },
-          },
-        },
       },
     },
     async (req, reply) => {

--- a/services/gateway/src/routes/support.ts
+++ b/services/gateway/src/routes/support.ts
@@ -79,97 +79,105 @@ export const registerSupportRoutes = async (
   // Caller is the ticket owner. The handler reads principal.userId for
   // the row; we still accept user_email + user_name from the body
   // (the monolith sends them — saves a /auth/me round-trip).
-  app.post('/api/v1/support/tickets', {
-    schema: {
-      tags: ['support'],
-      summary: 'Open a support ticket',
-      body: {
-        type: 'object',
-        properties: {
-          subject: { type: 'string' },
-          description: { type: 'string' },
-          category: { type: 'string' },
-          priority: { type: 'string' },
-          userEmail: { type: 'string' },
-          user_email: { type: 'string' },
-          userName: { type: 'string' },
-          user_name: { type: 'string' },
-          tags: { type: 'array', items: { type: 'string' } },
+  app.post(
+    '/api/v1/support/tickets',
+    {
+      schema: {
+        tags: ['support'],
+        summary: 'Open a support ticket',
+        body: {
+          type: 'object',
+          properties: {
+            subject: { type: 'string' },
+            description: { type: 'string' },
+            category: { type: 'string' },
+            priority: { type: 'string' },
+            userEmail: { type: 'string' },
+            user_email: { type: 'string' },
+            userName: { type: 'string' },
+            user_name: { type: 'string' },
+            tags: { type: 'array', items: { type: 'string' } },
+          },
+          additionalProperties: true,
         },
-        additionalProperties: true,
       },
     },
-  }, async (req, reply) => {
-    const body = (req.body ?? {}) as {
-      subject?: string;
-      description?: string;
-      category?: string;
-      priority?: string;
-      userEmail?: string;
-      user_email?: string;
-      userName?: string;
-      user_name?: string;
-      tags?: string[];
-    };
-    const grpcReq: OpenSupportTicketRequest = {
-      subject: body.subject ?? '',
-      description: body.description ?? '',
-      category: categoryFromString(body.category),
-      priority: priorityFromString(body.priority),
-      userEmail: body.userEmail ?? body.user_email ?? '',
-      userName: body.userName ?? body.user_name,
-      tags: body.tags ?? [],
-    };
-    try {
-      const res = await client.openSupportTicket(grpcReq, buildMetadata(req));
-      return reply.code(201).send({ success: true, data: res.ticket });
-    } catch (err) {
-      return handleGrpcError(err, reply);
+    async (req, reply) => {
+      const body = (req.body ?? {}) as {
+        subject?: string;
+        description?: string;
+        category?: string;
+        priority?: string;
+        userEmail?: string;
+        user_email?: string;
+        userName?: string;
+        user_name?: string;
+        tags?: string[];
+      };
+      const grpcReq: OpenSupportTicketRequest = {
+        subject: body.subject ?? '',
+        description: body.description ?? '',
+        category: categoryFromString(body.category),
+        priority: priorityFromString(body.priority),
+        userEmail: body.userEmail ?? body.user_email ?? '',
+        userName: body.userName ?? body.user_name,
+        tags: body.tags ?? [],
+      };
+      try {
+        const res = await client.openSupportTicket(grpcReq, buildMetadata(req));
+        return reply.code(201).send({ success: true, data: res.ticket });
+      } catch (err) {
+        return handleGrpcError(err, reply);
+      }
     }
-  });
+  );
 
   // ---- GET /api/v1/support/my-tickets ------------------------------
   // The handler self-scopes for non-admins, so no explicit user_id
   // filter needed.
-  app.get('/api/v1/support/my-tickets', {
-    schema: {
-      tags: ['support'],
-      summary: 'List support tickets for the current user',
-      querystring: {
-        type: 'object',
-        properties: {
-          status: { type: 'string' },
-          cursor: { type: 'string' },
-          limit: { type: 'string' },
+  app.get(
+    '/api/v1/support/my-tickets',
+    {
+      schema: {
+        tags: ['support'],
+        summary: 'List support tickets for the current user',
+        querystring: {
+          type: 'object',
+          properties: {
+            status: { type: 'string' },
+            cursor: { type: 'string' },
+            limit: { type: 'string' },
+          },
+          additionalProperties: true,
         },
-        additionalProperties: true,
       },
     },
-  }, async (req, reply) => {
-    const query = req.query as Record<string, string | undefined>;
-    const pagination = parsePagination(query, { limit: 0 });
-    if (!pagination.ok) {
-      return reply.code(400).send({ error: pagination.error });
+    async (req, reply) => {
+      const query = req.query as Record<string, string | undefined>;
+      const pagination = parsePagination(query, { limit: 0 });
+      if (!pagination.ok) {
+        return reply.code(400).send({ error: pagination.error });
+      }
+      const grpcReq: ListSupportTicketsRequest = {
+        status: statusFromString(query.status),
+        // page/limit — the monolith uses page-based; we forward limit
+        // only. Page-based pagination over a keyset cursor RPC is left
+        // to the SPA (cursor in/out).
+        limit: pagination.limit,
+        cursor: query.cursor,
+      } as ListSupportTicketsRequest;
+      try {
+        const res = await client.listSupportTickets(grpcReq, buildMetadata(req));
+        return reply.send({
+          success: true,
+          data: res.tickets ?? [],
+          nextCursor: res.nextCursor,
+        });
+      } catch (err) {
+        return handleGrpcError(err, reply);
+      }
     }
-    const grpcReq: ListSupportTicketsRequest = {
-      status: statusFromString(query.status),
-      // page/limit — the monolith uses page-based; we forward limit
-      // only. Page-based pagination over a keyset cursor RPC is left
-      // to the SPA (cursor in/out).
-      limit: pagination.limit,
-      cursor: query.cursor,
-    } as ListSupportTicketsRequest;
-    try {
-      const res = await client.listSupportTickets(grpcReq, buildMetadata(req));
-      return reply.send({
-        success: true,
-        data: res.tickets ?? [],
-        nextCursor: res.nextCursor,
-      });
-    } catch (err) {
-      return handleGrpcError(err, reply);
-    }
-  });
+  );
 
   // ---- GET /api/v1/support/tickets/:ticketId -----------------------
   app.get<{ Params: { ticketId: string } }>(

--- a/services/gateway/src/routes/support.ts
+++ b/services/gateway/src/routes/support.ts
@@ -79,7 +79,27 @@ export const registerSupportRoutes = async (
   // Caller is the ticket owner. The handler reads principal.userId for
   // the row; we still accept user_email + user_name from the body
   // (the monolith sends them — saves a /auth/me round-trip).
-  app.post('/api/v1/support/tickets', async (req, reply) => {
+  app.post('/api/v1/support/tickets', {
+    schema: {
+      tags: ['support'],
+      summary: 'Open a support ticket',
+      body: {
+        type: 'object',
+        properties: {
+          subject: { type: 'string' },
+          description: { type: 'string' },
+          category: { type: 'string' },
+          priority: { type: 'string' },
+          userEmail: { type: 'string' },
+          user_email: { type: 'string' },
+          userName: { type: 'string' },
+          user_name: { type: 'string' },
+          tags: { type: 'array', items: { type: 'string' } },
+        },
+        additionalProperties: true,
+      },
+    },
+  }, async (req, reply) => {
     const body = (req.body ?? {}) as {
       subject?: string;
       description?: string;
@@ -111,7 +131,21 @@ export const registerSupportRoutes = async (
   // ---- GET /api/v1/support/my-tickets ------------------------------
   // The handler self-scopes for non-admins, so no explicit user_id
   // filter needed.
-  app.get('/api/v1/support/my-tickets', async (req, reply) => {
+  app.get('/api/v1/support/my-tickets', {
+    schema: {
+      tags: ['support'],
+      summary: 'List support tickets for the current user',
+      querystring: {
+        type: 'object',
+        properties: {
+          status: { type: 'string' },
+          cursor: { type: 'string' },
+          limit: { type: 'string' },
+        },
+        additionalProperties: true,
+      },
+    },
+  }, async (req, reply) => {
     const query = req.query as Record<string, string | undefined>;
     const pagination = parsePagination(query, { limit: 0 });
     if (!pagination.ok) {
@@ -140,6 +174,18 @@ export const registerSupportRoutes = async (
   // ---- GET /api/v1/support/tickets/:ticketId -----------------------
   app.get<{ Params: { ticketId: string } }>(
     '/api/v1/support/tickets/:ticketId',
+    {
+      schema: {
+        tags: ['support'],
+        summary: 'Get a support ticket by ID',
+        params: {
+          type: 'object',
+          properties: {
+            ticketId: { type: 'string' },
+          },
+        },
+      },
+    },
     async (req, reply) => {
       const grpcReq: GetSupportTicketRequest = {
         ticketId: req.params.ticketId,
@@ -157,6 +203,25 @@ export const registerSupportRoutes = async (
   // ---- POST /api/v1/support/tickets/:ticketId/reply ----------------
   app.post<{ Params: { ticketId: string } }>(
     '/api/v1/support/tickets/:ticketId/reply',
+    {
+      schema: {
+        tags: ['support'],
+        summary: 'Reply to a support ticket',
+        params: {
+          type: 'object',
+          properties: {
+            ticketId: { type: 'string' },
+          },
+        },
+        body: {
+          type: 'object',
+          properties: {
+            content: { type: 'string' },
+          },
+          additionalProperties: true,
+        },
+      },
+    },
     async (req, reply) => {
       const body = (req.body ?? {}) as { content?: string };
       const grpcReq: RespondToTicketRequest = {
@@ -180,6 +245,18 @@ export const registerSupportRoutes = async (
   // included.
   app.get<{ Params: { ticketId: string } }>(
     '/api/v1/support/tickets/:ticketId/messages',
+    {
+      schema: {
+        tags: ['support'],
+        summary: 'Get support ticket messages',
+        params: {
+          type: 'object',
+          properties: {
+            ticketId: { type: 'string' },
+          },
+        },
+      },
+    },
     async (req, reply) => {
       const grpcReq: GetSupportTicketRequest = {
         ticketId: req.params.ticketId,

--- a/services/gateway/src/routes/uploads.ts
+++ b/services/gateway/src/routes/uploads.ts
@@ -94,7 +94,13 @@ export const registerUploadsRoutes = async (
   // the resize step is skipped).
   app.post(
     '/api/v1/uploads/images',
-    { config: { rateLimit: UPLOAD_RATE_LIMITS.images } },
+    {
+      config: { rateLimit: UPLOAD_RATE_LIMITS.images },
+      schema: {
+        tags: ['uploads'],
+        summary: 'Upload an image (multipart/form-data)',
+      },
+    },
     async (req, reply) => {
       if (typeof (req as { isMultipart?: () => boolean }).isMultipart !== 'function') {
         return reply.code(500).send({ error: 'multipart support not registered' });
@@ -168,7 +174,21 @@ export const registerUploadsRoutes = async (
     Params: { expiresAt: string; signature: string; '*': string };
   }>(
     '/uploads-signed/:expiresAt/:signature/*',
-    { config: { rateLimit: UPLOAD_RATE_LIMITS.signedServe } },
+    {
+      config: { rateLimit: UPLOAD_RATE_LIMITS.signedServe },
+      schema: {
+        tags: ['uploads'],
+        summary: 'Serve a signed upload URL',
+        security: [],
+        params: {
+          type: 'object',
+          properties: {
+            expiresAt: { type: 'string' },
+            signature: { type: 'string' },
+          },
+        },
+      },
+    },
     async (req, reply) => {
       if (!opts.signingSecret) {
         return reply.code(503).send({ error: 'Signed serving not configured' });

--- a/services/gateway/src/routes/uploads.ts
+++ b/services/gateway/src/routes/uploads.ts
@@ -180,13 +180,6 @@ export const registerUploadsRoutes = async (
         tags: ['uploads'],
         summary: 'Serve a signed upload URL',
         security: [],
-        params: {
-          type: 'object',
-          properties: {
-            expiresAt: { type: 'string' },
-            signature: { type: 'string' },
-          },
-        },
       },
     },
     async (req, reply) => {

--- a/services/gateway/src/routes/users.ts
+++ b/services/gateway/src/routes/users.ts
@@ -132,286 +132,322 @@ export const registerUsersRoutes = async (
   // The monolith mounts both /profile and /account for the same payload.
   // The /account routes already live in routes/auth.ts; we add /profile
   // here so lib.api's user.getProfile() call lands on a single seam.
-  app.get('/api/v1/users/profile', {
-    schema: {
-      tags: ['users'],
-      summary: 'Get current user profile',
-    },
-  }, async (req, reply) => {
-    const metadata = buildMetadata(req);
-    try {
-      const res = await authClient.getMe({} as GetMeRequest, metadata);
-      return reply.send(AuthV1.GetMeResponse.toJSON(res));
-    } catch (err) {
-      return handleGrpcError(err, reply);
-    }
-  });
-
-  app.put('/api/v1/users/profile', {
-    schema: {
-      tags: ['users'],
-      summary: 'Update current user profile',
-      body: {
-        type: 'object',
-        additionalProperties: true,
+  app.get(
+    '/api/v1/users/profile',
+    {
+      schema: {
+        tags: ['users'],
+        summary: 'Get current user profile',
       },
     },
-  }, async (req, reply) => {
-    const metadata = buildMetadata(req);
-    const b = (req.body ?? {}) as Record<string, unknown>;
-    const str = (k1: string, k2?: string): string | undefined => {
-      const v = (b[k1] ?? (k2 ? b[k2] : undefined)) as unknown;
-      return typeof v === 'string' ? v : undefined;
-    };
-    const grpcReq: UpdateAccountRequest = {
-      firstName: str('firstName', 'first_name'),
-      lastName: str('lastName', 'last_name'),
-      phoneNumber: str('phoneNumber', 'phone_number'),
-      bio: str('bio'),
-      timezone: str('timezone'),
-      language: str('language'),
-      country: str('country'),
-      city: str('city'),
-      addressLine1: str('addressLine1', 'address_line_1'),
-      addressLine2: str('addressLine2', 'address_line_2'),
-      postalCode: str('postalCode', 'postal_code'),
-    };
-    try {
-      const res = await authClient.updateAccount(grpcReq, metadata);
-      return reply.send(AuthV1.UpdateAccountResponse.toJSON(res));
-    } catch (err) {
-      return handleGrpcError(err, reply);
+    async (req, reply) => {
+      const metadata = buildMetadata(req);
+      try {
+        const res = await authClient.getMe({} as GetMeRequest, metadata);
+        return reply.send(AuthV1.GetMeResponse.toJSON(res));
+      } catch (err) {
+        return handleGrpcError(err, reply);
+      }
     }
-  });
+  );
+
+  app.put(
+    '/api/v1/users/profile',
+    {
+      schema: {
+        tags: ['users'],
+        summary: 'Update current user profile',
+        body: {
+          type: 'object',
+          additionalProperties: true,
+        },
+      },
+    },
+    async (req, reply) => {
+      const metadata = buildMetadata(req);
+      const b = (req.body ?? {}) as Record<string, unknown>;
+      const str = (k1: string, k2?: string): string | undefined => {
+        const v = (b[k1] ?? (k2 ? b[k2] : undefined)) as unknown;
+        return typeof v === 'string' ? v : undefined;
+      };
+      const grpcReq: UpdateAccountRequest = {
+        firstName: str('firstName', 'first_name'),
+        lastName: str('lastName', 'last_name'),
+        phoneNumber: str('phoneNumber', 'phone_number'),
+        bio: str('bio'),
+        timezone: str('timezone'),
+        language: str('language'),
+        country: str('country'),
+        city: str('city'),
+        addressLine1: str('addressLine1', 'address_line_1'),
+        addressLine2: str('addressLine2', 'address_line_2'),
+        postalCode: str('postalCode', 'postal_code'),
+      };
+      try {
+        const res = await authClient.updateAccount(grpcReq, metadata);
+        return reply.send(AuthV1.UpdateAccountResponse.toJSON(res));
+      } catch (err) {
+        return handleGrpcError(err, reply);
+      }
+    }
+  );
 
   // --- GET /api/v1/users/preferences --------------------------------
   // Fetches both backing rows in parallel and composes.
-  app.get('/api/v1/users/preferences', {
-    schema: {
-      tags: ['users'],
-      summary: 'Get current user preferences',
+  app.get(
+    '/api/v1/users/preferences',
+    {
+      schema: {
+        tags: ['users'],
+        summary: 'Get current user preferences',
+      },
     },
-  }, async (req, reply) => {
-    const metadata = buildMetadata(req);
-    try {
-      const [notif, privacy] = await Promise.all([
-        notificationsClient.getNotificationPreferences({}, metadata),
-        authClient.getPrivacyPreferences({} as GetPrivacyPreferencesRequest, metadata),
-      ]);
-      return reply.send({
-        success: true,
-        data: composePreferences(notif.preferences!, privacy.preferences!),
-      });
-    } catch (err) {
-      return handleGrpcError(err, reply);
+    async (req, reply) => {
+      const metadata = buildMetadata(req);
+      try {
+        const [notif, privacy] = await Promise.all([
+          notificationsClient.getNotificationPreferences({}, metadata),
+          authClient.getPrivacyPreferences({} as GetPrivacyPreferencesRequest, metadata),
+        ]);
+        return reply.send({
+          success: true,
+          data: composePreferences(notif.preferences!, privacy.preferences!),
+        });
+      } catch (err) {
+        return handleGrpcError(err, reply);
+      }
     }
-  });
+  );
 
   // --- PUT /api/v1/users/preferences --------------------------------
   // Splits the unified body across the two backing RPCs. Either patch
   // may be empty (no fields supplied for that slice) — the underlying
   // handlers no-op on an empty patch and return the current row, which
   // we then re-compose into the unified response.
-  app.put('/api/v1/users/preferences', {
-    schema: {
-      tags: ['users'],
-      summary: 'Update current user preferences',
-      body: {
-        type: 'object',
-        additionalProperties: true,
+  app.put(
+    '/api/v1/users/preferences',
+    {
+      schema: {
+        tags: ['users'],
+        summary: 'Update current user preferences',
+        body: {
+          type: 'object',
+          additionalProperties: true,
+        },
       },
     },
-  }, async (req, reply) => {
-    const metadata = buildMetadata(req);
-    const body = (req.body ?? {}) as Record<string, unknown>;
-    try {
-      const [notif, privacy] = await Promise.all([
-        notificationsClient.updateNotificationPreferences(buildNotifPatch(body), metadata),
-        authClient.updatePrivacyPreferences(buildPrivacyPatch(body), metadata),
-      ]);
-      return reply.send({
-        success: true,
-        message: 'Preferences updated successfully',
-        data: composePreferences(notif.preferences!, privacy.preferences!),
-      });
-    } catch (err) {
-      return handleGrpcError(err, reply);
+    async (req, reply) => {
+      const metadata = buildMetadata(req);
+      const body = (req.body ?? {}) as Record<string, unknown>;
+      try {
+        const [notif, privacy] = await Promise.all([
+          notificationsClient.updateNotificationPreferences(buildNotifPatch(body), metadata),
+          authClient.updatePrivacyPreferences(buildPrivacyPatch(body), metadata),
+        ]);
+        return reply.send({
+          success: true,
+          message: 'Preferences updated successfully',
+          data: composePreferences(notif.preferences!, privacy.preferences!),
+        });
+      } catch (err) {
+        return handleGrpcError(err, reply);
+      }
     }
-  });
+  );
 
   // --- POST /api/v1/users/preferences/reset -------------------------
   // Destroy + recreate both backing rows so the table-level defaults
   // win. The monolith returns the fresh defaults in the response body.
-  app.post('/api/v1/users/preferences/reset', {
-    schema: {
-      tags: ['users'],
-      summary: 'Reset current user preferences to defaults',
+  app.post(
+    '/api/v1/users/preferences/reset',
+    {
+      schema: {
+        tags: ['users'],
+        summary: 'Reset current user preferences to defaults',
+      },
     },
-  }, async (req, reply) => {
-    const metadata = buildMetadata(req);
-    try {
-      const [notif, privacy] = await Promise.all([
-        notificationsClient.resetNotificationPreferences({}, metadata),
-        authClient.resetPrivacyPreferences({} as ResetPrivacyPreferencesRequest, metadata),
-      ]);
-      return reply.send({
-        success: true,
-        message: 'Preferences reset to defaults',
-        data: composePreferences(notif.preferences!, privacy.preferences!),
-      });
-    } catch (err) {
-      return handleGrpcError(err, reply);
+    async (req, reply) => {
+      const metadata = buildMetadata(req);
+      try {
+        const [notif, privacy] = await Promise.all([
+          notificationsClient.resetNotificationPreferences({}, metadata),
+          authClient.resetPrivacyPreferences({} as ResetPrivacyPreferencesRequest, metadata),
+        ]);
+        return reply.send({
+          success: true,
+          message: 'Preferences reset to defaults',
+          data: composePreferences(notif.preferences!, privacy.preferences!),
+        });
+      } catch (err) {
+        return handleGrpcError(err, reply);
+      }
     }
-  });
+  );
 
   // --- Admin user management ----------------------------------------
   // These register AFTER /profile + /preferences (static segments win
   // Fastify's matcher) but BEFORE the dynamic GET /:userId below.
 
   // GET /api/v1/users/search
-  app.get('/api/v1/users/search', {
-    schema: {
-      tags: ['users'],
-      summary: 'Search users (admin)',
-      querystring: {
-        type: 'object',
-        properties: {
-          search: { type: 'string' },
-          status: { type: 'string' },
-          userType: { type: 'string' },
-          user_type: { type: 'string' },
-          emailVerified: { type: 'string' },
-          createdFrom: { type: 'string' },
-          created_from: { type: 'string' },
-          createdTo: { type: 'string' },
-          created_to: { type: 'string' },
-          page: { type: 'string' },
-          limit: { type: 'string' },
-          sortBy: { type: 'string' },
-          sort_by: { type: 'string' },
-          sortOrder: { type: 'string' },
-          sort_order: { type: 'string' },
+  app.get(
+    '/api/v1/users/search',
+    {
+      schema: {
+        tags: ['users'],
+        summary: 'Search users (admin)',
+        querystring: {
+          type: 'object',
+          properties: {
+            search: { type: 'string' },
+            status: { type: 'string' },
+            userType: { type: 'string' },
+            user_type: { type: 'string' },
+            emailVerified: { type: 'string' },
+            createdFrom: { type: 'string' },
+            created_from: { type: 'string' },
+            createdTo: { type: 'string' },
+            created_to: { type: 'string' },
+            page: { type: 'string' },
+            limit: { type: 'string' },
+            sortBy: { type: 'string' },
+            sort_by: { type: 'string' },
+            sortOrder: { type: 'string' },
+            sort_order: { type: 'string' },
+          },
+          additionalProperties: true,
         },
-        additionalProperties: true,
       },
     },
-  }, async (req, reply) => {
-    const metadata = buildMetadata(req);
-    const q = req.query as Record<string, string | undefined>;
-    const pagination = parsePagination(q, { limit: 0 });
-    if (!pagination.ok) {
-      return reply.code(400).send({ success: false, error: pagination.error });
+    async (req, reply) => {
+      const metadata = buildMetadata(req);
+      const q = req.query as Record<string, string | undefined>;
+      const pagination = parsePagination(q, { limit: 0 });
+      if (!pagination.ok) {
+        return reply.code(400).send({ success: false, error: pagination.error });
+      }
+      const grpcReq: SearchUsersRequest = {
+        search: q.search,
+        statusFilter: statusFilterFromString(q.status),
+        userTypeFilter: userTypeFilterFromString(q.userType ?? q.user_type),
+        emailVerified: q.emailVerified ? q.emailVerified === 'true' : undefined,
+        createdFrom: q.createdFrom ?? q.created_from,
+        createdTo: q.createdTo ?? q.created_to,
+        page: pagination.page,
+        limit: pagination.limit,
+        sortBy: q.sortBy ?? q.sort_by,
+        sortOrder: q.sortOrder ?? q.sort_order,
+      };
+      try {
+        const res = await authClient.searchUsers(grpcReq, metadata);
+        return reply.send({
+          success: true,
+          data: res.users.map(u => AuthV1.User.toJSON(u)),
+          pagination: {
+            page: res.page,
+            limit: grpcReq.limit || 20,
+            total: res.total,
+            totalPages: res.totalPages,
+          },
+        });
+      } catch (err) {
+        return handleGrpcError(err, reply);
+      }
     }
-    const grpcReq: SearchUsersRequest = {
-      search: q.search,
-      statusFilter: statusFilterFromString(q.status),
-      userTypeFilter: userTypeFilterFromString(q.userType ?? q.user_type),
-      emailVerified: q.emailVerified ? q.emailVerified === 'true' : undefined,
-      createdFrom: q.createdFrom ?? q.created_from,
-      createdTo: q.createdTo ?? q.created_to,
-      page: pagination.page,
-      limit: pagination.limit,
-      sortBy: q.sortBy ?? q.sort_by,
-      sortOrder: q.sortOrder ?? q.sort_order,
-    };
-    try {
-      const res = await authClient.searchUsers(grpcReq, metadata);
-      return reply.send({
-        success: true,
-        data: res.users.map(u => AuthV1.User.toJSON(u)),
-        pagination: {
-          page: res.page,
-          limit: grpcReq.limit || 20,
-          total: res.total,
-          totalPages: res.totalPages,
-        },
-      });
-    } catch (err) {
-      return handleGrpcError(err, reply);
-    }
-  });
+  );
 
   // GET /api/v1/users/statistics
-  app.get('/api/v1/users/statistics', {
-    schema: {
-      tags: ['users'],
-      summary: 'Get user statistics (admin)',
+  app.get(
+    '/api/v1/users/statistics',
+    {
+      schema: {
+        tags: ['users'],
+        summary: 'Get user statistics (admin)',
+      },
     },
-  }, async (req, reply) => {
-    const metadata = buildMetadata(req);
-    try {
-      const res = await authClient.getUserStatistics({}, metadata);
-      return reply.send({
-        success: true,
-        data: AuthV1.GetUserStatisticsResponse.toJSON(res),
-      });
-    } catch (err) {
-      return handleGrpcError(err, reply);
+    async (req, reply) => {
+      const metadata = buildMetadata(req);
+      try {
+        const res = await authClient.getUserStatistics({}, metadata);
+        return reply.send({
+          success: true,
+          data: AuthV1.GetUserStatisticsResponse.toJSON(res),
+        });
+      } catch (err) {
+        return handleGrpcError(err, reply);
+      }
     }
-  });
+  );
 
   // GET /api/v1/users/:userId
-  app.get<{ Params: { userId: string } }>('/api/v1/users/:userId', {
-    schema: {
-      tags: ['users'],
-      summary: 'Get a user by ID (admin)',
-      params: {
-        type: 'object',
-        properties: {
-          userId: { type: 'string' },
+  app.get<{ Params: { userId: string } }>(
+    '/api/v1/users/:userId',
+    {
+      schema: {
+        tags: ['users'],
+        summary: 'Get a user by ID (admin)',
+        params: {
+          type: 'object',
+          properties: {
+            userId: { type: 'string' },
+          },
         },
       },
     },
-  }, async (req, reply) => {
-    const metadata = buildMetadata(req);
-    try {
-      const res = await authClient.adminGetUser({ userId: req.params.userId }, metadata);
-      return reply.send({ success: true, data: AuthV1.User.toJSON(res.user!) });
-    } catch (err) {
-      return handleGrpcError(err, reply);
+    async (req, reply) => {
+      const metadata = buildMetadata(req);
+      try {
+        const res = await authClient.adminGetUser({ userId: req.params.userId }, metadata);
+        return reply.send({ success: true, data: AuthV1.User.toJSON(res.user!) });
+      } catch (err) {
+        return handleGrpcError(err, reply);
+      }
     }
-  });
+  );
 
   // PUT /api/v1/users/:userId — admin update.
-  app.put<{ Params: { userId: string } }>('/api/v1/users/:userId', {
-    schema: {
-      tags: ['users'],
-      summary: 'Update a user (admin)',
-      params: {
-        type: 'object',
-        properties: {
-          userId: { type: 'string' },
+  app.put<{ Params: { userId: string } }>(
+    '/api/v1/users/:userId',
+    {
+      schema: {
+        tags: ['users'],
+        summary: 'Update a user (admin)',
+        params: {
+          type: 'object',
+          properties: {
+            userId: { type: 'string' },
+          },
+        },
+        body: {
+          type: 'object',
+          additionalProperties: true,
         },
       },
-      body: {
-        type: 'object',
-        additionalProperties: true,
-      },
     },
-  }, async (req, reply) => {
-    const metadata = buildMetadata(req);
-    const body = (req.body ?? {}) as Record<string, unknown>;
-    const grpcReq: AdminUpdateUserRequest = {
-      userId: req.params.userId,
-      status: statusFilterFromString(typeof body.status === 'string' ? body.status : undefined),
-      userType: userTypeFilterFromString(
-        typeof body.userType === 'string'
-          ? body.userType
-          : typeof body.user_type === 'string'
-            ? body.user_type
-            : undefined
-      ),
-      emailVerified: typeof body.emailVerified === 'boolean' ? body.emailVerified : undefined,
-      firstName: typeof body.firstName === 'string' ? body.firstName : undefined,
-      lastName: typeof body.lastName === 'string' ? body.lastName : undefined,
-    };
-    try {
-      const res = await authClient.adminUpdateUser(grpcReq, metadata);
-      return reply.send({ success: true, data: AuthV1.User.toJSON(res.user!) });
-    } catch (err) {
-      return handleGrpcError(err, reply);
+    async (req, reply) => {
+      const metadata = buildMetadata(req);
+      const body = (req.body ?? {}) as Record<string, unknown>;
+      const grpcReq: AdminUpdateUserRequest = {
+        userId: req.params.userId,
+        status: statusFilterFromString(typeof body.status === 'string' ? body.status : undefined),
+        userType: userTypeFilterFromString(
+          typeof body.userType === 'string'
+            ? body.userType
+            : typeof body.user_type === 'string'
+              ? body.user_type
+              : undefined
+        ),
+        emailVerified: typeof body.emailVerified === 'boolean' ? body.emailVerified : undefined,
+        firstName: typeof body.firstName === 'string' ? body.firstName : undefined,
+        lastName: typeof body.lastName === 'string' ? body.lastName : undefined,
+      };
+      try {
+        const res = await authClient.adminUpdateUser(grpcReq, metadata);
+        return reply.send({ success: true, data: AuthV1.User.toJSON(res.user!) });
+      } catch (err) {
+        return handleGrpcError(err, reply);
+      }
     }
-  });
+  );
 
   // POST /api/v1/users/:userId/deactivate
   app.post<{ Params: { userId: string } }>(
@@ -492,89 +528,97 @@ export const registerUsersRoutes = async (
   // ('admin', 'suspended') rather than the proto SCREAMING_SNAKE names.
 
   // GET /api/v1/admin/users — list/search.
-  app.get('/api/v1/admin/users', {
-    schema: {
-      tags: ['users'],
-      summary: 'List or search users (admin)',
-      querystring: {
-        type: 'object',
-        properties: {
-          search: { type: 'string' },
-          status: { type: 'string' },
-          userType: { type: 'string' },
-          user_type: { type: 'string' },
-          emailVerified: { type: 'string' },
-          createdFrom: { type: 'string' },
-          created_from: { type: 'string' },
-          createdTo: { type: 'string' },
-          created_to: { type: 'string' },
-          page: { type: 'string' },
-          limit: { type: 'string' },
-          sortBy: { type: 'string' },
-          sort_by: { type: 'string' },
-          sortOrder: { type: 'string' },
-          sort_order: { type: 'string' },
+  app.get(
+    '/api/v1/admin/users',
+    {
+      schema: {
+        tags: ['users'],
+        summary: 'List or search users (admin)',
+        querystring: {
+          type: 'object',
+          properties: {
+            search: { type: 'string' },
+            status: { type: 'string' },
+            userType: { type: 'string' },
+            user_type: { type: 'string' },
+            emailVerified: { type: 'string' },
+            createdFrom: { type: 'string' },
+            created_from: { type: 'string' },
+            createdTo: { type: 'string' },
+            created_to: { type: 'string' },
+            page: { type: 'string' },
+            limit: { type: 'string' },
+            sortBy: { type: 'string' },
+            sort_by: { type: 'string' },
+            sortOrder: { type: 'string' },
+            sort_order: { type: 'string' },
+          },
+          additionalProperties: true,
         },
-        additionalProperties: true,
       },
     },
-  }, async (req, reply) => {
-    const metadata = buildMetadata(req);
-    const q = req.query as Record<string, string | undefined>;
-    const pagination = parsePagination(q, { limit: 0 });
-    if (!pagination.ok) {
-      return reply.code(400).send({ success: false, error: pagination.error });
+    async (req, reply) => {
+      const metadata = buildMetadata(req);
+      const q = req.query as Record<string, string | undefined>;
+      const pagination = parsePagination(q, { limit: 0 });
+      if (!pagination.ok) {
+        return reply.code(400).send({ success: false, error: pagination.error });
+      }
+      const grpcReq: SearchUsersRequest = {
+        search: q.search,
+        statusFilter: statusFilterFromString(q.status),
+        userTypeFilter: userTypeFilterFromString(q.userType ?? q.user_type),
+        emailVerified: q.emailVerified ? q.emailVerified === 'true' : undefined,
+        createdFrom: q.createdFrom ?? q.created_from,
+        createdTo: q.createdTo ?? q.created_to,
+        page: pagination.page,
+        limit: pagination.limit,
+        sortBy: q.sortBy ?? q.sort_by,
+        sortOrder: q.sortOrder ?? q.sort_order,
+      };
+      try {
+        const res = await authClient.searchUsers(grpcReq, metadata);
+        return reply.send({
+          success: true,
+          data: res.users.map(userToApiJson),
+          pagination: {
+            page: res.page,
+            limit: grpcReq.limit || 20,
+            total: res.total,
+            totalPages: res.totalPages,
+          },
+        });
+      } catch (err) {
+        return handleGrpcError(err, reply);
+      }
     }
-    const grpcReq: SearchUsersRequest = {
-      search: q.search,
-      statusFilter: statusFilterFromString(q.status),
-      userTypeFilter: userTypeFilterFromString(q.userType ?? q.user_type),
-      emailVerified: q.emailVerified ? q.emailVerified === 'true' : undefined,
-      createdFrom: q.createdFrom ?? q.created_from,
-      createdTo: q.createdTo ?? q.created_to,
-      page: pagination.page,
-      limit: pagination.limit,
-      sortBy: q.sortBy ?? q.sort_by,
-      sortOrder: q.sortOrder ?? q.sort_order,
-    };
-    try {
-      const res = await authClient.searchUsers(grpcReq, metadata);
-      return reply.send({
-        success: true,
-        data: res.users.map(userToApiJson),
-        pagination: {
-          page: res.page,
-          limit: grpcReq.limit || 20,
-          total: res.total,
-          totalPages: res.totalPages,
-        },
-      });
-    } catch (err) {
-      return handleGrpcError(err, reply);
-    }
-  });
+  );
 
   // GET /api/v1/admin/users/:userId — single user detail.
-  app.get<{ Params: { userId: string } }>('/api/v1/admin/users/:userId', {
-    schema: {
-      tags: ['users'],
-      summary: 'Get a user by ID (admin)',
-      params: {
-        type: 'object',
-        properties: {
-          userId: { type: 'string' },
+  app.get<{ Params: { userId: string } }>(
+    '/api/v1/admin/users/:userId',
+    {
+      schema: {
+        tags: ['users'],
+        summary: 'Get a user by ID (admin)',
+        params: {
+          type: 'object',
+          properties: {
+            userId: { type: 'string' },
+          },
         },
       },
     },
-  }, async (req, reply) => {
-    const metadata = buildMetadata(req);
-    try {
-      const res = await authClient.adminGetUser({ userId: req.params.userId }, metadata);
-      return reply.send({ success: true, data: userToApiJson(res.user!) });
-    } catch (err) {
-      return handleGrpcError(err, reply);
+    async (req, reply) => {
+      const metadata = buildMetadata(req);
+      try {
+        const res = await authClient.adminGetUser({ userId: req.params.userId }, metadata);
+        return reply.send({ success: true, data: userToApiJson(res.user!) });
+      } catch (err) {
+        return handleGrpcError(err, reply);
+      }
     }
-  });
+  );
 
   // PATCH /api/v1/admin/users/:userId/action — the per-user moderation
   // action the admin UI's bulk button calls once per row. Maps a small
@@ -631,52 +675,56 @@ export const registerUsersRoutes = async (
 
   // POST /api/v1/users/bulk-update — admin bulk status/role change.
   // POST so it never collides with the GET/PUT /:userId dynamic routes.
-  app.post('/api/v1/users/bulk-update', {
-    schema: {
-      tags: ['users'],
-      summary: 'Bulk update user status or role (admin)',
-      body: {
-        type: 'object',
-        properties: {
-          userIds: { type: 'array', items: { type: 'string' } },
-          user_ids: { type: 'array', items: { type: 'string' } },
-          status: { type: 'string' },
-          userType: { type: 'string' },
-          user_type: { type: 'string' },
-          reason: { type: 'string' },
+  app.post(
+    '/api/v1/users/bulk-update',
+    {
+      schema: {
+        tags: ['users'],
+        summary: 'Bulk update user status or role (admin)',
+        body: {
+          type: 'object',
+          properties: {
+            userIds: { type: 'array', items: { type: 'string' } },
+            user_ids: { type: 'array', items: { type: 'string' } },
+            status: { type: 'string' },
+            userType: { type: 'string' },
+            user_type: { type: 'string' },
+            reason: { type: 'string' },
+          },
+          additionalProperties: true,
         },
-        additionalProperties: true,
       },
     },
-  }, async (req, reply) => {
-    const metadata = buildMetadata(req);
-    const body = (req.body ?? {}) as {
-      userIds?: string[];
-      user_ids?: string[];
-      status?: string;
-      userType?: string;
-      user_type?: string;
-      reason?: string;
-    };
-    try {
-      const res = await authClient.bulkUpdateUsers(
-        {
-          userIds: body.userIds ?? body.user_ids ?? [],
-          status: statusFilterFromString(body.status),
-          userType: userTypeFilterFromString(body.userType ?? body.user_type),
-          reason: body.reason,
-        },
-        metadata
-      );
-      return reply.send({
-        success: true,
-        message: `Updated ${res.successCount} user(s), ${res.failedCount} failed`,
-        data: AuthV1.BulkUpdateUsersResponse.toJSON(res),
-      });
-    } catch (err) {
-      return handleGrpcError(err, reply);
+    async (req, reply) => {
+      const metadata = buildMetadata(req);
+      const body = (req.body ?? {}) as {
+        userIds?: string[];
+        user_ids?: string[];
+        status?: string;
+        userType?: string;
+        user_type?: string;
+        reason?: string;
+      };
+      try {
+        const res = await authClient.bulkUpdateUsers(
+          {
+            userIds: body.userIds ?? body.user_ids ?? [],
+            status: statusFilterFromString(body.status),
+            userType: userTypeFilterFromString(body.userType ?? body.user_type),
+            reason: body.reason,
+          },
+          metadata
+        );
+        return reply.send({
+          success: true,
+          message: `Updated ${res.successCount} user(s), ${res.failedCount} failed`,
+          data: AuthV1.BulkUpdateUsersResponse.toJSON(res),
+        });
+      } catch (err) {
+        return handleGrpcError(err, reply);
+      }
     }
-  });
+  );
 
   // GET /api/v1/users/:userId/permissions
   app.get<{ Params: { userId: string } }>(
@@ -742,45 +790,49 @@ export const registerUsersRoutes = async (
 
   // PUT /api/v1/users/:userId/role — change a single user's user_type.
   // Reuses AdminUpdateUser with only the user_type field set.
-  app.put<{ Params: { userId: string } }>('/api/v1/users/:userId/role', {
-    schema: {
-      tags: ['users'],
-      summary: 'Update a user role (admin)',
-      params: {
-        type: 'object',
-        properties: {
-          userId: { type: 'string' },
+  app.put<{ Params: { userId: string } }>(
+    '/api/v1/users/:userId/role',
+    {
+      schema: {
+        tags: ['users'],
+        summary: 'Update a user role (admin)',
+        params: {
+          type: 'object',
+          properties: {
+            userId: { type: 'string' },
+          },
         },
-      },
-      body: {
-        type: 'object',
-        properties: {
-          role: { type: 'string' },
-          userType: { type: 'string' },
-          user_type: { type: 'string' },
+        body: {
+          type: 'object',
+          properties: {
+            role: { type: 'string' },
+            userType: { type: 'string' },
+            user_type: { type: 'string' },
+          },
+          additionalProperties: true,
         },
-        additionalProperties: true,
       },
     },
-  }, async (req, reply) => {
-    const metadata = buildMetadata(req);
-    const body = (req.body ?? {}) as { role?: string; userType?: string; user_type?: string };
-    const grpcReq: AdminUpdateUserRequest = {
-      userId: req.params.userId,
-      status: AuthV1.UserStatus.USER_STATUS_UNSPECIFIED,
-      userType: userTypeFilterFromString(body.role ?? body.userType ?? body.user_type),
-    };
-    try {
-      const res = await authClient.adminUpdateUser(grpcReq, metadata);
-      return reply.send({
-        success: true,
-        message: 'User role updated',
-        data: AuthV1.User.toJSON(res.user!),
-      });
-    } catch (err) {
-      return handleGrpcError(err, reply);
+    async (req, reply) => {
+      const metadata = buildMetadata(req);
+      const body = (req.body ?? {}) as { role?: string; userType?: string; user_type?: string };
+      const grpcReq: AdminUpdateUserRequest = {
+        userId: req.params.userId,
+        status: AuthV1.UserStatus.USER_STATUS_UNSPECIFIED,
+        userType: userTypeFilterFromString(body.role ?? body.userType ?? body.user_type),
+      };
+      try {
+        const res = await authClient.adminUpdateUser(grpcReq, metadata);
+        return reply.send({
+          success: true,
+          message: 'User role updated',
+          data: AuthV1.User.toJSON(res.user!),
+        });
+      } catch (err) {
+        return handleGrpcError(err, reply);
+      }
     }
-  });
+  );
 };
 
 // --- Enum parsing helpers --------------------------------------------

--- a/services/gateway/src/routes/users.ts
+++ b/services/gateway/src/routes/users.ts
@@ -157,10 +157,6 @@ export const registerUsersRoutes = async (
       schema: {
         tags: ['users'],
         summary: 'Update current user profile',
-        body: {
-          type: 'object',
-          additionalProperties: true,
-        },
       },
     },
     async (req, reply) => {
@@ -230,10 +226,6 @@ export const registerUsersRoutes = async (
       schema: {
         tags: ['users'],
         summary: 'Update current user preferences',
-        body: {
-          type: 'object',
-          additionalProperties: true,
-        },
       },
     },
     async (req, reply) => {
@@ -295,27 +287,6 @@ export const registerUsersRoutes = async (
       schema: {
         tags: ['users'],
         summary: 'Search users (admin)',
-        querystring: {
-          type: 'object',
-          properties: {
-            search: { type: 'string' },
-            status: { type: 'string' },
-            userType: { type: 'string' },
-            user_type: { type: 'string' },
-            emailVerified: { type: 'string' },
-            createdFrom: { type: 'string' },
-            created_from: { type: 'string' },
-            createdTo: { type: 'string' },
-            created_to: { type: 'string' },
-            page: { type: 'string' },
-            limit: { type: 'string' },
-            sortBy: { type: 'string' },
-            sort_by: { type: 'string' },
-            sortOrder: { type: 'string' },
-            sort_order: { type: 'string' },
-          },
-          additionalProperties: true,
-        },
       },
     },
     async (req, reply) => {
@@ -385,12 +356,6 @@ export const registerUsersRoutes = async (
       schema: {
         tags: ['users'],
         summary: 'Get a user by ID (admin)',
-        params: {
-          type: 'object',
-          properties: {
-            userId: { type: 'string' },
-          },
-        },
       },
     },
     async (req, reply) => {
@@ -411,16 +376,6 @@ export const registerUsersRoutes = async (
       schema: {
         tags: ['users'],
         summary: 'Update a user (admin)',
-        params: {
-          type: 'object',
-          properties: {
-            userId: { type: 'string' },
-          },
-        },
-        body: {
-          type: 'object',
-          additionalProperties: true,
-        },
       },
     },
     async (req, reply) => {
@@ -456,19 +411,6 @@ export const registerUsersRoutes = async (
       schema: {
         tags: ['users'],
         summary: 'Deactivate a user (admin)',
-        params: {
-          type: 'object',
-          properties: {
-            userId: { type: 'string' },
-          },
-        },
-        body: {
-          type: 'object',
-          properties: {
-            reason: { type: 'string' },
-          },
-          additionalProperties: true,
-        },
       },
     },
     async (req, reply) => {
@@ -497,12 +439,6 @@ export const registerUsersRoutes = async (
       schema: {
         tags: ['users'],
         summary: 'Reactivate a user (admin)',
-        params: {
-          type: 'object',
-          properties: {
-            userId: { type: 'string' },
-          },
-        },
       },
     },
     async (req, reply) => {
@@ -534,27 +470,6 @@ export const registerUsersRoutes = async (
       schema: {
         tags: ['users'],
         summary: 'List or search users (admin)',
-        querystring: {
-          type: 'object',
-          properties: {
-            search: { type: 'string' },
-            status: { type: 'string' },
-            userType: { type: 'string' },
-            user_type: { type: 'string' },
-            emailVerified: { type: 'string' },
-            createdFrom: { type: 'string' },
-            created_from: { type: 'string' },
-            createdTo: { type: 'string' },
-            created_to: { type: 'string' },
-            page: { type: 'string' },
-            limit: { type: 'string' },
-            sortBy: { type: 'string' },
-            sort_by: { type: 'string' },
-            sortOrder: { type: 'string' },
-            sort_order: { type: 'string' },
-          },
-          additionalProperties: true,
-        },
       },
     },
     async (req, reply) => {
@@ -601,12 +516,6 @@ export const registerUsersRoutes = async (
       schema: {
         tags: ['users'],
         summary: 'Get a user by ID (admin)',
-        params: {
-          type: 'object',
-          properties: {
-            userId: { type: 'string' },
-          },
-        },
       },
     },
     async (req, reply) => {
@@ -629,19 +538,6 @@ export const registerUsersRoutes = async (
       schema: {
         tags: ['users'],
         summary: 'Apply a moderation action to a user (admin)',
-        params: {
-          type: 'object',
-          properties: {
-            userId: { type: 'string' },
-          },
-        },
-        body: {
-          type: 'object',
-          properties: {
-            action: { type: 'string' },
-          },
-          additionalProperties: true,
-        },
       },
     },
     async (req, reply) => {
@@ -681,18 +577,6 @@ export const registerUsersRoutes = async (
       schema: {
         tags: ['users'],
         summary: 'Bulk update user status or role (admin)',
-        body: {
-          type: 'object',
-          properties: {
-            userIds: { type: 'array', items: { type: 'string' } },
-            user_ids: { type: 'array', items: { type: 'string' } },
-            status: { type: 'string' },
-            userType: { type: 'string' },
-            user_type: { type: 'string' },
-            reason: { type: 'string' },
-          },
-          additionalProperties: true,
-        },
       },
     },
     async (req, reply) => {
@@ -733,12 +617,6 @@ export const registerUsersRoutes = async (
       schema: {
         tags: ['users'],
         summary: 'Get permissions for a user',
-        params: {
-          type: 'object',
-          properties: {
-            userId: { type: 'string' },
-          },
-        },
       },
     },
     async (req, reply) => {
@@ -760,12 +638,6 @@ export const registerUsersRoutes = async (
       schema: {
         tags: ['users'],
         summary: 'Get a user with their permissions',
-        params: {
-          type: 'object',
-          properties: {
-            userId: { type: 'string' },
-          },
-        },
       },
     },
     async (req, reply) => {
@@ -796,21 +668,6 @@ export const registerUsersRoutes = async (
       schema: {
         tags: ['users'],
         summary: 'Update a user role (admin)',
-        params: {
-          type: 'object',
-          properties: {
-            userId: { type: 'string' },
-          },
-        },
-        body: {
-          type: 'object',
-          properties: {
-            role: { type: 'string' },
-            userType: { type: 'string' },
-            user_type: { type: 'string' },
-          },
-          additionalProperties: true,
-        },
       },
     },
     async (req, reply) => {

--- a/services/gateway/src/routes/users.ts
+++ b/services/gateway/src/routes/users.ts
@@ -132,7 +132,12 @@ export const registerUsersRoutes = async (
   // The monolith mounts both /profile and /account for the same payload.
   // The /account routes already live in routes/auth.ts; we add /profile
   // here so lib.api's user.getProfile() call lands on a single seam.
-  app.get('/api/v1/users/profile', async (req, reply) => {
+  app.get('/api/v1/users/profile', {
+    schema: {
+      tags: ['users'],
+      summary: 'Get current user profile',
+    },
+  }, async (req, reply) => {
     const metadata = buildMetadata(req);
     try {
       const res = await authClient.getMe({} as GetMeRequest, metadata);
@@ -142,7 +147,16 @@ export const registerUsersRoutes = async (
     }
   });
 
-  app.put('/api/v1/users/profile', async (req, reply) => {
+  app.put('/api/v1/users/profile', {
+    schema: {
+      tags: ['users'],
+      summary: 'Update current user profile',
+      body: {
+        type: 'object',
+        additionalProperties: true,
+      },
+    },
+  }, async (req, reply) => {
     const metadata = buildMetadata(req);
     const b = (req.body ?? {}) as Record<string, unknown>;
     const str = (k1: string, k2?: string): string | undefined => {
@@ -172,7 +186,12 @@ export const registerUsersRoutes = async (
 
   // --- GET /api/v1/users/preferences --------------------------------
   // Fetches both backing rows in parallel and composes.
-  app.get('/api/v1/users/preferences', async (req, reply) => {
+  app.get('/api/v1/users/preferences', {
+    schema: {
+      tags: ['users'],
+      summary: 'Get current user preferences',
+    },
+  }, async (req, reply) => {
     const metadata = buildMetadata(req);
     try {
       const [notif, privacy] = await Promise.all([
@@ -193,7 +212,16 @@ export const registerUsersRoutes = async (
   // may be empty (no fields supplied for that slice) — the underlying
   // handlers no-op on an empty patch and return the current row, which
   // we then re-compose into the unified response.
-  app.put('/api/v1/users/preferences', async (req, reply) => {
+  app.put('/api/v1/users/preferences', {
+    schema: {
+      tags: ['users'],
+      summary: 'Update current user preferences',
+      body: {
+        type: 'object',
+        additionalProperties: true,
+      },
+    },
+  }, async (req, reply) => {
     const metadata = buildMetadata(req);
     const body = (req.body ?? {}) as Record<string, unknown>;
     try {
@@ -214,7 +242,12 @@ export const registerUsersRoutes = async (
   // --- POST /api/v1/users/preferences/reset -------------------------
   // Destroy + recreate both backing rows so the table-level defaults
   // win. The monolith returns the fresh defaults in the response body.
-  app.post('/api/v1/users/preferences/reset', async (req, reply) => {
+  app.post('/api/v1/users/preferences/reset', {
+    schema: {
+      tags: ['users'],
+      summary: 'Reset current user preferences to defaults',
+    },
+  }, async (req, reply) => {
     const metadata = buildMetadata(req);
     try {
       const [notif, privacy] = await Promise.all([
@@ -236,7 +269,33 @@ export const registerUsersRoutes = async (
   // Fastify's matcher) but BEFORE the dynamic GET /:userId below.
 
   // GET /api/v1/users/search
-  app.get('/api/v1/users/search', async (req, reply) => {
+  app.get('/api/v1/users/search', {
+    schema: {
+      tags: ['users'],
+      summary: 'Search users (admin)',
+      querystring: {
+        type: 'object',
+        properties: {
+          search: { type: 'string' },
+          status: { type: 'string' },
+          userType: { type: 'string' },
+          user_type: { type: 'string' },
+          emailVerified: { type: 'string' },
+          createdFrom: { type: 'string' },
+          created_from: { type: 'string' },
+          createdTo: { type: 'string' },
+          created_to: { type: 'string' },
+          page: { type: 'string' },
+          limit: { type: 'string' },
+          sortBy: { type: 'string' },
+          sort_by: { type: 'string' },
+          sortOrder: { type: 'string' },
+          sort_order: { type: 'string' },
+        },
+        additionalProperties: true,
+      },
+    },
+  }, async (req, reply) => {
     const metadata = buildMetadata(req);
     const q = req.query as Record<string, string | undefined>;
     const pagination = parsePagination(q, { limit: 0 });
@@ -273,7 +332,12 @@ export const registerUsersRoutes = async (
   });
 
   // GET /api/v1/users/statistics
-  app.get('/api/v1/users/statistics', async (req, reply) => {
+  app.get('/api/v1/users/statistics', {
+    schema: {
+      tags: ['users'],
+      summary: 'Get user statistics (admin)',
+    },
+  }, async (req, reply) => {
     const metadata = buildMetadata(req);
     try {
       const res = await authClient.getUserStatistics({}, metadata);
@@ -287,7 +351,18 @@ export const registerUsersRoutes = async (
   });
 
   // GET /api/v1/users/:userId
-  app.get<{ Params: { userId: string } }>('/api/v1/users/:userId', async (req, reply) => {
+  app.get<{ Params: { userId: string } }>('/api/v1/users/:userId', {
+    schema: {
+      tags: ['users'],
+      summary: 'Get a user by ID (admin)',
+      params: {
+        type: 'object',
+        properties: {
+          userId: { type: 'string' },
+        },
+      },
+    },
+  }, async (req, reply) => {
     const metadata = buildMetadata(req);
     try {
       const res = await authClient.adminGetUser({ userId: req.params.userId }, metadata);
@@ -298,7 +373,22 @@ export const registerUsersRoutes = async (
   });
 
   // PUT /api/v1/users/:userId — admin update.
-  app.put<{ Params: { userId: string } }>('/api/v1/users/:userId', async (req, reply) => {
+  app.put<{ Params: { userId: string } }>('/api/v1/users/:userId', {
+    schema: {
+      tags: ['users'],
+      summary: 'Update a user (admin)',
+      params: {
+        type: 'object',
+        properties: {
+          userId: { type: 'string' },
+        },
+      },
+      body: {
+        type: 'object',
+        additionalProperties: true,
+      },
+    },
+  }, async (req, reply) => {
     const metadata = buildMetadata(req);
     const body = (req.body ?? {}) as Record<string, unknown>;
     const grpcReq: AdminUpdateUserRequest = {
@@ -326,6 +416,25 @@ export const registerUsersRoutes = async (
   // POST /api/v1/users/:userId/deactivate
   app.post<{ Params: { userId: string } }>(
     '/api/v1/users/:userId/deactivate',
+    {
+      schema: {
+        tags: ['users'],
+        summary: 'Deactivate a user (admin)',
+        params: {
+          type: 'object',
+          properties: {
+            userId: { type: 'string' },
+          },
+        },
+        body: {
+          type: 'object',
+          properties: {
+            reason: { type: 'string' },
+          },
+          additionalProperties: true,
+        },
+      },
+    },
     async (req, reply) => {
       const metadata = buildMetadata(req);
       const body = (req.body ?? {}) as { reason?: string };
@@ -348,6 +457,18 @@ export const registerUsersRoutes = async (
   // POST /api/v1/users/:userId/reactivate
   app.post<{ Params: { userId: string } }>(
     '/api/v1/users/:userId/reactivate',
+    {
+      schema: {
+        tags: ['users'],
+        summary: 'Reactivate a user (admin)',
+        params: {
+          type: 'object',
+          properties: {
+            userId: { type: 'string' },
+          },
+        },
+      },
+    },
     async (req, reply) => {
       const metadata = buildMetadata(req);
       try {
@@ -371,7 +492,33 @@ export const registerUsersRoutes = async (
   // ('admin', 'suspended') rather than the proto SCREAMING_SNAKE names.
 
   // GET /api/v1/admin/users — list/search.
-  app.get('/api/v1/admin/users', async (req, reply) => {
+  app.get('/api/v1/admin/users', {
+    schema: {
+      tags: ['users'],
+      summary: 'List or search users (admin)',
+      querystring: {
+        type: 'object',
+        properties: {
+          search: { type: 'string' },
+          status: { type: 'string' },
+          userType: { type: 'string' },
+          user_type: { type: 'string' },
+          emailVerified: { type: 'string' },
+          createdFrom: { type: 'string' },
+          created_from: { type: 'string' },
+          createdTo: { type: 'string' },
+          created_to: { type: 'string' },
+          page: { type: 'string' },
+          limit: { type: 'string' },
+          sortBy: { type: 'string' },
+          sort_by: { type: 'string' },
+          sortOrder: { type: 'string' },
+          sort_order: { type: 'string' },
+        },
+        additionalProperties: true,
+      },
+    },
+  }, async (req, reply) => {
     const metadata = buildMetadata(req);
     const q = req.query as Record<string, string | undefined>;
     const pagination = parsePagination(q, { limit: 0 });
@@ -408,7 +555,18 @@ export const registerUsersRoutes = async (
   });
 
   // GET /api/v1/admin/users/:userId — single user detail.
-  app.get<{ Params: { userId: string } }>('/api/v1/admin/users/:userId', async (req, reply) => {
+  app.get<{ Params: { userId: string } }>('/api/v1/admin/users/:userId', {
+    schema: {
+      tags: ['users'],
+      summary: 'Get a user by ID (admin)',
+      params: {
+        type: 'object',
+        properties: {
+          userId: { type: 'string' },
+        },
+      },
+    },
+  }, async (req, reply) => {
     const metadata = buildMetadata(req);
     try {
       const res = await authClient.adminGetUser({ userId: req.params.userId }, metadata);
@@ -423,6 +581,25 @@ export const registerUsersRoutes = async (
   // action vocabulary onto the existing admin RPCs.
   app.patch<{ Params: { userId: string } }>(
     '/api/v1/admin/users/:userId/action',
+    {
+      schema: {
+        tags: ['users'],
+        summary: 'Apply a moderation action to a user (admin)',
+        params: {
+          type: 'object',
+          properties: {
+            userId: { type: 'string' },
+          },
+        },
+        body: {
+          type: 'object',
+          properties: {
+            action: { type: 'string' },
+          },
+          additionalProperties: true,
+        },
+      },
+    },
     async (req, reply) => {
       const metadata = buildMetadata(req);
       const body = (req.body ?? {}) as { action?: string };
@@ -454,7 +631,24 @@ export const registerUsersRoutes = async (
 
   // POST /api/v1/users/bulk-update — admin bulk status/role change.
   // POST so it never collides with the GET/PUT /:userId dynamic routes.
-  app.post('/api/v1/users/bulk-update', async (req, reply) => {
+  app.post('/api/v1/users/bulk-update', {
+    schema: {
+      tags: ['users'],
+      summary: 'Bulk update user status or role (admin)',
+      body: {
+        type: 'object',
+        properties: {
+          userIds: { type: 'array', items: { type: 'string' } },
+          user_ids: { type: 'array', items: { type: 'string' } },
+          status: { type: 'string' },
+          userType: { type: 'string' },
+          user_type: { type: 'string' },
+          reason: { type: 'string' },
+        },
+        additionalProperties: true,
+      },
+    },
+  }, async (req, reply) => {
     const metadata = buildMetadata(req);
     const body = (req.body ?? {}) as {
       userIds?: string[];
@@ -487,6 +681,18 @@ export const registerUsersRoutes = async (
   // GET /api/v1/users/:userId/permissions
   app.get<{ Params: { userId: string } }>(
     '/api/v1/users/:userId/permissions',
+    {
+      schema: {
+        tags: ['users'],
+        summary: 'Get permissions for a user',
+        params: {
+          type: 'object',
+          properties: {
+            userId: { type: 'string' },
+          },
+        },
+      },
+    },
     async (req, reply) => {
       const metadata = buildMetadata(req);
       try {
@@ -502,6 +708,18 @@ export const registerUsersRoutes = async (
   // row + their flattened permission set in one round trip.
   app.get<{ Params: { userId: string } }>(
     '/api/v1/users/:userId/with-permissions',
+    {
+      schema: {
+        tags: ['users'],
+        summary: 'Get a user with their permissions',
+        params: {
+          type: 'object',
+          properties: {
+            userId: { type: 'string' },
+          },
+        },
+      },
+    },
     async (req, reply) => {
       const metadata = buildMetadata(req);
       try {
@@ -524,7 +742,27 @@ export const registerUsersRoutes = async (
 
   // PUT /api/v1/users/:userId/role — change a single user's user_type.
   // Reuses AdminUpdateUser with only the user_type field set.
-  app.put<{ Params: { userId: string } }>('/api/v1/users/:userId/role', async (req, reply) => {
+  app.put<{ Params: { userId: string } }>('/api/v1/users/:userId/role', {
+    schema: {
+      tags: ['users'],
+      summary: 'Update a user role (admin)',
+      params: {
+        type: 'object',
+        properties: {
+          userId: { type: 'string' },
+        },
+      },
+      body: {
+        type: 'object',
+        properties: {
+          role: { type: 'string' },
+          userType: { type: 'string' },
+          user_type: { type: 'string' },
+        },
+        additionalProperties: true,
+      },
+    },
+  }, async (req, reply) => {
     const metadata = buildMetadata(req);
     const body = (req.body ?? {}) as { role?: string; userType?: string; user_type?: string };
     const grpcReq: AdminUpdateUserRequest = {


### PR DESCRIPTION
## Summary

- Removes `'unsafe-inline'` from `style-src` in the nginx CSP baked into `Dockerfile.app`. The codebase has fully migrated from styled-components to vanilla-extract (`.css.ts`); the exception is no longer justified.
- Updates the comment on those CSP lines to document why it was removed and reference ADS-847.
- Adds `scripts/check-csp-headers.mjs` — a static guard that parses the `Dockerfile.app` nginx CSP and fails CI if `'unsafe-inline'` ever re-appears in `style-src`.
- Wires the guard into `ci.yml` alongside the existing `check-docker-pinning.mjs` step.

**Before:** `style-src 'self' 'unsafe-inline'`
**After:** `style-src 'self'`

Note: this branch also carries the ADS-807 OpenAPI schema annotations (already reviewed in #1122) as a base — the ADS-847 work is the single commit on top.

Closes ADS-847.

## Test plan

- [ ] `node scripts/check-csp-headers.mjs` outputs `✓ CSP style-src is clean (1 policy checked)`
- [ ] CI "Verify CSP style-src has no unsafe-inline" step passes
- [ ] If `'unsafe-inline'` is manually re-added to `Dockerfile.app`, the guard script exits 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019oX3ZE4MPUbzyJHrWwsge1)_