### PR TITLE
refactor(gateway): remove vestigial cutover flags; always register routes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -555,23 +555,6 @@ jobs:
             # out.
             echo "UPLOAD_SIGNING_SECRET=$(openssl rand -base64 32)"
             echo "CORS_ORIGIN=http://localhost:3000,http://localhost:3001,http://localhost:3002"
-            # Phase 11 follow-up: per-domain cutover flags must be on so
-            # the gateway actually registers its /api/v1/* routes. With
-            # them off (the production-prod default during strangler
-            # migration) the gateway returns 404 for every API path,
-            # which makes the e2e suite uniformly red. The monolith is
-            # gone — there is no fall-through — so for e2e we want all
-            # extracted domains live.
-            echo "CUTOVER_AUTH=true"
-            echo "CUTOVER_NOTIFICATIONS=true"
-            echo "CUTOVER_PETS=true"
-            echo "CUTOVER_RESCUE=true"
-            echo "CUTOVER_APPLICATIONS=true"
-            echo "CUTOVER_MODERATION=true"
-            echo "CUTOVER_MATCHING=true"
-            echo "CUTOVER_AUDIT=true"
-            echo "CUTOVER_CHAT=true"
-            echo "CUTOVER_CMS=true"
             # Raise the gateway's global per-IP rate limit for e2e. A full
             # Playwright run drives the whole SPA (favourites, chats,
             # notifications, permissions, legal, match, csrf) across parallel

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -650,17 +650,17 @@ jobs:
               fi
             done
 
-            # ADS-813: smoke-check that the cutover-gated /api/v1/* routes are
-            # actually registered. /api/v1/auth/login only exists when
-            # CUTOVER_AUTH is on: an empty POST returns 400 when registered,
-            # 404 when the flags never reached the gateway.
-            echo "Smoke-checking POST /api/v1/auth/login (verifies CUTOVER flags are set)..."
+            # Smoke-check that the gateway registered its /api/v1/* routes.
+            # /api/v1/auth/login exists whenever the auth service client is
+            # wired: an empty POST returns 400 when registered, 404 if the
+            # gateway came up without its routes (e.g. a missing service URL).
+            echo "Smoke-checking POST /api/v1/auth/login (verifies gateway routes are registered)..."
             STATUS=$(docker compose -f $COMPOSE_FILE exec -T service-gateway \
               curl -o /dev/null -w '%{http_code}' -s -X POST \
               -H 'content-type: application/json' -d '{}' \
               http://localhost:4000/api/v1/auth/login 2>/dev/null || echo "000")
             if [ "$STATUS" = "404" ] || [ "$STATUS" = "000" ]; then
-              echo "ERROR: POST /api/v1/auth/login returned $STATUS — CUTOVER_* flags may be missing or gateway routes not registered."
+              echo "ERROR: POST /api/v1/auth/login returned $STATUS — gateway routes are not registered."
               exit 1
             fi
             echo "Smoke check passed (HTTP $STATUS)."

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -156,8 +156,7 @@ services:
           cpus: '0.25'
           memory: 128m
 
-  # NATS JetStream — event backbone for the extracted services. Required once
-  # any CUTOVER_<DOMAIN> flag is flipped on; harmless when all are off.
+  # NATS JetStream — event backbone for the extracted services.
   nats:
     image: nats:2.10-alpine@sha256:b83efabe3e7def1e0a4a31ec6e078999bb17c80363f881df35edc70fcb6bb927
     container_name: ads_prod_nats
@@ -210,20 +209,6 @@ services:
       # ADS-800: the gateway signs the x-principal-token it forwards on
       # every downstream gRPC call.
       PRINCIPAL_SIGNING_KEY_FILE: /run/secrets/principal_signing_key
-      # ADS-813: forward CUTOVER_* flags so the gateway registers /api/v1/*
-      # routes. Without these the gateway boots healthy but 404s every API
-      # route (compose does not pass host env implicitly). Default true — all
-      # domains are extracted in phase 11 and the monolith is gone.
-      CUTOVER_AUTH: '${CUTOVER_AUTH:-true}'
-      CUTOVER_NOTIFICATIONS: '${CUTOVER_NOTIFICATIONS:-true}'
-      CUTOVER_PETS: '${CUTOVER_PETS:-true}'
-      CUTOVER_RESCUE: '${CUTOVER_RESCUE:-true}'
-      CUTOVER_APPLICATIONS: '${CUTOVER_APPLICATIONS:-true}'
-      CUTOVER_MODERATION: '${CUTOVER_MODERATION:-true}'
-      CUTOVER_MATCHING: '${CUTOVER_MATCHING:-true}'
-      CUTOVER_AUDIT: '${CUTOVER_AUDIT:-true}'
-      CUTOVER_CHAT: '${CUTOVER_CHAT:-true}'
-      CUTOVER_CMS: '${CUTOVER_CMS:-true}'
     # Gateway has no DB; it needs the upload-signing secret plus the
     # principal-signing key (ADS-800 — it is the token signer).
     secrets:

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -138,8 +138,7 @@ services:
           memory: 128m
 
   # NATS JetStream — the event backbone for the extracted services
-  # (publish-after-commit + idempotent subscribers). Required once any
-  # CUTOVER_<DOMAIN> flag is flipped on; harmless when all are off.
+  # (publish-after-commit + idempotent subscribers).
   nats:
     image: nats:2.10-alpine@sha256:b83efabe3e7def1e0a4a31ec6e078999bb17c80363f881df35edc70fcb6bb927
     container_name: ads_staging_nats
@@ -190,20 +189,6 @@ services:
       # ADS-800: the gateway signs the x-principal-token it forwards on
       # every downstream gRPC call.
       PRINCIPAL_SIGNING_KEY_FILE: /run/secrets/principal_signing_key
-      # ADS-813: forward CUTOVER_* flags so the gateway registers /api/v1/*
-      # routes. Without these the gateway boots healthy but 404s every API
-      # route (compose does not pass host env implicitly). Default true — all
-      # domains are extracted in phase 11 and the monolith is gone.
-      CUTOVER_AUTH: '${CUTOVER_AUTH:-true}'
-      CUTOVER_NOTIFICATIONS: '${CUTOVER_NOTIFICATIONS:-true}'
-      CUTOVER_PETS: '${CUTOVER_PETS:-true}'
-      CUTOVER_RESCUE: '${CUTOVER_RESCUE:-true}'
-      CUTOVER_APPLICATIONS: '${CUTOVER_APPLICATIONS:-true}'
-      CUTOVER_MODERATION: '${CUTOVER_MODERATION:-true}'
-      CUTOVER_MATCHING: '${CUTOVER_MATCHING:-true}'
-      CUTOVER_AUDIT: '${CUTOVER_AUDIT:-true}'
-      CUTOVER_CHAT: '${CUTOVER_CHAT:-true}'
-      CUTOVER_CMS: '${CUTOVER_CMS:-true}'
     # Gateway has no DB; it needs the upload-signing secret plus the
     # principal-signing key (ADS-800 — it is the token signer).
     secrets:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -342,10 +342,9 @@ services:
 
   # ==========================================================================
   # EXTRACTED MICROSERVICES (CAD-style). Opt-in via `--profile services`.
-  # The gateway fronts /api/* and proxies to the monolith for every domain
-  # whose CUTOVER_<DOMAIN> flag is off (the default), so bringing these up
-  # changes nothing until a flag is flipped. gRPC URL defaults in the gateway
-  # config (service-<name>:<port>) match these container names.
+  # The gateway is the single REST surface fronting /api/* and routes each
+  # domain to its gRPC service. gRPC URL defaults in the gateway config
+  # (service-<name>:<port>) match these container names.
   # ==========================================================================
 
   service-gateway:
@@ -364,20 +363,6 @@ services:
       # Same Redis the other microservices use; the gateway gets its own
       # key namespace via the plugin's default nameSpace.
       REDIS_URL: redis://:${REDIS_PASSWORD}@redis:6379
-      # Phase 11: the monolith is deleted, so there is no proxy fall-through —
-      # a domain whose flag is off just 404s at the gateway. Dev and e2e want
-      # every extracted domain live, so default each flag on (overridable via
-      # .env). Without these the gateway registers no /api/v1/* routes at all.
-      CUTOVER_AUTH: ${CUTOVER_AUTH:-true}
-      CUTOVER_NOTIFICATIONS: ${CUTOVER_NOTIFICATIONS:-true}
-      CUTOVER_PETS: ${CUTOVER_PETS:-true}
-      CUTOVER_RESCUE: ${CUTOVER_RESCUE:-true}
-      CUTOVER_APPLICATIONS: ${CUTOVER_APPLICATIONS:-true}
-      CUTOVER_MODERATION: ${CUTOVER_MODERATION:-true}
-      CUTOVER_MATCHING: ${CUTOVER_MATCHING:-true}
-      CUTOVER_AUDIT: ${CUTOVER_AUDIT:-true}
-      CUTOVER_CHAT: ${CUTOVER_CHAT:-true}
-      CUTOVER_CMS: ${CUTOVER_CMS:-true}
       # ADS-800: same shared key as the *ms-env services — the gateway is
       # the signer, the services are the verifiers.
       PRINCIPAL_SIGNING_KEY: ${PRINCIPAL_SIGNING_KEY:-}

--- a/docs/README.md
+++ b/docs/README.md
@@ -44,7 +44,7 @@ Documentation for the adopt-don't-shop monorepo, organized by audience. The root
 ## Architecture
 
 - [ADR 0001 — entity detail pattern](./adr/0001-entity-detail-pattern.md) — canonical pattern for entity detail pages
-- [ADR 0002 — applications strangler cutover](./adr/0002-applications-strangler-cutover.md) — plan to move `/api/v1/applications/*` to the microservice
+- [ADR 0002 — applications strangler cutover](./adr/0002-applications-strangler-cutover.md) — _superseded_: historical plan to move `/api/v1/applications/*` to the microservice (cutover flags removed)
 - [ADR 0003 — idempotent event consumers](./adr/0003-idempotent-event-consumers.md) — at-least-once delivery + idempotent-consumer convention
 - [ADR 0004 — Postgres read-replica routing](./adr/0004-postgres-read-replica-routing.md) — optional read-replica pool in `@adopt-dont-shop/db`
 - [ADR — sticky sessions for Socket.IO](./architecture/adr-socket-sticky-sessions.md) — connection-cap mitigation for the WebSocket edge
@@ -167,7 +167,7 @@ Documentation for the adopt-don't-shop monorepo, organized by audience. The root
 - [Observability and alerting](./observability-alerting.md) — metrics, logs, alert routing (legacy — superseded by `slo.md`)
 - [Runbooks index](./runbooks/README.md) — runbook catalogue
 - [5xx spike runbook](./runbooks/5xx-spike.md) — diagnose elevated server errors
-- [Applications cutover runbook](./runbooks/applications-cutover.md) — route applications traffic to the microservice
+- [Applications cutover runbook](./runbooks/applications-cutover.md) — _obsolete_: the per-domain cutover mechanism has been removed
 - [DB pool exhaustion runbook](./runbooks/db-pool-exhaustion.md) — recover from connection saturation
 - [Deploy rollback runbook](./runbooks/deploy-rollback.md) — roll back a bad release
 - [GDPR erasure incident runbook](./runbooks/gdpr-erasure-incident.md) — recover a failed / timed-out erasure saga

--- a/docs/adr/0002-applications-strangler-cutover.md
+++ b/docs/adr/0002-applications-strangler-cutover.md
@@ -1,6 +1,13 @@
 # ADR 0002 — Applications strangler-fig cutover plan
 
-- Status: Proposed
+> **Superseded.** The per-domain `CUTOVER_<DOMAIN>` switches this ADR describes
+> have been removed. The residual monolith was deleted (Phase 11) and the
+> gateway now always registers a domain's routes when its gRPC client is wired —
+> there is no flag and no fall-through. The response-shape (view-adapter)
+> requirements below remain the standard for any gateway route. Retained for
+> historical context.
+
+- Status: Superseded
 - Date: 2026-06-06
 - Scope: `services/applications`, `services/gateway`, `services/api` (residual
   monolith), `lib.applications`

--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -15,7 +15,7 @@ decide in 10 seconds whether to escalate.
 | [`deploy-rollback.md`](./deploy-rollback.md)     | Bad deploy: image is live but error rate is up           |
 | [`migration-failure.md`](./migration-failure.md) | `service-backend-migrate` exited non-zero; backend won't start |
 | [`maintenance-mode.md`](./maintenance-mode.md)   | Planned outage, controlled brownout, or kill-switch needed |
-| [`applications-cutover.md`](./applications-cutover.md) | Flipping `/api/v1/applications/*` to the microservice (or rolling back) |
+| [`applications-cutover.md`](./applications-cutover.md) | _Obsolete_ — per-domain cutover flags removed; gateway always registers routes |
 
 ## On-call principles
 

--- a/docs/runbooks/applications-cutover.md
+++ b/docs/runbooks/applications-cutover.md
@@ -1,110 +1,29 @@
-# Applications strangler cutover
+# Applications strangler cutover — REMOVED
 
-How to move `/api/v1/applications/*` traffic from the residual monolith to
-`service.applications`, validate it, and roll back. Implements the flip of
-`CUTOVER_APPLICATIONS` from ADR 0002.
+> **This runbook is obsolete.** The per-domain `CUTOVER_<DOMAIN>` strangler
+> switches have been removed. The residual `service.backend` monolith was
+> deleted in Phase 11, so there is no longer anything to "cut over" to or roll
+> back to.
 
-**Default state:** `CUTOVER_APPLICATIONS=false`. The gateway does NOT register
-the applications routes, so `/api/v1/applications/*` proxies to the monolith —
-today's behaviour. Flipping the flag is the cutover; flipping it back is the
-rollback (instant, no data move).
+## What replaced it
 
-## ⚠️ Go / no-go — read before flipping
+The gateway is now the single REST surface. Each domain's `/api/v1/*` routes
+register automatically whenever that service's gRPC client is wired (i.e. its
+`*_GRPC_URL` is configured — which it always is via the gateway config
+defaults). There is no flag to flip and no monolith fall-through: any
+`/api/v1/*` path the gateway doesn't own returns `404`, and that 404 is now
+logged at `warn` so a misconfiguration (e.g. an unreachable service) is visible
+in the gateway logs.
 
-The contract + backfill are ready, but the flip is **gated on data ownership**.
-Confirm ALL of these before enabling in any shared environment:
+If a domain's routes are missing, the cause is operational, not a toggle:
 
-1. **`service.applications` is deployed and healthy** and reachable from the
-   gateway at `APPLICATIONS_GRPC_URL` (default `service-applications:6005`).
-2. **The backfill has run** (see below) and the new event store's row count
-   matches `SELECT count(*) FROM public.applications WHERE deleted_at IS NULL`.
-   The backfill's schema assumptions are verified against the monolith models.
-3. **The 13 monolith integrations are migrated, OR you accept staleness.** This
-   is the real blocker. After the flip, the SPA's writes go to
-   `service.applications`; the monolith's `applications` table stops receiving
-   them. Anything in the monolith that still reads that table directly — GDPR
-   erasure, analytics, weekly-digest, admin export, user/rescue deletion
-   cascades, upload-ACL, etc. (ADR 0002 Gap 3) — will see **stale** data. Do
-   NOT flip in production until Stage D migrates those consumers off the model
-   (or a transitional event-sync keeps the monolith table current). Flipping in
-   a staging/preview environment to validate the contract is fine.
-4. **Known contract gaps are acceptable for the environment** (see "Known gaps").
+- the backing service isn't reachable at its `*_GRPC_URL`, or
+- the gateway came up before the service was healthy.
 
-## Pre-flight
+Check `docker compose ps` and the gateway logs (`unmatched API route` warnings)
+rather than any `CUTOVER_*` variable — those no longer exist.
 
-```bash
-# 1. Deploy service.applications; confirm health + migrations.
-curl -fsS http://service-applications:5005/health/simple
+## Historical context
 
-# 2. Run the one-off backfill (idempotent — safe to re-run). It synthesizes an
-#    event stream per monolith application into the event store and projects the
-#    read model. Reads public.applications + application_answers/_references.
-#    (Run mechanism — npm script vs scheduled job — TBD with the team; the
-#    script is services/applications/src/backfill/run-backfill.ts.)
-
-# 3. Reconcile counts (should match):
-psql "$DATABASE_URL" -c "SELECT count(*) FROM public.applications WHERE deleted_at IS NULL;"
-psql "$DATABASE_URL" -c "SELECT count(*) FROM applications;"  # the new read model
-```
-
-## Enable
-
-Set on the GATEWAY environment, then restart/redeploy the gateway:
-
-```bash
-CUTOVER_APPLICATIONS=true
-APPLICATIONS_GRPC_URL=service-applications:6005   # if not already set
-```
-
-The gateway now registers `/api/v1/applications/*` and serves it from the
-service; everything else still proxies to the monolith.
-
-## Validate (smoke, as a seeded adopter + rescue-staff persona)
-
-```
-GET   /api/v1/applications                  → 200, { data: [...] } (no drafts)
-GET   /api/v1/applications/stats?rescue=…    → 200, { data: { total, submitted, underReview, approved, rejected, pendingReferences } }
-GET   /api/v1/applications/:id               → 200, { data: {...} } (404 for a draft id)
-POST  /api/v1/applications                   → 201, { data: { status: 'submitted', … } }
-PATCH /api/v1/applications/:id/status        → 200 (approved/rejected/withdrawn)
-PUT   /api/v1/applications/:id/withdraw       → 200
-```
-
-Each response must satisfy the SPA's `ApplicationSchema` / `ApplicationStatsSchema`
-Zod parse — the gateway view adapter (`routes/applications-view.ts`) guarantees
-the shape. Open `app.client` and confirm the application list, detail, and
-submit flows render without an "Error loading applications" page.
-
-## Rollback
-
-```bash
-CUTOVER_APPLICATIONS=false   # restart the gateway
-```
-
-Instant: the routes deregister and `/api/v1/applications/*` proxies to the
-monolith again. No data move is needed — the monolith table was never deleted.
-(Writes made to `service.applications` while the flag was on remain only in the
-new store; if you flipped in production and took writes, reconcile before
-re-enabling — another reason not to flip prod before Stage D.)
-
-## Known gaps (as of the cutover-readiness milestone)
-
-- **Documents** — upload/list/remove. Service-side metadata RPCs are being added;
-  the gateway multipart + object-storage upload path is a remaining follow-up.
-  Until both land, document features 404 under the flag.
-- **`PUT /:id` update** behaviour change: the service only allows answer edits
-  while `draft` / `under_review`; editing a decided application returns 400
-  (the monolith allowed freer edits).
-- **List pagination** — the gateway returns the first page; the SPA's current
-  list methods don't pass a cursor, so this is not user-visible, but large
-  rescue inboxes are not yet paged.
-- **No NATS publish from the backfill** — historical applications are seeded
-  without re-emitting `applications.*` events (intentional; downstream
-  consumers already hold the monolith's history).
-
-## Per-vertical note
-
-The same `CUTOVER_<DOMAIN>` switch exists for every extracted vertical (auth,
-pets, rescue, moderation, matching, audit). Each needs its own contract audit +
-view adapter + this same go/no-go before its flag is flipped — applications is
-the worked example.
+The original migration plan and response-shape contract requirements live in
+[ADR 0002](../adr/0002-applications-strangler-cutover.md), retained for history.

--- a/services/gateway/src/config.test.ts
+++ b/services/gateway/src/config.test.ts
@@ -11,37 +11,6 @@ describe('loadConfig', () => {
     expect(config.natsUrl).toBe('nats://nats:4222');
   });
 
-  it('defaults every cutover flag to false', () => {
-    const config = loadConfig({});
-    expect(config.cutover).toEqual({
-      auth: false,
-      notifications: false,
-      pets: false,
-      rescue: false,
-      applications: false,
-      moderation: false,
-      matching: false,
-      audit: false,
-      chat: false,
-      cms: false,
-    });
-  });
-
-  it('enables a cutover flag only for the exact string "true" (case-insensitive)', () => {
-    const config = loadConfig({
-      CUTOVER_PETS: 'true',
-      CUTOVER_AUTH: 'TRUE',
-      CUTOVER_APPLICATIONS: 'false',
-      CUTOVER_MATCHING: '1',
-      CUTOVER_AUDIT: '',
-    });
-    expect(config.cutover.pets).toBe(true);
-    expect(config.cutover.auth).toBe(true);
-    expect(config.cutover.applications).toBe(false);
-    expect(config.cutover.matching).toBe(false);
-    expect(config.cutover.audit).toBe(false);
-  });
-
   it('honours GATEWAY_PORT / GATEWAY_HOST / NODE_ENV / NATS_URL when set', () => {
     const config = loadConfig({
       GATEWAY_PORT: '4321',

--- a/services/gateway/src/config.ts
+++ b/services/gateway/src/config.ts
@@ -68,26 +68,6 @@ export type GatewayConfig = {
     // else that wants to mint a signed URL.
     signingSecret?: string;
   };
-  // Per-domain strangler cutover switches. When false (the default), the
-  // gateway does NOT register that domain's /api/v1/* routes, so requests
-  // fall through the catch-all proxy to the residual monolith — today's
-  // behaviour. Flip a domain to true ONLY once its gateway routes return
-  // a frontend-compatible response shape (see ADR 0002 — the gRPC
-  // proto-JSON shape diverges from the frontend contract, so a per-domain
-  // adapter must land before that domain goes live). Env:
-  // CUTOVER_<DOMAIN>=true.
-  cutover: {
-    auth: boolean;
-    notifications: boolean;
-    pets: boolean;
-    rescue: boolean;
-    applications: boolean;
-    moderation: boolean;
-    matching: boolean;
-    audit: boolean;
-    chat: boolean;
-    cms: boolean;
-  };
   // Gateway-folded routes — per the plan's "small static reads fold
   // into service.gateway" guidance. Each block is independently
   // toggle-able so a deploy can roll out legal vs config separately.
@@ -184,18 +164,6 @@ export const loadConfig = (env: NodeJS.ProcessEnv = process.env): GatewayConfig 
     chatGrpcUrl: env.CHAT_GRPC_URL?.trim() || DEFAULT_CHAT_GRPC_URL,
     cmsGrpcUrl: env.CMS_GRPC_URL?.trim() || DEFAULT_CMS_GRPC_URL,
     storage: buildStorageConfig(env),
-    cutover: {
-      auth: isEnabled(env.CUTOVER_AUTH),
-      notifications: isEnabled(env.CUTOVER_NOTIFICATIONS),
-      pets: isEnabled(env.CUTOVER_PETS),
-      rescue: isEnabled(env.CUTOVER_RESCUE),
-      applications: isEnabled(env.CUTOVER_APPLICATIONS),
-      moderation: isEnabled(env.CUTOVER_MODERATION),
-      matching: isEnabled(env.CUTOVER_MATCHING),
-      audit: isEnabled(env.CUTOVER_AUDIT),
-      chat: isEnabled(env.CUTOVER_CHAT),
-      cms: isEnabled(env.CUTOVER_CMS),
-    },
     legal: {
       enabled: env.GATEWAY_LEGAL_ENABLED?.trim().toLowerCase() !== 'false',
       docsDir: env.LEGAL_DOCS_DIR?.trim() || 'docs/legal',
@@ -249,8 +217,8 @@ function buildRateLimitConfig(env: NodeJS.ProcessEnv): GatewayConfig['rateLimit'
 // sets E2E_TOKEN_PEEK=true in a production deploy, this THROWS at boot so the
 // gateway never comes up exposing one-time secrets. The seam additionally
 // needs DATABASE_URL (which prod never wires to the gateway) — defence in
-// depth. Enabled requires the exact string "true" (case-insensitive), matching
-// the cutover-flag convention.
+// depth. Enabled requires the exact string "true" (case-insensitive), per the
+// isEnabled() convention.
 function buildTestTokenPeekConfig(env: NodeJS.ProcessEnv): GatewayConfig['testTokenPeek'] {
   const enabled = isEnabled(env.E2E_TOKEN_PEEK);
   const environment = env.NODE_ENV?.trim() || 'development';
@@ -265,9 +233,8 @@ function buildTestTokenPeekConfig(env: NodeJS.ProcessEnv): GatewayConfig['testTo
   };
 }
 
-// A cutover flag is on only for the exact string "true" (case-insensitive).
-// Anything else — unset, "false", "0", "" — leaves the domain proxied to
-// the monolith.
+// A boolean env flag is on only for the exact string "true" (case-insensitive).
+// Anything else — unset, "false", "0", "" — is treated as off.
 function isEnabled(raw: string | undefined): boolean {
   return raw?.trim().toLowerCase() === 'true';
 }

--- a/services/gateway/src/middleware/authenticate.ts
+++ b/services/gateway/src/middleware/authenticate.ts
@@ -177,6 +177,9 @@ export const registerAuthenticate = async (
         // a principal — but guard so a future contract drift fails
         // closed instead of silently forwarding unauth as auth.
         if (!isPublic) {
+          logger.warn('rejecting request: token validated but no principal returned', {
+            url: req.url,
+          });
           return reply.code(401).send({ error: 'invalid token' });
         }
         return;
@@ -235,7 +238,12 @@ export const registerAuthenticate = async (
       }
       const grpcCode = (err as { code?: number }).code;
       const httpStatus = grpcCode === grpcStatus.UNAUTHENTICATED ? 401 : 500;
-      if (httpStatus !== 401) {
+      if (httpStatus === 401) {
+        // Invalid / expired / revoked token on a protected path. Log at
+        // warn so a flood of 401s (e.g. a stale SPA session) is visible in
+        // the gateway logs instead of failing silently.
+        logger.warn('rejecting request: invalid token', { url: req.url });
+      } else {
         logger.error('ValidateToken upstream error', {
           err: (err as Error)?.message ?? String(err),
           url: req.url,

--- a/services/gateway/src/openapi.test.ts
+++ b/services/gateway/src/openapi.test.ts
@@ -66,25 +66,12 @@ const stubPetsClient = {
   getStats: () => Promise.resolve({}),
 } as unknown as Parameters<typeof createServer>[0]['petsClient'];
 
-const allCutover = {
-  auth: true,
-  notifications: false,
-  pets: true,
-  rescue: false,
-  applications: false,
-  moderation: false,
-  matching: false,
-  audit: false,
-  chat: false,
-  cms: false,
-} as const;
-
 describe('createServer — OpenAPI spec endpoint', () => {
   let server: FastifyInstance;
 
   beforeEach(async () => {
     server = await createServer({
-      config: { ...baseConfig, cutover: { ...allCutover } } as GatewayConfig,
+      config: baseConfig,
       logger: quietLogger,
       authClient: stubAuthClient,
       petsClient: stubPetsClient,

--- a/services/gateway/src/routes/applications-view.ts
+++ b/services/gateway/src/routes/applications-view.ts
@@ -3,8 +3,8 @@
 // The service.applications gRPC surface returns proto-JSON that diverges
 // from the frontend's `ApplicationSchema` (lib.applications). This module
 // is the read-side translation: a decoded proto `Application` →
-// the frontend's view shape, so flipping CUTOVER_APPLICATIONS on serves a
-// shape the SPA's Zod parse accepts unchanged.
+// the frontend's view shape, so the gateway serves a shape the SPA's Zod
+// parse accepts unchanged.
 //
 // Two divergences handled here:
 //

--- a/services/gateway/src/routes/applications.ts
+++ b/services/gateway/src/routes/applications.ts
@@ -1,8 +1,8 @@
 // REST → gRPC translation for /api/v1/applications/*.
 //
-// Phase 5.3d cutover. Same strangler-fig shape as routes/moderation.ts
-// (#929) / routes/matching.ts (#923) — registers BEFORE the catch-all
-// proxy so first-registered-wins prefix routing picks it off.
+// Same shape as routes/moderation.ts (#929) / routes/matching.ts (#923)
+// — registers BEFORE the /api/* 404 handler so first-registered-wins
+// prefix routing picks it off.
 //
 // Two layers (ADR 0002, Stage B):
 //
@@ -23,9 +23,8 @@
 //   withdraw,adopt}.
 //
 // Authz lives in the service handlers; the gateway stamps x-user-*
-// metadata via the Phase 2.5 authenticate middleware. These routes only
-// serve traffic when CUTOVER_APPLICATIONS is on (else /api/v1/* proxies
-// to the monolith) — see server.ts.
+// metadata via the authenticate middleware. These routes register
+// whenever the applications service client is wired — see server.ts.
 
 import rateLimit from '@fastify/rate-limit';
 import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';

--- a/services/gateway/src/routes/devices.ts
+++ b/services/gateway/src/routes/devices.ts
@@ -1,11 +1,10 @@
 // REST → gRPC translation for /api/v1/devices/*.
 //
-// service.notifications owns device_tokens (PR #956). The monolith
-// has exposed POST/GET/DELETE /api/v1/devices since before the
-// extraction; this plugin reproduces the same SPA-facing shape so the
-// cutover can flip CUTOVER_NOTIFICATIONS=true without the SPA noticing.
+// service.notifications owns device_tokens (PR #956). This plugin
+// exposes POST/GET/DELETE /api/v1/devices with the SPA-facing shape the
+// frontend already expects.
 //
-// Path shapes (monolith parity):
+// Path shapes:
 //   POST   /api/v1/devices              register
 //   GET    /api/v1/devices              list-self
 //   DELETE /api/v1/devices/:tokenId     unregister

--- a/services/gateway/src/routes/pets-view.ts
+++ b/services/gateway/src/routes/pets-view.ts
@@ -3,8 +3,8 @@
 // service.pets returns proto-JSON; the frontend lib.pets `PetSchema`
 // expects snake_case fields, lowercase enum tokens, the long-tail fields
 // unpacked from the proto's `extra_json` blob, and a `{ success, data,
-// meta }` envelope. This module is that translation so flipping
-// CUTOVER_PETS serves a shape the SPA's Zod parse accepts.
+// meta }` envelope. This module is that translation so the gateway
+// serves a shape the SPA's Zod parse accepts.
 //
 // Only `pet_id` + `name` are required on the frontend schema; everything
 // else is optional, so we map what the proto carries and omit the rest.

--- a/services/gateway/src/routes/rescues-public.ts
+++ b/services/gateway/src/routes/rescues-public.ts
@@ -5,8 +5,8 @@
 // envelope).
 //
 // The pre-existing /api/v1/rescue/* (singular) routes are kept as an
-// internal/raw shape; this module is the SPA-facing layer. Both gated
-// on cutover.rescue.
+// internal/raw shape; this module is the SPA-facing layer. Both register
+// when the rescue service client is wired.
 
 import rateLimit from '@fastify/rate-limit';
 import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';

--- a/services/gateway/src/routes/sessions.ts
+++ b/services/gateway/src/routes/sessions.ts
@@ -2,14 +2,14 @@
 //
 // Maps the SPA's existing session-management surface onto the auth
 // service's new ListSessions / RevokeSession RPCs (introduced in the
-// same PR that wires this route). Path shapes mirror the monolith
-// exactly so the SPA needs no change at cutover:
+// same PR that wires this route). Path shapes match what the SPA
+// already expects:
 //
 //   GET    /api/v1/sessions              listSessions
 //   DELETE /api/v1/sessions/:sessionId   revokeSession (204 on success)
 //
-// Mounted under the existing CUTOVER_AUTH flag — sessions are an auth
-// surface, so they cut over together with login/logout/etc.
+// Registers alongside the other auth routes (gated on the auth client
+// being wired).
 
 import type { FastifyInstance } from 'fastify';
 

--- a/services/gateway/src/routes/staff-foster.ts
+++ b/services/gateway/src/routes/staff-foster.ts
@@ -1,10 +1,9 @@
 // REST → gRPC translation for the rescue service's staff / foster /
-// invitation-read surface. Ports the monolith's /api/v1/staff/*,
-// /api/v1/foster/* and GET /api/v1/invitations/details/:token.
+// invitation-read surface. Serves /api/v1/staff/*, /api/v1/foster/* and
+// GET /api/v1/invitations/details/:token.
 //
-// Mounted under the rescue cutover flag. Responses use the monolith's
-// `{ success, data }` envelope so the SPA (lib.rescue, staff views)
-// doesn't notice the cutover.
+// Registers when the rescue service client is wired. Responses use the
+// `{ success, data }` envelope the SPA (lib.rescue, staff views) expects.
 
 import type { FastifyInstance } from 'fastify';
 

--- a/services/gateway/src/server.test.ts
+++ b/services/gateway/src/server.test.ts
@@ -284,18 +284,6 @@ describe('createServer — per-route rate limit override (auth login)', () => {
     server = await createServer({
       config: {
         ...baseConfig,
-        cutover: {
-          auth: true,
-          notifications: false,
-          pets: false,
-          rescue: false,
-          applications: false,
-          moderation: false,
-          matching: false,
-          audit: false,
-          chat: false,
-          cms: false,
-        },
         rateLimit: { redisUrl: undefined, max: 100, timeWindow: '1 minute' },
       },
       logger: quietLogger,
@@ -368,24 +356,11 @@ describe('createServer — Prometheus rate-limit counter', () => {
   });
 });
 
-// Per-domain cutover gate. With the flag OFF (default) the gateway does
-// NOT register the domain's /api/v1/* routes, so the request 404s.
-// With the flag ON the gateway's route plugin intercepts it.
-describe('createServer — per-domain cutover gate', () => {
+// Domain routes register whenever their gRPC client is wired — there is
+// no migration toggle anymore. A path whose client isn't wired, or that
+// the gateway doesn't own, falls through to the 404 handler.
+describe('createServer — domain route registration', () => {
   let server: FastifyInstance;
-
-  const allOff = {
-    auth: false,
-    notifications: false,
-    pets: false,
-    rescue: false,
-    applications: false,
-    moderation: false,
-    matching: false,
-    audit: false,
-    chat: false,
-    cms: false,
-  } as const;
 
   // A stub applications client whose List resolves an empty page. Only
   // the List path is exercised here.
@@ -397,29 +372,36 @@ describe('createServer — per-domain cutover gate', () => {
     await server?.close();
   });
 
-  it('404s /api/v1/applications when cutover.applications is OFF (even with a client)', async () => {
+  it('registers /api/v1/applications when the applications client is wired', async () => {
     server = await createServer({
-      config: { ...baseConfig, cutover: { ...allOff } },
+      config: baseConfig,
       logger: quietLogger,
       applicationsClient,
+    });
+    const res = await server.inject({ method: 'GET', url: '/api/v1/applications' });
+    // The gateway route served it — the view adapter wraps the (empty)
+    // result in the frontend's `{ data }` envelope.
+    expect(res.json()).toEqual({ data: [] });
+  });
+
+  it('404s /api/v1/applications when no applications client is wired', async () => {
+    server = await createServer({
+      config: baseConfig,
+      logger: quietLogger,
     });
     const res = await server.inject({ method: 'GET', url: '/api/v1/applications' });
     expect(res.statusCode).toBe(404);
   });
 
-  it('intercepts /api/v1/applications at the gateway route when cutover.applications is ON', async () => {
+  it('404s an /api/* path the gateway does not own', async () => {
     server = await createServer({
-      config: {
-        ...baseConfig,
-        cutover: { ...allOff, applications: true },
-      },
+      config: baseConfig,
       logger: quietLogger,
       applicationsClient,
     });
-    const res = await server.inject({ method: 'GET', url: '/api/v1/applications' });
-    // The gateway route served it — Stage B view adapter wraps the
-    // (empty) result in the frontend's `{ data }` envelope.
-    expect(res.json()).toEqual({ data: [] });
+    const res = await server.inject({ method: 'GET', url: '/api/v1/nonexistent' });
+    expect(res.statusCode).toBe(404);
+    expect(res.json()).toEqual({ error: 'not_found' });
   });
 });
 
@@ -452,26 +434,13 @@ describe('createServer — /docs gate (admin only)', () => {
     } as unknown as Parameters<typeof createServer>[0]['authClient'];
   }
 
-  const allCutoverOff = {
-    auth: false,
-    notifications: false,
-    pets: false,
-    rescue: false,
-    applications: false,
-    moderation: false,
-    matching: false,
-    audit: false,
-    chat: false,
-    cms: false,
-  } as const;
-
   afterEach(async () => {
     await server?.close();
   });
 
   it('returns 403 for unauthenticated requests to /docs when authClient is wired', async () => {
     server = await createServer({
-      config: { ...baseConfig, cutover: { ...allCutoverOff } },
+      config: baseConfig,
       logger: quietLogger,
       authClient: makeAuthClient([]), // stub — won't be called (no Bearer token)
     });
@@ -483,7 +452,7 @@ describe('createServer — /docs gate (admin only)', () => {
   it('returns 403 for non-admin authenticated requests to /docs', async () => {
     // Role 1 = adopter — not admin
     server = await createServer({
-      config: { ...baseConfig, cutover: { ...allCutoverOff } },
+      config: baseConfig,
       logger: quietLogger,
       authClient: makeAuthClient([1]),
     });
@@ -498,7 +467,7 @@ describe('createServer — /docs gate (admin only)', () => {
   it('allows admin users through to /docs', async () => {
     // Role 3 = admin
     server = await createServer({
-      config: { ...baseConfig, cutover: { ...allCutoverOff } },
+      config: baseConfig,
       logger: quietLogger,
       authClient: makeAuthClient([3]),
     });
@@ -514,7 +483,7 @@ describe('createServer — /docs gate (admin only)', () => {
   it('allows super_admin users through to /docs', async () => {
     // Role 5 = super_admin
     server = await createServer({
-      config: { ...baseConfig, cutover: { ...allCutoverOff } },
+      config: baseConfig,
       logger: quietLogger,
       authClient: makeAuthClient([5]),
     });
@@ -528,7 +497,7 @@ describe('createServer — /docs gate (admin only)', () => {
 
   it('serves /openapi.json without authentication (stays open for SDK tooling)', async () => {
     server = await createServer({
-      config: { ...baseConfig, cutover: { ...allCutoverOff } },
+      config: baseConfig,
       logger: quietLogger,
       authClient: makeAuthClient([]),
     });
@@ -538,7 +507,7 @@ describe('createServer — /docs gate (admin only)', () => {
 
   it('leaves /docs open when no authClient is wired (dev / smoke-test mode)', async () => {
     server = await createServer({
-      config: { ...baseConfig, cutover: { ...allCutoverOff } },
+      config: baseConfig,
       logger: quietLogger,
       // No authClient — authenticate middleware is skipped entirely
     });

--- a/services/gateway/src/server.ts
+++ b/services/gateway/src/server.ts
@@ -32,7 +32,7 @@ import {
 import cors from '@fastify/cors';
 import helmet from '@fastify/helmet';
 import rateLimit from '@fastify/rate-limit';
-import Fastify, { type FastifyInstance } from 'fastify';
+import Fastify, { type FastifyInstance, type FastifyReply, type FastifyRequest } from 'fastify';
 import Redis from 'ioredis';
 import { Counter } from 'prom-client';
 
@@ -385,17 +385,14 @@ export const createServer = async (opts: CreateServerOptions): Promise<FastifyIn
   }
 
   // Service-specific routes register at /api/v1/<domain> BEFORE the
-  // catch-all proxy — Fastify's first-registered-wins prefix routing
-  // picks them off before the catch-all sees the request.
+  // unmatched-route 404 handler — Fastify's first-registered-wins prefix
+  // routing picks them off before the catch-all sees the request.
   //
-  // Each domain registers ONLY when (a) its gRPC client is wired and
-  // (b) its per-domain cutover flag is on. The flag defaults off, so by
-  // default these routes are NOT registered and /api/v1/* falls through
-  // to the residual monolith — preserving today's behaviour. A domain
-  // goes live only once its routes return a frontend-compatible shape
-  // (ADR 0002). NOTE: the authenticate middleware above is independent
-  // of cutover.auth and always runs; only the /api/v1/auth/* ROUTES are
-  // gated here.
+  // Each domain registers when its gRPC client is wired. If a service's
+  // client is not configured (e.g. a partial test harness, or a service
+  // that hasn't come up), its routes are skipped and those paths fall to
+  // the 404 handler. There is no monolith fall-through — the gateway is
+  // the single REST surface.
   // Per-email rate limiter for the auth surface (ADS-844). Layered on top of
   // the per-IP @fastify/rate-limit cap to throttle an email-flood spread across
   // many IPs. Reuses the rate-limit Redis store when available so the cap is
@@ -406,18 +403,17 @@ export const createServer = async (opts: CreateServerOptions): Promise<FastifyIn
     redis: rateLimitRedis,
   });
 
-  const { cutover } = config;
-  if (opts.authClient && cutover.auth) {
+  if (opts.authClient) {
     await registerAuthRoutes(server, { client: opts.authClient, emailRateLimiter });
-    // /api/v1/sessions/* — list/revoke. Shares the auth cutover flag
-    // because it's the same identity surface from the SPA's POV.
+    // /api/v1/sessions/* — list/revoke. Same auth client because it's the
+    // same identity surface from the SPA's POV.
     await registerSessionsRoutes(server, { client: opts.authClient });
     // /api/v1/field-permissions/* — admin surface. Backed entirely by
     // service.auth (which owns the field_permissions table + lib.types
-    // defaults). Shares the auth cutover flag.
+    // defaults).
     await registerFieldPermissionsRoutes(server, { client: opts.authClient });
   }
-  if (opts.notificationsClient && cutover.notifications) {
+  if (opts.notificationsClient) {
     await registerNotificationsRoutes(server, { client: opts.notificationsClient });
     // /api/v1/devices/* — register / list / unregister device tokens.
     // Reuses the same notifications gRPC client (device token RPCs
@@ -426,25 +422,25 @@ export const createServer = async (opts: CreateServerOptions): Promise<FastifyIn
     // /api/v1/email/templates/* — admin email-template CRUD. The
     // email_templates table is owned by service.notifications.
     await registerEmailRoutes(server, { client: opts.notificationsClient });
-    // /api/v1/notifications/broadcast — admin fan-out. Sits under the
-    // notifications cutover gate (the upstream call lives in service.
-    // notifications, which in turn calls service.auth for the cohort).
+    // /api/v1/notifications/broadcast — admin fan-out (the upstream call
+    // lives in service.notifications, which in turn calls service.auth for
+    // the cohort).
     await registerBroadcastRoutes(server, { client: opts.notificationsClient });
   }
   // /api/v1/users/* — profile + composed preferences. Requires BOTH
   // auth (profile + privacy prefs) and notifications (in-app channel
-  // prefs) cutover so the unified GET /preferences can compose without
+  // prefs) clients so the unified GET /preferences can compose without
   // partial data.
-  if (opts.authClient && opts.notificationsClient && cutover.auth && cutover.notifications) {
+  if (opts.authClient && opts.notificationsClient) {
     await registerUsersRoutes(server, {
       authClient: opts.authClient,
       notificationsClient: opts.notificationsClient,
     });
   }
-  if (opts.petsClient && cutover.pets) {
+  if (opts.petsClient) {
     await registerPetsRoutes(server, { client: opts.petsClient });
   }
-  if (opts.rescueClient && cutover.rescue) {
+  if (opts.rescueClient) {
     await registerRescueRoutes(server, { client: opts.rescueClient });
     // SPA-facing surface at /api/v1/rescues/* (plural — the path
     // lib.rescue actually calls).
@@ -455,24 +451,24 @@ export const createServer = async (opts: CreateServerOptions): Promise<FastifyIn
   }
   // POST /api/v1/invitations/accept — register-on-accept. Orchestrates
   // auth (provision the invited user) + rescue (consume the invitation +
-  // attach staff membership), so it needs BOTH cutover flags on.
-  if (opts.authClient && opts.rescueClient && cutover.auth && cutover.rescue) {
+  // attach staff membership), so it needs BOTH clients wired.
+  if (opts.authClient && opts.rescueClient) {
     await registerInvitationAcceptRoutes(server, {
       authClient: opts.authClient,
       rescueClient: opts.rescueClient,
     });
   }
-  if (opts.auditClient && cutover.audit) {
+  if (opts.auditClient) {
     await registerAuditRoutes(server, { client: opts.auditClient });
     // /api/v1/reports/* — saved reports + templates. Owned by
-    // service.audit (same gRPC stub). Shares the audit cutover flag
-    // because the audit service ships the rows.
+    // service.audit (same gRPC stub) because the audit service ships the
+    // rows.
     await registerReportsRoutes(server, { client: opts.auditClient });
   }
-  if (opts.matchingClient && cutover.matching) {
+  if (opts.matchingClient) {
     await registerMatchingRoutes(server, { client: opts.matchingClient });
   }
-  if (opts.moderationClient && cutover.moderation) {
+  if (opts.moderationClient) {
     await registerModerationRoutes(server, { client: opts.moderationClient });
     // SPA-facing surface at /api/v1/admin/{moderation,support}/* with
     // frontend-shape envelopes (lib.moderation, lib.support-tickets).
@@ -507,7 +503,7 @@ export const createServer = async (opts: CreateServerOptions): Promise<FastifyIn
     signingSecret: config.storage.signingSecret,
   });
 
-  if (opts.applicationsClient && cutover.applications) {
+  if (opts.applicationsClient) {
     await registerApplicationsRoutes(server, { client: opts.applicationsClient });
     // Application document routes (multipart upload → storage → AddDocument).
     await registerApplicationDocumentsRoutes(server, {
@@ -515,24 +511,17 @@ export const createServer = async (opts: CreateServerOptions): Promise<FastifyIn
       storage: storageConfig,
     });
   }
-  if (opts.chatClient && cutover.chat) {
+  if (opts.chatClient) {
     await registerChatRoutes(server, { client: opts.chatClient });
   }
-  if (opts.cmsClient && cutover.cms) {
+  if (opts.cmsClient) {
     await registerCmsRoutes(server, { client: opts.cmsClient });
   }
   // /api/v1/dashboard/* — cross-service composition (pets stats + apps
   // stats + rescue staff count + recent pet/application activity). Only
-  // registers when ALL three backing services have a wired client AND
-  // are cutover, so partial-cutover envs don't return half-empty data.
-  if (
-    opts.petsClient &&
-    opts.applicationsClient &&
-    opts.rescueClient &&
-    cutover.pets &&
-    cutover.applications &&
-    cutover.rescue
-  ) {
+  // registers when ALL three backing services have a wired client, so a
+  // partial harness doesn't return half-empty data.
+  if (opts.petsClient && opts.applicationsClient && opts.rescueClient) {
     await registerDashboardRoutes(server, {
       petsClient: opts.petsClient,
       applicationsClient: opts.applicationsClient,
@@ -540,10 +529,10 @@ export const createServer = async (opts: CreateServerOptions): Promise<FastifyIn
     });
   }
 
-  // Gateway-folded surface — no upstream service required, no cutover
-  // flag. Per the plan: "CMS / legal / config — small static reads fold
-  // into service.gateway". CMS extraction itself is deferred (full DB
-  // schema + admin CRUD); legal markdown + public config land here.
+  // Gateway-folded surface — no upstream service required. Per the plan:
+  // "CMS / legal / config — small static reads fold into service.gateway".
+  // CMS extraction itself is deferred (full DB schema + admin CRUD); legal
+  // markdown + public config land here.
   if (config.legal.enabled) {
     await registerLegalRoutes(server, { docsDir: config.legal.docsDir });
   }
@@ -583,15 +572,21 @@ export const createServer = async (opts: CreateServerOptions): Promise<FastifyIn
     );
   }
 
-  // Phase 11: the residual monolith has been deleted, so the catch-all
-  // proxy is gone with it. Any /api/* path the gateway doesn't explicitly
-  // own now 404s rather than silently round-tripping bytes to a backend
-  // that doesn't exist.
-  server.get('/api/*', async (_req, reply) => reply.code(404).send({ error: 'not_found' }));
-  server.post('/api/*', async (_req, reply) => reply.code(404).send({ error: 'not_found' }));
-  server.put('/api/*', async (_req, reply) => reply.code(404).send({ error: 'not_found' }));
-  server.patch('/api/*', async (_req, reply) => reply.code(404).send({ error: 'not_found' }));
-  server.delete('/api/*', async (_req, reply) => reply.code(404).send({ error: 'not_found' }));
+  // Any /api/* path the gateway doesn't explicitly own 404s — the gateway
+  // is the single REST surface and there is no fall-through. We LOG every
+  // unmatched API request at warn: a 404 here usually means a service
+  // client wasn't wired (so its routes never registered) or the SPA is
+  // calling a path that doesn't exist. Without this line the failure is
+  // invisible in the logs (Fastify's own request logging is disabled).
+  const apiNotFound = async (req: FastifyRequest, reply: FastifyReply) => {
+    logger.warn('unmatched API route', { method: req.method, url: req.url });
+    return reply.code(404).send({ error: 'not_found' });
+  };
+  server.get('/api/*', apiNotFound);
+  server.post('/api/*', apiNotFound);
+  server.put('/api/*', apiNotFound);
+  server.patch('/api/*', apiNotFound);
+  server.delete('/api/*', apiNotFound);
 
   return server;
 };


### PR DESCRIPTION
## Why

While debugging "everything 404s / super admin has no perms / no logs", the root cause was the per-domain **`CUTOVER_<DOMAIN>`** flags.

These were strangler-fig scaffolding: when a flag was off, that domain's `/api/v1/*` routes weren't registered and requests **fell through to the residual monolith**. **Phase 11 deleted the monolith**, so an "off" flag no longer means "use the old thing" — it means **404 the entire domain**. A migration toggle with no migration target is just a footgun.

Every real environment already forced the flags on, which proves they no longer expressed a real choice:
- `docker-compose.{yml,staging,prod}.yml` → `${CUTOVER_*:-true}`
- `ci.yml` → all `true`; `deploy.yml` smoke-check fails if routes aren't registered

The only place anything defaulted **off** was the raw config default — which silently breaks native `pnpm dev` and any stray `.env`, returning 404 for every API call (read as "unauthorized" / "no perms" by the SPA).

## What

Remove the cutover layer end-to-end and rely only on the legitimate guard — *is this service's gRPC client wired?*

- **config** — drop the `cutover` block from `GatewayConfig` + its env parsing
- **server** — register each domain's routes whenever its client is wired (`index.ts` always constructs all clients, so all routes always register); no toggle
- **tests** — rewrite the per-domain "cutover gate" suite to assert always-registered-when-wired; drop the `cutover` config in the rate-limit/`/docs`/openapi suites
- **infra** — strip `CUTOVER_*` from dev/staging/prod compose, `ci.yml`, and the `deploy.yml` smoke check (the check itself stays — it still validates routes are registered)
- **docs** — supersede ADR 0002, mark the `applications-cutover` runbook obsolete

## Logging fix (same blind spot)

The reason this was invisible: the 404 catch-all and the invalid-token 401 path returned silently (Fastify request logging is off). Both now log at `warn`:
- gateway `unmatched API route` on any 404'd `/api/*`
- `rejecting request: invalid token` on a 401

## Verification

- `service.gateway` — **726 tests pass**, type-check ✅, lint ✅
- No `cutover` property access or `CUTOVER_*` env remains anywhere outside historical doc notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SoKhwmokUTRVtt1W1Te3Nu)_