### PR TITLE
feat(auth): add admin password reset endpoint

### DIFF
--- a/packages/proto/proto/adopt_dont_shop/auth/v1/auth.proto
+++ b/packages/proto/proto/adopt_dont_shop/auth/v1/auth.proto
@@ -181,6 +181,13 @@ service AuthService {
   // assignment from a non-super_admin actor.
   rpc BulkUpdateUsers(BulkUpdateUsersRequest) returns (BulkUpdateUsersResponse);
 
+  // Admin-initiated password reset. Generates a temporary password, hashes
+  // and stores it, clears any lockout, and revokes the target's active
+  // refresh tokens so existing sessions can't continue. Returns the
+  // plaintext temporary password for the admin to relay out-of-band.
+  // admin.users.update. Refuses resetting your own account via this path.
+  rpc AdminResetPassword(AdminResetPasswordRequest) returns (AdminResetPasswordResponse);
+
   // --- Field permissions admin -----------------------------------------
 
   // Returns the full default field-permission configuration (the
@@ -717,6 +724,16 @@ message ReactivateUserRequest {
 
 message ReactivateUserResponse {
   User user = 1;
+}
+
+message AdminResetPasswordRequest {
+  string user_id = 1;
+}
+
+message AdminResetPasswordResponse {
+  // Plaintext temporary password. Never persisted in the clear — the
+  // admin relays it to the user, who changes it on next sign-in.
+  string temporary_password = 1;
 }
 
 message GetUserStatisticsRequest {}

--- a/packages/proto/src/generated/proto/adopt_dont_shop/auth/v1/auth.ts
+++ b/packages/proto/src/generated/proto/adopt_dont_shop/auth/v1/auth.ts
@@ -792,6 +792,18 @@ export interface ReactivateUserResponse {
   user?: User | undefined;
 }
 
+export interface AdminResetPasswordRequest {
+  userId: string;
+}
+
+export interface AdminResetPasswordResponse {
+  /**
+   * Plaintext temporary password. Never persisted in the clear — the
+   * admin relays it to the user, who changes it on next sign-in.
+   */
+  temporaryPassword: string;
+}
+
 export interface GetUserStatisticsRequest {}
 
 export interface UserStatusCount {
@@ -6701,6 +6713,148 @@ export const ReactivateUserResponse: MessageFns<ReactivateUserResponse> = {
   },
 };
 
+function createBaseAdminResetPasswordRequest(): AdminResetPasswordRequest {
+  return { userId: '' };
+}
+
+export const AdminResetPasswordRequest: MessageFns<AdminResetPasswordRequest> = {
+  encode(
+    message: AdminResetPasswordRequest,
+    writer: BinaryWriter = new BinaryWriter()
+  ): BinaryWriter {
+    if (message.userId !== '') {
+      writer.uint32(10).string(message.userId);
+    }
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): AdminResetPasswordRequest {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseAdminResetPasswordRequest();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1: {
+          if (tag !== 10) {
+            break;
+          }
+
+          message.userId = reader.string();
+          continue;
+        }
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): AdminResetPasswordRequest {
+    return {
+      userId: isSet(object.userId)
+        ? globalThis.String(object.userId)
+        : isSet(object.user_id)
+          ? globalThis.String(object.user_id)
+          : '',
+    };
+  },
+
+  toJSON(message: AdminResetPasswordRequest): unknown {
+    const obj: any = {};
+    if (message.userId !== '') {
+      obj.userId = message.userId;
+    }
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<AdminResetPasswordRequest>, I>>(
+    base?: I
+  ): AdminResetPasswordRequest {
+    return AdminResetPasswordRequest.fromPartial(base ?? ({} as any));
+  },
+  fromPartial<I extends Exact<DeepPartial<AdminResetPasswordRequest>, I>>(
+    object: I
+  ): AdminResetPasswordRequest {
+    const message = createBaseAdminResetPasswordRequest();
+    message.userId = object.userId ?? '';
+    return message;
+  },
+};
+
+function createBaseAdminResetPasswordResponse(): AdminResetPasswordResponse {
+  return { temporaryPassword: '' };
+}
+
+export const AdminResetPasswordResponse: MessageFns<AdminResetPasswordResponse> = {
+  encode(
+    message: AdminResetPasswordResponse,
+    writer: BinaryWriter = new BinaryWriter()
+  ): BinaryWriter {
+    if (message.temporaryPassword !== '') {
+      writer.uint32(10).string(message.temporaryPassword);
+    }
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): AdminResetPasswordResponse {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseAdminResetPasswordResponse();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1: {
+          if (tag !== 10) {
+            break;
+          }
+
+          message.temporaryPassword = reader.string();
+          continue;
+        }
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): AdminResetPasswordResponse {
+    return {
+      temporaryPassword: isSet(object.temporaryPassword)
+        ? globalThis.String(object.temporaryPassword)
+        : isSet(object.temporary_password)
+          ? globalThis.String(object.temporary_password)
+          : '',
+    };
+  },
+
+  toJSON(message: AdminResetPasswordResponse): unknown {
+    const obj: any = {};
+    if (message.temporaryPassword !== '') {
+      obj.temporaryPassword = message.temporaryPassword;
+    }
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<AdminResetPasswordResponse>, I>>(
+    base?: I
+  ): AdminResetPasswordResponse {
+    return AdminResetPasswordResponse.fromPartial(base ?? ({} as any));
+  },
+  fromPartial<I extends Exact<DeepPartial<AdminResetPasswordResponse>, I>>(
+    object: I
+  ): AdminResetPasswordResponse {
+    const message = createBaseAdminResetPasswordResponse();
+    message.temporaryPassword = object.temporaryPassword ?? '';
+    return message;
+  },
+};
+
 function createBaseGetUserStatisticsRequest(): GetUserStatisticsRequest {
   return {};
 }
@@ -9697,6 +9851,26 @@ export const AuthServiceService = {
       BulkUpdateUsersResponse.decode(value),
   },
   /**
+   * Admin-initiated password reset. Generates a temporary password, hashes
+   * and stores it, clears any lockout, and revokes the target's active
+   * refresh tokens so existing sessions can't continue. Returns the
+   * plaintext temporary password for the admin to relay out-of-band.
+   * admin.users.update. Refuses resetting your own account via this path.
+   */
+  adminResetPassword: {
+    path: '/adopt_dont_shop.auth.v1.AuthService/AdminResetPassword' as const,
+    requestStream: false as const,
+    responseStream: false as const,
+    requestSerialize: (value: AdminResetPasswordRequest): Buffer =>
+      Buffer.from(AdminResetPasswordRequest.encode(value).finish()),
+    requestDeserialize: (value: Buffer): AdminResetPasswordRequest =>
+      AdminResetPasswordRequest.decode(value),
+    responseSerialize: (value: AdminResetPasswordResponse): Buffer =>
+      Buffer.from(AdminResetPasswordResponse.encode(value).finish()),
+    responseDeserialize: (value: Buffer): AdminResetPasswordResponse =>
+      AdminResetPasswordResponse.decode(value),
+  },
+  /**
    * Returns the full default field-permission configuration (the
    * hard-coded source-of-truth lib.types ships). Admin-only.
    * admin.field_permissions.read.
@@ -9990,6 +10164,14 @@ export interface AuthServiceServer extends UntypedServiceImplementation {
    * assignment from a non-super_admin actor.
    */
   bulkUpdateUsers: handleUnaryCall<BulkUpdateUsersRequest, BulkUpdateUsersResponse>;
+  /**
+   * Admin-initiated password reset. Generates a temporary password, hashes
+   * and stores it, clears any lockout, and revokes the target's active
+   * refresh tokens so existing sessions can't continue. Returns the
+   * plaintext temporary password for the admin to relay out-of-band.
+   * admin.users.update. Refuses resetting your own account via this path.
+   */
+  adminResetPassword: handleUnaryCall<AdminResetPasswordRequest, AdminResetPasswordResponse>;
   /**
    * Returns the full default field-permission configuration (the
    * hard-coded source-of-truth lib.types ships). Admin-only.
@@ -10619,6 +10801,28 @@ export interface AuthServiceClient extends Client {
     metadata: Metadata,
     options: Partial<CallOptions>,
     callback: (error: ServiceError | null, response: BulkUpdateUsersResponse) => void
+  ): ClientUnaryCall;
+  /**
+   * Admin-initiated password reset. Generates a temporary password, hashes
+   * and stores it, clears any lockout, and revokes the target's active
+   * refresh tokens so existing sessions can't continue. Returns the
+   * plaintext temporary password for the admin to relay out-of-band.
+   * admin.users.update. Refuses resetting your own account via this path.
+   */
+  adminResetPassword(
+    request: AdminResetPasswordRequest,
+    callback: (error: ServiceError | null, response: AdminResetPasswordResponse) => void
+  ): ClientUnaryCall;
+  adminResetPassword(
+    request: AdminResetPasswordRequest,
+    metadata: Metadata,
+    callback: (error: ServiceError | null, response: AdminResetPasswordResponse) => void
+  ): ClientUnaryCall;
+  adminResetPassword(
+    request: AdminResetPasswordRequest,
+    metadata: Metadata,
+    options: Partial<CallOptions>,
+    callback: (error: ServiceError | null, response: AdminResetPasswordResponse) => void
   ): ClientUnaryCall;
   /**
    * Returns the full default field-permission configuration (the

--- a/packages/proto/src/index.ts
+++ b/packages/proto/src/index.ts
@@ -150,6 +150,8 @@ export type {
   DeactivateUserResponse,
   ReactivateUserRequest,
   ReactivateUserResponse,
+  AdminResetPasswordRequest,
+  AdminResetPasswordResponse,
   GetUserStatisticsRequest,
   GetUserStatisticsResponse,
   GetUserPermissionsRequest,

--- a/services/auth/src/grpc/admin-handlers.test.ts
+++ b/services/auth/src/grpc/admin-handlers.test.ts
@@ -8,6 +8,7 @@ import { AuthV1 } from '@adopt-dont-shop/proto';
 
 import {
   adminGetUser,
+  adminResetPassword,
   adminUpdateUser,
   bulkUpdateUsers,
   deactivateUser,
@@ -296,6 +297,59 @@ describe('reactivateUser', () => {
     const res = await reactivateUser(mocks.deps, ADMIN, { userId: 'usr-1' });
     expect(res.user?.status).toBe(AuthV1.UserStatus.USER_STATUS_ACTIVE);
     expect(mocks.natsMock.publish.mock.calls[0][0]).toBe('auth.userReactivated');
+  });
+});
+
+// --- adminResetPassword ----------------------------------------------
+
+describe('adminResetPassword', () => {
+  let mocks: ReturnType<typeof makeMocks>;
+  beforeEach(() => {
+    mocks = makeMocks();
+    (mocks.deps.passwordHasher.hash as ReturnType<typeof vi.fn>).mockResolvedValue('hashed-temp');
+  });
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('rejects principals without admin.users.update', async () => {
+    await expect(
+      adminResetPassword(mocks.deps, NO_PERMS, { userId: 'usr-1' })
+    ).rejects.toMatchObject({ code: 'PERMISSION_DENIED' });
+  });
+
+  it('rejects a missing user_id', async () => {
+    await expect(adminResetPassword(mocks.deps, ADMIN, { userId: '' })).rejects.toMatchObject({
+      code: 'INVALID_ARGUMENT',
+    });
+  });
+
+  it('refuses resetting your own account', async () => {
+    await expect(
+      adminResetPassword(mocks.deps, ADMIN, { userId: 'svc-admin' })
+    ).rejects.toMatchObject({ code: 'INVALID_ARGUMENT' });
+  });
+
+  it('maps a missing user to NOT_FOUND', async () => {
+    mocks.clientScript.push({ rows: [] }); // UPDATE auth.users returns no rows
+    await expect(adminResetPassword(mocks.deps, ADMIN, { userId: 'ghost' })).rejects.toMatchObject({
+      code: 'NOT_FOUND',
+    });
+  });
+
+  it('hashes a generated password, revokes sessions, and publishes the event', async () => {
+    mocks.clientScript.push({ rows: [{ user_id: 'usr-1' }] }); // UPDATE auth.users
+    mocks.clientScript.push({ rows: [] }); // UPDATE auth.refresh_tokens
+
+    const res = await adminResetPassword(mocks.deps, ADMIN, { userId: 'usr-1' });
+
+    // A non-empty plaintext temp password is returned to the admin...
+    expect(res.temporaryPassword).toBeTruthy();
+    // ...and it is the plaintext that was hashed (never persisted in clear).
+    const hashMock = mocks.deps.passwordHasher.hash as ReturnType<typeof vi.fn>;
+    expect(hashMock).toHaveBeenCalledTimes(1);
+    expect(hashMock).toHaveBeenCalledWith(res.temporaryPassword);
+    expect(mocks.natsMock.publish.mock.calls[0][0]).toBe('auth.passwordResetByAdmin');
   });
 });
 

--- a/services/auth/src/grpc/admin-handlers.ts
+++ b/services/auth/src/grpc/admin-handlers.ts
@@ -7,6 +7,8 @@
 // Reuses rowToProtoUser + UserRow + the enum maps from handlers.ts so
 // the admin view returns the same User shape GetMe does.
 
+import { randomBytes } from 'node:crypto';
+
 import { hasPermission, type Principal } from '@adopt-dont-shop/authz';
 import { withTransaction } from '@adopt-dont-shop/events';
 import type { Permission } from '@adopt-dont-shop/lib.types';
@@ -14,6 +16,8 @@ import {
   AuthV1,
   type AdminGetUserRequest,
   type AdminGetUserResponse,
+  type AdminResetPasswordRequest,
+  type AdminResetPasswordResponse,
   type AdminUpdateUserRequest,
   type AdminUpdateUserResponse,
   type BulkUpdateUsersRequest,
@@ -341,6 +345,69 @@ async function setStatus(
     throw new HandlerError('INTERNAL', 'status update returned no rows');
   }
   return { user: rowToProtoUser(updated) };
+}
+
+// --- AdminResetPassword ----------------------------------------------
+
+// A URL-safe random string with enough entropy to be a one-time password.
+// 18 bytes → 24 base64url chars; communicated out-of-band and changed by
+// the user on next sign-in.
+function generateTemporaryPassword(): string {
+  return randomBytes(18).toString('base64url');
+}
+
+export async function adminResetPassword(
+  deps: HandlerDeps,
+  principal: Principal,
+  req: AdminResetPasswordRequest
+): Promise<AdminResetPasswordResponse> {
+  if (!req.userId) {
+    throw new HandlerError('INVALID_ARGUMENT', 'user_id is required');
+  }
+  if (!hasPermission(principal, ADMIN_USERS_UPDATE)) {
+    throw new HandlerError('PERMISSION_DENIED', `'${ADMIN_USERS_UPDATE}' required`);
+  }
+  if (req.userId === principal.userId) {
+    throw new HandlerError('INVALID_ARGUMENT', 'cannot reset your own password via the admin path');
+  }
+
+  const temporaryPassword = generateTemporaryPassword();
+  const passwordHash = await deps.passwordHasher.hash(temporaryPassword);
+
+  await withTransaction(deps, async ({ client, publish }) => {
+    const res = await client.query<{ user_id: string }>(
+      `
+      UPDATE auth.users
+      SET password = $1, login_attempts = 0, locked_until = NULL,
+          updated_at = now(), version = version + 1
+      WHERE user_id = $2 AND deleted_at IS NULL
+      RETURNING user_id
+      `,
+      [passwordHash, req.userId]
+    );
+    if (res.rows.length === 0) {
+      throw new HandlerError('NOT_FOUND', `user ${req.userId} not found`);
+    }
+
+    // Revoke active refresh tokens so existing sessions can't continue
+    // under the old credentials.
+    await client.query(
+      `
+      UPDATE auth.refresh_tokens
+      SET revoked_at = now(), is_revoked = true, updated_at = now()
+      WHERE user_id = $1 AND revoked_at IS NULL
+      `,
+      [req.userId]
+    );
+
+    publish({
+      type: 'auth.passwordResetByAdmin',
+      id: `auth.passwordResetByAdmin.${req.userId}.${Date.now()}`,
+      payload: { userId: req.userId, resetBy: principal.userId },
+    });
+  });
+
+  return { temporaryPassword };
 }
 
 // --- GetUserStatistics -----------------------------------------------

--- a/services/auth/src/grpc/server.ts
+++ b/services/auth/src/grpc/server.ts
@@ -39,6 +39,7 @@ import {
 } from './handlers.js';
 import {
   adminGetUser,
+  adminResetPassword,
   adminUpdateUser,
   bulkUpdateUsers,
   deactivateUser,
@@ -121,6 +122,7 @@ export const createGrpcServer = (opts: CreateGrpcServerOptions): Server => {
     getUserStatistics: adapt(getUserStatistics, { deps, logger }),
     getUserPermissions: adapt(getUserPermissions, { deps, logger }),
     bulkUpdateUsers: adapt(bulkUpdateUsers, { deps, logger }),
+    adminResetPassword: adapt(adminResetPassword, { deps, logger }),
     listUserIdsByCohort: adapt(listUserIdsByCohort, { deps, logger }),
     // Field-level permissions admin — /api/v1/field-permissions/*.
     getFieldPermissionDefaults: adapt(getFieldPermissionDefaults, { deps, logger }),
@@ -164,6 +166,7 @@ export const createGrpcServer = (opts: CreateGrpcServerOptions): Server => {
       'getUserStatistics',
       'getUserPermissions',
       'bulkUpdateUsers',
+      'adminResetPassword',
       'listUserIdsByCohort',
       'getFieldPermissionDefaults',
       'getFieldPermissionDefaultsForRole',

--- a/services/gateway/src/grpc-clients/auth-client.ts
+++ b/services/gateway/src/grpc-clients/auth-client.ts
@@ -67,6 +67,8 @@ import {
   type DeactivateUserResponse,
   type ReactivateUserRequest,
   type ReactivateUserResponse,
+  type AdminResetPasswordRequest,
+  type AdminResetPasswordResponse,
   type GetUserStatisticsRequest,
   type GetUserStatisticsResponse,
   type GetUserPermissionsRequest,
@@ -145,6 +147,10 @@ export type AuthClient = {
   ): Promise<AdminUpdateUserResponse>;
   deactivateUser(req: DeactivateUserRequest, metadata: Metadata): Promise<DeactivateUserResponse>;
   reactivateUser(req: ReactivateUserRequest, metadata: Metadata): Promise<ReactivateUserResponse>;
+  adminResetPassword(
+    req: AdminResetPasswordRequest,
+    metadata: Metadata
+  ): Promise<AdminResetPasswordResponse>;
   getUserStatistics(
     req: GetUserStatisticsRequest,
     metadata: Metadata
@@ -273,6 +279,7 @@ export const createAuthClient = (opts: CreateAuthClientOptions): AuthClient => {
     deactivateUser: (req, metadata) => callUnary(stub.deactivateUser, req, metadata, false),
     reactivateUser: (req, metadata) => callUnary(stub.reactivateUser, req, metadata, false),
     bulkUpdateUsers: (req, metadata) => callUnary(stub.bulkUpdateUsers, req, metadata, false),
+    adminResetPassword: (req, metadata) => callUnary(stub.adminResetPassword, req, metadata, false),
     upsertFieldPermission: (req, metadata) =>
       callUnary(stub.upsertFieldPermission, req, metadata, false),
     bulkUpsertFieldPermissions: (req, metadata) =>

--- a/services/gateway/src/routes/users.test.ts
+++ b/services/gateway/src/routes/users.test.ts
@@ -75,6 +75,7 @@ function makeAuthClient(): AuthClient & {
   getUserStatisticsMock: ReturnType<typeof vi.fn>;
   getUserPermissionsMock: ReturnType<typeof vi.fn>;
   bulkUpdateUsersMock: ReturnType<typeof vi.fn>;
+  adminResetPasswordMock: ReturnType<typeof vi.fn>;
 } {
   const getMeMock = vi.fn();
   const updateAccountMock = vi.fn();
@@ -89,6 +90,7 @@ function makeAuthClient(): AuthClient & {
   const getUserStatisticsMock = vi.fn();
   const getUserPermissionsMock = vi.fn();
   const bulkUpdateUsersMock = vi.fn();
+  const adminResetPasswordMock = vi.fn();
   return {
     getMe: getMeMock,
     updateAccount: updateAccountMock,
@@ -103,6 +105,7 @@ function makeAuthClient(): AuthClient & {
     getUserStatistics: getUserStatisticsMock,
     getUserPermissions: getUserPermissionsMock,
     bulkUpdateUsers: bulkUpdateUsersMock,
+    adminResetPassword: adminResetPasswordMock,
     login: vi.fn(),
     logout: vi.fn(),
     refreshToken: vi.fn(),
@@ -130,6 +133,7 @@ function makeAuthClient(): AuthClient & {
     getUserStatisticsMock,
     getUserPermissionsMock,
     bulkUpdateUsersMock,
+    adminResetPasswordMock,
   };
 }
 
@@ -624,6 +628,62 @@ describe('/api/v1/admin/users surface', () => {
     expect(res.statusCode).toBe(400);
     expect(auth.adminUpdateUserMock).not.toHaveBeenCalled();
     expect(auth.reactivateUserMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('POST /api/v1/admin/users/:userId/reset-password', () => {
+  let app: FastifyInstance;
+  let auth: ReturnType<typeof makeAuthClient>;
+  let notif: ReturnType<typeof makeNotifClient>;
+
+  beforeEach(async () => {
+    auth = makeAuthClient();
+    notif = makeNotifClient();
+    app = await buildApp(auth, notif);
+  });
+  afterEach(async () => {
+    await app.close();
+  });
+
+  it('returns the temporary password under the snake_case key the SPA reads', async () => {
+    auth.adminResetPasswordMock.mockResolvedValueOnce({ temporaryPassword: 'tmp-Abc123' });
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/v1/admin/users/usr-9/reset-password',
+      headers: { 'x-user-id': 'svc-admin', 'x-user-roles': 'admin' },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual({ temporary_password: 'tmp-Abc123' });
+    const [grpcReq] = auth.adminResetPasswordMock.mock.calls[0] as [{ userId: string }, Metadata];
+    expect(grpcReq.userId).toBe('usr-9');
+  });
+
+  it('maps PERMISSION_DENIED → 403', async () => {
+    auth.adminResetPasswordMock.mockRejectedValueOnce({
+      code: status.PERMISSION_DENIED,
+      details: 'no',
+    });
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/v1/admin/users/usr-9/reset-password',
+      headers: { 'x-user-id': 'svc-admin', 'x-user-roles': 'admin' },
+    });
+    expect(res.statusCode).toBe(403);
+  });
+
+  it('maps NOT_FOUND → 404', async () => {
+    auth.adminResetPasswordMock.mockRejectedValueOnce({
+      code: status.NOT_FOUND,
+      details: 'gone',
+    });
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/v1/admin/users/ghost/reset-password',
+      headers: { 'x-user-id': 'svc-admin', 'x-user-roles': 'admin' },
+    });
+    expect(res.statusCode).toBe(404);
   });
 });
 

--- a/services/gateway/src/routes/users.ts
+++ b/services/gateway/src/routes/users.ts
@@ -569,6 +569,28 @@ export const registerUsersRoutes = async (
     }
   );
 
+  // POST /api/v1/admin/users/:userId/reset-password — admin-initiated
+  // password reset. Returns the plaintext temporary password for the
+  // admin to relay; the user changes it on next sign-in.
+  app.post<{ Params: { userId: string } }>(
+    '/api/v1/admin/users/:userId/reset-password',
+    {
+      schema: {
+        tags: ['users'],
+        summary: 'Reset a user password and return a temporary one (admin)',
+      },
+    },
+    async (req, reply) => {
+      const metadata = buildMetadata(req);
+      try {
+        const res = await authClient.adminResetPassword({ userId: req.params.userId }, metadata);
+        return reply.send({ temporary_password: res.temporaryPassword });
+      } catch (err) {
+        return handleGrpcError(err, reply);
+      }
+    }
+  );
+
   // POST /api/v1/users/bulk-update — admin bulk status/role change.
   // POST so it never collides with the GET/PUT /:userId dynamic routes.
   app.post(


### PR DESCRIPTION
## Context

This started as an audit of **app.admin** routes — checking that every admin route has corresponding backend service functionality. The audit found that several admin features call `/api/v1/admin/...` endpoints the gateway does not implement. This PR is the **first slice** of fixing those gaps.

## What this fixes

The admin SPA's **"reset password"** action on the Users page calls `POST /api/v1/admin/users/:userId/reset-password`, but:
- the gateway had no such route, and
- the auth service had no RPC to back it.

So the button 404'd.

## Change

- **proto** (`auth.proto`): new `AdminResetPassword(AdminResetPasswordRequest) → AdminResetPasswordResponse` RPC + regenerated TS (`src/generated`, Prettier-formatted to match committed style).
- **service.auth** (`admin-handlers.ts`): new `adminResetPassword` handler — generates a temporary password, hashes + stores it, clears any account lockout (`login_attempts`/`locked_until`), and revokes the target's active refresh tokens so existing sessions can't continue. Returns the plaintext temp password for the admin to relay out-of-band. Gated on `admin.users.update`; refuses resetting your own account via this path. Emits `auth.passwordResetByAdmin`.
- **gateway** (`users.ts` + `auth-client.ts`): `POST /api/v1/admin/users/:userId/reset-password` → `adminResetPassword`, returning `{ temporary_password }` (the snake_case key the SPA reads).

## Tests

- `services/auth/src/grpc/admin-handlers.test.ts` — permission denied, missing id, self-reset refusal, NOT_FOUND, and success (hashes the returned plaintext, revokes sessions, publishes the event).
- `services/gateway/src/routes/users.test.ts` — returns the temp password, maps `PERMISSION_DENIED → 403` and `NOT_FOUND → 404`.

All affected suites pass; `tsc` and ESLint clean on touched packages; proto regenerated.

## Remaining gaps from the audit (not in this PR)

These admin features also call missing backends and are candidates for follow-up slices (most need new gRPC RPCs and, in some cases, new DB tables):

- **Security Center** (`/security`) — entire `securityService` (sessions, IP rules, lock/unlock, login history, suspicious activity); no backend.
- **Inbox** (`/inbox`) — `/api/v1/admin/inbox(/assign)`; no backend.
- **Analytics** (`/analytics`) — `/api/v1/admin/metrics`, `/api/v1/admin/analytics/dashboard`; no backend.
- **Privacy Tools** (`/privacy-tools`) — `/api/v1/privacy/admin/users/:id/export` + `/delete-request`; no backend.
- **Broadcast preview** — `GET /api/v1/notifications/broadcast/preview`; no backend (send works).
- **Entity activity feeds** — `…/:id/activity` for 7 entity types; no backend (flagged "Phase 2" in the service).
- **Rescue admin actions** — frontend calls plural `/api/v1/rescues/:id/...` for verify/reject/staff/invitations/send-email/plan/bulk-update while the gateway exposes only singular `/api/v1/rescue/:id/verify` + `/invitations`.

Separately, several `userManagementService` methods (`searchUsers`, `getUserStats`, `exportUsers`, `sendNotification`, `getUserRescues`, `getUserApplications`) are **not called by any UI** — they look like dead code and are better removed than backed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EgwcaPwDJBjJJr68hnjeMX)_