### PR TITLE
fix(gateway): add plural PUT route for rescue profile updates (ADS-876, step 1)

### DIFF
--- a/services/gateway/src/routes/rescues-public.test.ts
+++ b/services/gateway/src/routes/rescues-public.test.ts
@@ -156,4 +156,22 @@ describe('rescues public routes', () => {
     });
     expect(res.statusCode).toBe(201);
   });
+
+  it('PUT /api/v1/rescues/:id forwards the update payload and returns the envelope', async () => {
+    mocks.update.mockResolvedValueOnce({ rescue: RESCUE });
+    const res = await app.inject({
+      method: 'PUT',
+      url: '/api/v1/rescues/rsc-1',
+      payload: { name: 'Happy Tails Renamed', city: 'Leeds' },
+    });
+    expect(res.statusCode).toBe(200);
+    const body = res.json() as { success: boolean; data: { rescue_id: string } };
+    expect(body.success).toBe(true);
+    expect(body.data.rescue_id).toBe('rsc-1');
+    expect(mocks.update.mock.calls[0][0]).toMatchObject({
+      rescueId: 'rsc-1',
+      name: 'Happy Tails Renamed',
+      city: 'Leeds',
+    });
+  });
 });

--- a/services/gateway/src/routes/rescues-public.ts
+++ b/services/gateway/src/routes/rescues-public.ts
@@ -15,6 +15,7 @@ import {
   RescueV1,
   type CreateRescueRequest,
   type ListRescuesRequest,
+  type UpdateRescueRequest,
 } from '@adopt-dont-shop/proto';
 
 import type { RescueClient } from '../grpc-clients/rescue-client.js';
@@ -234,7 +235,35 @@ export const registerRescuesPublicRoutes = async (
       }
     }
   );
+
+  // PUT /api/v1/rescues/:id — profile update. lib.rescue / app.rescue's
+  // Settings page write to the plural base path (matching the read routes
+  // above), unlike the singular /api/v1/rescue/:id PATCH route.
+  app.put<{ Params: { id: string }; Body: UpdateRescueBody }>(
+    '/api/v1/rescues/:id',
+    {
+      config: { rateLimit: RL_WRITE },
+      schema: {
+        tags: ['rescues'],
+        summary: 'Update a rescue profile',
+      },
+    },
+    async (req, reply) => {
+      const grpcReq: UpdateRescueRequest = { rescueId: req.params.id, ...(req.body ?? {}) };
+      try {
+        const res = await client.update(grpcReq, buildMetadata(req));
+        if (res.rescue === undefined) {
+          return reply.code(404).send({ success: false, error: 'rescue not found' });
+        }
+        return reply.send(rescueDataEnvelope(res.rescue));
+      } catch (err) {
+        return handleGrpcError(err, reply);
+      }
+    }
+  );
 };
+
+type UpdateRescueBody = Partial<Omit<UpdateRescueRequest, 'rescueId'>>;
 
 // --- Helpers ---------------------------------------------------------
 


### PR DESCRIPTION
## Summary

First step toward [ADS-876](https://linear.app/ideasquared/issue/ADS-876/librescue-profilelogoimagesadoption-policy-writes-404-singular-vs): `lib.rescue` and `app.rescue`'s Settings page write to the **plural** `/api/v1/rescues/:id` base path, but the gateway only registered the rescue-update handler on the **singular** `/api/v1/rescue/:id` route. Saving a rescue profile from the Settings page 404'd.

- Adds `PUT /api/v1/rescues/:id` to `services/gateway/src/routes/rescues-public.ts`, delegating to the same `RescueService.Update` RPC as the existing singular route and returning the standard `{ success, data }` envelope.
- Existing singular `PATCH /api/v1/rescue/:id` route is untouched.

## Remaining scope for ADS-876 (follow-up, not in this PR)

- `rescueService.updateAdoptionPolicies` / `getAdoptionPolicies` in `lib.rescue` call `GET`/`PUT /api/v1/rescues/:id/adoption-policies`, which has no backing route at all (the rescue gRPC service stores adoption policies inside the `settings` JSON blob, updatable today only via `settingsJson` on the full `Update` RPC). This needs a small dedicated sub-resource route.
- `lib.rescue/src/constants/endpoints.ts` also defines `UPLOAD_LOGO`, `UPLOAD_IMAGES`, `VERIFY_RESCUE`, `RESCUE_STATS`, `ADOPTION_METRICS`, `RESCUE_REVIEWS`, `ADD_REVIEW`, `FOLLOW_RESCUE`, `UNFOLLOW_RESCUE` on the plural base path — confirmed these are **not currently called anywhere** in `rescue-service.ts` or any app, so left alone per "don't fix what isn't exercised."

## Test plan
- [x] Added a failing test for `PUT /api/v1/rescues/:id`, confirmed red, then implemented the route (TDD)
- [x] `pnpm exec vitest run src/routes` in `services/gateway` — 525/525 passing
- [x] `tsc --noEmit` shows no new errors introduced by this change
- [x] `eslint` clean on changed files


---
_Generated by [Claude Code](https://claude.ai/code/session_014nrdihtyduXfgC4y1fPFiH)_