### PR TITLE
feat: match top-picks endpoint + frontend MatchingService

### DIFF
--- a/apps/client/src/components/home/TopPicksHomeModule.test.tsx
+++ b/apps/client/src/components/home/TopPicksHomeModule.test.tsx
@@ -4,7 +4,7 @@ import { TopPicksHomeModule } from './TopPicksHomeModule';
 
 const authState = { isAuthenticated: false };
 const matchPreferencesState = { hasPreferences: false, isLoading: false };
-const apiGet = vi.fn();
+const getTopPicks = vi.fn();
 
 vi.mock('@adopt-dont-shop/lib.auth', async () => {
   const actual = await vi.importActual<typeof import('@adopt-dont-shop/lib.auth')>(
@@ -21,8 +21,8 @@ vi.mock('@/hooks/useMatchPreferences', () => ({
 }));
 
 vi.mock('@/services', () => ({
-  apiService: {
-    get: (...args: unknown[]) => apiGet(...args),
+  matchingService: {
+    getTopPicks: (...args: unknown[]) => getTopPicks(...args),
   },
 }));
 
@@ -30,40 +30,38 @@ beforeEach(() => {
   authState.isAuthenticated = false;
   matchPreferencesState.hasPreferences = false;
   matchPreferencesState.isLoading = false;
-  apiGet.mockReset();
+  getTopPicks.mockReset();
 });
 
 describe('TopPicksHomeModule', () => {
   it('renders nothing for signed-out users', () => {
     const { container } = renderWithProviders(<TopPicksHomeModule />);
     expect(container).toBeEmptyDOMElement();
-    expect(apiGet).not.toHaveBeenCalled();
+    expect(getTopPicks).not.toHaveBeenCalled();
   });
 
   it('renders nothing for signed-in users without preferences', () => {
     authState.isAuthenticated = true;
     const { container } = renderWithProviders(<TopPicksHomeModule />);
     expect(container).toBeEmptyDOMElement();
-    expect(apiGet).not.toHaveBeenCalled();
+    expect(getTopPicks).not.toHaveBeenCalled();
   });
 
   it('shows the Your top picks heading and See all link when preferences exist and picks load', async () => {
     authState.isAuthenticated = true;
     matchPreferencesState.hasPreferences = true;
-    apiGet.mockResolvedValueOnce({
-      data: [
-        {
-          petId: 'pet-1',
-          name: 'Rex',
-          type: 'dog',
-          ageGroup: 'adult',
-          size: 'medium',
-          score: 87,
-          reasons: [],
-          rescueName: 'Happy Rescue',
-        },
-      ],
-    });
+    getTopPicks.mockResolvedValueOnce([
+      {
+        petId: 'pet-1',
+        name: 'Rex',
+        type: 'dog',
+        ageGroup: 'adult',
+        size: 'medium',
+        score: 87,
+        reasons: [],
+        rescueName: 'Happy Rescue',
+      },
+    ]);
     renderWithProviders(<TopPicksHomeModule />);
     await waitFor(() =>
       expect(screen.getByRole('heading', { name: /your top picks/i })).toBeInTheDocument()
@@ -78,9 +76,9 @@ describe('TopPicksHomeModule', () => {
   it('renders nothing when the API returns an empty result', async () => {
     authState.isAuthenticated = true;
     matchPreferencesState.hasPreferences = true;
-    apiGet.mockResolvedValueOnce({ data: [] });
+    getTopPicks.mockResolvedValueOnce([]);
     const { container } = renderWithProviders(<TopPicksHomeModule />);
-    await waitFor(() => expect(apiGet).toHaveBeenCalled());
+    await waitFor(() => expect(getTopPicks).toHaveBeenCalled());
     await waitFor(() => expect(container).toBeEmptyDOMElement());
   });
 });

--- a/apps/client/src/components/home/TopPicksHomeModule.tsx
+++ b/apps/client/src/components/home/TopPicksHomeModule.tsx
@@ -10,7 +10,7 @@ import { PetCardSkeletonGrid } from '@/components/skeletons';
 import { useAuth } from '@adopt-dont-shop/lib.auth';
 import type { MatchTopPick } from '@adopt-dont-shop/lib.matching';
 import { useMatchPreferences } from '@/hooks/useMatchPreferences';
-import { apiService } from '@/services';
+import { matchingService } from '@/services';
 import { resolveFileUrl } from '@/utils/fileUtils';
 import * as styles from './TopPicksHomeModule.css';
 
@@ -55,11 +55,9 @@ export const TopPicksHomeModule: React.FC = () => {
       try {
         setLoading(true);
         setErrored(false);
-        const res = await apiService.get<{ data: MatchTopPick[] }>(
-          '/api/v1/match/top-picks?limit=3'
-        );
+        const data = await matchingService.getTopPicks(3);
         if (!cancelled) {
-          setPicks(res.data ?? []);
+          setPicks(data);
         }
       } catch {
         if (!cancelled) {

--- a/apps/client/src/hooks/useMatchPreferences.test.ts
+++ b/apps/client/src/hooks/useMatchPreferences.test.ts
@@ -14,35 +14,35 @@ vi.mock('@adopt-dont-shop/lib.auth', async () => {
   };
 });
 
-const apiGet = vi.fn();
+const getMatchProfile = vi.fn();
 vi.mock('@/services', () => ({
-  apiService: {
-    get: (...args: unknown[]) => apiGet(...args),
+  matchingService: {
+    getMatchProfile: (...args: unknown[]) => getMatchProfile(...args),
   },
 }));
 
 beforeEach(() => {
   authState.isAuthenticated = false;
-  apiGet.mockReset();
+  getMatchProfile.mockReset();
 });
 
 describe('useMatchPreferences', () => {
   it('reports no preferences for signed-out users and does not call the API', () => {
     const { result } = renderHook(() => useMatchPreferences());
     expect(result.current.hasPreferences).toBe(false);
-    expect(apiGet).not.toHaveBeenCalled();
+    expect(getMatchProfile).not.toHaveBeenCalled();
   });
 
   it('reports preferences when the profile has at least one preferred list populated', async () => {
     authState.isAuthenticated = true;
-    apiGet.mockResolvedValueOnce({ data: { preferred_types: ['dog'] } });
+    getMatchProfile.mockResolvedValueOnce({ preferred_types: ['dog'] });
     const { result } = renderHook(() => useMatchPreferences());
     await waitFor(() => expect(result.current.hasPreferences).toBe(true));
   });
 
   it('reports no preferences when the profile is the empty placeholder', async () => {
     authState.isAuthenticated = true;
-    apiGet.mockResolvedValueOnce({ data: { lifestyle: {} } });
+    getMatchProfile.mockResolvedValueOnce({ lifestyle: {} });
     const { result } = renderHook(() => useMatchPreferences());
     await waitFor(() => expect(result.current.isLoading).toBe(false));
     expect(result.current.hasPreferences).toBe(false);
@@ -50,13 +50,11 @@ describe('useMatchPreferences', () => {
 
   it('treats an empty preferred_types array as no preferences', async () => {
     authState.isAuthenticated = true;
-    apiGet.mockResolvedValueOnce({
-      data: {
-        preferred_types: [],
-        preferred_sizes: [],
-        preferred_age_groups: [],
-        preferred_energy: [],
-      },
+    getMatchProfile.mockResolvedValueOnce({
+      preferred_types: [],
+      preferred_sizes: [],
+      preferred_age_groups: [],
+      preferred_energy: [],
     });
     const { result } = renderHook(() => useMatchPreferences());
     await waitFor(() => expect(result.current.isLoading).toBe(false));
@@ -65,7 +63,7 @@ describe('useMatchPreferences', () => {
 
   it('reports no preferences if the API fails', async () => {
     authState.isAuthenticated = true;
-    apiGet.mockRejectedValueOnce(new Error('boom'));
+    getMatchProfile.mockRejectedValueOnce(new Error('boom'));
     const { result } = renderHook(() => useMatchPreferences());
     await waitFor(() => expect(result.current.isLoading).toBe(false));
     expect(result.current.hasPreferences).toBe(false);

--- a/apps/client/src/hooks/useMatchPreferences.ts
+++ b/apps/client/src/hooks/useMatchPreferences.ts
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 import { useAuth } from '@adopt-dont-shop/lib.auth';
 import type { AdopterMatchProfile } from '@adopt-dont-shop/lib.matching';
-import { apiService } from '@/services';
+import { matchingService } from '@/services';
 
 type UseMatchPreferencesReturn = {
   hasPreferences: boolean;
@@ -46,11 +46,9 @@ export const useMatchPreferences = (): UseMatchPreferencesReturn => {
     const load = async () => {
       try {
         setIsLoading(true);
-        const res = await apiService.get<{ data: Partial<AdopterMatchProfile> }>(
-          '/api/v1/match/profile'
-        );
+        const profile = await matchingService.getMatchProfile();
         if (!cancelled) {
-          setHasPreferences(hasAnyPreference(res.data));
+          setHasPreferences(hasAnyPreference(profile));
         }
       } catch {
         if (!cancelled) {

--- a/apps/client/src/pages/OnboardingWizardPage.test.tsx
+++ b/apps/client/src/pages/OnboardingWizardPage.test.tsx
@@ -17,9 +17,9 @@ const getMock = vi.fn();
 const putMock = vi.fn();
 
 vi.mock('@/services', () => ({
-  apiService: {
-    get: (...args: unknown[]) => getMock(...args),
-    put: (...args: unknown[]) => putMock(...args),
+  matchingService: {
+    getMatchProfile: (...args: unknown[]) => getMock(...args),
+    updateMatchProfile: (...args: unknown[]) => putMock(...args),
   },
 }));
 
@@ -68,17 +68,15 @@ describe('OnboardingWizardPage', () => {
     getMock.mockReset();
     putMock.mockReset();
     getMock.mockResolvedValue({
-      data: {
-        preferred_types: [],
-        preferred_sizes: [],
-        preferred_age_groups: [],
-        preferred_energy: [],
-        lifestyle: {},
-        max_distance_km: null,
-        open_to_special_needs: false,
-        notify_new_matches: false,
-        allergies: null,
-      },
+      preferred_types: [],
+      preferred_sizes: [],
+      preferred_age_groups: [],
+      preferred_energy: [],
+      lifestyle: {},
+      max_distance_km: null,
+      open_to_special_needs: false,
+      notify_new_matches: false,
+      allergies: null,
     });
   });
 
@@ -157,7 +155,7 @@ describe('OnboardingWizardPage', () => {
 
   it('submits all data to PUT /api/v1/match/profile on step 4 and navigates to top-picks', async () => {
     const user = userEvent.setup();
-    putMock.mockResolvedValue({ data: {} });
+    putMock.mockResolvedValue(undefined);
     renderPage();
 
     await waitFor(() => {
@@ -184,8 +182,7 @@ describe('OnboardingWizardPage', () => {
       expect(putMock).toHaveBeenCalledTimes(1);
     });
 
-    const [url, payload] = putMock.mock.calls[0] as [string, Record<string, unknown>];
-    expect(url).toBe('/api/v1/match/profile');
+    const [payload] = putMock.mock.calls[0] as [Record<string, unknown>];
     expect(payload).toHaveProperty('lifestyle');
     expect(payload).toHaveProperty('allergies');
     expect(payload).toHaveProperty('preferred_types');
@@ -221,17 +218,15 @@ describe('OnboardingWizardPage', () => {
 
   it('loads existing match profile data on mount', async () => {
     getMock.mockResolvedValue({
-      data: {
-        preferred_types: ['dog', 'cat'],
-        preferred_sizes: ['medium'],
-        preferred_age_groups: ['adult'],
-        preferred_energy: ['medium'],
-        lifestyle: { housing_type: 'apartment', has_children: false, yard: false },
-        max_distance_km: 25,
-        open_to_special_needs: true,
-        notify_new_matches: true,
-        allergies: 'cats',
-      },
+      preferred_types: ['dog', 'cat'],
+      preferred_sizes: ['medium'],
+      preferred_age_groups: ['adult'],
+      preferred_energy: ['medium'],
+      lifestyle: { housing_type: 'apartment', has_children: false, yard: false },
+      max_distance_km: 25,
+      open_to_special_needs: true,
+      notify_new_matches: true,
+      allergies: 'cats',
     });
 
     renderPage();
@@ -259,17 +254,15 @@ describe('OnboardingWizardPage', () => {
   describe('ADS-688 persistence fixes', () => {
     it('restores the original children_type selection on reload', async () => {
       getMock.mockResolvedValue({
-        data: {
-          preferred_types: [],
-          preferred_sizes: [],
-          preferred_age_groups: [],
-          preferred_energy: [],
-          lifestyle: { children_type: 'older', has_children: true },
-          max_distance_km: null,
-          open_to_special_needs: false,
-          notify_new_matches: false,
-          allergies: null,
-        },
+        preferred_types: [],
+        preferred_sizes: [],
+        preferred_age_groups: [],
+        preferred_energy: [],
+        lifestyle: { children_type: 'older', has_children: true },
+        max_distance_km: null,
+        open_to_special_needs: false,
+        notify_new_matches: false,
+        allergies: null,
       });
 
       renderPage();
@@ -284,17 +277,15 @@ describe('OnboardingWizardPage', () => {
 
     it('restores the original other_pets_type selection on reload', async () => {
       getMock.mockResolvedValue({
-        data: {
-          preferred_types: [],
-          preferred_sizes: [],
-          preferred_age_groups: [],
-          preferred_energy: [],
-          lifestyle: { other_pets_type: 'cats', has_other_pets: true },
-          max_distance_km: null,
-          open_to_special_needs: false,
-          notify_new_matches: false,
-          allergies: null,
-        },
+        preferred_types: [],
+        preferred_sizes: [],
+        preferred_age_groups: [],
+        preferred_energy: [],
+        lifestyle: { other_pets_type: 'cats', has_other_pets: true },
+        max_distance_km: null,
+        open_to_special_needs: false,
+        notify_new_matches: false,
+        allergies: null,
       });
 
       renderPage();
@@ -308,17 +299,15 @@ describe('OnboardingWizardPage', () => {
 
     it('restores "A mix" selection on reload', async () => {
       getMock.mockResolvedValue({
-        data: {
-          preferred_types: [],
-          preferred_sizes: [],
-          preferred_age_groups: [],
-          preferred_energy: [],
-          lifestyle: { other_pets_type: 'mixed', has_other_pets: true },
-          max_distance_km: null,
-          open_to_special_needs: false,
-          notify_new_matches: false,
-          allergies: null,
-        },
+        preferred_types: [],
+        preferred_sizes: [],
+        preferred_age_groups: [],
+        preferred_energy: [],
+        lifestyle: { other_pets_type: 'mixed', has_other_pets: true },
+        max_distance_km: null,
+        open_to_special_needs: false,
+        notify_new_matches: false,
+        allergies: null,
       });
 
       renderPage();
@@ -332,7 +321,7 @@ describe('OnboardingWizardPage', () => {
 
     it('includes activity_level and children_type/other_pets_type in the submitted payload', async () => {
       const user = userEvent.setup();
-      putMock.mockResolvedValue({ data: {} });
+      putMock.mockResolvedValue(undefined);
       renderPage();
 
       await waitFor(() => {
@@ -352,7 +341,7 @@ describe('OnboardingWizardPage', () => {
         expect(putMock).toHaveBeenCalledTimes(1);
       });
 
-      const [, payload] = putMock.mock.calls[0] as [string, { lifestyle: Record<string, unknown> }];
+      const [payload] = putMock.mock.calls[0] as [{ lifestyle: Record<string, unknown> }];
       expect(payload.lifestyle.children_type).toBe('older');
       expect(payload.lifestyle.other_pets_type).toBe('cats');
       expect(payload.lifestyle.activity_level).toBe('high');

--- a/apps/client/src/pages/OnboardingWizardPage.tsx
+++ b/apps/client/src/pages/OnboardingWizardPage.tsx
@@ -3,7 +3,7 @@ import { Alert, Button, Card, Spinner } from '@adopt-dont-shop/lib.components';
 import type { AdopterLifestyle } from '@adopt-dont-shop/lib.matching';
 import React, { useEffect, useState } from 'react';
 import { useNavigate, Link } from 'react-router-dom';
-import { apiService } from '@/services';
+import { matchingService } from '@/services';
 import * as styles from './OnboardingWizardPage.css';
 
 /**
@@ -230,44 +230,33 @@ export const OnboardingWizardPage: React.FC = () => {
     }
     const load = async () => {
       try {
-        const res = await apiService.get<{
-          data: {
-            preferred_types: string[] | null;
-            preferred_sizes: string[] | null;
-            preferred_age_groups: string[] | null;
-            preferred_energy: string[] | null;
-            lifestyle: AdopterLifestyle;
-            max_distance_km: number | null;
-            open_to_special_needs: boolean;
-            notify_new_matches: boolean;
-            allergies: string | null;
-          };
-        }>('/api/v1/match/profile');
-        const p = res.data;
-        // ADS-688: prefer the granular `*_type` field the wizard now persists.
-        // Fall back to the boolean for profiles created before that field
-        // existed (true → first non-"none" choice; false → "none").
-        const restoredChildren =
-          p.lifestyle?.children_type ?? (p.lifestyle?.has_children ? 'young' : 'none');
-        const restoredOtherPets =
-          p.lifestyle?.other_pets_type ?? (p.lifestyle?.has_other_pets ? 'dogs' : 'none');
-        setForm(f => ({
-          ...f,
-          preferred_types: p.preferred_types ?? [],
-          preferred_sizes: p.preferred_sizes ?? [],
-          preferred_age_groups: p.preferred_age_groups ?? [],
-          preferred_energy: p.preferred_energy ?? [],
-          housing_type: p.lifestyle?.housing_type ?? '',
-          has_children: restoredChildren,
-          has_other_pets: restoredOtherPets,
-          activity_level: p.lifestyle?.activity_level ?? '',
-          hours_alone_daily: p.lifestyle?.hours_alone_daily ?? 0,
-          yard: p.lifestyle?.yard ?? false,
-          max_distance_km: p.max_distance_km ?? '',
-          open_to_special_needs: !!p.open_to_special_needs,
-          notify_new_matches: !!p.notify_new_matches,
-          allergies: p.allergies ?? '',
-        }));
+        const p = await matchingService.getMatchProfile();
+        if (p) {
+          // ADS-688: prefer the granular `*_type` field the wizard now persists.
+          // Fall back to the boolean for profiles created before that field
+          // existed (true → first non-"none" choice; false → "none").
+          const restoredChildren =
+            p.lifestyle?.children_type ?? (p.lifestyle?.has_children ? 'young' : 'none');
+          const restoredOtherPets =
+            p.lifestyle?.other_pets_type ?? (p.lifestyle?.has_other_pets ? 'dogs' : 'none');
+          setForm(f => ({
+            ...f,
+            preferred_types: p.preferred_types ?? [],
+            preferred_sizes: p.preferred_sizes ?? [],
+            preferred_age_groups: p.preferred_age_groups ?? [],
+            preferred_energy: p.preferred_energy ?? [],
+            housing_type: p.lifestyle?.housing_type ?? '',
+            has_children: restoredChildren,
+            has_other_pets: restoredOtherPets,
+            activity_level: p.lifestyle?.activity_level ?? '',
+            hours_alone_daily: p.lifestyle?.hours_alone_daily ?? 0,
+            yard: p.lifestyle?.yard ?? false,
+            max_distance_km: p.max_distance_km ?? '',
+            open_to_special_needs: !!p.open_to_special_needs,
+            notify_new_matches: !!p.notify_new_matches,
+            allergies: p.allergies ?? '',
+          }));
+        }
       } catch {
         // First-time load — empty profile is fine.
       } finally {
@@ -361,7 +350,7 @@ export const OnboardingWizardPage: React.FC = () => {
     try {
       setSaving(true);
       setError(null);
-      await apiService.put('/api/v1/match/profile', buildPayload());
+      await matchingService.updateMatchProfile(buildPayload());
       navigate('/match/top-picks');
     } catch (err) {
       console.error('Failed to save match profile', err);

--- a/apps/client/src/pages/TopPicksPage.test.tsx
+++ b/apps/client/src/pages/TopPicksPage.test.tsx
@@ -10,13 +10,13 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { renderWithProviders, screen, waitFor, fireEvent } from '@/test-utils';
 
-const apiGet = vi.fn();
+const getTopPicks = vi.fn();
 const mockNavigate = vi.fn();
 let mockIsAuthenticated = true;
 
 vi.mock('@/services', () => ({
-  apiService: {
-    get: (...args: unknown[]) => apiGet(...args),
+  matchingService: {
+    getTopPicks: (...args: unknown[]) => getTopPicks(...args),
   },
 }));
 
@@ -65,13 +65,13 @@ describe('TopPicksPage (signed out)', () => {
       screen.getByRole('heading', { name: /sign in for your top picks/i })
     ).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /sign in/i })).toBeInTheDocument();
-    expect(apiGet).not.toHaveBeenCalled();
+    expect(getTopPicks).not.toHaveBeenCalled();
   });
 });
 
 describe('TopPicksPage (signed in)', () => {
   it('shows a loading spinner while picks are being fetched', () => {
-    apiGet.mockReturnValue(new Promise(() => {}));
+    getTopPicks.mockReturnValue(new Promise(() => {}));
 
     renderWithProviders(<TopPicksPage />);
 
@@ -79,7 +79,7 @@ describe('TopPicksPage (signed in)', () => {
   });
 
   it('renders an error message when the request fails', async () => {
-    apiGet.mockRejectedValue(new Error('boom'));
+    getTopPicks.mockRejectedValue(new Error('boom'));
 
     renderWithProviders(<TopPicksPage />);
 
@@ -87,7 +87,7 @@ describe('TopPicksPage (signed in)', () => {
   });
 
   it('nudges the user to set preferences when there are no picks', async () => {
-    apiGet.mockResolvedValue({ data: [] });
+    getTopPicks.mockResolvedValue([]);
 
     renderWithProviders(<TopPicksPage />);
 
@@ -96,7 +96,7 @@ describe('TopPicksPage (signed in)', () => {
   });
 
   it('renders the picks grid with the pet name and a match-quality badge', async () => {
-    apiGet.mockResolvedValue({ data: [buildPick({ score: 80 })] });
+    getTopPicks.mockResolvedValue([buildPick({ score: 80 })]);
 
     renderWithProviders(<TopPicksPage />);
 
@@ -106,15 +106,15 @@ describe('TopPicksPage (signed in)', () => {
   });
 
   it('requests the top-picks endpoint with a limit', async () => {
-    apiGet.mockResolvedValue({ data: [] });
+    getTopPicks.mockResolvedValue([]);
 
     renderWithProviders(<TopPicksPage />);
 
-    await waitFor(() => expect(apiGet).toHaveBeenCalledWith('/api/v1/match/top-picks?limit=10'));
+    await waitFor(() => expect(getTopPicks).toHaveBeenCalledWith(10));
   });
 
   it('navigates to the pet details page when a card is activated', async () => {
-    apiGet.mockResolvedValue({ data: [buildPick({ petId: 'pet-42' })] });
+    getTopPicks.mockResolvedValue([buildPick({ petId: 'pet-42' })]);
 
     renderWithProviders(<TopPicksPage />);
 

--- a/apps/client/src/pages/TopPicksPage.tsx
+++ b/apps/client/src/pages/TopPicksPage.tsx
@@ -10,7 +10,7 @@ import {
 import type { MatchTopPick } from '@adopt-dont-shop/lib.matching';
 import React, { useEffect, useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
-import { apiService } from '@/services';
+import { matchingService } from '@/services';
 import { resolveFileUrl } from '@/utils/fileUtils';
 import * as styles from './TopPicksPage.css';
 
@@ -51,11 +51,9 @@ export const TopPicksPage: React.FC = () => {
       try {
         setLoading(true);
         setError(null);
-        const res = await apiService.get<{ data: MatchTopPick[] }>(
-          '/api/v1/match/top-picks?limit=10'
-        );
+        const data = await matchingService.getTopPicks(10);
         if (!cancelled) {
-          setPicks(res.data ?? []);
+          setPicks(data);
         }
       } catch (err) {
         if (!cancelled) {

--- a/apps/client/src/services/index.ts
+++ b/apps/client/src/services/index.ts
@@ -3,6 +3,7 @@ export {
   analyticsService,
   applicationService,
   discoveryService,
+  matchingService,
   petService,
   rescueService,
   authService,

--- a/apps/client/src/services/libraryServices.ts
+++ b/apps/client/src/services/libraryServices.ts
@@ -11,6 +11,7 @@ import { DiscoveryService } from '@adopt-dont-shop/lib.discovery';
 import { PetsService } from '@adopt-dont-shop/lib.pets';
 import { RescueService } from '@adopt-dont-shop/lib.rescue';
 import { ChatService } from '@adopt-dont-shop/lib.chat';
+import { MatchingService } from '@adopt-dont-shop/lib.matching';
 import { SearchService } from '@adopt-dont-shop/lib.search';
 import { NotificationsService } from '@adopt-dont-shop/lib.notifications';
 import { PermissionsService } from '@adopt-dont-shop/lib.permissions';
@@ -43,6 +44,10 @@ export const applicationService = new ApplicationsService(globalApiService, serv
 export const discoveryService = new DiscoveryService(serviceConfig);
 
 export const petService = new PetsService(globalApiService);
+
+// Shares the global apiService so top-picks / match-profile calls carry
+// the same auth + CSRF state as the rest of the app.
+export const matchingService = new MatchingService(globalApiService);
 
 export const rescueService = new RescueService(globalApiService, serviceConfig);
 

--- a/packages/lib.matching/package.json
+++ b/packages/lib.matching/package.json
@@ -37,7 +37,9 @@
   ],
   "author": "Adopt Don't Shop Team",
   "license": "MIT",
-  "dependencies": {},
+  "dependencies": {
+    "@adopt-dont-shop/lib.api": "workspace:*"
+  },
   "devDependencies": {
     "@adopt-dont-shop/eslint-config-base": "workspace:*",
     "@types/node": "^25.9.1"

--- a/packages/lib.matching/src/index.ts
+++ b/packages/lib.matching/src/index.ts
@@ -73,3 +73,5 @@ export type MatchTopPick = {
   breedName?: string | null;
   photoUrl?: string | null;
 };
+
+export { MatchingService } from './matching-service';

--- a/packages/lib.matching/src/matching-service.test.ts
+++ b/packages/lib.matching/src/matching-service.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import type { ApiService } from '@adopt-dont-shop/lib.api';
+
+import { MatchingService } from './matching-service';
+
+type ApiStub = { get?: ReturnType<typeof vi.fn>; put?: ReturnType<typeof vi.fn> };
+
+const makeApi = (stub: ApiStub = {}): ApiService =>
+  ({ get: stub.get ?? vi.fn(), put: stub.put ?? vi.fn() }) as unknown as ApiService;
+
+describe('MatchingService', () => {
+  describe('getTopPicks', () => {
+    it('requests the picks with the given limit and unwraps the data envelope', async () => {
+      const picks = [{ petId: 'p-1', name: 'Bella', reasons: [] }];
+      const get = vi.fn().mockResolvedValue({ data: picks });
+      const service = new MatchingService(makeApi({ get }));
+
+      const result = await service.getTopPicks(5);
+
+      expect(get).toHaveBeenCalledWith('/api/v1/match/top-picks?limit=5');
+      expect(result).toEqual(picks);
+    });
+
+    it('defaults the limit to 10 when none is given', async () => {
+      const get = vi.fn().mockResolvedValue({ data: [] });
+      const service = new MatchingService(makeApi({ get }));
+
+      await service.getTopPicks();
+
+      expect(get).toHaveBeenCalledWith('/api/v1/match/top-picks?limit=10');
+    });
+
+    it('returns an empty array when the response carries no data', async () => {
+      const get = vi.fn().mockResolvedValue({});
+      const service = new MatchingService(makeApi({ get }));
+
+      expect(await service.getTopPicks()).toEqual([]);
+    });
+  });
+
+  describe('getMatchProfile', () => {
+    it('unwraps the profile data envelope', async () => {
+      const profile = { user_id: 'u-1', preferred_types: ['dog'] };
+      const get = vi.fn().mockResolvedValue({ data: profile });
+      const service = new MatchingService(makeApi({ get }));
+
+      const result = await service.getMatchProfile();
+
+      expect(get).toHaveBeenCalledWith('/api/v1/match/profile');
+      expect(result).toEqual(profile);
+    });
+
+    it('returns null when the response carries no profile', async () => {
+      const get = vi.fn().mockResolvedValue({});
+      const service = new MatchingService(makeApi({ get }));
+
+      expect(await service.getMatchProfile()).toBeNull();
+    });
+  });
+
+  describe('updateMatchProfile', () => {
+    it('PUTs the profile payload to the match profile endpoint', async () => {
+      const put = vi.fn().mockResolvedValue({});
+      const service = new MatchingService(makeApi({ put }));
+      const payload = { preferred_types: ['cat'], open_to_special_needs: true };
+
+      await service.updateMatchProfile(payload);
+
+      expect(put).toHaveBeenCalledWith('/api/v1/match/profile', payload);
+    });
+  });
+});

--- a/packages/lib.matching/src/matching-service.ts
+++ b/packages/lib.matching/src/matching-service.ts
@@ -1,0 +1,41 @@
+import { ApiService } from '@adopt-dont-shop/lib.api';
+
+import type { AdopterMatchProfile, MatchTopPick } from './index';
+
+/**
+ * Client for the adopter-matching API surface served by the gateway
+ * (`/api/v1/match/*`). Wraps the top-picks read and the match-profile
+ * read/write so the app.client components stop hand-rolling `apiService`
+ * calls and share one typed contract.
+ */
+export class MatchingService {
+  private readonly apiService: ApiService;
+
+  constructor(apiService: ApiService = new ApiService()) {
+    this.apiService = apiService;
+  }
+
+  /**
+   * Personalised "top picks" scored against the adopter's stored match
+   * profile. Returns an empty list when the user has no picks yet.
+   */
+  async getTopPicks(limit = 10): Promise<MatchTopPick[]> {
+    const res = await this.apiService.get<{ data: MatchTopPick[] }>(
+      `/api/v1/match/top-picks?limit=${limit}`
+    );
+    return res.data ?? [];
+  }
+
+  /** The signed-in adopter's saved match profile, or null when unset. */
+  async getMatchProfile(): Promise<Partial<AdopterMatchProfile> | null> {
+    const res = await this.apiService.get<{ data: Partial<AdopterMatchProfile> }>(
+      '/api/v1/match/profile'
+    );
+    return res.data ?? null;
+  }
+
+  /** Upsert the adopter's match profile (onboarding wizard save). */
+  async updateMatchProfile(profile: Partial<AdopterMatchProfile>): Promise<void> {
+    await this.apiService.put('/api/v1/match/profile', profile);
+  }
+}

--- a/packages/lib.matching/vitest.config.ts
+++ b/packages/lib.matching/vitest.config.ts
@@ -3,9 +3,10 @@ import { defineLibConfig } from '../../vitest.shared.config';
 export default defineLibConfig({
   test: {
     coverage: {
-      // ADS-717: lib.matching only exports type definitions and constants
-      // from index.ts which is excluded from coverage. No coverable
-      // source files exist, so thresholds are held at 0.
+      // ADS-717: index.ts is type definitions + constants (excluded from
+      // coverage). The MatchingService client is the only coverable source
+      // and is fully covered by matching-service.test.ts, but thresholds
+      // are held at 0 to avoid coupling the gate to that single file.
       thresholds: {
         statements: 0,
         branches: 0,

--- a/packages/proto/proto/adopt_dont_shop/matching/v1/matching.proto
+++ b/packages/proto/proto/adopt_dont_shop/matching/v1/matching.proto
@@ -78,6 +78,16 @@ service MatchingService {
   // Aggregate swipe counts for a single session. Caller MUST own the
   // session (or be admin).
   rpc GetSessionStats(GetSessionStatsRequest) returns (GetSessionStatsResponse);
+
+  // --- Top picks ---------------------------------------------------------
+
+  // Get a short, personalised "top picks" list for the calling principal —
+  // distinct from Recommend (the swipe-queue feed): top picks reads the
+  // user's STORED match profile (preferred types/sizes/age groups/energy/
+  // temperament) rather than session filters, excludes already-swiped pets,
+  // and attaches reason chips explaining each pick. Stateless — no session
+  // required, no mutation.
+  rpc GetTopPicks(GetTopPicksRequest) returns (GetTopPicksResponse);
 }
 
 // ===== Enums =========================================================
@@ -325,6 +335,50 @@ message UpsertMatchProfileRequest {
 
 message UpsertMatchProfileResponse {
   MatchProfile profile = 1;
+}
+
+// ===== Top picks ======================================================
+
+// A reason chip explaining why a pick was surfaced. `kind` mirrors the
+// SPA's ReasonChipKind vocabulary (pref_match, lifestyle, distance,
+// similar_to_liked, fresh) as a lowercase string rather than an enum —
+// the chip set is presentation-driven and may grow without a proto
+// regen; `label` is the human-readable text the SPA renders verbatim.
+message TopPickReasonChip {
+  string kind = 1;
+  string label = 2;
+}
+
+// TopPick is the top-picks surface's per-pet payload — a superset of
+// PetCandidate's intent but independently shaped since top picks carries
+// size/age_group/reasons/rescue_name that PetCandidate does not.
+message TopPick {
+  string pet_id = 1;
+  string name = 2;
+  // Lowercase species/size/age-group tokens (same vocabulary as the
+  // filters_json the SPA sends elsewhere — e.g. 'dog', 'medium', 'adult').
+  string type = 3;
+  string age_group = 4;
+  string size = 5;
+  // The scorer's result for this pick, on [0.0, 1.0].
+  float score = 6;
+  repeated TopPickReasonChip reasons = 7;
+  string rescue_name = 8;
+  // Pets has no breed NAME (only breed_id) and no photo/image field, so
+  // these stay unset until that data is available — both are optional in
+  // the SPA's MatchTopPick type for exactly this reason.
+  optional string breed_name = 9;
+  optional string photo_url = 10;
+}
+
+message GetTopPicksRequest {
+  // Defaults to 10, max 50 — top picks is a short curated list, not a
+  // paginated feed.
+  uint32 limit = 1;
+}
+
+message GetTopPicksResponse {
+  repeated TopPick picks = 1;
 }
 
 // ===== Swipe statistics ==============================================

--- a/packages/proto/src/generated/proto/adopt_dont_shop/matching/v1/matching.ts
+++ b/packages/proto/src/generated/proto/adopt_dont_shop/matching/v1/matching.ts
@@ -5,7 +5,7 @@
 // source: proto/adopt_dont_shop/matching/v1/matching.proto
 
 /* eslint-disable */
-import { BinaryReader, BinaryWriter } from "@bufbuild/protobuf/wire";
+import { BinaryReader, BinaryWriter } from '@bufbuild/protobuf/wire';
 import {
   type CallOptions,
   type ChannelCredentials,
@@ -17,9 +17,9 @@ import {
   type Metadata,
   type ServiceError,
   type UntypedServiceImplementation,
-} from "@grpc/grpc-js";
+} from '@grpc/grpc-js';
 
-export const protobufPackage = "adopt_dont_shop.matching.v1";
+export const protobufPackage = 'adopt_dont_shop.matching.v1';
 
 export enum SwipeAction {
   SWIPE_ACTION_UNSPECIFIED = 0,
@@ -39,22 +39,22 @@ export enum SwipeAction {
 export function swipeActionFromJSON(object: any): SwipeAction {
   switch (object) {
     case 0:
-    case "SWIPE_ACTION_UNSPECIFIED":
+    case 'SWIPE_ACTION_UNSPECIFIED':
       return SwipeAction.SWIPE_ACTION_UNSPECIFIED;
     case 1:
-    case "SWIPE_ACTION_LIKE":
+    case 'SWIPE_ACTION_LIKE':
       return SwipeAction.SWIPE_ACTION_LIKE;
     case 2:
-    case "SWIPE_ACTION_PASS":
+    case 'SWIPE_ACTION_PASS':
       return SwipeAction.SWIPE_ACTION_PASS;
     case 3:
-    case "SWIPE_ACTION_SUPER_LIKE":
+    case 'SWIPE_ACTION_SUPER_LIKE':
       return SwipeAction.SWIPE_ACTION_SUPER_LIKE;
     case 4:
-    case "SWIPE_ACTION_INFO":
+    case 'SWIPE_ACTION_INFO':
       return SwipeAction.SWIPE_ACTION_INFO;
     case -1:
-    case "UNRECOGNIZED":
+    case 'UNRECOGNIZED':
     default:
       return SwipeAction.UNRECOGNIZED;
   }
@@ -63,18 +63,18 @@ export function swipeActionFromJSON(object: any): SwipeAction {
 export function swipeActionToJSON(object: SwipeAction): string {
   switch (object) {
     case SwipeAction.SWIPE_ACTION_UNSPECIFIED:
-      return "SWIPE_ACTION_UNSPECIFIED";
+      return 'SWIPE_ACTION_UNSPECIFIED';
     case SwipeAction.SWIPE_ACTION_LIKE:
-      return "SWIPE_ACTION_LIKE";
+      return 'SWIPE_ACTION_LIKE';
     case SwipeAction.SWIPE_ACTION_PASS:
-      return "SWIPE_ACTION_PASS";
+      return 'SWIPE_ACTION_PASS';
     case SwipeAction.SWIPE_ACTION_SUPER_LIKE:
-      return "SWIPE_ACTION_SUPER_LIKE";
+      return 'SWIPE_ACTION_SUPER_LIKE';
     case SwipeAction.SWIPE_ACTION_INFO:
-      return "SWIPE_ACTION_INFO";
+      return 'SWIPE_ACTION_INFO';
     case SwipeAction.UNRECOGNIZED:
     default:
-      return "UNRECOGNIZED";
+      return 'UNRECOGNIZED';
   }
 }
 
@@ -90,22 +90,22 @@ export enum DeviceType {
 export function deviceTypeFromJSON(object: any): DeviceType {
   switch (object) {
     case 0:
-    case "DEVICE_TYPE_UNSPECIFIED":
+    case 'DEVICE_TYPE_UNSPECIFIED':
       return DeviceType.DEVICE_TYPE_UNSPECIFIED;
     case 1:
-    case "DEVICE_TYPE_DESKTOP":
+    case 'DEVICE_TYPE_DESKTOP':
       return DeviceType.DEVICE_TYPE_DESKTOP;
     case 2:
-    case "DEVICE_TYPE_MOBILE":
+    case 'DEVICE_TYPE_MOBILE':
       return DeviceType.DEVICE_TYPE_MOBILE;
     case 3:
-    case "DEVICE_TYPE_TABLET":
+    case 'DEVICE_TYPE_TABLET':
       return DeviceType.DEVICE_TYPE_TABLET;
     case 4:
-    case "DEVICE_TYPE_UNKNOWN":
+    case 'DEVICE_TYPE_UNKNOWN':
       return DeviceType.DEVICE_TYPE_UNKNOWN;
     case -1:
-    case "UNRECOGNIZED":
+    case 'UNRECOGNIZED':
     default:
       return DeviceType.UNRECOGNIZED;
   }
@@ -114,18 +114,18 @@ export function deviceTypeFromJSON(object: any): DeviceType {
 export function deviceTypeToJSON(object: DeviceType): string {
   switch (object) {
     case DeviceType.DEVICE_TYPE_UNSPECIFIED:
-      return "DEVICE_TYPE_UNSPECIFIED";
+      return 'DEVICE_TYPE_UNSPECIFIED';
     case DeviceType.DEVICE_TYPE_DESKTOP:
-      return "DEVICE_TYPE_DESKTOP";
+      return 'DEVICE_TYPE_DESKTOP';
     case DeviceType.DEVICE_TYPE_MOBILE:
-      return "DEVICE_TYPE_MOBILE";
+      return 'DEVICE_TYPE_MOBILE';
     case DeviceType.DEVICE_TYPE_TABLET:
-      return "DEVICE_TYPE_TABLET";
+      return 'DEVICE_TYPE_TABLET';
     case DeviceType.DEVICE_TYPE_UNKNOWN:
-      return "DEVICE_TYPE_UNKNOWN";
+      return 'DEVICE_TYPE_UNKNOWN';
     case DeviceType.UNRECOGNIZED:
     default:
-      return "UNRECOGNIZED";
+      return 'UNRECOGNIZED';
   }
 }
 
@@ -167,13 +167,9 @@ export interface PetCandidate {
   age?: string | undefined;
   rescueId: string;
   /** Primary image URL the SPA renders first. */
-  primaryImageUrl?:
-    | string
-    | undefined;
+  primaryImageUrl?: string | undefined;
   /** Short description the swipe card surfaces. */
-  shortDescription?:
-    | string
-    | undefined;
+  shortDescription?: string | undefined;
   /**
    * The recommender's score for this candidate, on [0.0, 1.0].
    * Higher = better fit. SPA may render this as a heart-meter or
@@ -212,9 +208,7 @@ export interface StartSessionRequest {
 }
 
 export interface StartSessionResponse {
-  session?:
-    | SwipeSession
-    | undefined;
+  session?: SwipeSession | undefined;
   /**
    * True when this call created the session; false when an existing
    * active session was returned (idempotency signal).
@@ -268,18 +262,14 @@ export interface RecordSwipeRequest {
 }
 
 export interface RecordSwipeResponse {
-  action?:
-    | SwipeActionRecord
-    | undefined;
+  action?: SwipeActionRecord | undefined;
   /** Echo of the updated session counters for the SPA's HUD. */
   session?: SwipeSession | undefined;
 }
 
 export interface SearchPetsRequest {
   /** Free-text query (matched against pet name + description). */
-  query?:
-    | string
-    | undefined;
+  query?: string | undefined;
   /** Same JSONB filters shape as a session. */
   filtersJson?: string | undefined;
   cursor?: string | undefined;
@@ -338,8 +328,7 @@ export interface MatchProfile {
   updatedAt: string;
 }
 
-export interface GetMatchProfileRequest {
-}
+export interface GetMatchProfileRequest {}
 
 export interface GetMatchProfileResponse {
   profile?: MatchProfile | undefined;
@@ -377,6 +366,58 @@ export interface UpsertMatchProfileResponse {
   profile?: MatchProfile | undefined;
 }
 
+/**
+ * A reason chip explaining why a pick was surfaced. `kind` mirrors the
+ * SPA's ReasonChipKind vocabulary (pref_match, lifestyle, distance,
+ * similar_to_liked, fresh) as a lowercase string rather than an enum —
+ * the chip set is presentation-driven and may grow without a proto
+ * regen; `label` is the human-readable text the SPA renders verbatim.
+ */
+export interface TopPickReasonChip {
+  kind: string;
+  label: string;
+}
+
+/**
+ * TopPick is the top-picks surface's per-pet payload — a superset of
+ * PetCandidate's intent but independently shaped since top picks carries
+ * size/age_group/reasons/rescue_name that PetCandidate does not.
+ */
+export interface TopPick {
+  petId: string;
+  name: string;
+  /**
+   * Lowercase species/size/age-group tokens (same vocabulary as the
+   * filters_json the SPA sends elsewhere — e.g. 'dog', 'medium', 'adult').
+   */
+  type: string;
+  ageGroup: string;
+  size: string;
+  /** The scorer's result for this pick, on [0.0, 1.0]. */
+  score: number;
+  reasons: TopPickReasonChip[];
+  rescueName: string;
+  /**
+   * Pets has no breed NAME (only breed_id) and no photo/image field, so
+   * these stay unset until that data is available — both are optional in
+   * the SPA's MatchTopPick type for exactly this reason.
+   */
+  breedName?: string | undefined;
+  photoUrl?: string | undefined;
+}
+
+export interface GetTopPicksRequest {
+  /**
+   * Defaults to 10, max 50 — top picks is a short curated list, not a
+   * paginated feed.
+   */
+  limit: number;
+}
+
+export interface GetTopPicksResponse {
+  picks: TopPick[];
+}
+
 export interface SwipeStats {
   totalSwipes: number;
   likes: number;
@@ -407,33 +448,33 @@ export interface GetSessionStatsResponse {
 
 function createBaseSwipeSession(): SwipeSession {
   return {
-    sessionId: "",
+    sessionId: '',
     userId: undefined,
-    startTime: "",
+    startTime: '',
     endTime: undefined,
     totalSwipes: 0,
     likes: 0,
     passes: 0,
     superLikes: 0,
-    filtersJson: "",
+    filtersJson: '',
     ipAddress: undefined,
     userAgent: undefined,
     deviceType: 0,
     isActive: false,
-    createdAt: "",
-    updatedAt: "",
+    createdAt: '',
+    updatedAt: '',
   };
 }
 
 export const SwipeSession: MessageFns<SwipeSession> = {
   encode(message: SwipeSession, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    if (message.sessionId !== "") {
+    if (message.sessionId !== '') {
       writer.uint32(10).string(message.sessionId);
     }
     if (message.userId !== undefined) {
       writer.uint32(18).string(message.userId);
     }
-    if (message.startTime !== "") {
+    if (message.startTime !== '') {
       writer.uint32(26).string(message.startTime);
     }
     if (message.endTime !== undefined) {
@@ -451,7 +492,7 @@ export const SwipeSession: MessageFns<SwipeSession> = {
     if (message.superLikes !== 0) {
       writer.uint32(64).uint32(message.superLikes);
     }
-    if (message.filtersJson !== "") {
+    if (message.filtersJson !== '') {
       writer.uint32(74).string(message.filtersJson);
     }
     if (message.ipAddress !== undefined) {
@@ -466,10 +507,10 @@ export const SwipeSession: MessageFns<SwipeSession> = {
     if (message.isActive !== false) {
       writer.uint32(104).bool(message.isActive);
     }
-    if (message.createdAt !== "") {
+    if (message.createdAt !== '') {
       writer.uint32(114).string(message.createdAt);
     }
-    if (message.updatedAt !== "") {
+    if (message.updatedAt !== '') {
       writer.uint32(122).string(message.updatedAt);
     }
     return writer;
@@ -616,82 +657,82 @@ export const SwipeSession: MessageFns<SwipeSession> = {
       sessionId: isSet(object.sessionId)
         ? globalThis.String(object.sessionId)
         : isSet(object.session_id)
-        ? globalThis.String(object.session_id)
-        : "",
+          ? globalThis.String(object.session_id)
+          : '',
       userId: isSet(object.userId)
         ? globalThis.String(object.userId)
         : isSet(object.user_id)
-        ? globalThis.String(object.user_id)
-        : undefined,
+          ? globalThis.String(object.user_id)
+          : undefined,
       startTime: isSet(object.startTime)
         ? globalThis.String(object.startTime)
         : isSet(object.start_time)
-        ? globalThis.String(object.start_time)
-        : "",
+          ? globalThis.String(object.start_time)
+          : '',
       endTime: isSet(object.endTime)
         ? globalThis.String(object.endTime)
         : isSet(object.end_time)
-        ? globalThis.String(object.end_time)
-        : undefined,
+          ? globalThis.String(object.end_time)
+          : undefined,
       totalSwipes: isSet(object.totalSwipes)
         ? globalThis.Number(object.totalSwipes)
         : isSet(object.total_swipes)
-        ? globalThis.Number(object.total_swipes)
-        : 0,
+          ? globalThis.Number(object.total_swipes)
+          : 0,
       likes: isSet(object.likes) ? globalThis.Number(object.likes) : 0,
       passes: isSet(object.passes) ? globalThis.Number(object.passes) : 0,
       superLikes: isSet(object.superLikes)
         ? globalThis.Number(object.superLikes)
         : isSet(object.super_likes)
-        ? globalThis.Number(object.super_likes)
-        : 0,
+          ? globalThis.Number(object.super_likes)
+          : 0,
       filtersJson: isSet(object.filtersJson)
         ? globalThis.String(object.filtersJson)
         : isSet(object.filters_json)
-        ? globalThis.String(object.filters_json)
-        : "",
+          ? globalThis.String(object.filters_json)
+          : '',
       ipAddress: isSet(object.ipAddress)
         ? globalThis.String(object.ipAddress)
         : isSet(object.ip_address)
-        ? globalThis.String(object.ip_address)
-        : undefined,
+          ? globalThis.String(object.ip_address)
+          : undefined,
       userAgent: isSet(object.userAgent)
         ? globalThis.String(object.userAgent)
         : isSet(object.user_agent)
-        ? globalThis.String(object.user_agent)
-        : undefined,
+          ? globalThis.String(object.user_agent)
+          : undefined,
       deviceType: isSet(object.deviceType)
         ? deviceTypeFromJSON(object.deviceType)
         : isSet(object.device_type)
-        ? deviceTypeFromJSON(object.device_type)
-        : 0,
+          ? deviceTypeFromJSON(object.device_type)
+          : 0,
       isActive: isSet(object.isActive)
         ? globalThis.Boolean(object.isActive)
         : isSet(object.is_active)
-        ? globalThis.Boolean(object.is_active)
-        : false,
+          ? globalThis.Boolean(object.is_active)
+          : false,
       createdAt: isSet(object.createdAt)
         ? globalThis.String(object.createdAt)
         : isSet(object.created_at)
-        ? globalThis.String(object.created_at)
-        : "",
+          ? globalThis.String(object.created_at)
+          : '',
       updatedAt: isSet(object.updatedAt)
         ? globalThis.String(object.updatedAt)
         : isSet(object.updated_at)
-        ? globalThis.String(object.updated_at)
-        : "",
+          ? globalThis.String(object.updated_at)
+          : '',
     };
   },
 
   toJSON(message: SwipeSession): unknown {
     const obj: any = {};
-    if (message.sessionId !== "") {
+    if (message.sessionId !== '') {
       obj.sessionId = message.sessionId;
     }
     if (message.userId !== undefined) {
       obj.userId = message.userId;
     }
-    if (message.startTime !== "") {
+    if (message.startTime !== '') {
       obj.startTime = message.startTime;
     }
     if (message.endTime !== undefined) {
@@ -709,7 +750,7 @@ export const SwipeSession: MessageFns<SwipeSession> = {
     if (message.superLikes !== 0) {
       obj.superLikes = Math.round(message.superLikes);
     }
-    if (message.filtersJson !== "") {
+    if (message.filtersJson !== '') {
       obj.filtersJson = message.filtersJson;
     }
     if (message.ipAddress !== undefined) {
@@ -724,10 +765,10 @@ export const SwipeSession: MessageFns<SwipeSession> = {
     if (message.isActive !== false) {
       obj.isActive = message.isActive;
     }
-    if (message.createdAt !== "") {
+    if (message.createdAt !== '') {
       obj.createdAt = message.createdAt;
     }
-    if (message.updatedAt !== "") {
+    if (message.updatedAt !== '') {
       obj.updatedAt = message.updatedAt;
     }
     return obj;
@@ -738,33 +779,33 @@ export const SwipeSession: MessageFns<SwipeSession> = {
   },
   fromPartial<I extends Exact<DeepPartial<SwipeSession>, I>>(object: I): SwipeSession {
     const message = createBaseSwipeSession();
-    message.sessionId = object.sessionId ?? "";
+    message.sessionId = object.sessionId ?? '';
     message.userId = object.userId ?? undefined;
-    message.startTime = object.startTime ?? "";
+    message.startTime = object.startTime ?? '';
     message.endTime = object.endTime ?? undefined;
     message.totalSwipes = object.totalSwipes ?? 0;
     message.likes = object.likes ?? 0;
     message.passes = object.passes ?? 0;
     message.superLikes = object.superLikes ?? 0;
-    message.filtersJson = object.filtersJson ?? "";
+    message.filtersJson = object.filtersJson ?? '';
     message.ipAddress = object.ipAddress ?? undefined;
     message.userAgent = object.userAgent ?? undefined;
     message.deviceType = object.deviceType ?? 0;
     message.isActive = object.isActive ?? false;
-    message.createdAt = object.createdAt ?? "";
-    message.updatedAt = object.updatedAt ?? "";
+    message.createdAt = object.createdAt ?? '';
+    message.updatedAt = object.updatedAt ?? '';
     return message;
   },
 };
 
 function createBasePetCandidate(): PetCandidate {
   return {
-    petId: "",
-    name: "",
-    species: "",
+    petId: '',
+    name: '',
+    species: '',
     breed: undefined,
     age: undefined,
-    rescueId: "",
+    rescueId: '',
     primaryImageUrl: undefined,
     shortDescription: undefined,
     score: 0,
@@ -773,13 +814,13 @@ function createBasePetCandidate(): PetCandidate {
 
 export const PetCandidate: MessageFns<PetCandidate> = {
   encode(message: PetCandidate, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    if (message.petId !== "") {
+    if (message.petId !== '') {
       writer.uint32(10).string(message.petId);
     }
-    if (message.name !== "") {
+    if (message.name !== '') {
       writer.uint32(18).string(message.name);
     }
-    if (message.species !== "") {
+    if (message.species !== '') {
       writer.uint32(26).string(message.species);
     }
     if (message.breed !== undefined) {
@@ -788,7 +829,7 @@ export const PetCandidate: MessageFns<PetCandidate> = {
     if (message.age !== undefined) {
       writer.uint32(42).string(message.age);
     }
-    if (message.rescueId !== "") {
+    if (message.rescueId !== '') {
       writer.uint32(50).string(message.rescueId);
     }
     if (message.primaryImageUrl !== undefined) {
@@ -896,40 +937,40 @@ export const PetCandidate: MessageFns<PetCandidate> = {
       petId: isSet(object.petId)
         ? globalThis.String(object.petId)
         : isSet(object.pet_id)
-        ? globalThis.String(object.pet_id)
-        : "",
-      name: isSet(object.name) ? globalThis.String(object.name) : "",
-      species: isSet(object.species) ? globalThis.String(object.species) : "",
+          ? globalThis.String(object.pet_id)
+          : '',
+      name: isSet(object.name) ? globalThis.String(object.name) : '',
+      species: isSet(object.species) ? globalThis.String(object.species) : '',
       breed: isSet(object.breed) ? globalThis.String(object.breed) : undefined,
       age: isSet(object.age) ? globalThis.String(object.age) : undefined,
       rescueId: isSet(object.rescueId)
         ? globalThis.String(object.rescueId)
         : isSet(object.rescue_id)
-        ? globalThis.String(object.rescue_id)
-        : "",
+          ? globalThis.String(object.rescue_id)
+          : '',
       primaryImageUrl: isSet(object.primaryImageUrl)
         ? globalThis.String(object.primaryImageUrl)
         : isSet(object.primary_image_url)
-        ? globalThis.String(object.primary_image_url)
-        : undefined,
+          ? globalThis.String(object.primary_image_url)
+          : undefined,
       shortDescription: isSet(object.shortDescription)
         ? globalThis.String(object.shortDescription)
         : isSet(object.short_description)
-        ? globalThis.String(object.short_description)
-        : undefined,
+          ? globalThis.String(object.short_description)
+          : undefined,
       score: isSet(object.score) ? globalThis.Number(object.score) : 0,
     };
   },
 
   toJSON(message: PetCandidate): unknown {
     const obj: any = {};
-    if (message.petId !== "") {
+    if (message.petId !== '') {
       obj.petId = message.petId;
     }
-    if (message.name !== "") {
+    if (message.name !== '') {
       obj.name = message.name;
     }
-    if (message.species !== "") {
+    if (message.species !== '') {
       obj.species = message.species;
     }
     if (message.breed !== undefined) {
@@ -938,7 +979,7 @@ export const PetCandidate: MessageFns<PetCandidate> = {
     if (message.age !== undefined) {
       obj.age = message.age;
     }
-    if (message.rescueId !== "") {
+    if (message.rescueId !== '') {
       obj.rescueId = message.rescueId;
     }
     if (message.primaryImageUrl !== undefined) {
@@ -958,12 +999,12 @@ export const PetCandidate: MessageFns<PetCandidate> = {
   },
   fromPartial<I extends Exact<DeepPartial<PetCandidate>, I>>(object: I): PetCandidate {
     const message = createBasePetCandidate();
-    message.petId = object.petId ?? "";
-    message.name = object.name ?? "";
-    message.species = object.species ?? "";
+    message.petId = object.petId ?? '';
+    message.name = object.name ?? '';
+    message.species = object.species ?? '';
     message.breed = object.breed ?? undefined;
     message.age = object.age ?? undefined;
-    message.rescueId = object.rescueId ?? "";
+    message.rescueId = object.rescueId ?? '';
     message.primaryImageUrl = object.primaryImageUrl ?? undefined;
     message.shortDescription = object.shortDescription ?? undefined;
     message.score = object.score ?? 0;
@@ -973,12 +1014,12 @@ export const PetCandidate: MessageFns<PetCandidate> = {
 
 function createBaseSwipeActionRecord(): SwipeActionRecord {
   return {
-    swipeActionId: "",
-    sessionId: "",
-    petId: "",
+    swipeActionId: '',
+    sessionId: '',
+    petId: '',
     userId: undefined,
     action: 0,
-    timestamp: "",
+    timestamp: '',
     responseTime: undefined,
     deviceType: undefined,
   };
@@ -986,13 +1027,13 @@ function createBaseSwipeActionRecord(): SwipeActionRecord {
 
 export const SwipeActionRecord: MessageFns<SwipeActionRecord> = {
   encode(message: SwipeActionRecord, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    if (message.swipeActionId !== "") {
+    if (message.swipeActionId !== '') {
       writer.uint32(10).string(message.swipeActionId);
     }
-    if (message.sessionId !== "") {
+    if (message.sessionId !== '') {
       writer.uint32(18).string(message.sessionId);
     }
-    if (message.petId !== "") {
+    if (message.petId !== '') {
       writer.uint32(26).string(message.petId);
     }
     if (message.userId !== undefined) {
@@ -1001,7 +1042,7 @@ export const SwipeActionRecord: MessageFns<SwipeActionRecord> = {
     if (message.action !== 0) {
       writer.uint32(40).int32(message.action);
     }
-    if (message.timestamp !== "") {
+    if (message.timestamp !== '') {
       writer.uint32(50).string(message.timestamp);
     }
     if (message.responseTime !== undefined) {
@@ -1098,47 +1139,47 @@ export const SwipeActionRecord: MessageFns<SwipeActionRecord> = {
       swipeActionId: isSet(object.swipeActionId)
         ? globalThis.String(object.swipeActionId)
         : isSet(object.swipe_action_id)
-        ? globalThis.String(object.swipe_action_id)
-        : "",
+          ? globalThis.String(object.swipe_action_id)
+          : '',
       sessionId: isSet(object.sessionId)
         ? globalThis.String(object.sessionId)
         : isSet(object.session_id)
-        ? globalThis.String(object.session_id)
-        : "",
+          ? globalThis.String(object.session_id)
+          : '',
       petId: isSet(object.petId)
         ? globalThis.String(object.petId)
         : isSet(object.pet_id)
-        ? globalThis.String(object.pet_id)
-        : "",
+          ? globalThis.String(object.pet_id)
+          : '',
       userId: isSet(object.userId)
         ? globalThis.String(object.userId)
         : isSet(object.user_id)
-        ? globalThis.String(object.user_id)
-        : undefined,
+          ? globalThis.String(object.user_id)
+          : undefined,
       action: isSet(object.action) ? swipeActionFromJSON(object.action) : 0,
-      timestamp: isSet(object.timestamp) ? globalThis.String(object.timestamp) : "",
+      timestamp: isSet(object.timestamp) ? globalThis.String(object.timestamp) : '',
       responseTime: isSet(object.responseTime)
         ? globalThis.Number(object.responseTime)
         : isSet(object.response_time)
-        ? globalThis.Number(object.response_time)
-        : undefined,
+          ? globalThis.Number(object.response_time)
+          : undefined,
       deviceType: isSet(object.deviceType)
         ? globalThis.String(object.deviceType)
         : isSet(object.device_type)
-        ? globalThis.String(object.device_type)
-        : undefined,
+          ? globalThis.String(object.device_type)
+          : undefined,
     };
   },
 
   toJSON(message: SwipeActionRecord): unknown {
     const obj: any = {};
-    if (message.swipeActionId !== "") {
+    if (message.swipeActionId !== '') {
       obj.swipeActionId = message.swipeActionId;
     }
-    if (message.sessionId !== "") {
+    if (message.sessionId !== '') {
       obj.sessionId = message.sessionId;
     }
-    if (message.petId !== "") {
+    if (message.petId !== '') {
       obj.petId = message.petId;
     }
     if (message.userId !== undefined) {
@@ -1147,7 +1188,7 @@ export const SwipeActionRecord: MessageFns<SwipeActionRecord> = {
     if (message.action !== 0) {
       obj.action = swipeActionToJSON(message.action);
     }
-    if (message.timestamp !== "") {
+    if (message.timestamp !== '') {
       obj.timestamp = message.timestamp;
     }
     if (message.responseTime !== undefined) {
@@ -1164,12 +1205,12 @@ export const SwipeActionRecord: MessageFns<SwipeActionRecord> = {
   },
   fromPartial<I extends Exact<DeepPartial<SwipeActionRecord>, I>>(object: I): SwipeActionRecord {
     const message = createBaseSwipeActionRecord();
-    message.swipeActionId = object.swipeActionId ?? "";
-    message.sessionId = object.sessionId ?? "";
-    message.petId = object.petId ?? "";
+    message.swipeActionId = object.swipeActionId ?? '';
+    message.sessionId = object.sessionId ?? '';
+    message.petId = object.petId ?? '';
     message.userId = object.userId ?? undefined;
     message.action = object.action ?? 0;
-    message.timestamp = object.timestamp ?? "";
+    message.timestamp = object.timestamp ?? '';
     message.responseTime = object.responseTime ?? undefined;
     message.deviceType = object.deviceType ?? undefined;
     return message;
@@ -1250,23 +1291,23 @@ export const StartSessionRequest: MessageFns<StartSessionRequest> = {
       filtersJson: isSet(object.filtersJson)
         ? globalThis.String(object.filtersJson)
         : isSet(object.filters_json)
-        ? globalThis.String(object.filters_json)
-        : undefined,
+          ? globalThis.String(object.filters_json)
+          : undefined,
       deviceType: isSet(object.deviceType)
         ? deviceTypeFromJSON(object.deviceType)
         : isSet(object.device_type)
-        ? deviceTypeFromJSON(object.device_type)
-        : 0,
+          ? deviceTypeFromJSON(object.device_type)
+          : 0,
       userAgent: isSet(object.userAgent)
         ? globalThis.String(object.userAgent)
         : isSet(object.user_agent)
-        ? globalThis.String(object.user_agent)
-        : undefined,
+          ? globalThis.String(object.user_agent)
+          : undefined,
       ipAddress: isSet(object.ipAddress)
         ? globalThis.String(object.ipAddress)
         : isSet(object.ip_address)
-        ? globalThis.String(object.ip_address)
-        : undefined,
+          ? globalThis.String(object.ip_address)
+          : undefined,
     };
   },
 
@@ -1290,7 +1331,9 @@ export const StartSessionRequest: MessageFns<StartSessionRequest> = {
   create<I extends Exact<DeepPartial<StartSessionRequest>, I>>(base?: I): StartSessionRequest {
     return StartSessionRequest.fromPartial(base ?? ({} as any));
   },
-  fromPartial<I extends Exact<DeepPartial<StartSessionRequest>, I>>(object: I): StartSessionRequest {
+  fromPartial<I extends Exact<DeepPartial<StartSessionRequest>, I>>(
+    object: I
+  ): StartSessionRequest {
     const message = createBaseStartSessionRequest();
     message.filtersJson = object.filtersJson ?? undefined;
     message.deviceType = object.deviceType ?? 0;
@@ -1368,23 +1411,26 @@ export const StartSessionResponse: MessageFns<StartSessionResponse> = {
   create<I extends Exact<DeepPartial<StartSessionResponse>, I>>(base?: I): StartSessionResponse {
     return StartSessionResponse.fromPartial(base ?? ({} as any));
   },
-  fromPartial<I extends Exact<DeepPartial<StartSessionResponse>, I>>(object: I): StartSessionResponse {
+  fromPartial<I extends Exact<DeepPartial<StartSessionResponse>, I>>(
+    object: I
+  ): StartSessionResponse {
     const message = createBaseStartSessionResponse();
-    message.session = (object.session !== undefined && object.session !== null)
-      ? SwipeSession.fromPartial(object.session)
-      : undefined;
+    message.session =
+      object.session !== undefined && object.session !== null
+        ? SwipeSession.fromPartial(object.session)
+        : undefined;
     message.created = object.created ?? false;
     return message;
   },
 };
 
 function createBaseEndSessionRequest(): EndSessionRequest {
-  return { sessionId: "" };
+  return { sessionId: '' };
 }
 
 export const EndSessionRequest: MessageFns<EndSessionRequest> = {
   encode(message: EndSessionRequest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    if (message.sessionId !== "") {
+    if (message.sessionId !== '') {
       writer.uint32(10).string(message.sessionId);
     }
     return writer;
@@ -1419,14 +1465,14 @@ export const EndSessionRequest: MessageFns<EndSessionRequest> = {
       sessionId: isSet(object.sessionId)
         ? globalThis.String(object.sessionId)
         : isSet(object.session_id)
-        ? globalThis.String(object.session_id)
-        : "",
+          ? globalThis.String(object.session_id)
+          : '',
     };
   },
 
   toJSON(message: EndSessionRequest): unknown {
     const obj: any = {};
-    if (message.sessionId !== "") {
+    if (message.sessionId !== '') {
       obj.sessionId = message.sessionId;
     }
     return obj;
@@ -1437,7 +1483,7 @@ export const EndSessionRequest: MessageFns<EndSessionRequest> = {
   },
   fromPartial<I extends Exact<DeepPartial<EndSessionRequest>, I>>(object: I): EndSessionRequest {
     const message = createBaseEndSessionRequest();
-    message.sessionId = object.sessionId ?? "";
+    message.sessionId = object.sessionId ?? '';
     return message;
   },
 };
@@ -1495,20 +1541,21 @@ export const EndSessionResponse: MessageFns<EndSessionResponse> = {
   },
   fromPartial<I extends Exact<DeepPartial<EndSessionResponse>, I>>(object: I): EndSessionResponse {
     const message = createBaseEndSessionResponse();
-    message.session = (object.session !== undefined && object.session !== null)
-      ? SwipeSession.fromPartial(object.session)
-      : undefined;
+    message.session =
+      object.session !== undefined && object.session !== null
+        ? SwipeSession.fromPartial(object.session)
+        : undefined;
     return message;
   },
 };
 
 function createBaseRecommendRequest(): RecommendRequest {
-  return { sessionId: "", limit: 0, filtersJsonOverride: undefined };
+  return { sessionId: '', limit: 0, filtersJsonOverride: undefined };
 }
 
 export const RecommendRequest: MessageFns<RecommendRequest> = {
   encode(message: RecommendRequest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    if (message.sessionId !== "") {
+    if (message.sessionId !== '') {
       writer.uint32(10).string(message.sessionId);
     }
     if (message.limit !== 0) {
@@ -1565,20 +1612,20 @@ export const RecommendRequest: MessageFns<RecommendRequest> = {
       sessionId: isSet(object.sessionId)
         ? globalThis.String(object.sessionId)
         : isSet(object.session_id)
-        ? globalThis.String(object.session_id)
-        : "",
+          ? globalThis.String(object.session_id)
+          : '',
       limit: isSet(object.limit) ? globalThis.Number(object.limit) : 0,
       filtersJsonOverride: isSet(object.filtersJsonOverride)
         ? globalThis.String(object.filtersJsonOverride)
         : isSet(object.filters_json_override)
-        ? globalThis.String(object.filters_json_override)
-        : undefined,
+          ? globalThis.String(object.filters_json_override)
+          : undefined,
     };
   },
 
   toJSON(message: RecommendRequest): unknown {
     const obj: any = {};
-    if (message.sessionId !== "") {
+    if (message.sessionId !== '') {
       obj.sessionId = message.sessionId;
     }
     if (message.limit !== 0) {
@@ -1595,7 +1642,7 @@ export const RecommendRequest: MessageFns<RecommendRequest> = {
   },
   fromPartial<I extends Exact<DeepPartial<RecommendRequest>, I>>(object: I): RecommendRequest {
     const message = createBaseRecommendRequest();
-    message.sessionId = object.sessionId ?? "";
+    message.sessionId = object.sessionId ?? '';
     message.limit = object.limit ?? 0;
     message.filtersJsonOverride = object.filtersJsonOverride ?? undefined;
     return message;
@@ -1661,7 +1708,7 @@ export const RecommendResponse: MessageFns<RecommendResponse> = {
   toJSON(message: RecommendResponse): unknown {
     const obj: any = {};
     if (message.candidates?.length) {
-      obj.candidates = message.candidates.map((e) => PetCandidate.toJSON(e));
+      obj.candidates = message.candidates.map(e => PetCandidate.toJSON(e));
     }
     if (message.exhausted !== false) {
       obj.exhausted = message.exhausted;
@@ -1674,22 +1721,22 @@ export const RecommendResponse: MessageFns<RecommendResponse> = {
   },
   fromPartial<I extends Exact<DeepPartial<RecommendResponse>, I>>(object: I): RecommendResponse {
     const message = createBaseRecommendResponse();
-    message.candidates = object.candidates?.map((e) => PetCandidate.fromPartial(e)) || [];
+    message.candidates = object.candidates?.map(e => PetCandidate.fromPartial(e)) || [];
     message.exhausted = object.exhausted ?? false;
     return message;
   },
 };
 
 function createBaseRecordSwipeRequest(): RecordSwipeRequest {
-  return { sessionId: "", petId: "", action: 0, responseTime: undefined, deviceType: undefined };
+  return { sessionId: '', petId: '', action: 0, responseTime: undefined, deviceType: undefined };
 }
 
 export const RecordSwipeRequest: MessageFns<RecordSwipeRequest> = {
   encode(message: RecordSwipeRequest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    if (message.sessionId !== "") {
+    if (message.sessionId !== '') {
       writer.uint32(10).string(message.sessionId);
     }
-    if (message.petId !== "") {
+    if (message.petId !== '') {
       writer.uint32(18).string(message.petId);
     }
     if (message.action !== 0) {
@@ -1765,33 +1812,33 @@ export const RecordSwipeRequest: MessageFns<RecordSwipeRequest> = {
       sessionId: isSet(object.sessionId)
         ? globalThis.String(object.sessionId)
         : isSet(object.session_id)
-        ? globalThis.String(object.session_id)
-        : "",
+          ? globalThis.String(object.session_id)
+          : '',
       petId: isSet(object.petId)
         ? globalThis.String(object.petId)
         : isSet(object.pet_id)
-        ? globalThis.String(object.pet_id)
-        : "",
+          ? globalThis.String(object.pet_id)
+          : '',
       action: isSet(object.action) ? swipeActionFromJSON(object.action) : 0,
       responseTime: isSet(object.responseTime)
         ? globalThis.Number(object.responseTime)
         : isSet(object.response_time)
-        ? globalThis.Number(object.response_time)
-        : undefined,
+          ? globalThis.Number(object.response_time)
+          : undefined,
       deviceType: isSet(object.deviceType)
         ? globalThis.String(object.deviceType)
         : isSet(object.device_type)
-        ? globalThis.String(object.device_type)
-        : undefined,
+          ? globalThis.String(object.device_type)
+          : undefined,
     };
   },
 
   toJSON(message: RecordSwipeRequest): unknown {
     const obj: any = {};
-    if (message.sessionId !== "") {
+    if (message.sessionId !== '') {
       obj.sessionId = message.sessionId;
     }
-    if (message.petId !== "") {
+    if (message.petId !== '') {
       obj.petId = message.petId;
     }
     if (message.action !== 0) {
@@ -1811,8 +1858,8 @@ export const RecordSwipeRequest: MessageFns<RecordSwipeRequest> = {
   },
   fromPartial<I extends Exact<DeepPartial<RecordSwipeRequest>, I>>(object: I): RecordSwipeRequest {
     const message = createBaseRecordSwipeRequest();
-    message.sessionId = object.sessionId ?? "";
-    message.petId = object.petId ?? "";
+    message.sessionId = object.sessionId ?? '';
+    message.petId = object.petId ?? '';
     message.action = object.action ?? 0;
     message.responseTime = object.responseTime ?? undefined;
     message.deviceType = object.deviceType ?? undefined;
@@ -1888,14 +1935,18 @@ export const RecordSwipeResponse: MessageFns<RecordSwipeResponse> = {
   create<I extends Exact<DeepPartial<RecordSwipeResponse>, I>>(base?: I): RecordSwipeResponse {
     return RecordSwipeResponse.fromPartial(base ?? ({} as any));
   },
-  fromPartial<I extends Exact<DeepPartial<RecordSwipeResponse>, I>>(object: I): RecordSwipeResponse {
+  fromPartial<I extends Exact<DeepPartial<RecordSwipeResponse>, I>>(
+    object: I
+  ): RecordSwipeResponse {
     const message = createBaseRecordSwipeResponse();
-    message.action = (object.action !== undefined && object.action !== null)
-      ? SwipeActionRecord.fromPartial(object.action)
-      : undefined;
-    message.session = (object.session !== undefined && object.session !== null)
-      ? SwipeSession.fromPartial(object.session)
-      : undefined;
+    message.action =
+      object.action !== undefined && object.action !== null
+        ? SwipeActionRecord.fromPartial(object.action)
+        : undefined;
+    message.session =
+      object.session !== undefined && object.session !== null
+        ? SwipeSession.fromPartial(object.session)
+        : undefined;
     return message;
   },
 };
@@ -1975,8 +2026,8 @@ export const SearchPetsRequest: MessageFns<SearchPetsRequest> = {
       filtersJson: isSet(object.filtersJson)
         ? globalThis.String(object.filtersJson)
         : isSet(object.filters_json)
-        ? globalThis.String(object.filters_json)
-        : undefined,
+          ? globalThis.String(object.filters_json)
+          : undefined,
       cursor: isSet(object.cursor) ? globalThis.String(object.cursor) : undefined,
       limit: isSet(object.limit) ? globalThis.Number(object.limit) : 0,
     };
@@ -2067,15 +2118,15 @@ export const SearchPetsResponse: MessageFns<SearchPetsResponse> = {
       nextCursor: isSet(object.nextCursor)
         ? globalThis.String(object.nextCursor)
         : isSet(object.next_cursor)
-        ? globalThis.String(object.next_cursor)
-        : undefined,
+          ? globalThis.String(object.next_cursor)
+          : undefined,
     };
   },
 
   toJSON(message: SearchPetsResponse): unknown {
     const obj: any = {};
     if (message.results?.length) {
-      obj.results = message.results.map((e) => PetCandidate.toJSON(e));
+      obj.results = message.results.map(e => PetCandidate.toJSON(e));
     }
     if (message.nextCursor !== undefined) {
       obj.nextCursor = message.nextCursor;
@@ -2088,7 +2139,7 @@ export const SearchPetsResponse: MessageFns<SearchPetsResponse> = {
   },
   fromPartial<I extends Exact<DeepPartial<SearchPetsResponse>, I>>(object: I): SearchPetsResponse {
     const message = createBaseSearchPetsResponse();
-    message.results = object.results?.map((e) => PetCandidate.fromPartial(e)) || [];
+    message.results = object.results?.map(e => PetCandidate.fromPartial(e)) || [];
     message.nextCursor = object.nextCursor ?? undefined;
     return message;
   },
@@ -2099,7 +2150,10 @@ function createBaseListSwipeHistoryRequest(): ListSwipeHistoryRequest {
 }
 
 export const ListSwipeHistoryRequest: MessageFns<ListSwipeHistoryRequest> = {
-  encode(message: ListSwipeHistoryRequest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+  encode(
+    message: ListSwipeHistoryRequest,
+    writer: BinaryWriter = new BinaryWriter()
+  ): BinaryWriter {
     if (message.actionFilter !== undefined) {
       writer.uint32(8).int32(message.actionFilter);
     }
@@ -2157,8 +2211,8 @@ export const ListSwipeHistoryRequest: MessageFns<ListSwipeHistoryRequest> = {
       actionFilter: isSet(object.actionFilter)
         ? swipeActionFromJSON(object.actionFilter)
         : isSet(object.action_filter)
-        ? swipeActionFromJSON(object.action_filter)
-        : undefined,
+          ? swipeActionFromJSON(object.action_filter)
+          : undefined,
       cursor: isSet(object.cursor) ? globalThis.String(object.cursor) : undefined,
       limit: isSet(object.limit) ? globalThis.Number(object.limit) : 0,
     };
@@ -2178,10 +2232,14 @@ export const ListSwipeHistoryRequest: MessageFns<ListSwipeHistoryRequest> = {
     return obj;
   },
 
-  create<I extends Exact<DeepPartial<ListSwipeHistoryRequest>, I>>(base?: I): ListSwipeHistoryRequest {
+  create<I extends Exact<DeepPartial<ListSwipeHistoryRequest>, I>>(
+    base?: I
+  ): ListSwipeHistoryRequest {
     return ListSwipeHistoryRequest.fromPartial(base ?? ({} as any));
   },
-  fromPartial<I extends Exact<DeepPartial<ListSwipeHistoryRequest>, I>>(object: I): ListSwipeHistoryRequest {
+  fromPartial<I extends Exact<DeepPartial<ListSwipeHistoryRequest>, I>>(
+    object: I
+  ): ListSwipeHistoryRequest {
     const message = createBaseListSwipeHistoryRequest();
     message.actionFilter = object.actionFilter ?? undefined;
     message.cursor = object.cursor ?? undefined;
@@ -2195,7 +2253,10 @@ function createBaseListSwipeHistoryResponse(): ListSwipeHistoryResponse {
 }
 
 export const ListSwipeHistoryResponse: MessageFns<ListSwipeHistoryResponse> = {
-  encode(message: ListSwipeHistoryResponse, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+  encode(
+    message: ListSwipeHistoryResponse,
+    writer: BinaryWriter = new BinaryWriter()
+  ): BinaryWriter {
     for (const v of message.actions) {
       SwipeActionRecord.encode(v!, writer.uint32(10).fork()).join();
     }
@@ -2245,15 +2306,15 @@ export const ListSwipeHistoryResponse: MessageFns<ListSwipeHistoryResponse> = {
       nextCursor: isSet(object.nextCursor)
         ? globalThis.String(object.nextCursor)
         : isSet(object.next_cursor)
-        ? globalThis.String(object.next_cursor)
-        : undefined,
+          ? globalThis.String(object.next_cursor)
+          : undefined,
     };
   },
 
   toJSON(message: ListSwipeHistoryResponse): unknown {
     const obj: any = {};
     if (message.actions?.length) {
-      obj.actions = message.actions.map((e) => SwipeActionRecord.toJSON(e));
+      obj.actions = message.actions.map(e => SwipeActionRecord.toJSON(e));
     }
     if (message.nextCursor !== undefined) {
       obj.nextCursor = message.nextCursor;
@@ -2261,12 +2322,16 @@ export const ListSwipeHistoryResponse: MessageFns<ListSwipeHistoryResponse> = {
     return obj;
   },
 
-  create<I extends Exact<DeepPartial<ListSwipeHistoryResponse>, I>>(base?: I): ListSwipeHistoryResponse {
+  create<I extends Exact<DeepPartial<ListSwipeHistoryResponse>, I>>(
+    base?: I
+  ): ListSwipeHistoryResponse {
     return ListSwipeHistoryResponse.fromPartial(base ?? ({} as any));
   },
-  fromPartial<I extends Exact<DeepPartial<ListSwipeHistoryResponse>, I>>(object: I): ListSwipeHistoryResponse {
+  fromPartial<I extends Exact<DeepPartial<ListSwipeHistoryResponse>, I>>(
+    object: I
+  ): ListSwipeHistoryResponse {
     const message = createBaseListSwipeHistoryResponse();
-    message.actions = object.actions?.map((e) => SwipeActionRecord.fromPartial(e)) || [];
+    message.actions = object.actions?.map(e => SwipeActionRecord.fromPartial(e)) || [];
     message.nextCursor = object.nextCursor ?? undefined;
     return message;
   },
@@ -2274,47 +2339,47 @@ export const ListSwipeHistoryResponse: MessageFns<ListSwipeHistoryResponse> = {
 
 function createBaseMatchProfile(): MatchProfile {
   return {
-    userId: "",
-    preferredTypesJson: "",
-    preferredSizesJson: "",
-    preferredAgeGroupsJson: "",
-    preferredEnergyJson: "",
-    preferredTemperamentJson: "",
-    lifestyleJson: "",
+    userId: '',
+    preferredTypesJson: '',
+    preferredSizesJson: '',
+    preferredAgeGroupsJson: '',
+    preferredEnergyJson: '',
+    preferredTemperamentJson: '',
+    lifestyleJson: '',
     maxDistanceKm: undefined,
     openToSpecialNeeds: false,
     notifyNewMatches: false,
     minNotificationScore: 0,
     lastNotifiedAt: undefined,
-    inferredPrefsJson: "",
+    inferredPrefsJson: '',
     prefsUpdatedAt: undefined,
     allergies: undefined,
-    createdAt: "",
-    updatedAt: "",
+    createdAt: '',
+    updatedAt: '',
   };
 }
 
 export const MatchProfile: MessageFns<MatchProfile> = {
   encode(message: MatchProfile, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    if (message.userId !== "") {
+    if (message.userId !== '') {
       writer.uint32(10).string(message.userId);
     }
-    if (message.preferredTypesJson !== "") {
+    if (message.preferredTypesJson !== '') {
       writer.uint32(18).string(message.preferredTypesJson);
     }
-    if (message.preferredSizesJson !== "") {
+    if (message.preferredSizesJson !== '') {
       writer.uint32(26).string(message.preferredSizesJson);
     }
-    if (message.preferredAgeGroupsJson !== "") {
+    if (message.preferredAgeGroupsJson !== '') {
       writer.uint32(34).string(message.preferredAgeGroupsJson);
     }
-    if (message.preferredEnergyJson !== "") {
+    if (message.preferredEnergyJson !== '') {
       writer.uint32(42).string(message.preferredEnergyJson);
     }
-    if (message.preferredTemperamentJson !== "") {
+    if (message.preferredTemperamentJson !== '') {
       writer.uint32(50).string(message.preferredTemperamentJson);
     }
-    if (message.lifestyleJson !== "") {
+    if (message.lifestyleJson !== '') {
       writer.uint32(58).string(message.lifestyleJson);
     }
     if (message.maxDistanceKm !== undefined) {
@@ -2332,7 +2397,7 @@ export const MatchProfile: MessageFns<MatchProfile> = {
     if (message.lastNotifiedAt !== undefined) {
       writer.uint32(98).string(message.lastNotifiedAt);
     }
-    if (message.inferredPrefsJson !== "") {
+    if (message.inferredPrefsJson !== '') {
       writer.uint32(106).string(message.inferredPrefsJson);
     }
     if (message.prefsUpdatedAt !== undefined) {
@@ -2341,10 +2406,10 @@ export const MatchProfile: MessageFns<MatchProfile> = {
     if (message.allergies !== undefined) {
       writer.uint32(122).string(message.allergies);
     }
-    if (message.createdAt !== "") {
+    if (message.createdAt !== '') {
       writer.uint32(130).string(message.createdAt);
     }
-    if (message.updatedAt !== "") {
+    if (message.updatedAt !== '') {
       writer.uint32(138).string(message.updatedAt);
     }
     return writer;
@@ -2507,108 +2572,108 @@ export const MatchProfile: MessageFns<MatchProfile> = {
       userId: isSet(object.userId)
         ? globalThis.String(object.userId)
         : isSet(object.user_id)
-        ? globalThis.String(object.user_id)
-        : "",
+          ? globalThis.String(object.user_id)
+          : '',
       preferredTypesJson: isSet(object.preferredTypesJson)
         ? globalThis.String(object.preferredTypesJson)
         : isSet(object.preferred_types_json)
-        ? globalThis.String(object.preferred_types_json)
-        : "",
+          ? globalThis.String(object.preferred_types_json)
+          : '',
       preferredSizesJson: isSet(object.preferredSizesJson)
         ? globalThis.String(object.preferredSizesJson)
         : isSet(object.preferred_sizes_json)
-        ? globalThis.String(object.preferred_sizes_json)
-        : "",
+          ? globalThis.String(object.preferred_sizes_json)
+          : '',
       preferredAgeGroupsJson: isSet(object.preferredAgeGroupsJson)
         ? globalThis.String(object.preferredAgeGroupsJson)
         : isSet(object.preferred_age_groups_json)
-        ? globalThis.String(object.preferred_age_groups_json)
-        : "",
+          ? globalThis.String(object.preferred_age_groups_json)
+          : '',
       preferredEnergyJson: isSet(object.preferredEnergyJson)
         ? globalThis.String(object.preferredEnergyJson)
         : isSet(object.preferred_energy_json)
-        ? globalThis.String(object.preferred_energy_json)
-        : "",
+          ? globalThis.String(object.preferred_energy_json)
+          : '',
       preferredTemperamentJson: isSet(object.preferredTemperamentJson)
         ? globalThis.String(object.preferredTemperamentJson)
         : isSet(object.preferred_temperament_json)
-        ? globalThis.String(object.preferred_temperament_json)
-        : "",
+          ? globalThis.String(object.preferred_temperament_json)
+          : '',
       lifestyleJson: isSet(object.lifestyleJson)
         ? globalThis.String(object.lifestyleJson)
         : isSet(object.lifestyle_json)
-        ? globalThis.String(object.lifestyle_json)
-        : "",
+          ? globalThis.String(object.lifestyle_json)
+          : '',
       maxDistanceKm: isSet(object.maxDistanceKm)
         ? globalThis.Number(object.maxDistanceKm)
         : isSet(object.max_distance_km)
-        ? globalThis.Number(object.max_distance_km)
-        : undefined,
+          ? globalThis.Number(object.max_distance_km)
+          : undefined,
       openToSpecialNeeds: isSet(object.openToSpecialNeeds)
         ? globalThis.Boolean(object.openToSpecialNeeds)
         : isSet(object.open_to_special_needs)
-        ? globalThis.Boolean(object.open_to_special_needs)
-        : false,
+          ? globalThis.Boolean(object.open_to_special_needs)
+          : false,
       notifyNewMatches: isSet(object.notifyNewMatches)
         ? globalThis.Boolean(object.notifyNewMatches)
         : isSet(object.notify_new_matches)
-        ? globalThis.Boolean(object.notify_new_matches)
-        : false,
+          ? globalThis.Boolean(object.notify_new_matches)
+          : false,
       minNotificationScore: isSet(object.minNotificationScore)
         ? globalThis.Number(object.minNotificationScore)
         : isSet(object.min_notification_score)
-        ? globalThis.Number(object.min_notification_score)
-        : 0,
+          ? globalThis.Number(object.min_notification_score)
+          : 0,
       lastNotifiedAt: isSet(object.lastNotifiedAt)
         ? globalThis.String(object.lastNotifiedAt)
         : isSet(object.last_notified_at)
-        ? globalThis.String(object.last_notified_at)
-        : undefined,
+          ? globalThis.String(object.last_notified_at)
+          : undefined,
       inferredPrefsJson: isSet(object.inferredPrefsJson)
         ? globalThis.String(object.inferredPrefsJson)
         : isSet(object.inferred_prefs_json)
-        ? globalThis.String(object.inferred_prefs_json)
-        : "",
+          ? globalThis.String(object.inferred_prefs_json)
+          : '',
       prefsUpdatedAt: isSet(object.prefsUpdatedAt)
         ? globalThis.String(object.prefsUpdatedAt)
         : isSet(object.prefs_updated_at)
-        ? globalThis.String(object.prefs_updated_at)
-        : undefined,
+          ? globalThis.String(object.prefs_updated_at)
+          : undefined,
       allergies: isSet(object.allergies) ? globalThis.String(object.allergies) : undefined,
       createdAt: isSet(object.createdAt)
         ? globalThis.String(object.createdAt)
         : isSet(object.created_at)
-        ? globalThis.String(object.created_at)
-        : "",
+          ? globalThis.String(object.created_at)
+          : '',
       updatedAt: isSet(object.updatedAt)
         ? globalThis.String(object.updatedAt)
         : isSet(object.updated_at)
-        ? globalThis.String(object.updated_at)
-        : "",
+          ? globalThis.String(object.updated_at)
+          : '',
     };
   },
 
   toJSON(message: MatchProfile): unknown {
     const obj: any = {};
-    if (message.userId !== "") {
+    if (message.userId !== '') {
       obj.userId = message.userId;
     }
-    if (message.preferredTypesJson !== "") {
+    if (message.preferredTypesJson !== '') {
       obj.preferredTypesJson = message.preferredTypesJson;
     }
-    if (message.preferredSizesJson !== "") {
+    if (message.preferredSizesJson !== '') {
       obj.preferredSizesJson = message.preferredSizesJson;
     }
-    if (message.preferredAgeGroupsJson !== "") {
+    if (message.preferredAgeGroupsJson !== '') {
       obj.preferredAgeGroupsJson = message.preferredAgeGroupsJson;
     }
-    if (message.preferredEnergyJson !== "") {
+    if (message.preferredEnergyJson !== '') {
       obj.preferredEnergyJson = message.preferredEnergyJson;
     }
-    if (message.preferredTemperamentJson !== "") {
+    if (message.preferredTemperamentJson !== '') {
       obj.preferredTemperamentJson = message.preferredTemperamentJson;
     }
-    if (message.lifestyleJson !== "") {
+    if (message.lifestyleJson !== '') {
       obj.lifestyleJson = message.lifestyleJson;
     }
     if (message.maxDistanceKm !== undefined) {
@@ -2626,7 +2691,7 @@ export const MatchProfile: MessageFns<MatchProfile> = {
     if (message.lastNotifiedAt !== undefined) {
       obj.lastNotifiedAt = message.lastNotifiedAt;
     }
-    if (message.inferredPrefsJson !== "") {
+    if (message.inferredPrefsJson !== '') {
       obj.inferredPrefsJson = message.inferredPrefsJson;
     }
     if (message.prefsUpdatedAt !== undefined) {
@@ -2635,10 +2700,10 @@ export const MatchProfile: MessageFns<MatchProfile> = {
     if (message.allergies !== undefined) {
       obj.allergies = message.allergies;
     }
-    if (message.createdAt !== "") {
+    if (message.createdAt !== '') {
       obj.createdAt = message.createdAt;
     }
-    if (message.updatedAt !== "") {
+    if (message.updatedAt !== '') {
       obj.updatedAt = message.updatedAt;
     }
     return obj;
@@ -2649,23 +2714,23 @@ export const MatchProfile: MessageFns<MatchProfile> = {
   },
   fromPartial<I extends Exact<DeepPartial<MatchProfile>, I>>(object: I): MatchProfile {
     const message = createBaseMatchProfile();
-    message.userId = object.userId ?? "";
-    message.preferredTypesJson = object.preferredTypesJson ?? "";
-    message.preferredSizesJson = object.preferredSizesJson ?? "";
-    message.preferredAgeGroupsJson = object.preferredAgeGroupsJson ?? "";
-    message.preferredEnergyJson = object.preferredEnergyJson ?? "";
-    message.preferredTemperamentJson = object.preferredTemperamentJson ?? "";
-    message.lifestyleJson = object.lifestyleJson ?? "";
+    message.userId = object.userId ?? '';
+    message.preferredTypesJson = object.preferredTypesJson ?? '';
+    message.preferredSizesJson = object.preferredSizesJson ?? '';
+    message.preferredAgeGroupsJson = object.preferredAgeGroupsJson ?? '';
+    message.preferredEnergyJson = object.preferredEnergyJson ?? '';
+    message.preferredTemperamentJson = object.preferredTemperamentJson ?? '';
+    message.lifestyleJson = object.lifestyleJson ?? '';
     message.maxDistanceKm = object.maxDistanceKm ?? undefined;
     message.openToSpecialNeeds = object.openToSpecialNeeds ?? false;
     message.notifyNewMatches = object.notifyNewMatches ?? false;
     message.minNotificationScore = object.minNotificationScore ?? 0;
     message.lastNotifiedAt = object.lastNotifiedAt ?? undefined;
-    message.inferredPrefsJson = object.inferredPrefsJson ?? "";
+    message.inferredPrefsJson = object.inferredPrefsJson ?? '';
     message.prefsUpdatedAt = object.prefsUpdatedAt ?? undefined;
     message.allergies = object.allergies ?? undefined;
-    message.createdAt = object.createdAt ?? "";
-    message.updatedAt = object.updatedAt ?? "";
+    message.createdAt = object.createdAt ?? '';
+    message.updatedAt = object.updatedAt ?? '';
     return message;
   },
 };
@@ -2704,10 +2769,14 @@ export const GetMatchProfileRequest: MessageFns<GetMatchProfileRequest> = {
     return obj;
   },
 
-  create<I extends Exact<DeepPartial<GetMatchProfileRequest>, I>>(base?: I): GetMatchProfileRequest {
+  create<I extends Exact<DeepPartial<GetMatchProfileRequest>, I>>(
+    base?: I
+  ): GetMatchProfileRequest {
     return GetMatchProfileRequest.fromPartial(base ?? ({} as any));
   },
-  fromPartial<I extends Exact<DeepPartial<GetMatchProfileRequest>, I>>(_: I): GetMatchProfileRequest {
+  fromPartial<I extends Exact<DeepPartial<GetMatchProfileRequest>, I>>(
+    _: I
+  ): GetMatchProfileRequest {
     const message = createBaseGetMatchProfileRequest();
     return message;
   },
@@ -2718,7 +2787,10 @@ function createBaseGetMatchProfileResponse(): GetMatchProfileResponse {
 }
 
 export const GetMatchProfileResponse: MessageFns<GetMatchProfileResponse> = {
-  encode(message: GetMatchProfileResponse, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+  encode(
+    message: GetMatchProfileResponse,
+    writer: BinaryWriter = new BinaryWriter()
+  ): BinaryWriter {
     if (message.profile !== undefined) {
       MatchProfile.encode(message.profile, writer.uint32(10).fork()).join();
     }
@@ -2761,31 +2833,36 @@ export const GetMatchProfileResponse: MessageFns<GetMatchProfileResponse> = {
     return obj;
   },
 
-  create<I extends Exact<DeepPartial<GetMatchProfileResponse>, I>>(base?: I): GetMatchProfileResponse {
+  create<I extends Exact<DeepPartial<GetMatchProfileResponse>, I>>(
+    base?: I
+  ): GetMatchProfileResponse {
     return GetMatchProfileResponse.fromPartial(base ?? ({} as any));
   },
-  fromPartial<I extends Exact<DeepPartial<GetMatchProfileResponse>, I>>(object: I): GetMatchProfileResponse {
+  fromPartial<I extends Exact<DeepPartial<GetMatchProfileResponse>, I>>(
+    object: I
+  ): GetMatchProfileResponse {
     const message = createBaseGetMatchProfileResponse();
-    message.profile = (object.profile !== undefined && object.profile !== null)
-      ? MatchProfile.fromPartial(object.profile)
-      : undefined;
+    message.profile =
+      object.profile !== undefined && object.profile !== null
+        ? MatchProfile.fromPartial(object.profile)
+        : undefined;
     return message;
   },
 };
 
 function createBaseUpsertMatchProfileRequest(): UpsertMatchProfileRequest {
   return {
-    preferredTypesJson: "",
+    preferredTypesJson: '',
     setPreferredTypes: false,
-    preferredSizesJson: "",
+    preferredSizesJson: '',
     setPreferredSizes: false,
-    preferredAgeGroupsJson: "",
+    preferredAgeGroupsJson: '',
     setPreferredAgeGroups: false,
-    preferredEnergyJson: "",
+    preferredEnergyJson: '',
     setPreferredEnergy: false,
-    preferredTemperamentJson: "",
+    preferredTemperamentJson: '',
     setPreferredTemperament: false,
-    lifestyleJson: "",
+    lifestyleJson: '',
     setLifestyle: false,
     maxDistanceKm: undefined,
     openToSpecialNeeds: undefined,
@@ -2797,38 +2874,41 @@ function createBaseUpsertMatchProfileRequest(): UpsertMatchProfileRequest {
 }
 
 export const UpsertMatchProfileRequest: MessageFns<UpsertMatchProfileRequest> = {
-  encode(message: UpsertMatchProfileRequest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    if (message.preferredTypesJson !== "") {
+  encode(
+    message: UpsertMatchProfileRequest,
+    writer: BinaryWriter = new BinaryWriter()
+  ): BinaryWriter {
+    if (message.preferredTypesJson !== '') {
       writer.uint32(10).string(message.preferredTypesJson);
     }
     if (message.setPreferredTypes !== false) {
       writer.uint32(16).bool(message.setPreferredTypes);
     }
-    if (message.preferredSizesJson !== "") {
+    if (message.preferredSizesJson !== '') {
       writer.uint32(26).string(message.preferredSizesJson);
     }
     if (message.setPreferredSizes !== false) {
       writer.uint32(32).bool(message.setPreferredSizes);
     }
-    if (message.preferredAgeGroupsJson !== "") {
+    if (message.preferredAgeGroupsJson !== '') {
       writer.uint32(42).string(message.preferredAgeGroupsJson);
     }
     if (message.setPreferredAgeGroups !== false) {
       writer.uint32(48).bool(message.setPreferredAgeGroups);
     }
-    if (message.preferredEnergyJson !== "") {
+    if (message.preferredEnergyJson !== '') {
       writer.uint32(58).string(message.preferredEnergyJson);
     }
     if (message.setPreferredEnergy !== false) {
       writer.uint32(64).bool(message.setPreferredEnergy);
     }
-    if (message.preferredTemperamentJson !== "") {
+    if (message.preferredTemperamentJson !== '') {
       writer.uint32(74).string(message.preferredTemperamentJson);
     }
     if (message.setPreferredTemperament !== false) {
       writer.uint32(80).bool(message.setPreferredTemperament);
     }
-    if (message.lifestyleJson !== "") {
+    if (message.lifestyleJson !== '') {
       writer.uint32(90).string(message.lifestyleJson);
     }
     if (message.setLifestyle !== false) {
@@ -3020,125 +3100,125 @@ export const UpsertMatchProfileRequest: MessageFns<UpsertMatchProfileRequest> = 
       preferredTypesJson: isSet(object.preferredTypesJson)
         ? globalThis.String(object.preferredTypesJson)
         : isSet(object.preferred_types_json)
-        ? globalThis.String(object.preferred_types_json)
-        : "",
+          ? globalThis.String(object.preferred_types_json)
+          : '',
       setPreferredTypes: isSet(object.setPreferredTypes)
         ? globalThis.Boolean(object.setPreferredTypes)
         : isSet(object.set_preferred_types)
-        ? globalThis.Boolean(object.set_preferred_types)
-        : false,
+          ? globalThis.Boolean(object.set_preferred_types)
+          : false,
       preferredSizesJson: isSet(object.preferredSizesJson)
         ? globalThis.String(object.preferredSizesJson)
         : isSet(object.preferred_sizes_json)
-        ? globalThis.String(object.preferred_sizes_json)
-        : "",
+          ? globalThis.String(object.preferred_sizes_json)
+          : '',
       setPreferredSizes: isSet(object.setPreferredSizes)
         ? globalThis.Boolean(object.setPreferredSizes)
         : isSet(object.set_preferred_sizes)
-        ? globalThis.Boolean(object.set_preferred_sizes)
-        : false,
+          ? globalThis.Boolean(object.set_preferred_sizes)
+          : false,
       preferredAgeGroupsJson: isSet(object.preferredAgeGroupsJson)
         ? globalThis.String(object.preferredAgeGroupsJson)
         : isSet(object.preferred_age_groups_json)
-        ? globalThis.String(object.preferred_age_groups_json)
-        : "",
+          ? globalThis.String(object.preferred_age_groups_json)
+          : '',
       setPreferredAgeGroups: isSet(object.setPreferredAgeGroups)
         ? globalThis.Boolean(object.setPreferredAgeGroups)
         : isSet(object.set_preferred_age_groups)
-        ? globalThis.Boolean(object.set_preferred_age_groups)
-        : false,
+          ? globalThis.Boolean(object.set_preferred_age_groups)
+          : false,
       preferredEnergyJson: isSet(object.preferredEnergyJson)
         ? globalThis.String(object.preferredEnergyJson)
         : isSet(object.preferred_energy_json)
-        ? globalThis.String(object.preferred_energy_json)
-        : "",
+          ? globalThis.String(object.preferred_energy_json)
+          : '',
       setPreferredEnergy: isSet(object.setPreferredEnergy)
         ? globalThis.Boolean(object.setPreferredEnergy)
         : isSet(object.set_preferred_energy)
-        ? globalThis.Boolean(object.set_preferred_energy)
-        : false,
+          ? globalThis.Boolean(object.set_preferred_energy)
+          : false,
       preferredTemperamentJson: isSet(object.preferredTemperamentJson)
         ? globalThis.String(object.preferredTemperamentJson)
         : isSet(object.preferred_temperament_json)
-        ? globalThis.String(object.preferred_temperament_json)
-        : "",
+          ? globalThis.String(object.preferred_temperament_json)
+          : '',
       setPreferredTemperament: isSet(object.setPreferredTemperament)
         ? globalThis.Boolean(object.setPreferredTemperament)
         : isSet(object.set_preferred_temperament)
-        ? globalThis.Boolean(object.set_preferred_temperament)
-        : false,
+          ? globalThis.Boolean(object.set_preferred_temperament)
+          : false,
       lifestyleJson: isSet(object.lifestyleJson)
         ? globalThis.String(object.lifestyleJson)
         : isSet(object.lifestyle_json)
-        ? globalThis.String(object.lifestyle_json)
-        : "",
+          ? globalThis.String(object.lifestyle_json)
+          : '',
       setLifestyle: isSet(object.setLifestyle)
         ? globalThis.Boolean(object.setLifestyle)
         : isSet(object.set_lifestyle)
-        ? globalThis.Boolean(object.set_lifestyle)
-        : false,
+          ? globalThis.Boolean(object.set_lifestyle)
+          : false,
       maxDistanceKm: isSet(object.maxDistanceKm)
         ? globalThis.Number(object.maxDistanceKm)
         : isSet(object.max_distance_km)
-        ? globalThis.Number(object.max_distance_km)
-        : undefined,
+          ? globalThis.Number(object.max_distance_km)
+          : undefined,
       openToSpecialNeeds: isSet(object.openToSpecialNeeds)
         ? globalThis.Boolean(object.openToSpecialNeeds)
         : isSet(object.open_to_special_needs)
-        ? globalThis.Boolean(object.open_to_special_needs)
-        : undefined,
+          ? globalThis.Boolean(object.open_to_special_needs)
+          : undefined,
       notifyNewMatches: isSet(object.notifyNewMatches)
         ? globalThis.Boolean(object.notifyNewMatches)
         : isSet(object.notify_new_matches)
-        ? globalThis.Boolean(object.notify_new_matches)
-        : undefined,
+          ? globalThis.Boolean(object.notify_new_matches)
+          : undefined,
       minNotificationScore: isSet(object.minNotificationScore)
         ? globalThis.Number(object.minNotificationScore)
         : isSet(object.min_notification_score)
-        ? globalThis.Number(object.min_notification_score)
-        : undefined,
+          ? globalThis.Number(object.min_notification_score)
+          : undefined,
       allergies: isSet(object.allergies) ? globalThis.String(object.allergies) : undefined,
       setAllergies: isSet(object.setAllergies)
         ? globalThis.Boolean(object.setAllergies)
         : isSet(object.set_allergies)
-        ? globalThis.Boolean(object.set_allergies)
-        : false,
+          ? globalThis.Boolean(object.set_allergies)
+          : false,
     };
   },
 
   toJSON(message: UpsertMatchProfileRequest): unknown {
     const obj: any = {};
-    if (message.preferredTypesJson !== "") {
+    if (message.preferredTypesJson !== '') {
       obj.preferredTypesJson = message.preferredTypesJson;
     }
     if (message.setPreferredTypes !== false) {
       obj.setPreferredTypes = message.setPreferredTypes;
     }
-    if (message.preferredSizesJson !== "") {
+    if (message.preferredSizesJson !== '') {
       obj.preferredSizesJson = message.preferredSizesJson;
     }
     if (message.setPreferredSizes !== false) {
       obj.setPreferredSizes = message.setPreferredSizes;
     }
-    if (message.preferredAgeGroupsJson !== "") {
+    if (message.preferredAgeGroupsJson !== '') {
       obj.preferredAgeGroupsJson = message.preferredAgeGroupsJson;
     }
     if (message.setPreferredAgeGroups !== false) {
       obj.setPreferredAgeGroups = message.setPreferredAgeGroups;
     }
-    if (message.preferredEnergyJson !== "") {
+    if (message.preferredEnergyJson !== '') {
       obj.preferredEnergyJson = message.preferredEnergyJson;
     }
     if (message.setPreferredEnergy !== false) {
       obj.setPreferredEnergy = message.setPreferredEnergy;
     }
-    if (message.preferredTemperamentJson !== "") {
+    if (message.preferredTemperamentJson !== '') {
       obj.preferredTemperamentJson = message.preferredTemperamentJson;
     }
     if (message.setPreferredTemperament !== false) {
       obj.setPreferredTemperament = message.setPreferredTemperament;
     }
-    if (message.lifestyleJson !== "") {
+    if (message.lifestyleJson !== '') {
       obj.lifestyleJson = message.lifestyleJson;
     }
     if (message.setLifestyle !== false) {
@@ -3165,22 +3245,26 @@ export const UpsertMatchProfileRequest: MessageFns<UpsertMatchProfileRequest> = 
     return obj;
   },
 
-  create<I extends Exact<DeepPartial<UpsertMatchProfileRequest>, I>>(base?: I): UpsertMatchProfileRequest {
+  create<I extends Exact<DeepPartial<UpsertMatchProfileRequest>, I>>(
+    base?: I
+  ): UpsertMatchProfileRequest {
     return UpsertMatchProfileRequest.fromPartial(base ?? ({} as any));
   },
-  fromPartial<I extends Exact<DeepPartial<UpsertMatchProfileRequest>, I>>(object: I): UpsertMatchProfileRequest {
+  fromPartial<I extends Exact<DeepPartial<UpsertMatchProfileRequest>, I>>(
+    object: I
+  ): UpsertMatchProfileRequest {
     const message = createBaseUpsertMatchProfileRequest();
-    message.preferredTypesJson = object.preferredTypesJson ?? "";
+    message.preferredTypesJson = object.preferredTypesJson ?? '';
     message.setPreferredTypes = object.setPreferredTypes ?? false;
-    message.preferredSizesJson = object.preferredSizesJson ?? "";
+    message.preferredSizesJson = object.preferredSizesJson ?? '';
     message.setPreferredSizes = object.setPreferredSizes ?? false;
-    message.preferredAgeGroupsJson = object.preferredAgeGroupsJson ?? "";
+    message.preferredAgeGroupsJson = object.preferredAgeGroupsJson ?? '';
     message.setPreferredAgeGroups = object.setPreferredAgeGroups ?? false;
-    message.preferredEnergyJson = object.preferredEnergyJson ?? "";
+    message.preferredEnergyJson = object.preferredEnergyJson ?? '';
     message.setPreferredEnergy = object.setPreferredEnergy ?? false;
-    message.preferredTemperamentJson = object.preferredTemperamentJson ?? "";
+    message.preferredTemperamentJson = object.preferredTemperamentJson ?? '';
     message.setPreferredTemperament = object.setPreferredTemperament ?? false;
-    message.lifestyleJson = object.lifestyleJson ?? "";
+    message.lifestyleJson = object.lifestyleJson ?? '';
     message.setLifestyle = object.setLifestyle ?? false;
     message.maxDistanceKm = object.maxDistanceKm ?? undefined;
     message.openToSpecialNeeds = object.openToSpecialNeeds ?? undefined;
@@ -3197,7 +3281,10 @@ function createBaseUpsertMatchProfileResponse(): UpsertMatchProfileResponse {
 }
 
 export const UpsertMatchProfileResponse: MessageFns<UpsertMatchProfileResponse> = {
-  encode(message: UpsertMatchProfileResponse, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+  encode(
+    message: UpsertMatchProfileResponse,
+    writer: BinaryWriter = new BinaryWriter()
+  ): BinaryWriter {
     if (message.profile !== undefined) {
       MatchProfile.encode(message.profile, writer.uint32(10).fork()).join();
     }
@@ -3240,14 +3327,454 @@ export const UpsertMatchProfileResponse: MessageFns<UpsertMatchProfileResponse> 
     return obj;
   },
 
-  create<I extends Exact<DeepPartial<UpsertMatchProfileResponse>, I>>(base?: I): UpsertMatchProfileResponse {
+  create<I extends Exact<DeepPartial<UpsertMatchProfileResponse>, I>>(
+    base?: I
+  ): UpsertMatchProfileResponse {
     return UpsertMatchProfileResponse.fromPartial(base ?? ({} as any));
   },
-  fromPartial<I extends Exact<DeepPartial<UpsertMatchProfileResponse>, I>>(object: I): UpsertMatchProfileResponse {
+  fromPartial<I extends Exact<DeepPartial<UpsertMatchProfileResponse>, I>>(
+    object: I
+  ): UpsertMatchProfileResponse {
     const message = createBaseUpsertMatchProfileResponse();
-    message.profile = (object.profile !== undefined && object.profile !== null)
-      ? MatchProfile.fromPartial(object.profile)
-      : undefined;
+    message.profile =
+      object.profile !== undefined && object.profile !== null
+        ? MatchProfile.fromPartial(object.profile)
+        : undefined;
+    return message;
+  },
+};
+
+function createBaseTopPickReasonChip(): TopPickReasonChip {
+  return { kind: '', label: '' };
+}
+
+export const TopPickReasonChip: MessageFns<TopPickReasonChip> = {
+  encode(message: TopPickReasonChip, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+    if (message.kind !== '') {
+      writer.uint32(10).string(message.kind);
+    }
+    if (message.label !== '') {
+      writer.uint32(18).string(message.label);
+    }
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): TopPickReasonChip {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseTopPickReasonChip();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1: {
+          if (tag !== 10) {
+            break;
+          }
+
+          message.kind = reader.string();
+          continue;
+        }
+        case 2: {
+          if (tag !== 18) {
+            break;
+          }
+
+          message.label = reader.string();
+          continue;
+        }
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): TopPickReasonChip {
+    return {
+      kind: isSet(object.kind) ? globalThis.String(object.kind) : '',
+      label: isSet(object.label) ? globalThis.String(object.label) : '',
+    };
+  },
+
+  toJSON(message: TopPickReasonChip): unknown {
+    const obj: any = {};
+    if (message.kind !== '') {
+      obj.kind = message.kind;
+    }
+    if (message.label !== '') {
+      obj.label = message.label;
+    }
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<TopPickReasonChip>, I>>(base?: I): TopPickReasonChip {
+    return TopPickReasonChip.fromPartial(base ?? ({} as any));
+  },
+  fromPartial<I extends Exact<DeepPartial<TopPickReasonChip>, I>>(object: I): TopPickReasonChip {
+    const message = createBaseTopPickReasonChip();
+    message.kind = object.kind ?? '';
+    message.label = object.label ?? '';
+    return message;
+  },
+};
+
+function createBaseTopPick(): TopPick {
+  return {
+    petId: '',
+    name: '',
+    type: '',
+    ageGroup: '',
+    size: '',
+    score: 0,
+    reasons: [],
+    rescueName: '',
+    breedName: undefined,
+    photoUrl: undefined,
+  };
+}
+
+export const TopPick: MessageFns<TopPick> = {
+  encode(message: TopPick, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+    if (message.petId !== '') {
+      writer.uint32(10).string(message.petId);
+    }
+    if (message.name !== '') {
+      writer.uint32(18).string(message.name);
+    }
+    if (message.type !== '') {
+      writer.uint32(26).string(message.type);
+    }
+    if (message.ageGroup !== '') {
+      writer.uint32(34).string(message.ageGroup);
+    }
+    if (message.size !== '') {
+      writer.uint32(42).string(message.size);
+    }
+    if (message.score !== 0) {
+      writer.uint32(53).float(message.score);
+    }
+    for (const v of message.reasons) {
+      TopPickReasonChip.encode(v!, writer.uint32(58).fork()).join();
+    }
+    if (message.rescueName !== '') {
+      writer.uint32(66).string(message.rescueName);
+    }
+    if (message.breedName !== undefined) {
+      writer.uint32(74).string(message.breedName);
+    }
+    if (message.photoUrl !== undefined) {
+      writer.uint32(82).string(message.photoUrl);
+    }
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): TopPick {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseTopPick();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1: {
+          if (tag !== 10) {
+            break;
+          }
+
+          message.petId = reader.string();
+          continue;
+        }
+        case 2: {
+          if (tag !== 18) {
+            break;
+          }
+
+          message.name = reader.string();
+          continue;
+        }
+        case 3: {
+          if (tag !== 26) {
+            break;
+          }
+
+          message.type = reader.string();
+          continue;
+        }
+        case 4: {
+          if (tag !== 34) {
+            break;
+          }
+
+          message.ageGroup = reader.string();
+          continue;
+        }
+        case 5: {
+          if (tag !== 42) {
+            break;
+          }
+
+          message.size = reader.string();
+          continue;
+        }
+        case 6: {
+          if (tag !== 53) {
+            break;
+          }
+
+          message.score = reader.float();
+          continue;
+        }
+        case 7: {
+          if (tag !== 58) {
+            break;
+          }
+
+          message.reasons.push(TopPickReasonChip.decode(reader, reader.uint32()));
+          continue;
+        }
+        case 8: {
+          if (tag !== 66) {
+            break;
+          }
+
+          message.rescueName = reader.string();
+          continue;
+        }
+        case 9: {
+          if (tag !== 74) {
+            break;
+          }
+
+          message.breedName = reader.string();
+          continue;
+        }
+        case 10: {
+          if (tag !== 82) {
+            break;
+          }
+
+          message.photoUrl = reader.string();
+          continue;
+        }
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): TopPick {
+    return {
+      petId: isSet(object.petId)
+        ? globalThis.String(object.petId)
+        : isSet(object.pet_id)
+          ? globalThis.String(object.pet_id)
+          : '',
+      name: isSet(object.name) ? globalThis.String(object.name) : '',
+      type: isSet(object.type) ? globalThis.String(object.type) : '',
+      ageGroup: isSet(object.ageGroup)
+        ? globalThis.String(object.ageGroup)
+        : isSet(object.age_group)
+          ? globalThis.String(object.age_group)
+          : '',
+      size: isSet(object.size) ? globalThis.String(object.size) : '',
+      score: isSet(object.score) ? globalThis.Number(object.score) : 0,
+      reasons: globalThis.Array.isArray(object?.reasons)
+        ? object.reasons.map((e: any) => TopPickReasonChip.fromJSON(e))
+        : [],
+      rescueName: isSet(object.rescueName)
+        ? globalThis.String(object.rescueName)
+        : isSet(object.rescue_name)
+          ? globalThis.String(object.rescue_name)
+          : '',
+      breedName: isSet(object.breedName)
+        ? globalThis.String(object.breedName)
+        : isSet(object.breed_name)
+          ? globalThis.String(object.breed_name)
+          : undefined,
+      photoUrl: isSet(object.photoUrl)
+        ? globalThis.String(object.photoUrl)
+        : isSet(object.photo_url)
+          ? globalThis.String(object.photo_url)
+          : undefined,
+    };
+  },
+
+  toJSON(message: TopPick): unknown {
+    const obj: any = {};
+    if (message.petId !== '') {
+      obj.petId = message.petId;
+    }
+    if (message.name !== '') {
+      obj.name = message.name;
+    }
+    if (message.type !== '') {
+      obj.type = message.type;
+    }
+    if (message.ageGroup !== '') {
+      obj.ageGroup = message.ageGroup;
+    }
+    if (message.size !== '') {
+      obj.size = message.size;
+    }
+    if (message.score !== 0) {
+      obj.score = message.score;
+    }
+    if (message.reasons?.length) {
+      obj.reasons = message.reasons.map(e => TopPickReasonChip.toJSON(e));
+    }
+    if (message.rescueName !== '') {
+      obj.rescueName = message.rescueName;
+    }
+    if (message.breedName !== undefined) {
+      obj.breedName = message.breedName;
+    }
+    if (message.photoUrl !== undefined) {
+      obj.photoUrl = message.photoUrl;
+    }
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<TopPick>, I>>(base?: I): TopPick {
+    return TopPick.fromPartial(base ?? ({} as any));
+  },
+  fromPartial<I extends Exact<DeepPartial<TopPick>, I>>(object: I): TopPick {
+    const message = createBaseTopPick();
+    message.petId = object.petId ?? '';
+    message.name = object.name ?? '';
+    message.type = object.type ?? '';
+    message.ageGroup = object.ageGroup ?? '';
+    message.size = object.size ?? '';
+    message.score = object.score ?? 0;
+    message.reasons = object.reasons?.map(e => TopPickReasonChip.fromPartial(e)) || [];
+    message.rescueName = object.rescueName ?? '';
+    message.breedName = object.breedName ?? undefined;
+    message.photoUrl = object.photoUrl ?? undefined;
+    return message;
+  },
+};
+
+function createBaseGetTopPicksRequest(): GetTopPicksRequest {
+  return { limit: 0 };
+}
+
+export const GetTopPicksRequest: MessageFns<GetTopPicksRequest> = {
+  encode(message: GetTopPicksRequest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+    if (message.limit !== 0) {
+      writer.uint32(8).uint32(message.limit);
+    }
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): GetTopPicksRequest {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseGetTopPicksRequest();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1: {
+          if (tag !== 8) {
+            break;
+          }
+
+          message.limit = reader.uint32();
+          continue;
+        }
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): GetTopPicksRequest {
+    return { limit: isSet(object.limit) ? globalThis.Number(object.limit) : 0 };
+  },
+
+  toJSON(message: GetTopPicksRequest): unknown {
+    const obj: any = {};
+    if (message.limit !== 0) {
+      obj.limit = Math.round(message.limit);
+    }
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<GetTopPicksRequest>, I>>(base?: I): GetTopPicksRequest {
+    return GetTopPicksRequest.fromPartial(base ?? ({} as any));
+  },
+  fromPartial<I extends Exact<DeepPartial<GetTopPicksRequest>, I>>(object: I): GetTopPicksRequest {
+    const message = createBaseGetTopPicksRequest();
+    message.limit = object.limit ?? 0;
+    return message;
+  },
+};
+
+function createBaseGetTopPicksResponse(): GetTopPicksResponse {
+  return { picks: [] };
+}
+
+export const GetTopPicksResponse: MessageFns<GetTopPicksResponse> = {
+  encode(message: GetTopPicksResponse, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+    for (const v of message.picks) {
+      TopPick.encode(v!, writer.uint32(10).fork()).join();
+    }
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): GetTopPicksResponse {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseGetTopPicksResponse();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1: {
+          if (tag !== 10) {
+            break;
+          }
+
+          message.picks.push(TopPick.decode(reader, reader.uint32()));
+          continue;
+        }
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): GetTopPicksResponse {
+    return {
+      picks: globalThis.Array.isArray(object?.picks)
+        ? object.picks.map((e: any) => TopPick.fromJSON(e))
+        : [],
+    };
+  },
+
+  toJSON(message: GetTopPicksResponse): unknown {
+    const obj: any = {};
+    if (message.picks?.length) {
+      obj.picks = message.picks.map(e => TopPick.toJSON(e));
+    }
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<GetTopPicksResponse>, I>>(base?: I): GetTopPicksResponse {
+    return GetTopPicksResponse.fromPartial(base ?? ({} as any));
+  },
+  fromPartial<I extends Exact<DeepPartial<GetTopPicksResponse>, I>>(
+    object: I
+  ): GetTopPicksResponse {
+    const message = createBaseGetTopPicksResponse();
+    message.picks = object.picks?.map(e => TopPick.fromPartial(e)) || [];
     return message;
   },
 };
@@ -3337,20 +3864,20 @@ export const SwipeStats: MessageFns<SwipeStats> = {
       totalSwipes: isSet(object.totalSwipes)
         ? globalThis.Number(object.totalSwipes)
         : isSet(object.total_swipes)
-        ? globalThis.Number(object.total_swipes)
-        : 0,
+          ? globalThis.Number(object.total_swipes)
+          : 0,
       likes: isSet(object.likes) ? globalThis.Number(object.likes) : 0,
       passes: isSet(object.passes) ? globalThis.Number(object.passes) : 0,
       superLikes: isSet(object.superLikes)
         ? globalThis.Number(object.superLikes)
         : isSet(object.super_likes)
-        ? globalThis.Number(object.super_likes)
-        : 0,
+          ? globalThis.Number(object.super_likes)
+          : 0,
       infoViews: isSet(object.infoViews)
         ? globalThis.Number(object.infoViews)
         : isSet(object.info_views)
-        ? globalThis.Number(object.info_views)
-        : 0,
+          ? globalThis.Number(object.info_views)
+          : 0,
     };
   },
 
@@ -3393,7 +3920,10 @@ function createBaseGetUserSwipeStatsRequest(): GetUserSwipeStatsRequest {
 }
 
 export const GetUserSwipeStatsRequest: MessageFns<GetUserSwipeStatsRequest> = {
-  encode(message: GetUserSwipeStatsRequest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+  encode(
+    message: GetUserSwipeStatsRequest,
+    writer: BinaryWriter = new BinaryWriter()
+  ): BinaryWriter {
     if (message.userId !== undefined) {
       writer.uint32(10).string(message.userId);
     }
@@ -3429,8 +3959,8 @@ export const GetUserSwipeStatsRequest: MessageFns<GetUserSwipeStatsRequest> = {
       userId: isSet(object.userId)
         ? globalThis.String(object.userId)
         : isSet(object.user_id)
-        ? globalThis.String(object.user_id)
-        : undefined,
+          ? globalThis.String(object.user_id)
+          : undefined,
     };
   },
 
@@ -3442,10 +3972,14 @@ export const GetUserSwipeStatsRequest: MessageFns<GetUserSwipeStatsRequest> = {
     return obj;
   },
 
-  create<I extends Exact<DeepPartial<GetUserSwipeStatsRequest>, I>>(base?: I): GetUserSwipeStatsRequest {
+  create<I extends Exact<DeepPartial<GetUserSwipeStatsRequest>, I>>(
+    base?: I
+  ): GetUserSwipeStatsRequest {
     return GetUserSwipeStatsRequest.fromPartial(base ?? ({} as any));
   },
-  fromPartial<I extends Exact<DeepPartial<GetUserSwipeStatsRequest>, I>>(object: I): GetUserSwipeStatsRequest {
+  fromPartial<I extends Exact<DeepPartial<GetUserSwipeStatsRequest>, I>>(
+    object: I
+  ): GetUserSwipeStatsRequest {
     const message = createBaseGetUserSwipeStatsRequest();
     message.userId = object.userId ?? undefined;
     return message;
@@ -3457,7 +3991,10 @@ function createBaseGetUserSwipeStatsResponse(): GetUserSwipeStatsResponse {
 }
 
 export const GetUserSwipeStatsResponse: MessageFns<GetUserSwipeStatsResponse> = {
-  encode(message: GetUserSwipeStatsResponse, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+  encode(
+    message: GetUserSwipeStatsResponse,
+    writer: BinaryWriter = new BinaryWriter()
+  ): BinaryWriter {
     if (message.stats !== undefined) {
       SwipeStats.encode(message.stats, writer.uint32(10).fork()).join();
     }
@@ -3500,25 +4037,30 @@ export const GetUserSwipeStatsResponse: MessageFns<GetUserSwipeStatsResponse> = 
     return obj;
   },
 
-  create<I extends Exact<DeepPartial<GetUserSwipeStatsResponse>, I>>(base?: I): GetUserSwipeStatsResponse {
+  create<I extends Exact<DeepPartial<GetUserSwipeStatsResponse>, I>>(
+    base?: I
+  ): GetUserSwipeStatsResponse {
     return GetUserSwipeStatsResponse.fromPartial(base ?? ({} as any));
   },
-  fromPartial<I extends Exact<DeepPartial<GetUserSwipeStatsResponse>, I>>(object: I): GetUserSwipeStatsResponse {
+  fromPartial<I extends Exact<DeepPartial<GetUserSwipeStatsResponse>, I>>(
+    object: I
+  ): GetUserSwipeStatsResponse {
     const message = createBaseGetUserSwipeStatsResponse();
-    message.stats = (object.stats !== undefined && object.stats !== null)
-      ? SwipeStats.fromPartial(object.stats)
-      : undefined;
+    message.stats =
+      object.stats !== undefined && object.stats !== null
+        ? SwipeStats.fromPartial(object.stats)
+        : undefined;
     return message;
   },
 };
 
 function createBaseGetSessionStatsRequest(): GetSessionStatsRequest {
-  return { sessionId: "" };
+  return { sessionId: '' };
 }
 
 export const GetSessionStatsRequest: MessageFns<GetSessionStatsRequest> = {
   encode(message: GetSessionStatsRequest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    if (message.sessionId !== "") {
+    if (message.sessionId !== '') {
       writer.uint32(10).string(message.sessionId);
     }
     return writer;
@@ -3553,25 +4095,29 @@ export const GetSessionStatsRequest: MessageFns<GetSessionStatsRequest> = {
       sessionId: isSet(object.sessionId)
         ? globalThis.String(object.sessionId)
         : isSet(object.session_id)
-        ? globalThis.String(object.session_id)
-        : "",
+          ? globalThis.String(object.session_id)
+          : '',
     };
   },
 
   toJSON(message: GetSessionStatsRequest): unknown {
     const obj: any = {};
-    if (message.sessionId !== "") {
+    if (message.sessionId !== '') {
       obj.sessionId = message.sessionId;
     }
     return obj;
   },
 
-  create<I extends Exact<DeepPartial<GetSessionStatsRequest>, I>>(base?: I): GetSessionStatsRequest {
+  create<I extends Exact<DeepPartial<GetSessionStatsRequest>, I>>(
+    base?: I
+  ): GetSessionStatsRequest {
     return GetSessionStatsRequest.fromPartial(base ?? ({} as any));
   },
-  fromPartial<I extends Exact<DeepPartial<GetSessionStatsRequest>, I>>(object: I): GetSessionStatsRequest {
+  fromPartial<I extends Exact<DeepPartial<GetSessionStatsRequest>, I>>(
+    object: I
+  ): GetSessionStatsRequest {
     const message = createBaseGetSessionStatsRequest();
-    message.sessionId = object.sessionId ?? "";
+    message.sessionId = object.sessionId ?? '';
     return message;
   },
 };
@@ -3581,7 +4127,10 @@ function createBaseGetSessionStatsResponse(): GetSessionStatsResponse {
 }
 
 export const GetSessionStatsResponse: MessageFns<GetSessionStatsResponse> = {
-  encode(message: GetSessionStatsResponse, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+  encode(
+    message: GetSessionStatsResponse,
+    writer: BinaryWriter = new BinaryWriter()
+  ): BinaryWriter {
     if (message.stats !== undefined) {
       SwipeStats.encode(message.stats, writer.uint32(10).fork()).join();
     }
@@ -3624,14 +4173,19 @@ export const GetSessionStatsResponse: MessageFns<GetSessionStatsResponse> = {
     return obj;
   },
 
-  create<I extends Exact<DeepPartial<GetSessionStatsResponse>, I>>(base?: I): GetSessionStatsResponse {
+  create<I extends Exact<DeepPartial<GetSessionStatsResponse>, I>>(
+    base?: I
+  ): GetSessionStatsResponse {
     return GetSessionStatsResponse.fromPartial(base ?? ({} as any));
   },
-  fromPartial<I extends Exact<DeepPartial<GetSessionStatsResponse>, I>>(object: I): GetSessionStatsResponse {
+  fromPartial<I extends Exact<DeepPartial<GetSessionStatsResponse>, I>>(
+    object: I
+  ): GetSessionStatsResponse {
     const message = createBaseGetSessionStatsResponse();
-    message.stats = (object.stats !== undefined && object.stats !== null)
-      ? SwipeStats.fromPartial(object.stats)
-      : undefined;
+    message.stats =
+      object.stats !== undefined && object.stats !== null
+        ? SwipeStats.fromPartial(object.stats)
+        : undefined;
     return message;
   },
 };
@@ -3662,26 +4216,30 @@ export const MatchingServiceService = {
    * filters here.
    */
   startSession: {
-    path: "/adopt_dont_shop.matching.v1.MatchingService/StartSession" as const,
+    path: '/adopt_dont_shop.matching.v1.MatchingService/StartSession' as const,
     requestStream: false as const,
     responseStream: false as const,
-    requestSerialize: (value: StartSessionRequest): Buffer => Buffer.from(StartSessionRequest.encode(value).finish()),
+    requestSerialize: (value: StartSessionRequest): Buffer =>
+      Buffer.from(StartSessionRequest.encode(value).finish()),
     requestDeserialize: (value: Buffer): StartSessionRequest => StartSessionRequest.decode(value),
     responseSerialize: (value: StartSessionResponse): Buffer =>
       Buffer.from(StartSessionResponse.encode(value).finish()),
-    responseDeserialize: (value: Buffer): StartSessionResponse => StartSessionResponse.decode(value),
+    responseDeserialize: (value: Buffer): StartSessionResponse =>
+      StartSessionResponse.decode(value),
   },
   /**
    * Close an open session. Marks is_active=false and stamps end_time.
    * Idempotent on already-closed sessions.
    */
   endSession: {
-    path: "/adopt_dont_shop.matching.v1.MatchingService/EndSession" as const,
+    path: '/adopt_dont_shop.matching.v1.MatchingService/EndSession' as const,
     requestStream: false as const,
     responseStream: false as const,
-    requestSerialize: (value: EndSessionRequest): Buffer => Buffer.from(EndSessionRequest.encode(value).finish()),
+    requestSerialize: (value: EndSessionRequest): Buffer =>
+      Buffer.from(EndSessionRequest.encode(value).finish()),
     requestDeserialize: (value: Buffer): EndSessionRequest => EndSessionRequest.decode(value),
-    responseSerialize: (value: EndSessionResponse): Buffer => Buffer.from(EndSessionResponse.encode(value).finish()),
+    responseSerialize: (value: EndSessionResponse): Buffer =>
+      Buffer.from(EndSessionResponse.encode(value).finish()),
     responseDeserialize: (value: Buffer): EndSessionResponse => EndSessionResponse.decode(value),
   },
   /**
@@ -3693,12 +4251,14 @@ export const MatchingServiceService = {
    * the queue runs low.
    */
   recommend: {
-    path: "/adopt_dont_shop.matching.v1.MatchingService/Recommend" as const,
+    path: '/adopt_dont_shop.matching.v1.MatchingService/Recommend' as const,
     requestStream: false as const,
     responseStream: false as const,
-    requestSerialize: (value: RecommendRequest): Buffer => Buffer.from(RecommendRequest.encode(value).finish()),
+    requestSerialize: (value: RecommendRequest): Buffer =>
+      Buffer.from(RecommendRequest.encode(value).finish()),
     requestDeserialize: (value: Buffer): RecommendRequest => RecommendRequest.decode(value),
-    responseSerialize: (value: RecommendResponse): Buffer => Buffer.from(RecommendResponse.encode(value).finish()),
+    responseSerialize: (value: RecommendResponse): Buffer =>
+      Buffer.from(RecommendResponse.encode(value).finish()),
     responseDeserialize: (value: Buffer): RecommendResponse => RecommendResponse.decode(value),
   },
   /**
@@ -3709,12 +4269,14 @@ export const MatchingServiceService = {
    * surface "user X super-liked your pet" notifications.
    */
   recordSwipe: {
-    path: "/adopt_dont_shop.matching.v1.MatchingService/RecordSwipe" as const,
+    path: '/adopt_dont_shop.matching.v1.MatchingService/RecordSwipe' as const,
     requestStream: false as const,
     responseStream: false as const,
-    requestSerialize: (value: RecordSwipeRequest): Buffer => Buffer.from(RecordSwipeRequest.encode(value).finish()),
+    requestSerialize: (value: RecordSwipeRequest): Buffer =>
+      Buffer.from(RecordSwipeRequest.encode(value).finish()),
     requestDeserialize: (value: Buffer): RecordSwipeRequest => RecordSwipeRequest.decode(value),
-    responseSerialize: (value: RecordSwipeResponse): Buffer => Buffer.from(RecordSwipeResponse.encode(value).finish()),
+    responseSerialize: (value: RecordSwipeResponse): Buffer =>
+      Buffer.from(RecordSwipeResponse.encode(value).finish()),
     responseDeserialize: (value: Buffer): RecordSwipeResponse => RecordSwipeResponse.decode(value),
   },
   /**
@@ -3725,12 +4287,14 @@ export const MatchingServiceService = {
    * service.pets via gRPC; matching service is stateless on this RPC.
    */
   searchPets: {
-    path: "/adopt_dont_shop.matching.v1.MatchingService/SearchPets" as const,
+    path: '/adopt_dont_shop.matching.v1.MatchingService/SearchPets' as const,
     requestStream: false as const,
     responseStream: false as const,
-    requestSerialize: (value: SearchPetsRequest): Buffer => Buffer.from(SearchPetsRequest.encode(value).finish()),
+    requestSerialize: (value: SearchPetsRequest): Buffer =>
+      Buffer.from(SearchPetsRequest.encode(value).finish()),
     requestDeserialize: (value: Buffer): SearchPetsRequest => SearchPetsRequest.decode(value),
-    responseSerialize: (value: SearchPetsResponse): Buffer => Buffer.from(SearchPetsResponse.encode(value).finish()),
+    responseSerialize: (value: SearchPetsResponse): Buffer =>
+      Buffer.from(SearchPetsResponse.encode(value).finish()),
     responseDeserialize: (value: Buffer): SearchPetsResponse => SearchPetsResponse.decode(value),
   },
   /**
@@ -3739,30 +4303,34 @@ export const MatchingServiceService = {
    * in the SPA. Filterable by action type.
    */
   listSwipeHistory: {
-    path: "/adopt_dont_shop.matching.v1.MatchingService/ListSwipeHistory" as const,
+    path: '/adopt_dont_shop.matching.v1.MatchingService/ListSwipeHistory' as const,
     requestStream: false as const,
     responseStream: false as const,
     requestSerialize: (value: ListSwipeHistoryRequest): Buffer =>
       Buffer.from(ListSwipeHistoryRequest.encode(value).finish()),
-    requestDeserialize: (value: Buffer): ListSwipeHistoryRequest => ListSwipeHistoryRequest.decode(value),
+    requestDeserialize: (value: Buffer): ListSwipeHistoryRequest =>
+      ListSwipeHistoryRequest.decode(value),
     responseSerialize: (value: ListSwipeHistoryResponse): Buffer =>
       Buffer.from(ListSwipeHistoryResponse.encode(value).finish()),
-    responseDeserialize: (value: Buffer): ListSwipeHistoryResponse => ListSwipeHistoryResponse.decode(value),
+    responseDeserialize: (value: Buffer): ListSwipeHistoryResponse =>
+      ListSwipeHistoryResponse.decode(value),
   },
   /**
    * Read the calling principal's match profile, returning empty defaults
    * when the row doesn't exist yet (the SPA renders an empty form).
    */
   getMatchProfile: {
-    path: "/adopt_dont_shop.matching.v1.MatchingService/GetMatchProfile" as const,
+    path: '/adopt_dont_shop.matching.v1.MatchingService/GetMatchProfile' as const,
     requestStream: false as const,
     responseStream: false as const,
     requestSerialize: (value: GetMatchProfileRequest): Buffer =>
       Buffer.from(GetMatchProfileRequest.encode(value).finish()),
-    requestDeserialize: (value: Buffer): GetMatchProfileRequest => GetMatchProfileRequest.decode(value),
+    requestDeserialize: (value: Buffer): GetMatchProfileRequest =>
+      GetMatchProfileRequest.decode(value),
     responseSerialize: (value: GetMatchProfileResponse): Buffer =>
       Buffer.from(GetMatchProfileResponse.encode(value).finish()),
-    responseDeserialize: (value: Buffer): GetMatchProfileResponse => GetMatchProfileResponse.decode(value),
+    responseDeserialize: (value: Buffer): GetMatchProfileResponse =>
+      GetMatchProfileResponse.decode(value),
   },
   /**
    * Create-or-update the calling principal's match profile. Only the
@@ -3770,15 +4338,17 @@ export const MatchingServiceService = {
    * current value (or the column default on first insert).
    */
   upsertMatchProfile: {
-    path: "/adopt_dont_shop.matching.v1.MatchingService/UpsertMatchProfile" as const,
+    path: '/adopt_dont_shop.matching.v1.MatchingService/UpsertMatchProfile' as const,
     requestStream: false as const,
     responseStream: false as const,
     requestSerialize: (value: UpsertMatchProfileRequest): Buffer =>
       Buffer.from(UpsertMatchProfileRequest.encode(value).finish()),
-    requestDeserialize: (value: Buffer): UpsertMatchProfileRequest => UpsertMatchProfileRequest.decode(value),
+    requestDeserialize: (value: Buffer): UpsertMatchProfileRequest =>
+      UpsertMatchProfileRequest.decode(value),
     responseSerialize: (value: UpsertMatchProfileResponse): Buffer =>
       Buffer.from(UpsertMatchProfileResponse.encode(value).finish()),
-    responseDeserialize: (value: Buffer): UpsertMatchProfileResponse => UpsertMatchProfileResponse.decode(value),
+    responseDeserialize: (value: Buffer): UpsertMatchProfileResponse =>
+      UpsertMatchProfileResponse.decode(value),
   },
   /**
    * Aggregate swipe counts for a user (total / likes / passes /
@@ -3786,30 +4356,53 @@ export const MatchingServiceService = {
    * via swipes:read:any.
    */
   getUserSwipeStats: {
-    path: "/adopt_dont_shop.matching.v1.MatchingService/GetUserSwipeStats" as const,
+    path: '/adopt_dont_shop.matching.v1.MatchingService/GetUserSwipeStats' as const,
     requestStream: false as const,
     responseStream: false as const,
     requestSerialize: (value: GetUserSwipeStatsRequest): Buffer =>
       Buffer.from(GetUserSwipeStatsRequest.encode(value).finish()),
-    requestDeserialize: (value: Buffer): GetUserSwipeStatsRequest => GetUserSwipeStatsRequest.decode(value),
+    requestDeserialize: (value: Buffer): GetUserSwipeStatsRequest =>
+      GetUserSwipeStatsRequest.decode(value),
     responseSerialize: (value: GetUserSwipeStatsResponse): Buffer =>
       Buffer.from(GetUserSwipeStatsResponse.encode(value).finish()),
-    responseDeserialize: (value: Buffer): GetUserSwipeStatsResponse => GetUserSwipeStatsResponse.decode(value),
+    responseDeserialize: (value: Buffer): GetUserSwipeStatsResponse =>
+      GetUserSwipeStatsResponse.decode(value),
   },
   /**
    * Aggregate swipe counts for a single session. Caller MUST own the
    * session (or be admin).
    */
   getSessionStats: {
-    path: "/adopt_dont_shop.matching.v1.MatchingService/GetSessionStats" as const,
+    path: '/adopt_dont_shop.matching.v1.MatchingService/GetSessionStats' as const,
     requestStream: false as const,
     responseStream: false as const,
     requestSerialize: (value: GetSessionStatsRequest): Buffer =>
       Buffer.from(GetSessionStatsRequest.encode(value).finish()),
-    requestDeserialize: (value: Buffer): GetSessionStatsRequest => GetSessionStatsRequest.decode(value),
+    requestDeserialize: (value: Buffer): GetSessionStatsRequest =>
+      GetSessionStatsRequest.decode(value),
     responseSerialize: (value: GetSessionStatsResponse): Buffer =>
       Buffer.from(GetSessionStatsResponse.encode(value).finish()),
-    responseDeserialize: (value: Buffer): GetSessionStatsResponse => GetSessionStatsResponse.decode(value),
+    responseDeserialize: (value: Buffer): GetSessionStatsResponse =>
+      GetSessionStatsResponse.decode(value),
+  },
+  /**
+   * Get a short, personalised "top picks" list for the calling principal —
+   * distinct from Recommend (the swipe-queue feed): top picks reads the
+   * user's STORED match profile (preferred types/sizes/age groups/energy/
+   * temperament) rather than session filters, excludes already-swiped pets,
+   * and attaches reason chips explaining each pick. Stateless — no session
+   * required, no mutation.
+   */
+  getTopPicks: {
+    path: '/adopt_dont_shop.matching.v1.MatchingService/GetTopPicks' as const,
+    requestStream: false as const,
+    responseStream: false as const,
+    requestSerialize: (value: GetTopPicksRequest): Buffer =>
+      Buffer.from(GetTopPicksRequest.encode(value).finish()),
+    requestDeserialize: (value: Buffer): GetTopPicksRequest => GetTopPicksRequest.decode(value),
+    responseSerialize: (value: GetTopPicksResponse): Buffer =>
+      Buffer.from(GetTopPicksResponse.encode(value).finish()),
+    responseDeserialize: (value: Buffer): GetTopPicksResponse => GetTopPicksResponse.decode(value),
   },
 } as const;
 
@@ -3880,6 +4473,15 @@ export interface MatchingServiceServer extends UntypedServiceImplementation {
    * session (or be admin).
    */
   getSessionStats: handleUnaryCall<GetSessionStatsRequest, GetSessionStatsResponse>;
+  /**
+   * Get a short, personalised "top picks" list for the calling principal —
+   * distinct from Recommend (the swipe-queue feed): top picks reads the
+   * user's STORED match profile (preferred types/sizes/age groups/energy/
+   * temperament) rather than session filters, excludes already-swiped pets,
+   * and attaches reason chips explaining each pick. Stateless — no session
+   * required, no mutation.
+   */
+  getTopPicks: handleUnaryCall<GetTopPicksRequest, GetTopPicksResponse>;
 }
 
 export interface MatchingServiceClient extends Client {
@@ -3892,18 +4494,18 @@ export interface MatchingServiceClient extends Client {
    */
   startSession(
     request: StartSessionRequest,
-    callback: (error: ServiceError | null, response: StartSessionResponse) => void,
+    callback: (error: ServiceError | null, response: StartSessionResponse) => void
   ): ClientUnaryCall;
   startSession(
     request: StartSessionRequest,
     metadata: Metadata,
-    callback: (error: ServiceError | null, response: StartSessionResponse) => void,
+    callback: (error: ServiceError | null, response: StartSessionResponse) => void
   ): ClientUnaryCall;
   startSession(
     request: StartSessionRequest,
     metadata: Metadata,
     options: Partial<CallOptions>,
-    callback: (error: ServiceError | null, response: StartSessionResponse) => void,
+    callback: (error: ServiceError | null, response: StartSessionResponse) => void
   ): ClientUnaryCall;
   /**
    * Close an open session. Marks is_active=false and stamps end_time.
@@ -3911,18 +4513,18 @@ export interface MatchingServiceClient extends Client {
    */
   endSession(
     request: EndSessionRequest,
-    callback: (error: ServiceError | null, response: EndSessionResponse) => void,
+    callback: (error: ServiceError | null, response: EndSessionResponse) => void
   ): ClientUnaryCall;
   endSession(
     request: EndSessionRequest,
     metadata: Metadata,
-    callback: (error: ServiceError | null, response: EndSessionResponse) => void,
+    callback: (error: ServiceError | null, response: EndSessionResponse) => void
   ): ClientUnaryCall;
   endSession(
     request: EndSessionRequest,
     metadata: Metadata,
     options: Partial<CallOptions>,
-    callback: (error: ServiceError | null, response: EndSessionResponse) => void,
+    callback: (error: ServiceError | null, response: EndSessionResponse) => void
   ): ClientUnaryCall;
   /**
    * Get the top-K recommendations for the calling principal. Reads
@@ -3934,18 +4536,18 @@ export interface MatchingServiceClient extends Client {
    */
   recommend(
     request: RecommendRequest,
-    callback: (error: ServiceError | null, response: RecommendResponse) => void,
+    callback: (error: ServiceError | null, response: RecommendResponse) => void
   ): ClientUnaryCall;
   recommend(
     request: RecommendRequest,
     metadata: Metadata,
-    callback: (error: ServiceError | null, response: RecommendResponse) => void,
+    callback: (error: ServiceError | null, response: RecommendResponse) => void
   ): ClientUnaryCall;
   recommend(
     request: RecommendRequest,
     metadata: Metadata,
     options: Partial<CallOptions>,
-    callback: (error: ServiceError | null, response: RecommendResponse) => void,
+    callback: (error: ServiceError | null, response: RecommendResponse) => void
   ): ClientUnaryCall;
   /**
    * Record a swipe action and tick the session's counters
@@ -3956,18 +4558,18 @@ export interface MatchingServiceClient extends Client {
    */
   recordSwipe(
     request: RecordSwipeRequest,
-    callback: (error: ServiceError | null, response: RecordSwipeResponse) => void,
+    callback: (error: ServiceError | null, response: RecordSwipeResponse) => void
   ): ClientUnaryCall;
   recordSwipe(
     request: RecordSwipeRequest,
     metadata: Metadata,
-    callback: (error: ServiceError | null, response: RecordSwipeResponse) => void,
+    callback: (error: ServiceError | null, response: RecordSwipeResponse) => void
   ): ClientUnaryCall;
   recordSwipe(
     request: RecordSwipeRequest,
     metadata: Metadata,
     options: Partial<CallOptions>,
-    callback: (error: ServiceError | null, response: RecordSwipeResponse) => void,
+    callback: (error: ServiceError | null, response: RecordSwipeResponse) => void
   ): ClientUnaryCall;
   /**
    * Search pets — the explicit search surface that absorbs the
@@ -3978,18 +4580,18 @@ export interface MatchingServiceClient extends Client {
    */
   searchPets(
     request: SearchPetsRequest,
-    callback: (error: ServiceError | null, response: SearchPetsResponse) => void,
+    callback: (error: ServiceError | null, response: SearchPetsResponse) => void
   ): ClientUnaryCall;
   searchPets(
     request: SearchPetsRequest,
     metadata: Metadata,
-    callback: (error: ServiceError | null, response: SearchPetsResponse) => void,
+    callback: (error: ServiceError | null, response: SearchPetsResponse) => void
   ): ClientUnaryCall;
   searchPets(
     request: SearchPetsRequest,
     metadata: Metadata,
     options: Partial<CallOptions>,
-    callback: (error: ServiceError | null, response: SearchPetsResponse) => void,
+    callback: (error: ServiceError | null, response: SearchPetsResponse) => void
   ): ClientUnaryCall;
   /**
    * List the calling principal's swipe history — what they liked,
@@ -3998,18 +4600,18 @@ export interface MatchingServiceClient extends Client {
    */
   listSwipeHistory(
     request: ListSwipeHistoryRequest,
-    callback: (error: ServiceError | null, response: ListSwipeHistoryResponse) => void,
+    callback: (error: ServiceError | null, response: ListSwipeHistoryResponse) => void
   ): ClientUnaryCall;
   listSwipeHistory(
     request: ListSwipeHistoryRequest,
     metadata: Metadata,
-    callback: (error: ServiceError | null, response: ListSwipeHistoryResponse) => void,
+    callback: (error: ServiceError | null, response: ListSwipeHistoryResponse) => void
   ): ClientUnaryCall;
   listSwipeHistory(
     request: ListSwipeHistoryRequest,
     metadata: Metadata,
     options: Partial<CallOptions>,
-    callback: (error: ServiceError | null, response: ListSwipeHistoryResponse) => void,
+    callback: (error: ServiceError | null, response: ListSwipeHistoryResponse) => void
   ): ClientUnaryCall;
   /**
    * Read the calling principal's match profile, returning empty defaults
@@ -4017,18 +4619,18 @@ export interface MatchingServiceClient extends Client {
    */
   getMatchProfile(
     request: GetMatchProfileRequest,
-    callback: (error: ServiceError | null, response: GetMatchProfileResponse) => void,
+    callback: (error: ServiceError | null, response: GetMatchProfileResponse) => void
   ): ClientUnaryCall;
   getMatchProfile(
     request: GetMatchProfileRequest,
     metadata: Metadata,
-    callback: (error: ServiceError | null, response: GetMatchProfileResponse) => void,
+    callback: (error: ServiceError | null, response: GetMatchProfileResponse) => void
   ): ClientUnaryCall;
   getMatchProfile(
     request: GetMatchProfileRequest,
     metadata: Metadata,
     options: Partial<CallOptions>,
-    callback: (error: ServiceError | null, response: GetMatchProfileResponse) => void,
+    callback: (error: ServiceError | null, response: GetMatchProfileResponse) => void
   ): ClientUnaryCall;
   /**
    * Create-or-update the calling principal's match profile. Only the
@@ -4037,18 +4639,18 @@ export interface MatchingServiceClient extends Client {
    */
   upsertMatchProfile(
     request: UpsertMatchProfileRequest,
-    callback: (error: ServiceError | null, response: UpsertMatchProfileResponse) => void,
+    callback: (error: ServiceError | null, response: UpsertMatchProfileResponse) => void
   ): ClientUnaryCall;
   upsertMatchProfile(
     request: UpsertMatchProfileRequest,
     metadata: Metadata,
-    callback: (error: ServiceError | null, response: UpsertMatchProfileResponse) => void,
+    callback: (error: ServiceError | null, response: UpsertMatchProfileResponse) => void
   ): ClientUnaryCall;
   upsertMatchProfile(
     request: UpsertMatchProfileRequest,
     metadata: Metadata,
     options: Partial<CallOptions>,
-    callback: (error: ServiceError | null, response: UpsertMatchProfileResponse) => void,
+    callback: (error: ServiceError | null, response: UpsertMatchProfileResponse) => void
   ): ClientUnaryCall;
   /**
    * Aggregate swipe counts for a user (total / likes / passes /
@@ -4057,18 +4659,18 @@ export interface MatchingServiceClient extends Client {
    */
   getUserSwipeStats(
     request: GetUserSwipeStatsRequest,
-    callback: (error: ServiceError | null, response: GetUserSwipeStatsResponse) => void,
+    callback: (error: ServiceError | null, response: GetUserSwipeStatsResponse) => void
   ): ClientUnaryCall;
   getUserSwipeStats(
     request: GetUserSwipeStatsRequest,
     metadata: Metadata,
-    callback: (error: ServiceError | null, response: GetUserSwipeStatsResponse) => void,
+    callback: (error: ServiceError | null, response: GetUserSwipeStatsResponse) => void
   ): ClientUnaryCall;
   getUserSwipeStats(
     request: GetUserSwipeStatsRequest,
     metadata: Metadata,
     options: Partial<CallOptions>,
-    callback: (error: ServiceError | null, response: GetUserSwipeStatsResponse) => void,
+    callback: (error: ServiceError | null, response: GetUserSwipeStatsResponse) => void
   ): ClientUnaryCall;
   /**
    * Aggregate swipe counts for a single session. Caller MUST own the
@@ -4076,40 +4678,72 @@ export interface MatchingServiceClient extends Client {
    */
   getSessionStats(
     request: GetSessionStatsRequest,
-    callback: (error: ServiceError | null, response: GetSessionStatsResponse) => void,
+    callback: (error: ServiceError | null, response: GetSessionStatsResponse) => void
   ): ClientUnaryCall;
   getSessionStats(
     request: GetSessionStatsRequest,
     metadata: Metadata,
-    callback: (error: ServiceError | null, response: GetSessionStatsResponse) => void,
+    callback: (error: ServiceError | null, response: GetSessionStatsResponse) => void
   ): ClientUnaryCall;
   getSessionStats(
     request: GetSessionStatsRequest,
     metadata: Metadata,
     options: Partial<CallOptions>,
-    callback: (error: ServiceError | null, response: GetSessionStatsResponse) => void,
+    callback: (error: ServiceError | null, response: GetSessionStatsResponse) => void
+  ): ClientUnaryCall;
+  /**
+   * Get a short, personalised "top picks" list for the calling principal —
+   * distinct from Recommend (the swipe-queue feed): top picks reads the
+   * user's STORED match profile (preferred types/sizes/age groups/energy/
+   * temperament) rather than session filters, excludes already-swiped pets,
+   * and attaches reason chips explaining each pick. Stateless — no session
+   * required, no mutation.
+   */
+  getTopPicks(
+    request: GetTopPicksRequest,
+    callback: (error: ServiceError | null, response: GetTopPicksResponse) => void
+  ): ClientUnaryCall;
+  getTopPicks(
+    request: GetTopPicksRequest,
+    metadata: Metadata,
+    callback: (error: ServiceError | null, response: GetTopPicksResponse) => void
+  ): ClientUnaryCall;
+  getTopPicks(
+    request: GetTopPicksRequest,
+    metadata: Metadata,
+    options: Partial<CallOptions>,
+    callback: (error: ServiceError | null, response: GetTopPicksResponse) => void
   ): ClientUnaryCall;
 }
 
 export const MatchingServiceClient = makeGenericClientConstructor(
   MatchingServiceService,
-  "adopt_dont_shop.matching.v1.MatchingService",
+  'adopt_dont_shop.matching.v1.MatchingService'
 ) as unknown as {
-  new (address: string, credentials: ChannelCredentials, options?: Partial<ClientOptions>): MatchingServiceClient;
+  new (
+    address: string,
+    credentials: ChannelCredentials,
+    options?: Partial<ClientOptions>
+  ): MatchingServiceClient;
   service: typeof MatchingServiceService;
   serviceName: string;
 };
 
 type Builtin = Date | Function | Uint8Array | string | number | boolean | undefined;
 
-export type DeepPartial<T> = T extends Builtin ? T
-  : T extends globalThis.Array<infer U> ? globalThis.Array<DeepPartial<U>>
-  : T extends ReadonlyArray<infer U> ? ReadonlyArray<DeepPartial<U>>
-  : T extends {} ? { [K in keyof T]?: DeepPartial<T[K]> }
-  : Partial<T>;
+export type DeepPartial<T> = T extends Builtin
+  ? T
+  : T extends globalThis.Array<infer U>
+    ? globalThis.Array<DeepPartial<U>>
+    : T extends ReadonlyArray<infer U>
+      ? ReadonlyArray<DeepPartial<U>>
+      : T extends {}
+        ? { [K in keyof T]?: DeepPartial<T[K]> }
+        : Partial<T>;
 
 type KeysOfUnion<T> = T extends T ? keyof T : never;
-export type Exact<P, I extends P> = P extends Builtin ? P
+export type Exact<P, I extends P> = P extends Builtin
+  ? P
   : P & { [K in keyof P]: Exact<P[K], I[K]> } & { [K in Exclude<keyof I, KeysOfUnion<P>>]: never };
 
 function isSet(value: any): boolean {

--- a/packages/proto/src/index.ts
+++ b/packages/proto/src/index.ts
@@ -355,6 +355,10 @@ export type {
   GetUserSwipeStatsResponse,
   GetSessionStatsRequest,
   GetSessionStatsResponse,
+  TopPick,
+  TopPickReasonChip,
+  GetTopPicksRequest,
+  GetTopPicksResponse,
   MatchingServiceServer,
   MatchingServiceClient,
 } from './generated/proto/adopt_dont_shop/matching/v1/matching.js';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1268,6 +1268,9 @@ importers:
 
   packages/lib.matching:
     dependencies:
+      '@adopt-dont-shop/lib.api':
+        specifier: workspace:*
+        version: link:../lib.api
       typescript:
         specifier: ^6.0.0
         version: 6.0.3

--- a/services/gateway/src/grpc-clients/matching-client.ts
+++ b/services/gateway/src/grpc-clients/matching-client.ts
@@ -21,6 +21,8 @@ import {
   type GetMatchProfileResponse,
   type GetSessionStatsRequest,
   type GetSessionStatsResponse,
+  type GetTopPicksRequest,
+  type GetTopPicksResponse,
   type GetUserSwipeStatsRequest,
   type GetUserSwipeStatsResponse,
   type ListSwipeHistoryRequest,
@@ -67,6 +69,7 @@ export type MatchingClient = {
     req: GetSessionStatsRequest,
     metadata: Metadata
   ): Promise<GetSessionStatsResponse>;
+  getTopPicks(req: GetTopPicksRequest, metadata: Metadata): Promise<GetTopPicksResponse>;
   close(): void;
 };
 
@@ -141,6 +144,7 @@ export const createMatchingClient = (opts: CreateMatchingClientOptions): Matchin
     getMatchProfile: (req, metadata) => callUnary(stub.getMatchProfile, req, metadata, true),
     getUserSwipeStats: (req, metadata) => callUnary(stub.getUserSwipeStats, req, metadata, true),
     getSessionStats: (req, metadata) => callUnary(stub.getSessionStats, req, metadata, true),
+    getTopPicks: (req, metadata) => callUnary(stub.getTopPicks, req, metadata, true),
     close: () => stub.close(),
   };
 };

--- a/services/gateway/src/routes/matching-view.test.ts
+++ b/services/gateway/src/routes/matching-view.test.ts
@@ -1,8 +1,18 @@
 import { describe, expect, it } from 'vitest';
 
-import type { PetCandidate, RecommendResponse, SearchPetsResponse } from '@adopt-dont-shop/proto';
+import type {
+  GetTopPicksResponse,
+  PetCandidate,
+  RecommendResponse,
+  SearchPetsResponse,
+} from '@adopt-dont-shop/proto';
 
-import { petCandidateToView, recommendToQueue, searchToView } from './matching-view.js';
+import {
+  petCandidateToView,
+  recommendToQueue,
+  searchToView,
+  topPicksToView,
+} from './matching-view.js';
 
 function makeCandidate(overrides: Partial<PetCandidate> = {}): PetCandidate {
   return {
@@ -89,5 +99,77 @@ describe('searchToView', () => {
   it('omits next_cursor when absent or empty', () => {
     const env = searchToView({ results: [], nextCursor: '' } as SearchPetsResponse);
     expect('next_cursor' in env).toBe(false);
+  });
+});
+
+describe('topPicksToView', () => {
+  it('maps proto TopPicks to the SPA MatchTopPick shape, preserving default fields', () => {
+    const view = topPicksToView({
+      picks: [
+        {
+          petId: 'pet-1',
+          name: 'Bella',
+          type: 'cat',
+          ageGroup: 'baby',
+          size: 'small',
+          score: 0.74,
+          reasons: [{ kind: 'pref_match', label: 'Matches your preferences' }],
+          rescueName: 'Happy Tails',
+        },
+      ],
+    } as GetTopPicksResponse);
+
+    expect(view).toEqual([
+      {
+        petId: 'pet-1',
+        name: 'Bella',
+        type: 'cat',
+        ageGroup: 'baby',
+        size: 'small',
+        score: 0.74,
+        reasons: [{ kind: 'pref_match', label: 'Matches your preferences' }],
+        rescueName: 'Happy Tails',
+      },
+    ]);
+  });
+
+  it('keeps zero score, empty rescue name and empty reasons rather than dropping them', () => {
+    const view = topPicksToView({
+      picks: [
+        {
+          petId: 'pet-2',
+          name: 'Rex',
+          type: 'dog',
+          ageGroup: 'adult',
+          size: 'medium',
+          score: 0,
+          reasons: [],
+          rescueName: '',
+        },
+      ],
+    } as GetTopPicksResponse);
+
+    expect(view[0]).toMatchObject({ petId: 'pet-2', score: 0, rescueName: '', reasons: [] });
+  });
+
+  it('forwards breedName and photoUrl when present', () => {
+    const view = topPicksToView({
+      picks: [
+        {
+          petId: 'pet-3',
+          name: 'Max',
+          type: 'dog',
+          ageGroup: 'young',
+          size: 'large',
+          score: 0.5,
+          reasons: [],
+          rescueName: 'Rescue',
+          breedName: 'Labrador',
+          photoUrl: '/uploads/pets/pet-3.jpg',
+        },
+      ],
+    } as GetTopPicksResponse);
+
+    expect(view[0]).toMatchObject({ breedName: 'Labrador', photoUrl: '/uploads/pets/pet-3.jpg' });
   });
 });

--- a/services/gateway/src/routes/matching-view.ts
+++ b/services/gateway/src/routes/matching-view.ts
@@ -13,7 +13,13 @@
 // Both surfaces are read-only, so the adapter is one-directional: proto
 // PetCandidate → frontend pet view, then build the per-route envelope.
 
-import type { PetCandidate, RecommendResponse, SearchPetsResponse } from '@adopt-dont-shop/proto';
+import type {
+  GetTopPicksResponse,
+  PetCandidate,
+  RecommendResponse,
+  SearchPetsResponse,
+  TopPick,
+} from '@adopt-dont-shop/proto';
 
 export type DiscoveryPetView = {
   pet_id: string;
@@ -92,4 +98,46 @@ export function searchToView(res: SearchPetsResponse): SearchPetsView {
     view.next_cursor = res.nextCursor;
   }
   return view;
+}
+
+// proto TopPick → the SPA's MatchTopPick (lib.matching). The shapes are
+// camelCase-identical, but we build the object explicitly rather than
+// using TopPick.toJSON so default-valued fields (score 0, empty
+// rescueName, empty reasons) survive — the SPA's MatchTopPick type
+// requires them.
+export type TopPickView = {
+  petId: string;
+  name: string;
+  type: string;
+  ageGroup: string;
+  size: string;
+  score: number;
+  reasons: ReadonlyArray<{ kind: string; label: string }>;
+  rescueName: string;
+  breedName?: string;
+  photoUrl?: string;
+};
+
+function topPickToView(pick: TopPick): TopPickView {
+  const view: TopPickView = {
+    petId: pick.petId,
+    name: pick.name,
+    type: pick.type,
+    ageGroup: pick.ageGroup,
+    size: pick.size,
+    score: pick.score,
+    reasons: pick.reasons.map(r => ({ kind: r.kind, label: r.label })),
+    rescueName: pick.rescueName,
+  };
+  if (pick.breedName !== undefined) {
+    view.breedName = pick.breedName;
+  }
+  if (pick.photoUrl !== undefined) {
+    view.photoUrl = pick.photoUrl;
+  }
+  return view;
+}
+
+export function topPicksToView(res: GetTopPicksResponse): TopPickView[] {
+  return res.picks.map(topPickToView);
 }

--- a/services/gateway/src/routes/matching.test.ts
+++ b/services/gateway/src/routes/matching.test.ts
@@ -28,6 +28,7 @@ function makeClient(): {
   upsertMatchProfileMock: ReturnType<typeof vi.fn>;
   getUserSwipeStatsMock: ReturnType<typeof vi.fn>;
   getSessionStatsMock: ReturnType<typeof vi.fn>;
+  getTopPicksMock: ReturnType<typeof vi.fn>;
 } {
   const startSessionMock = vi.fn();
   const endSessionMock = vi.fn();
@@ -39,6 +40,7 @@ function makeClient(): {
   const upsertMatchProfileMock = vi.fn();
   const getUserSwipeStatsMock = vi.fn();
   const getSessionStatsMock = vi.fn();
+  const getTopPicksMock = vi.fn();
   const client: MatchingClient = {
     startSession: startSessionMock,
     endSession: endSessionMock,
@@ -50,6 +52,7 @@ function makeClient(): {
     upsertMatchProfile: upsertMatchProfileMock,
     getUserSwipeStats: getUserSwipeStatsMock,
     getSessionStats: getSessionStatsMock,
+    getTopPicks: getTopPicksMock,
     close: vi.fn(),
   };
   return {
@@ -64,6 +67,7 @@ function makeClient(): {
     upsertMatchProfileMock,
     getUserSwipeStatsMock,
     getSessionStatsMock,
+    getTopPicksMock,
   };
 }
 
@@ -642,6 +646,86 @@ describe('match profile + swipe stats', () => {
       const res = await app.inject({
         method: 'GET',
         url: '/api/v1/discovery/swipe/stats/usr-other',
+        headers: ADOPTER_HEADERS,
+      });
+      expect(res.statusCode).toBe(403);
+    } finally {
+      await app.close();
+    }
+  });
+});
+
+describe('GET /api/v1/match/top-picks (GetTopPicks)', () => {
+  it('returns the SPA-shaped top picks under a data envelope', async () => {
+    const m = makeClient();
+    m.getTopPicksMock.mockResolvedValue({
+      picks: [
+        {
+          petId: 'pet-1',
+          name: 'Bella',
+          type: 'cat',
+          ageGroup: 'baby',
+          size: 'small',
+          score: 0.74,
+          reasons: [{ kind: 'pref_match', label: 'Matches your preferences' }],
+          rescueName: 'Happy Tails',
+        },
+      ],
+    });
+    const app = await makeApp(m.client);
+    try {
+      const res = await app.inject({
+        method: 'GET',
+        url: '/api/v1/match/top-picks?limit=3',
+        headers: ADOPTER_HEADERS,
+      });
+      expect(res.statusCode).toBe(200);
+      const body = JSON.parse(res.body) as { success: boolean; data: unknown[] };
+      expect(body.success).toBe(true);
+      expect(body.data).toEqual([
+        {
+          petId: 'pet-1',
+          name: 'Bella',
+          type: 'cat',
+          ageGroup: 'baby',
+          size: 'small',
+          score: 0.74,
+          reasons: [{ kind: 'pref_match', label: 'Matches your preferences' }],
+          rescueName: 'Happy Tails',
+        },
+      ]);
+      // The query limit is forwarded to the gRPC request.
+      expect(m.getTopPicksMock.mock.calls[0][0]).toEqual({ limit: 3 });
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('defaults the limit to 10 when the query param is absent', async () => {
+    const m = makeClient();
+    m.getTopPicksMock.mockResolvedValue({ picks: [] });
+    const app = await makeApp(m.client);
+    try {
+      const res = await app.inject({
+        method: 'GET',
+        url: '/api/v1/match/top-picks',
+        headers: ADOPTER_HEADERS,
+      });
+      expect(res.statusCode).toBe(200);
+      expect(m.getTopPicksMock.mock.calls[0][0]).toEqual({ limit: 10 });
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('maps an upstream PERMISSION_DENIED to 403', async () => {
+    const m = makeClient();
+    m.getTopPicksMock.mockRejectedValue({ code: grpcStatus.PERMISSION_DENIED, details: 'no' });
+    const app = await makeApp(m.client);
+    try {
+      const res = await app.inject({
+        method: 'GET',
+        url: '/api/v1/match/top-picks',
         headers: ADOPTER_HEADERS,
       });
       expect(res.statusCode).toBe(403);

--- a/services/gateway/src/routes/matching.ts
+++ b/services/gateway/src/routes/matching.ts
@@ -30,6 +30,7 @@ import type { FastifyInstance, FastifyRequest } from 'fastify';
 import {
   MatchingV1,
   type EndSessionRequest,
+  type GetTopPicksRequest,
   type ListSwipeHistoryRequest,
   type RecommendRequest,
   type RecordSwipeRequest,
@@ -39,7 +40,7 @@ import {
 
 import type { MatchingClient } from '../grpc-clients/matching-client.js';
 
-import { recommendToQueue, searchToView } from './matching-view.js';
+import { recommendToQueue, searchToView, topPicksToView } from './matching-view.js';
 import { buildMetadata } from '../middleware/metadata.js';
 import { handleGrpcError } from '../middleware/grpc-error.js';
 import { parsePagination } from '../middleware/pagination.js';
@@ -61,6 +62,8 @@ const MATCHING_RATE_LIMITS = {
   // Discovery + search are the chatty browse paths.
   recommend: { max: 120, timeWindow: '1 minute' },
   search: { max: 120, timeWindow: '1 minute' },
+  // Top picks is a curated read the SPA loads on the home + picks pages.
+  topPicks: { max: 60, timeWindow: '1 minute' },
 } as const;
 
 type StartSessionBody = {
@@ -345,6 +348,28 @@ export const registerMatchingRoutes = async (
     }
   );
 
+  // ---- Top picks ---------------------------------------------------
+  // GET /api/v1/match/top-picks?limit=N — a short, personalised picks
+  // list scored against the adopter's stored match profile. Returns the
+  // SPA's MatchTopPick[] under a { success, data } envelope.
+  app.get(
+    '/api/v1/match/top-picks',
+    {
+      config: { rateLimit: MATCHING_RATE_LIMITS.topPicks },
+      schema: { tags: ['matching'] },
+    },
+    async (req, reply) => {
+      const query = req.query as Record<string, string | undefined>;
+      const grpcReq: GetTopPicksRequest = { limit: parseTopPicksLimit(query.limit) };
+      try {
+        const res = await client.getTopPicks(grpcReq, buildMetadata(req));
+        return reply.send({ success: true, data: topPicksToView(res) });
+      } catch (err) {
+        return handleGrpcError(err, reply);
+      }
+    }
+  );
+
   // ---- Swipe statistics --------------------------------------------
   // GET /api/v1/discovery/swipe/stats/:userId
   app.get<{ Params: { userId: string } }>(
@@ -480,6 +505,17 @@ function clampLimit(raw: number | undefined): number {
     return 20;
   }
   return Math.min(Math.max(Math.trunc(raw), 1), 100);
+}
+
+// Top picks is a short curated list: default 10, capped at 50. An absent
+// or unparseable query param falls back to the default. The matching
+// service re-clamps with the same bounds as defence-in-depth.
+function parseTopPicksLimit(raw: string | undefined): number {
+  const parsed = raw === undefined ? NaN : Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return 10;
+  }
+  return Math.min(parsed, 50);
 }
 
 // Implicit-session helper: when the SPA doesn't carry a sessionId on

--- a/services/matching/src/config.test.ts
+++ b/services/matching/src/config.test.ts
@@ -11,6 +11,7 @@ describe('loadConfig', () => {
     expect(config.grpcPort).toBe(6008);
     expect(config.schema).toBe('matching');
     expect(config.petsGrpcUrl).toBe('service-pets:6003');
+    expect(config.rescueGrpcUrl).toBe('service-rescue:6004');
   });
 
   it('honours all env overrides when set', () => {
@@ -23,11 +24,13 @@ describe('loadConfig', () => {
       DATABASE_URL: 'postgres://x',
       NATS_URL: 'nats://nats.internal:4222',
       PETS_GRPC_URL: 'pets.internal:6003',
+      RESCUE_GRPC_URL: 'rescue.internal:6004',
     });
     expect(config.port).toBe(5500);
     expect(config.grpcPort).toBe(6500);
     expect(config.schema).toBe('matching_test');
     expect(config.petsGrpcUrl).toBe('pets.internal:6003');
+    expect(config.rescueGrpcUrl).toBe('rescue.internal:6004');
   });
 
   it('rejects a non-numeric MATCHING_PORT', () => {

--- a/services/matching/src/config.ts
+++ b/services/matching/src/config.ts
@@ -27,6 +27,10 @@ export type MatchingConfig = {
   // stateless compute, not a denormalised projection of pets).
   // Defaults to the same service-pets:6003 address the gateway uses.
   petsGrpcUrl: string;
+  // service.rescue gRPC URL — GetTopPicks resolves each pick's rescue
+  // name via RescueService.Get. Defaults to the same service-rescue:6004
+  // address the gateway uses.
+  rescueGrpcUrl: string;
 };
 
 const DEFAULT_PORT = 5008;
@@ -35,6 +39,7 @@ const DEFAULT_HOST = '0.0.0.0';
 const DEFAULT_SCHEMA = 'matching';
 const DEFAULT_NATS_URL = 'nats://nats:4222';
 const DEFAULT_PETS_GRPC_URL = 'service-pets:6003';
+const DEFAULT_RESCUE_GRPC_URL = 'service-rescue:6004';
 
 export const loadConfig = (env: NodeJS.ProcessEnv = process.env): MatchingConfig => {
   const port = parsePort(env.MATCHING_PORT, DEFAULT_PORT, 'MATCHING_PORT');
@@ -51,5 +56,6 @@ export const loadConfig = (env: NodeJS.ProcessEnv = process.env): MatchingConfig
     schema: env.MATCHING_SCHEMA?.trim() || DEFAULT_SCHEMA,
     natsUrl: env.NATS_URL?.trim() || DEFAULT_NATS_URL,
     petsGrpcUrl: env.PETS_GRPC_URL?.trim() || DEFAULT_PETS_GRPC_URL,
+    rescueGrpcUrl: env.RESCUE_GRPC_URL?.trim() || DEFAULT_RESCUE_GRPC_URL,
   };
 };

--- a/services/matching/src/grpc/pet-tokens.ts
+++ b/services/matching/src/grpc/pet-tokens.ts
@@ -1,0 +1,75 @@
+// Shared lowercase-token <-> proto-enum lookup tables for the pets
+// PetType / PetSize / PetAgeGroup enums. Both the filters_json the SPA
+// sends (Recommend, SearchPets) and the lowercase tokens the top-picks
+// surface returns (TopPick.type/size/age_group) use this exact
+// vocabulary, so the tables live here once rather than duplicated per
+// handler file.
+
+import { PetsV1 } from '@adopt-dont-shop/proto';
+
+export const SPECIES_TO_TYPE: Record<string, PetsV1.PetType> = {
+  dog: PetsV1.PetType.PET_TYPE_DOG,
+  cat: PetsV1.PetType.PET_TYPE_CAT,
+  rabbit: PetsV1.PetType.PET_TYPE_RABBIT,
+  bird: PetsV1.PetType.PET_TYPE_BIRD,
+  reptile: PetsV1.PetType.PET_TYPE_REPTILE,
+  small_mammal: PetsV1.PetType.PET_TYPE_SMALL_MAMMAL,
+  fish: PetsV1.PetType.PET_TYPE_FISH,
+  other: PetsV1.PetType.PET_TYPE_OTHER,
+};
+
+export const SIZE_TO_ENUM: Record<string, PetsV1.PetSize> = {
+  extra_small: PetsV1.PetSize.PET_SIZE_EXTRA_SMALL,
+  small: PetsV1.PetSize.PET_SIZE_SMALL,
+  medium: PetsV1.PetSize.PET_SIZE_MEDIUM,
+  large: PetsV1.PetSize.PET_SIZE_LARGE,
+  extra_large: PetsV1.PetSize.PET_SIZE_EXTRA_LARGE,
+};
+
+export const AGE_GROUP_TO_ENUM: Record<string, PetsV1.PetAgeGroup> = {
+  baby: PetsV1.PetAgeGroup.PET_AGE_GROUP_BABY,
+  young: PetsV1.PetAgeGroup.PET_AGE_GROUP_YOUNG,
+  adult: PetsV1.PetAgeGroup.PET_AGE_GROUP_ADULT,
+  senior: PetsV1.PetAgeGroup.PET_AGE_GROUP_SENIOR,
+};
+
+// PetType enum → the lowercase species token PetCandidate.species /
+// TopPick.type carry. UNSPECIFIED / UNRECOGNIZED fall back to 'unknown'.
+export const TYPE_TO_SPECIES: Record<PetsV1.PetType, string> = {
+  [PetsV1.PetType.PET_TYPE_UNSPECIFIED]: 'unknown',
+  [PetsV1.PetType.PET_TYPE_DOG]: 'dog',
+  [PetsV1.PetType.PET_TYPE_CAT]: 'cat',
+  [PetsV1.PetType.PET_TYPE_RABBIT]: 'rabbit',
+  [PetsV1.PetType.PET_TYPE_BIRD]: 'bird',
+  [PetsV1.PetType.PET_TYPE_REPTILE]: 'reptile',
+  [PetsV1.PetType.PET_TYPE_SMALL_MAMMAL]: 'small_mammal',
+  [PetsV1.PetType.PET_TYPE_FISH]: 'fish',
+  [PetsV1.PetType.PET_TYPE_OTHER]: 'other',
+  [PetsV1.PetType.UNRECOGNIZED]: 'unknown',
+};
+
+export const SIZE_TO_TOKEN: Record<PetsV1.PetSize, string> = {
+  [PetsV1.PetSize.PET_SIZE_UNSPECIFIED]: 'unknown',
+  [PetsV1.PetSize.PET_SIZE_EXTRA_SMALL]: 'extra_small',
+  [PetsV1.PetSize.PET_SIZE_SMALL]: 'small',
+  [PetsV1.PetSize.PET_SIZE_MEDIUM]: 'medium',
+  [PetsV1.PetSize.PET_SIZE_LARGE]: 'large',
+  [PetsV1.PetSize.PET_SIZE_EXTRA_LARGE]: 'extra_large',
+  [PetsV1.PetSize.UNRECOGNIZED]: 'unknown',
+};
+
+export const AGE_GROUP_TO_TOKEN: Record<PetsV1.PetAgeGroup, string> = {
+  [PetsV1.PetAgeGroup.PET_AGE_GROUP_UNSPECIFIED]: 'unknown',
+  [PetsV1.PetAgeGroup.PET_AGE_GROUP_BABY]: 'baby',
+  [PetsV1.PetAgeGroup.PET_AGE_GROUP_YOUNG]: 'young',
+  [PetsV1.PetAgeGroup.PET_AGE_GROUP_ADULT]: 'adult',
+  [PetsV1.PetAgeGroup.PET_AGE_GROUP_SENIOR]: 'senior',
+  [PetsV1.PetAgeGroup.UNRECOGNIZED]: 'unknown',
+};
+
+export function lookupToken<T>(value: unknown, table: Record<string, T>): T | undefined {
+  if (typeof value !== 'string') {
+    return undefined;
+  }
+  return table[value.trim().toLowerCase()];
+}

--- a/services/matching/src/grpc/recommend-handlers.ts
+++ b/services/matching/src/grpc/recommend-handlers.ts
@@ -27,6 +27,13 @@ import {
 } from '@adopt-dont-shop/proto';
 
 import { HandlerError, type HandlerDeps } from './adapter.js';
+import {
+  AGE_GROUP_TO_ENUM,
+  lookupToken,
+  SIZE_TO_ENUM,
+  SPECIES_TO_TYPE,
+  TYPE_TO_SPECIES,
+} from './pet-tokens.js';
 import type { PetsClient } from './pets-client.js';
 import { principalToMetadata } from './principal.js';
 import { scoreCandidates, type RecommendPreferences } from './recommend-scoring.js';
@@ -176,7 +183,8 @@ async function listPetsResponse(
 // — where the same pet can have many rows from repeat swipes — collapses
 // to one exclusion per pet. 'info' actions are trace views, not
 // decisions, so they don't exclude a pet from future recommendations.
-async function fetchSwipedPetIds(deps: HandlerDeps, userId: string): Promise<Set<string>> {
+// Exported so GetTopPicks applies the exact same exclusion rule.
+export async function fetchSwipedPetIds(deps: HandlerDeps, userId: string): Promise<Set<string>> {
   const { rows } = await deps.pool.query<{ pet_id: string }>(
     `SELECT DISTINCT pet_id
        FROM matching.swipe_actions
@@ -223,32 +231,6 @@ function readField(obj: object, key: string): unknown {
     : undefined;
 }
 
-const SPECIES_TO_TYPE: Record<string, PetsV1.PetType> = {
-  dog: PetsV1.PetType.PET_TYPE_DOG,
-  cat: PetsV1.PetType.PET_TYPE_CAT,
-  rabbit: PetsV1.PetType.PET_TYPE_RABBIT,
-  bird: PetsV1.PetType.PET_TYPE_BIRD,
-  reptile: PetsV1.PetType.PET_TYPE_REPTILE,
-  small_mammal: PetsV1.PetType.PET_TYPE_SMALL_MAMMAL,
-  fish: PetsV1.PetType.PET_TYPE_FISH,
-  other: PetsV1.PetType.PET_TYPE_OTHER,
-};
-
-const SIZE_TO_ENUM: Record<string, PetsV1.PetSize> = {
-  extra_small: PetsV1.PetSize.PET_SIZE_EXTRA_SMALL,
-  small: PetsV1.PetSize.PET_SIZE_SMALL,
-  medium: PetsV1.PetSize.PET_SIZE_MEDIUM,
-  large: PetsV1.PetSize.PET_SIZE_LARGE,
-  extra_large: PetsV1.PetSize.PET_SIZE_EXTRA_LARGE,
-};
-
-const AGE_GROUP_TO_ENUM: Record<string, PetsV1.PetAgeGroup> = {
-  baby: PetsV1.PetAgeGroup.PET_AGE_GROUP_BABY,
-  young: PetsV1.PetAgeGroup.PET_AGE_GROUP_YOUNG,
-  adult: PetsV1.PetAgeGroup.PET_AGE_GROUP_ADULT,
-  senior: PetsV1.PetAgeGroup.PET_AGE_GROUP_SENIOR,
-};
-
 function mapSpecies(value: unknown): PetsV1.PetType | undefined {
   return lookupToken(value, SPECIES_TO_TYPE);
 }
@@ -260,28 +242,6 @@ function mapSize(value: unknown): PetsV1.PetSize | undefined {
 function mapAgeGroup(value: unknown): PetsV1.PetAgeGroup | undefined {
   return lookupToken(value, AGE_GROUP_TO_ENUM);
 }
-
-function lookupToken<T>(value: unknown, table: Record<string, T>): T | undefined {
-  if (typeof value !== 'string') {
-    return undefined;
-  }
-  return table[value.trim().toLowerCase()];
-}
-
-// PetType enum → the lowercase species token PetCandidate.species
-// carries. UNSPECIFIED / UNRECOGNIZED fall back to 'unknown'.
-const TYPE_TO_SPECIES: Record<PetsV1.PetType, string> = {
-  [PetsV1.PetType.PET_TYPE_UNSPECIFIED]: 'unknown',
-  [PetsV1.PetType.PET_TYPE_DOG]: 'dog',
-  [PetsV1.PetType.PET_TYPE_CAT]: 'cat',
-  [PetsV1.PetType.PET_TYPE_RABBIT]: 'rabbit',
-  [PetsV1.PetType.PET_TYPE_BIRD]: 'bird',
-  [PetsV1.PetType.PET_TYPE_REPTILE]: 'reptile',
-  [PetsV1.PetType.PET_TYPE_SMALL_MAMMAL]: 'small_mammal',
-  [PetsV1.PetType.PET_TYPE_FISH]: 'fish',
-  [PetsV1.PetType.PET_TYPE_OTHER]: 'other',
-  [PetsV1.PetType.UNRECOGNIZED]: 'unknown',
-};
 
 // Pet (pets vertical) → PetCandidate (matching's swipe-card subset).
 // The pets Pet message has no plain `breed` name (only breedId) nor an

--- a/services/matching/src/grpc/rescue-client.test.ts
+++ b/services/matching/src/grpc/rescue-client.test.ts
@@ -1,0 +1,167 @@
+// Behaviour tests for the matching rescue-client. Mirrors
+// services/notifications/src/grpc/rescue-client.test.ts: a real
+// @grpc/grpc-js Server bound to 127.0.0.1:0, torn down in afterEach.
+
+import {
+  Metadata,
+  Server,
+  ServerCredentials,
+  ServerUnaryCall,
+  sendUnaryData,
+  ServiceError,
+  status,
+} from '@grpc/grpc-js';
+
+import { RescueV1, type GetRescueRequest, type GetRescueResponse } from '@adopt-dont-shop/proto';
+import {
+  PRINCIPAL_TOKEN_HEADER,
+  resetDefaultPrincipalSigningKeyForTests,
+  verifyPrincipalToken,
+} from '@adopt-dont-shop/service-bootstrap';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { createRescueClient } from './rescue-client.js';
+
+const makeServiceError = (code: number, details: string): ServiceError => {
+  const err = new Error(details) as ServiceError;
+  err.code = code;
+  err.details = details;
+  err.metadata = new Metadata();
+  return err;
+};
+
+describe('createRescueClient — rescue name lookup', () => {
+  let server: Server;
+  let port: number;
+
+  beforeEach(() => {
+    server = new Server();
+  });
+
+  afterEach(async () => {
+    await new Promise<void>(resolve => server.tryShutdown(() => resolve()));
+  });
+
+  const startServer = async (): Promise<number> =>
+    new Promise<number>((resolve, reject) => {
+      server.bindAsync('127.0.0.1:0', ServerCredentials.createInsecure(), (err, boundPort) =>
+        err ? reject(err) : resolve(boundPort)
+      );
+    });
+
+  it('returns the rescue name from Get', async () => {
+    server.addService(RescueV1.RescueServiceService, {
+      get: (
+        _call: ServerUnaryCall<GetRescueRequest, GetRescueResponse>,
+        cb: sendUnaryData<GetRescueResponse>
+      ) => {
+        cb(null, {
+          rescue: RescueV1.Rescue.fromPartial({ rescueId: 'res-1', name: 'Happy Tails' }),
+        });
+      },
+    });
+
+    port = await startServer();
+    const client = createRescueClient({ address: `127.0.0.1:${port}`, deadlineMs: 2_000 });
+    try {
+      expect(await client.getRescueName('res-1')).toBe('Happy Tails');
+    } finally {
+      client.close();
+    }
+  });
+
+  it('returns null when the rescue has no name set', async () => {
+    server.addService(RescueV1.RescueServiceService, {
+      get: (
+        _call: ServerUnaryCall<GetRescueRequest, GetRescueResponse>,
+        cb: sendUnaryData<GetRescueResponse>
+      ) => {
+        cb(null, { rescue: undefined });
+      },
+    });
+
+    port = await startServer();
+    const client = createRescueClient({ address: `127.0.0.1:${port}`, deadlineMs: 2_000 });
+    try {
+      expect(await client.getRescueName('res-missing')).toBeNull();
+    } finally {
+      client.close();
+    }
+  });
+
+  it('retries Get on a transient UNAVAILABLE', async () => {
+    let callCount = 0;
+    server.addService(RescueV1.RescueServiceService, {
+      get: (
+        _call: ServerUnaryCall<GetRescueRequest, GetRescueResponse>,
+        cb: sendUnaryData<GetRescueResponse>
+      ) => {
+        callCount += 1;
+        if (callCount === 1) {
+          cb(makeServiceError(status.UNAVAILABLE, 'service unavailable'), null);
+        } else {
+          cb(null, { rescue: RescueV1.Rescue.fromPartial({ rescueId: 'res-1', name: 'Retried' }) });
+        }
+      },
+    });
+
+    port = await startServer();
+    const client = createRescueClient({ address: `127.0.0.1:${port}`, deadlineMs: 2_000 });
+    try {
+      expect(await client.getRescueName('res-1')).toBe('Retried');
+      expect(callCount).toBe(2);
+    } finally {
+      client.close();
+    }
+  });
+});
+
+describe('createRescueClient — signed system principal', () => {
+  const SIGNING_KEY = 'matching-test-signing-key';
+  let server: Server;
+
+  beforeEach(() => {
+    server = new Server();
+  });
+
+  afterEach(async () => {
+    delete process.env.PRINCIPAL_SIGNING_KEY;
+    resetDefaultPrincipalSigningKeyForTests();
+    await new Promise<void>(resolve => server.tryShutdown(() => resolve()));
+  });
+
+  it('stamps a super_admin principal carrying rescues.read so it can read any rescue', async () => {
+    process.env.PRINCIPAL_SIGNING_KEY = SIGNING_KEY;
+    resetDefaultPrincipalSigningKeyForTests();
+
+    const captured: Metadata[] = [];
+    server.addService(RescueV1.RescueServiceService, {
+      get: (
+        call: ServerUnaryCall<GetRescueRequest, GetRescueResponse>,
+        cb: sendUnaryData<GetRescueResponse>
+      ) => {
+        captured.push(call.metadata);
+        cb(null, { rescue: undefined });
+      },
+    });
+    const port = await new Promise<number>((resolve, reject) => {
+      server.bindAsync('127.0.0.1:0', ServerCredentials.createInsecure(), (err, boundPort) =>
+        err ? reject(err) : resolve(boundPort)
+      );
+    });
+
+    const client = createRescueClient({ address: `127.0.0.1:${port}` });
+    try {
+      await client.getRescueName('res-1');
+      expect(captured).toHaveLength(1);
+      const token = String(captured[0].get(PRINCIPAL_TOKEN_HEADER)[0]);
+      const principal = verifyPrincipalToken(token, SIGNING_KEY);
+      expect(principal.userId).toBe('svc-matching');
+      expect(principal.roles).toEqual(['super_admin']);
+      expect(principal.permissions).toEqual(['rescues.read']);
+    } finally {
+      client.close();
+    }
+  });
+});

--- a/services/matching/src/grpc/rescue-client.ts
+++ b/services/matching/src/grpc/rescue-client.ts
@@ -1,0 +1,121 @@
+// Service-to-service gRPC client for service.rescue — GetTopPicks
+// resolves each pick's rescue name via RescueService.Get. Mirrors
+// services/notifications/src/grpc/rescue-client.ts (signed system
+// principal, retry on UNAVAILABLE / DEADLINE_EXCEEDED, a per-call
+// deadline), trimmed to just the lookup top-picks needs.
+
+import { credentials, status, type CallOptions, Metadata } from '@grpc/grpc-js';
+
+import { RescueV1, type GetRescueRequest, type GetRescueResponse } from '@adopt-dont-shop/proto';
+import {
+  getDefaultPrincipalSigningKey,
+  PRINCIPAL_TOKEN_HEADER,
+  signPrincipalToken,
+} from '@adopt-dont-shop/service-bootstrap';
+
+export type CreateRescueClientOptions = {
+  address: string;
+  // System principal metadata. RescueService.Get gates on `rescues.read`.
+  systemUserId?: string;
+  systemRoles?: string;
+  systemPermissions?: string;
+  deadlineMs?: number;
+  maxRetries?: number;
+};
+
+const DEFAULT_DEADLINE_MS = 5_000;
+const DEFAULT_MAX_RETRIES = 2;
+const RETRYABLE_CODES = new Set([status.UNAVAILABLE, status.DEADLINE_EXCEEDED]);
+
+const isRetryableError = (err: unknown): boolean => {
+  if (err === null || typeof err !== 'object') {
+    return false;
+  }
+  const code = (err as { code?: unknown }).code;
+  return typeof code === 'number' && RETRYABLE_CODES.has(code);
+};
+
+const sleep = (ms: number): Promise<void> => new Promise(resolve => setTimeout(resolve, ms));
+
+const splitList = (raw: string): string[] =>
+  raw
+    .split(',')
+    .map(s => s.trim())
+    .filter(Boolean);
+
+const jitteredBackoff = (attempt: number, baseMs: number): number => {
+  const base = baseMs * Math.pow(2, attempt - 1);
+  return base * (0.75 + Math.random() * 0.5);
+};
+
+export type RescueNameClient = {
+  getRescueName: (rescueId: string) => Promise<string | null>;
+  close(): void;
+};
+
+export function createRescueClient(opts: CreateRescueClientOptions): RescueNameClient {
+  const stub = new RescueV1.RescueServiceClient(opts.address, credentials.createInsecure());
+  const deadlineMs = opts.deadlineMs ?? DEFAULT_DEADLINE_MS;
+  const maxRetries = opts.maxRetries ?? DEFAULT_MAX_RETRIES;
+
+  const systemPrincipal = {
+    userId: opts.systemUserId ?? 'svc-matching',
+    roles: splitList(opts.systemRoles ?? 'super_admin'),
+    permissions: splitList(opts.systemPermissions ?? 'rescues.read'),
+  };
+
+  const buildSystemMetadata = (): Metadata => {
+    const meta = new Metadata();
+    meta.set('x-user-id', systemPrincipal.userId);
+    meta.set('x-user-roles', systemPrincipal.roles.join(','));
+    meta.set('x-user-permissions', systemPrincipal.permissions.join(','));
+    const signingKey = getDefaultPrincipalSigningKey();
+    if (signingKey) {
+      meta.set(PRINCIPAL_TOKEN_HEADER, signPrincipalToken(systemPrincipal, signingKey));
+    }
+    return meta;
+  };
+
+  const callWithRetry = <Req, Res>(
+    fn: (
+      req: Req,
+      metadata: Metadata,
+      options: Partial<CallOptions>,
+      cb: (err: unknown, res: Res) => void
+    ) => unknown,
+    req: Req
+  ): Promise<Res> => {
+    const attempt = (remaining: number): Promise<Res> =>
+      new Promise<Res>((resolve, reject) => {
+        const options: Partial<CallOptions> = {
+          deadline: new Date(Date.now() + deadlineMs),
+        };
+        fn.call(stub, req, buildSystemMetadata(), options, (err: unknown, res: Res) => {
+          if (err) {
+            if (remaining > 0 && isRetryableError(err)) {
+              const retryIndex = maxRetries - remaining + 1;
+              sleep(jitteredBackoff(retryIndex, 100))
+                .then(() => attempt(remaining - 1))
+                .then(resolve, reject);
+            } else {
+              reject(err);
+            }
+            return;
+          }
+          resolve(res);
+        });
+      });
+
+    return attempt(maxRetries);
+  };
+
+  return {
+    getRescueName: async (rescueId: string): Promise<string | null> => {
+      const res = await callWithRetry<GetRescueRequest, GetRescueResponse>(stub.get, {
+        rescueId,
+      });
+      return res.rescue?.name ?? null;
+    },
+    close: () => stub.close(),
+  };
+}

--- a/services/matching/src/grpc/server.test.ts
+++ b/services/matching/src/grpc/server.test.ts
@@ -25,20 +25,32 @@ const config: MatchingConfig = {
   schema: 'matching',
   natsUrl: 'nats://localhost:4222',
   petsGrpcUrl: 'service-pets:6003',
+  rescueGrpcUrl: 'service-rescue:6004',
 };
 
 const pool = {} as unknown as Pool;
 const nats = {} as unknown as NatsConnection;
-// Inject a stub pets client so the test doesn't construct a real gRPC
-// channel just to assert handler registration.
+// Inject stub downstream clients so the test doesn't construct real gRPC
+// channels just to assert handler registration.
 const petsClient = {
   listPets: () => Promise.reject(new Error('not used')),
   close: () => undefined,
 } as unknown as Parameters<typeof createGrpcServer>[0]['petsClient'];
+const rescueClient = {
+  getRescueName: () => Promise.reject(new Error('not used')),
+  close: () => undefined,
+} as unknown as Parameters<typeof createGrpcServer>[0]['rescueClient'];
 
 describe('createGrpcServer', () => {
   it('registers all six MatchingService methods on the grpc.Server', () => {
-    const server = createGrpcServer({ config, pool, nats, logger: quietLogger, petsClient });
+    const server = createGrpcServer({
+      config,
+      pool,
+      nats,
+      logger: quietLogger,
+      petsClient,
+      rescueClient,
+    });
     const handlers = (server as unknown as { handlers: Map<string, unknown> }).handlers;
 
     expect(handlers.has('/adopt_dont_shop.matching.v1.MatchingService/StartSession')).toBe(true);
@@ -55,7 +67,14 @@ describe('createGrpcServer', () => {
     const definition = MatchingV1.MatchingServiceService;
     const expectedPaths = Object.values(definition).map(d => (d as { path: string }).path);
 
-    const server = createGrpcServer({ config, pool, nats, logger: quietLogger, petsClient });
+    const server = createGrpcServer({
+      config,
+      pool,
+      nats,
+      logger: quietLogger,
+      petsClient,
+      rescueClient,
+    });
     const handlers = (server as unknown as { handlers: Map<string, unknown> }).handlers;
 
     for (const p of expectedPaths) {

--- a/services/matching/src/grpc/server.ts
+++ b/services/matching/src/grpc/server.ts
@@ -26,6 +26,8 @@ import {
   upsertMatchProfile,
 } from './profile-stats-handlers.js';
 import { makeRecommend, makeSearchPets } from './recommend-handlers.js';
+import { createRescueClient, type RescueNameClient } from './rescue-client.js';
+import { makeGetTopPicks } from './top-picks-handlers.js';
 
 export type CreateGrpcServerOptions = {
   config: MatchingConfig;
@@ -37,6 +39,10 @@ export type CreateGrpcServerOptions = {
   // client is built from config.petsGrpcUrl. startGrpcServer always
   // builds + owns one so it can close it on shutdown.
   petsClient?: PetsClient;
+  // Injected for GetTopPicks's rescue-name resolution. Same lifecycle as
+  // petsClient: optional for direct/test construction, built + owned by
+  // startGrpcServer from config.rescueGrpcUrl in production.
+  rescueClient?: RescueNameClient;
 };
 
 export type { RunningGrpcServer };
@@ -45,6 +51,7 @@ export const createGrpcServer = (opts: CreateGrpcServerOptions): Server => {
   const { config, pool, nats, logger } = opts;
   const deps = { pool, nats };
   const petsClient = opts.petsClient ?? createPetsClient({ address: config.petsGrpcUrl });
+  const rescueClient = opts.rescueClient ?? createRescueClient({ address: config.rescueGrpcUrl });
   const server = new Server();
 
   server.addService(MatchingV1.MatchingServiceService, {
@@ -58,6 +65,7 @@ export const createGrpcServer = (opts: CreateGrpcServerOptions): Server => {
     upsertMatchProfile: adapt(upsertMatchProfile, { deps, logger }),
     getUserSwipeStats: adapt(getUserSwipeStats, { deps, logger }),
     getSessionStats: adapt(getSessionStats, { deps, logger }),
+    getTopPicks: adapt(makeGetTopPicks(petsClient, rescueClient), { deps, logger }),
   });
 
   logger.info('gRPC MatchingService registered', {
@@ -72,6 +80,7 @@ export const createGrpcServer = (opts: CreateGrpcServerOptions): Server => {
       'upsertMatchProfile',
       'getUserSwipeStats',
       'getSessionStats',
+      'getTopPicks',
     ],
     grpcPort: config.grpcPort,
   });
@@ -83,9 +92,10 @@ export const startGrpcServer = async (
   opts: CreateGrpcServerOptions
 ): Promise<RunningGrpcServer> => {
   const { config, logger } = opts;
-  // Build + own the pets client here so it's closed on shutdown.
+  // Build + own the downstream clients here so they're closed on shutdown.
   const petsClient = opts.petsClient ?? createPetsClient({ address: config.petsGrpcUrl });
-  const server = createGrpcServer({ ...opts, petsClient });
+  const rescueClient = opts.rescueClient ?? createRescueClient({ address: config.rescueGrpcUrl });
+  const server = createGrpcServer({ ...opts, petsClient, rescueClient });
   const running = await startGrpcServerShared(server, config, logger);
 
   return {
@@ -96,10 +106,15 @@ export const startGrpcServer = async (
           if (err) {
             logger.error('gRPC server shutdown error', { err });
           }
-          try {
-            petsClient.close();
-          } catch (closeErr) {
-            logger.error('pets client close error', { err: closeErr });
+          for (const [name, client] of [
+            ['pets', petsClient],
+            ['rescue', rescueClient],
+          ] as const) {
+            try {
+              client.close();
+            } catch (closeErr) {
+              logger.error(`${name} client close error`, { err: closeErr });
+            }
           }
           resolve();
         });

--- a/services/matching/src/grpc/top-picks-handlers.test.ts
+++ b/services/matching/src/grpc/top-picks-handlers.test.ts
@@ -1,0 +1,289 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  PetsV1,
+  type ListPetsResponse,
+  type Pet,
+  type GetTopPicksRequest,
+} from '@adopt-dont-shop/proto';
+
+import type { HandlerDeps } from './adapter.js';
+import type { PetsClient } from './pets-client.js';
+import type { RescueNameClient } from './rescue-client.js';
+import { makeGetTopPicks } from './top-picks-handlers.js';
+
+function makePrincipal(
+  overrides: Partial<{ userId: string; permissions: string[]; roles: string[] }> = {}
+) {
+  return {
+    userId: overrides.userId ?? 'usr-1',
+    roles: overrides.roles ?? ['adopter'],
+    permissions: overrides.permissions ?? ['pets.read'],
+    rescueId: undefined,
+  } as unknown as Parameters<ReturnType<typeof makeGetTopPicks>>[1];
+}
+
+type ProfileRow = {
+  preferred_types: unknown[] | null;
+  preferred_sizes: unknown[] | null;
+  preferred_age_groups: unknown[] | null;
+  lifestyle: Record<string, unknown>;
+};
+
+// A pool stub that answers the two reads the handler makes — the match
+// profile SELECT and the swipe-history exclusion — by branching on the
+// SQL text. `profile: null` simulates an adopter with no saved profile.
+function makeDeps(opts: { profile?: ProfileRow | null; swiped?: string[] } = {}): HandlerDeps {
+  const query = vi.fn((sql: string) => {
+    if (sql.includes('adopter_match_profiles')) {
+      const noProfile = opts.profile === null || opts.profile === undefined;
+      return Promise.resolve({ rows: noProfile ? [] : [opts.profile] });
+    }
+    if (sql.includes('swipe_actions')) {
+      return Promise.resolve({ rows: (opts.swiped ?? []).map(pet_id => ({ pet_id })) });
+    }
+    return Promise.resolve({ rows: [] });
+  });
+  return { pool: { query } } as unknown as HandlerDeps;
+}
+
+function makePetsClient(listPets: ReturnType<typeof vi.fn>): PetsClient {
+  return { listPets, close: vi.fn() } as unknown as PetsClient;
+}
+
+function makeRescueClient(
+  getRescueName: ReturnType<typeof vi.fn> = vi.fn().mockResolvedValue('A Rescue')
+): RescueNameClient {
+  return { getRescueName, close: vi.fn() };
+}
+
+function makePet(overrides: Partial<Pet> & { petId: string }): Pet {
+  return {
+    name: 'Rex',
+    type: PetsV1.PetType.PET_TYPE_DOG,
+    status: PetsV1.PetStatus.PET_STATUS_AVAILABLE,
+    gender: PetsV1.PetGender.PET_GENDER_UNSPECIFIED,
+    size: PetsV1.PetSize.PET_SIZE_MEDIUM,
+    ageGroup: PetsV1.PetAgeGroup.PET_AGE_GROUP_ADULT,
+    archived: false,
+    featured: false,
+    priorityListing: false,
+    specialNeeds: false,
+    houseTrained: false,
+    temperamentJson: '[]',
+    tagsJson: '[]',
+    extraJson: '{}',
+    viewCount: 0,
+    favoriteCount: 0,
+    applicationCount: 0,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+const listResponse = (pets: Pet[]): ListPetsResponse => ({ pets });
+const req = (limit = 10): GetTopPicksRequest => ({ limit });
+
+describe('makeGetTopPicks', () => {
+  it('throws PERMISSION_DENIED without pets.read', async () => {
+    const getTopPicks = makeGetTopPicks(makePetsClient(vi.fn()), makeRescueClient());
+    await expect(
+      getTopPicks(makeDeps(), makePrincipal({ permissions: [] }), req())
+    ).rejects.toMatchObject({ code: 'PERMISSION_DENIED' });
+  });
+
+  it('only requests available pets from service.pets', async () => {
+    const listPets = vi.fn().mockResolvedValue(listResponse([]));
+    const getTopPicks = makeGetTopPicks(makePetsClient(listPets), makeRescueClient());
+
+    await getTopPicks(makeDeps(), makePrincipal(), req());
+
+    expect(listPets.mock.calls[0][0].statusFilter).toBe(PetsV1.PetStatus.PET_STATUS_AVAILABLE);
+  });
+
+  it('returns scored picks with lowercase tokens and a resolved rescue name', async () => {
+    const listPets = vi.fn().mockResolvedValue(
+      listResponse([
+        makePet({
+          petId: 'p-1',
+          name: 'Bella',
+          rescueId: 'rsc-1',
+          type: PetsV1.PetType.PET_TYPE_CAT,
+          size: PetsV1.PetSize.PET_SIZE_SMALL,
+          ageGroup: PetsV1.PetAgeGroup.PET_AGE_GROUP_BABY,
+        }),
+      ])
+    );
+    const getRescueName = vi.fn().mockResolvedValue('Happy Tails');
+    const getTopPicks = makeGetTopPicks(makePetsClient(listPets), makeRescueClient(getRescueName));
+
+    const res = await getTopPicks(makeDeps(), makePrincipal(), req());
+
+    expect(res.picks).toHaveLength(1);
+    expect(res.picks[0]).toMatchObject({
+      petId: 'p-1',
+      name: 'Bella',
+      type: 'cat',
+      size: 'small',
+      ageGroup: 'baby',
+      rescueName: 'Happy Tails',
+    });
+    expect(res.picks[0].score).toBeGreaterThanOrEqual(0);
+    expect(res.picks[0].score).toBeLessThanOrEqual(1);
+  });
+
+  it('ranks a pet matching the stored profile above a non-matching one', async () => {
+    const listPets = vi
+      .fn()
+      .mockResolvedValue(
+        listResponse([
+          makePet({ petId: 'cat', rescueId: 'rsc-1', type: PetsV1.PetType.PET_TYPE_CAT }),
+          makePet({ petId: 'dog', rescueId: 'rsc-1', type: PetsV1.PetType.PET_TYPE_DOG }),
+        ])
+      );
+    const getTopPicks = makeGetTopPicks(makePetsClient(listPets), makeRescueClient());
+
+    const res = await getTopPicks(
+      makeDeps({
+        profile: {
+          preferred_types: ['dog'],
+          preferred_sizes: null,
+          preferred_age_groups: null,
+          lifestyle: {},
+        },
+      }),
+      makePrincipal(),
+      req()
+    );
+
+    expect(res.picks[0].petId).toBe('dog');
+    expect(res.picks[0].reasons.some(r => r.kind === 'pref_match')).toBe(true);
+  });
+
+  it('excludes pets the caller has already swiped', async () => {
+    const listPets = vi
+      .fn()
+      .mockResolvedValue(
+        listResponse([
+          makePet({ petId: 'seen', rescueId: 'rsc-1' }),
+          makePet({ petId: 'fresh', rescueId: 'rsc-1' }),
+        ])
+      );
+    const getTopPicks = makeGetTopPicks(makePetsClient(listPets), makeRescueClient());
+
+    const res = await getTopPicks(makeDeps({ swiped: ['seen'] }), makePrincipal(), req());
+
+    const ids = res.picks.map(p => p.petId);
+    expect(ids).toContain('fresh');
+    expect(ids).not.toContain('seen');
+  });
+
+  it('caps the result at the requested limit', async () => {
+    const pets = Array.from({ length: 5 }, (_, i) =>
+      makePet({ petId: `p-${i}`, rescueId: 'rsc-1' })
+    );
+    const listPets = vi.fn().mockResolvedValue(listResponse(pets));
+    const getTopPicks = makeGetTopPicks(makePetsClient(listPets), makeRescueClient());
+
+    const res = await getTopPicks(makeDeps(), makePrincipal(), req(2));
+
+    expect(res.picks).toHaveLength(2);
+  });
+
+  it('resolves each distinct rescue exactly once even across many picks', async () => {
+    const listPets = vi
+      .fn()
+      .mockResolvedValue(
+        listResponse([
+          makePet({ petId: 'a', rescueId: 'rsc-1' }),
+          makePet({ petId: 'b', rescueId: 'rsc-1' }),
+          makePet({ petId: 'c', rescueId: 'rsc-2' }),
+        ])
+      );
+    const getRescueName = vi.fn().mockResolvedValue('Some Rescue');
+    const getTopPicks = makeGetTopPicks(makePetsClient(listPets), makeRescueClient(getRescueName));
+
+    await getTopPicks(makeDeps(), makePrincipal(), req());
+
+    expect(getRescueName).toHaveBeenCalledTimes(2);
+    expect(getRescueName.mock.calls.map(c => c[0]).sort()).toEqual(['rsc-1', 'rsc-2']);
+  });
+
+  it('leaves rescueName empty when the rescue lookup yields nothing', async () => {
+    const listPets = vi
+      .fn()
+      .mockResolvedValue(listResponse([makePet({ petId: 'p-1', rescueId: 'rsc-1' })]));
+    const getRescueName = vi.fn().mockResolvedValue(null);
+    const getTopPicks = makeGetTopPicks(makePetsClient(listPets), makeRescueClient(getRescueName));
+
+    const res = await getTopPicks(makeDeps(), makePrincipal(), req());
+
+    expect(res.picks[0].rescueName).toBe('');
+  });
+
+  it('still returns picks when the adopter has no saved profile', async () => {
+    const listPets = vi
+      .fn()
+      .mockResolvedValue(listResponse([makePet({ petId: 'p-1', rescueId: 'rsc-1' })]));
+    const getTopPicks = makeGetTopPicks(makePetsClient(listPets), makeRescueClient());
+
+    const res = await getTopPicks(makeDeps({ profile: null }), makePrincipal(), req());
+
+    expect(res.picks).toHaveLength(1);
+    expect(res.picks[0].reasons.some(r => r.kind === 'pref_match')).toBe(false);
+  });
+
+  it('surfaces a lifestyle chip when a child-friendly pet meets a household with children', async () => {
+    const listPets = vi.fn().mockResolvedValue(
+      listResponse([
+        makePet({
+          petId: 'p-1',
+          rescueId: 'rsc-1',
+          extraJson: JSON.stringify({ goodWithChildren: true }),
+        }),
+      ])
+    );
+    const getTopPicks = makeGetTopPicks(makePetsClient(listPets), makeRescueClient());
+
+    const res = await getTopPicks(
+      makeDeps({
+        profile: {
+          preferred_types: null,
+          preferred_sizes: null,
+          preferred_age_groups: null,
+          lifestyle: { has_children: true },
+        },
+      }),
+      makePrincipal(),
+      req()
+    );
+
+    expect(res.picks[0].reasons.some(r => r.kind === 'lifestyle')).toBe(true);
+  });
+
+  it('forwards the caller identity to service.pets as metadata', async () => {
+    const listPets = vi.fn().mockResolvedValue(listResponse([]));
+    const getTopPicks = makeGetTopPicks(makePetsClient(listPets), makeRescueClient());
+
+    await getTopPicks(makeDeps(), makePrincipal({ userId: 'usr-9' }), req());
+
+    expect(listPets.mock.calls[0][1].get('x-user-id')).toEqual(['usr-9']);
+  });
+
+  it('maps a pets PERMISSION_DENIED (grpc code 7) onto PERMISSION_DENIED', async () => {
+    const listPets = vi.fn().mockRejectedValue({ code: 7 });
+    const getTopPicks = makeGetTopPicks(makePetsClient(listPets), makeRescueClient());
+    await expect(getTopPicks(makeDeps(), makePrincipal(), req())).rejects.toMatchObject({
+      code: 'PERMISSION_DENIED',
+    });
+  });
+
+  it('maps an unexpected pets error onto INTERNAL', async () => {
+    const listPets = vi.fn().mockRejectedValue(new Error('boom'));
+    const getTopPicks = makeGetTopPicks(makePetsClient(listPets), makeRescueClient());
+    await expect(getTopPicks(makeDeps(), makePrincipal(), req())).rejects.toMatchObject({
+      code: 'INTERNAL',
+    });
+  });
+});

--- a/services/matching/src/grpc/top-picks-handlers.ts
+++ b/services/matching/src/grpc/top-picks-handlers.ts
@@ -1,0 +1,224 @@
+// gRPC handler for MatchingService.GetTopPicks — a short, personalised
+// "top picks" list distinct from Recommend's swipe feed.
+//
+// Unlike Recommend (which scores against the session's transient
+// filters), top picks reads the adopter's STORED match profile
+// (preferred types / sizes / age groups + lifestyle) from
+// matching.adopter_match_profiles, scores the available pets against it
+// with the pure scorer in top-picks-scoring.ts, excludes already-swiped
+// pets (same rule as Recommend), and resolves each pick's rescue name
+// over gRPC. Stateless — no swipe session required, no mutation.
+
+import { requirePermission, type Principal } from '@adopt-dont-shop/authz';
+import { PETS_VIEW } from '@adopt-dont-shop/lib.types';
+import {
+  PetsV1,
+  type GetTopPicksRequest,
+  type GetTopPicksResponse,
+  type ListPetsRequest,
+  type Pet,
+  type TopPick,
+} from '@adopt-dont-shop/proto';
+
+import { HandlerError, type HandlerDeps } from './adapter.js';
+import {
+  AGE_GROUP_TO_ENUM,
+  AGE_GROUP_TO_TOKEN,
+  lookupToken,
+  SIZE_TO_ENUM,
+  SIZE_TO_TOKEN,
+  SPECIES_TO_TYPE,
+  TYPE_TO_SPECIES,
+} from './pet-tokens.js';
+import type { PetsClient } from './pets-client.js';
+import { principalToMetadata } from './principal.js';
+import { fetchSwipedPetIds } from './recommend-handlers.js';
+import type { RescueNameClient } from './rescue-client.js';
+import { scoreTopPicks, type TopPickPreferences } from './top-picks-scoring.js';
+
+// grpc-js PERMISSION_DENIED, returned by service.pets' List gate.
+const PETS_GRPC_PERMISSION_DENIED = 7;
+
+const DEFAULT_LIMIT = 10;
+const MAX_LIMIT = 50;
+// service.pets caps List at 100/page; pull the max so the scorer ranks a
+// real pool rather than a single SPA page before slicing to the top-K.
+const CANDIDATE_FETCH = 100;
+
+export function makeGetTopPicks(
+  petsClient: PetsClient,
+  rescueClient: RescueNameClient
+): (
+  deps: HandlerDeps,
+  principal: Principal,
+  req: GetTopPicksRequest
+) => Promise<GetTopPicksResponse> {
+  return async (deps, principal, req) => {
+    if (!requirePermission(principal, PETS_VIEW)) {
+      throw new HandlerError('PERMISSION_DENIED', `'${PETS_VIEW}' required`);
+    }
+
+    const limit = clamp(req.limit, DEFAULT_LIMIT, MAX_LIMIT);
+    const preferences = await loadPreferences(deps, principal.userId);
+
+    const listReq: ListPetsRequest = {
+      limit: CANDIDATE_FETCH,
+      statusFilter: PetsV1.PetStatus.PET_STATUS_AVAILABLE,
+      typeFilter: PetsV1.PetType.PET_TYPE_UNSPECIFIED,
+      sizeFilter: PetsV1.PetSize.PET_SIZE_UNSPECIFIED,
+    };
+    const pets = await listAvailablePets(petsClient, principal, listReq);
+
+    const swiped = await fetchSwipedPetIds(deps, principal.userId);
+    const fresh = pets.filter(pet => !swiped.has(pet.petId));
+
+    const ranked = scoreTopPicks(fresh, preferences).slice(0, limit);
+
+    const rescueNames = await resolveRescueNames(
+      rescueClient,
+      ranked.map(r => r.pet)
+    );
+    const picks = ranked.map(({ pet, score, reasons }) =>
+      toTopPick(pet, score, reasons, rescueNames)
+    );
+
+    return { picks };
+  };
+}
+
+function clamp(raw: number, fallback: number, max: number): number {
+  if (!Number.isFinite(raw) || raw <= 0) {
+    return fallback;
+  }
+  return Math.min(Math.trunc(raw), max);
+}
+
+type ProfileRow = {
+  preferred_types: unknown[] | null;
+  preferred_sizes: unknown[] | null;
+  preferred_age_groups: unknown[] | null;
+  lifestyle: Record<string, unknown> | null;
+};
+
+// Read the adopter's stored match profile and map its lowercase token
+// arrays onto the proto enum sets the scorer needs. A missing profile
+// yields empty preferences — every candidate then scores purely on
+// recency + promotion (no preference signal to discriminate on).
+async function loadPreferences(deps: HandlerDeps, userId: string): Promise<TopPickPreferences> {
+  const { rows } = await deps.pool.query<ProfileRow>(
+    `SELECT preferred_types, preferred_sizes, preferred_age_groups, lifestyle
+       FROM matching.adopter_match_profiles
+      WHERE user_id = $1
+      LIMIT 1`,
+    [userId]
+  );
+  const row = rows[0];
+  if (row === undefined) {
+    return emptyPreferences();
+  }
+  return {
+    preferredTypes: tokensToEnumSet(row.preferred_types, SPECIES_TO_TYPE),
+    preferredSizes: tokensToEnumSet(row.preferred_sizes, SIZE_TO_ENUM),
+    preferredAgeGroups: tokensToEnumSet(row.preferred_age_groups, AGE_GROUP_TO_ENUM),
+    lifestyle: parseLifestyle(row.lifestyle),
+  };
+}
+
+function emptyPreferences(): TopPickPreferences {
+  return {
+    preferredTypes: new Set(),
+    preferredSizes: new Set(),
+    preferredAgeGroups: new Set(),
+    lifestyle: {},
+  };
+}
+
+function tokensToEnumSet<T>(tokens: unknown[] | null, table: Record<string, T>): ReadonlySet<T> {
+  const set = new Set<T>();
+  if (tokens === null) {
+    return set;
+  }
+  for (const token of tokens) {
+    const enumValue = lookupToken(token, table);
+    if (enumValue !== undefined) {
+      set.add(enumValue);
+    }
+  }
+  return set;
+}
+
+function parseLifestyle(
+  lifestyle: Record<string, unknown> | null
+): TopPickPreferences['lifestyle'] {
+  if (lifestyle === null) {
+    return {};
+  }
+  return {
+    hasChildren: readBool(lifestyle, 'has_children'),
+    hasOtherPets: readBool(lifestyle, 'has_other_pets'),
+    otherPetsType: readOtherPetsType(lifestyle),
+  };
+}
+
+function readBool(obj: Record<string, unknown>, key: string): boolean | undefined {
+  const value = obj[key];
+  return typeof value === 'boolean' ? value : undefined;
+}
+
+function readOtherPetsType(
+  obj: Record<string, unknown>
+): TopPickPreferences['lifestyle']['otherPetsType'] {
+  const value = obj['other_pets_type'];
+  if (value === 'none' || value === 'dogs' || value === 'cats' || value === 'mixed') {
+    return value;
+  }
+  return undefined;
+}
+
+async function listAvailablePets(
+  petsClient: PetsClient,
+  principal: Principal,
+  req: ListPetsRequest
+): Promise<ReadonlyArray<Pet>> {
+  try {
+    const res = await petsClient.listPets(req, principalToMetadata(principal));
+    return res.pets;
+  } catch (err) {
+    const code = (err as { code?: number }).code;
+    if (code === PETS_GRPC_PERMISSION_DENIED) {
+      throw new HandlerError('PERMISSION_DENIED', 'not allowed to read pets');
+    }
+    throw new HandlerError('INTERNAL', 'failed to read candidate pets');
+  }
+}
+
+// Resolve the rescue name for every distinct rescue in the pick set in
+// one batch, deduping so a rescue with several picks is fetched once.
+async function resolveRescueNames(
+  rescueClient: RescueNameClient,
+  pets: ReadonlyArray<Pet>
+): Promise<Map<string, string>> {
+  const ids = [...new Set(pets.map(pet => pet.rescueId).filter((id): id is string => !!id))];
+  const entries = await Promise.all(
+    ids.map(async id => [id, (await rescueClient.getRescueName(id)) ?? ''] as const)
+  );
+  return new Map(entries);
+}
+
+function toTopPick(
+  pet: Pet,
+  score: number,
+  reasons: ReadonlyArray<{ kind: string; label: string }>,
+  rescueNames: Map<string, string>
+): TopPick {
+  return {
+    petId: pet.petId,
+    name: pet.name,
+    type: TYPE_TO_SPECIES[pet.type] ?? 'unknown',
+    ageGroup: AGE_GROUP_TO_TOKEN[pet.ageGroup] ?? 'unknown',
+    size: SIZE_TO_TOKEN[pet.size] ?? 'unknown',
+    score,
+    reasons: reasons.map(r => ({ kind: r.kind, label: r.label })),
+    rescueName: (pet.rescueId && rescueNames.get(pet.rescueId)) || '',
+  };
+}

--- a/services/matching/src/grpc/top-picks-scoring.test.ts
+++ b/services/matching/src/grpc/top-picks-scoring.test.ts
@@ -1,0 +1,204 @@
+import { describe, expect, it } from 'vitest';
+
+import { PetsV1, type Pet } from '@adopt-dont-shop/proto';
+
+import { scoreTopPicks, type TopPickPreferences } from './top-picks-scoring.js';
+
+// Minimal Pet factory — only the fields the scorer reads matter; the
+// rest take harmless defaults.
+function makePet(overrides: Partial<Pet> & { petId: string }): Pet {
+  return {
+    name: 'Rex',
+    type: PetsV1.PetType.PET_TYPE_DOG,
+    status: PetsV1.PetStatus.PET_STATUS_AVAILABLE,
+    gender: PetsV1.PetGender.PET_GENDER_UNSPECIFIED,
+    size: PetsV1.PetSize.PET_SIZE_MEDIUM,
+    ageGroup: PetsV1.PetAgeGroup.PET_AGE_GROUP_ADULT,
+    archived: false,
+    featured: false,
+    priorityListing: false,
+    specialNeeds: false,
+    houseTrained: false,
+    temperamentJson: '[]',
+    tagsJson: '[]',
+    extraJson: '{}',
+    viewCount: 0,
+    favoriteCount: 0,
+    applicationCount: 0,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+const NO_PREFERENCES: TopPickPreferences = {
+  preferredTypes: new Set(),
+  preferredSizes: new Set(),
+  preferredAgeGroups: new Set(),
+  lifestyle: {},
+};
+
+describe('scoreTopPicks', () => {
+  it('returns an empty list for no candidates', () => {
+    expect(scoreTopPicks([], NO_PREFERENCES)).toEqual([]);
+  });
+
+  it('produces scores within [0, 1] for every candidate', () => {
+    const result = scoreTopPicks(
+      [
+        makePet({ petId: 'a', availableSince: '2026-06-01T00:00:00.000Z', featured: true }),
+        makePet({ petId: 'b', availableSince: '2026-01-01T00:00:00.000Z' }),
+      ],
+      NO_PREFERENCES
+    );
+    for (const { score } of result) {
+      expect(score).toBeGreaterThanOrEqual(0);
+      expect(score).toBeLessThanOrEqual(1);
+    }
+  });
+
+  it('ranks a pet matching the stored type/size/age preferences above a non-matching one', () => {
+    const when = '2026-03-01T00:00:00.000Z';
+    const result = scoreTopPicks(
+      [
+        makePet({
+          petId: 'mismatch',
+          availableSince: when,
+          type: PetsV1.PetType.PET_TYPE_CAT,
+          size: PetsV1.PetSize.PET_SIZE_LARGE,
+          ageGroup: PetsV1.PetAgeGroup.PET_AGE_GROUP_SENIOR,
+        }),
+        makePet({
+          petId: 'match',
+          availableSince: when,
+          type: PetsV1.PetType.PET_TYPE_DOG,
+          size: PetsV1.PetSize.PET_SIZE_SMALL,
+          ageGroup: PetsV1.PetAgeGroup.PET_AGE_GROUP_BABY,
+        }),
+      ],
+      {
+        preferredTypes: new Set([PetsV1.PetType.PET_TYPE_DOG]),
+        preferredSizes: new Set([PetsV1.PetSize.PET_SIZE_SMALL]),
+        preferredAgeGroups: new Set([PetsV1.PetAgeGroup.PET_AGE_GROUP_BABY]),
+        lifestyle: {},
+      }
+    );
+    expect(result[0].pet.petId).toBe('match');
+    expect(result[0].score).toBeGreaterThan(result[1].score);
+  });
+
+  it('attaches a pref_match reason chip only to pets matching a stored preference', () => {
+    const when = '2026-03-01T00:00:00.000Z';
+    const result = scoreTopPicks(
+      [
+        makePet({ petId: 'dog', availableSince: when, type: PetsV1.PetType.PET_TYPE_DOG }),
+        makePet({ petId: 'cat', availableSince: when, type: PetsV1.PetType.PET_TYPE_CAT }),
+      ],
+      {
+        preferredTypes: new Set([PetsV1.PetType.PET_TYPE_DOG]),
+        preferredSizes: new Set(),
+        preferredAgeGroups: new Set(),
+        lifestyle: {},
+      }
+    );
+    const byId = new Map(result.map(r => [r.pet.petId, r]));
+    expect(byId.get('dog')?.reasons.some(r => r.kind === 'pref_match')).toBe(true);
+    expect(byId.get('cat')?.reasons.some(r => r.kind === 'pref_match')).toBe(false);
+  });
+
+  it('never emits a pref_match chip when the adopter set no preferences', () => {
+    const result = scoreTopPicks(
+      [makePet({ petId: 'a', availableSince: '2026-03-01T00:00:00.000Z' })],
+      NO_PREFERENCES
+    );
+    expect(result[0].reasons.some(r => r.kind === 'pref_match')).toBe(false);
+  });
+
+  it('attaches a lifestyle chip when a child-friendly pet meets a household with children', () => {
+    const result = scoreTopPicks(
+      [
+        makePet({
+          petId: 'kid-safe',
+          availableSince: '2026-03-01T00:00:00.000Z',
+          extraJson: JSON.stringify({ goodWithChildren: true }),
+        }),
+      ],
+      { ...NO_PREFERENCES, lifestyle: { hasChildren: true } }
+    );
+    expect(result[0].reasons.some(r => r.kind === 'lifestyle')).toBe(true);
+  });
+
+  it('omits the lifestyle chip when the household has no children even if the pet is child-friendly', () => {
+    const result = scoreTopPicks(
+      [
+        makePet({
+          petId: 'kid-safe',
+          availableSince: '2026-03-01T00:00:00.000Z',
+          extraJson: JSON.stringify({ goodWithChildren: true }),
+        }),
+      ],
+      { ...NO_PREFERENCES, lifestyle: { hasChildren: false } }
+    );
+    expect(result[0].reasons.some(r => r.kind === 'lifestyle')).toBe(false);
+  });
+
+  it('matches a dog-friendly pet against a household with dogs', () => {
+    const result = scoreTopPicks(
+      [
+        makePet({
+          petId: 'dog-ok',
+          availableSince: '2026-03-01T00:00:00.000Z',
+          extraJson: JSON.stringify({ goodWithDogs: true }),
+        }),
+      ],
+      { ...NO_PREFERENCES, lifestyle: { hasOtherPets: true, otherPetsType: 'dogs' } }
+    );
+    expect(result[0].reasons.some(r => r.kind === 'lifestyle')).toBe(true);
+  });
+
+  it('attaches a fresh chip to the most recently available pet', () => {
+    const result = scoreTopPicks(
+      [
+        makePet({ petId: 'old', availableSince: '2026-01-01T00:00:00.000Z' }),
+        makePet({ petId: 'new', availableSince: '2026-06-01T00:00:00.000Z' }),
+      ],
+      NO_PREFERENCES
+    );
+    const byId = new Map(result.map(r => [r.pet.petId, r]));
+    expect(byId.get('new')?.reasons.some(r => r.kind === 'fresh')).toBe(true);
+    expect(byId.get('old')?.reasons.some(r => r.kind === 'fresh')).toBe(false);
+  });
+
+  it('boosts a featured pet over a plain one of equal recency and preference fit', () => {
+    const when = '2026-03-01T00:00:00.000Z';
+    const result = scoreTopPicks(
+      [
+        makePet({ petId: 'plain', availableSince: when }),
+        makePet({ petId: 'promoted', availableSince: when, featured: true }),
+      ],
+      NO_PREFERENCES
+    );
+    expect(result[0].pet.petId).toBe('promoted');
+  });
+
+  it('breaks score ties deterministically on petId ascending', () => {
+    const when = '2026-03-01T00:00:00.000Z';
+    const result = scoreTopPicks(
+      [
+        makePet({ petId: 'z', availableSince: when }),
+        makePet({ petId: 'a', availableSince: when }),
+      ],
+      NO_PREFERENCES
+    );
+    expect(result.map(r => r.pet.petId)).toEqual(['a', 'z']);
+  });
+
+  it('tolerates an unparseable extra_json without throwing', () => {
+    const result = scoreTopPicks(
+      [makePet({ petId: 'a', availableSince: '2026-03-01T00:00:00.000Z', extraJson: 'not json' })],
+      { ...NO_PREFERENCES, lifestyle: { hasChildren: true } }
+    );
+    expect(result).toHaveLength(1);
+    expect(result[0].reasons.some(r => r.kind === 'lifestyle')).toBe(false);
+  });
+});

--- a/services/matching/src/grpc/top-picks-scoring.ts
+++ b/services/matching/src/grpc/top-picks-scoring.ts
@@ -1,0 +1,222 @@
+// Pure ranking for GetTopPicks — no I/O, fully unit-testable.
+//
+// Top picks differs from Recommend's swipe feed: it scores a candidate
+// set against the adopter's STORED match profile (preferred types /
+// sizes / age groups + lifestyle) rather than transient session filters,
+// and attaches human-readable "reason chips" explaining each pick.
+//
+// score ∈ [0, 1] is a weighted blend of three signals:
+//
+//   1. Preference match (weight 0.5) — the share of the adopter's SET
+//      preference dimensions (type / size / age group) the pet satisfies.
+//      Dimensions the adopter left empty don't discriminate; when the
+//      adopter set NO preferences at all the axis collapses to 1.0.
+//
+//   2. Recency (weight 0.3) — freshly-listed pets surface first.
+//      Normalised linearly against the freshest availableSince in the
+//      set (newest 1.0, oldest 0.0); unknown freshness scores 0.
+//
+//   3. Promotion (weight 0.2) — the rescue's `featured` / priorityListing
+//      boost flags.
+//
+// Lifestyle does NOT carry its own scoring weight — household fit is a
+// soft, presentational signal surfaced only as a reason chip, never a
+// rank multiplier (a child-friendly pet shouldn't outrank a better
+// preference match just because the adopter has kids).
+//
+// Weights sum to 1.0 so the blend stays within [0, 1].
+
+import { PetsV1, type Pet } from '@adopt-dont-shop/proto';
+
+const PREF_MATCH_WEIGHT = 0.5;
+const RECENCY_WEIGHT = 0.3;
+const PROMOTION_WEIGHT = 0.2;
+
+// A recency component at or above this surfaces the "fresh" chip.
+const FRESH_CHIP_THRESHOLD = 0.8;
+
+// The adopter's stored match profile, pre-mapped to proto enums by the
+// handler. Empty sets mean "no preference on this dimension".
+export type TopPickPreferences = {
+  preferredTypes: ReadonlySet<PetsV1.PetType>;
+  preferredSizes: ReadonlySet<PetsV1.PetSize>;
+  preferredAgeGroups: ReadonlySet<PetsV1.PetAgeGroup>;
+  lifestyle: {
+    hasChildren?: boolean;
+    hasOtherPets?: boolean;
+    otherPetsType?: 'none' | 'dogs' | 'cats' | 'mixed';
+  };
+};
+
+export type TopPickReason = {
+  kind: string;
+  label: string;
+};
+
+export type ScoredTopPick = {
+  pet: Pet;
+  score: number;
+  reasons: ReadonlyArray<TopPickReason>;
+};
+
+export function scoreTopPicks(
+  candidates: ReadonlyArray<Pet>,
+  preferences: TopPickPreferences
+): ReadonlyArray<ScoredTopPick> {
+  if (candidates.length === 0) {
+    return [];
+  }
+
+  const timestamps = candidates
+    .map(pet => availableSinceMs(pet))
+    .filter((ms): ms is number => ms !== undefined);
+  const newest = timestamps.length > 0 ? Math.max(...timestamps) : undefined;
+  const oldest = timestamps.length > 0 ? Math.min(...timestamps) : undefined;
+
+  const scored = candidates.map(pet => {
+    const recency = recencyScore(pet, newest, oldest);
+    const prefMatch = preferenceMatchScore(pet, preferences);
+    const promotion = pet.featured || pet.priorityListing ? 1 : 0;
+
+    const raw =
+      prefMatch.score * PREF_MATCH_WEIGHT + recency * RECENCY_WEIGHT + promotion * PROMOTION_WEIGHT;
+    const score = Math.min(1, Math.max(0, raw));
+
+    return { pet, score, reasons: buildReasons(pet, preferences, prefMatch.matched, recency) };
+  });
+
+  return [...scored].sort((a, b) => {
+    if (b.score !== a.score) {
+      return b.score - a.score;
+    }
+    return a.pet.petId < b.pet.petId ? -1 : a.pet.petId > b.pet.petId ? 1 : 0;
+  });
+}
+
+type PreferenceMatch = {
+  // Mean satisfaction across the SET dimensions (1.0 when none set).
+  score: number;
+  // True when at least one set dimension was satisfied.
+  matched: boolean;
+};
+
+function preferenceMatchScore(pet: Pet, preferences: TopPickPreferences): PreferenceMatch {
+  const dimensions: boolean[] = [];
+  if (preferences.preferredTypes.size > 0) {
+    dimensions.push(preferences.preferredTypes.has(pet.type));
+  }
+  if (preferences.preferredSizes.size > 0) {
+    dimensions.push(preferences.preferredSizes.has(pet.size));
+  }
+  if (preferences.preferredAgeGroups.size > 0) {
+    dimensions.push(preferences.preferredAgeGroups.has(pet.ageGroup));
+  }
+
+  if (dimensions.length === 0) {
+    return { score: 1, matched: false };
+  }
+  const hits = dimensions.filter(Boolean).length;
+  return { score: hits / dimensions.length, matched: hits > 0 };
+}
+
+function recencyScore(pet: Pet, newest: number | undefined, oldest: number | undefined): number {
+  if (newest === undefined || oldest === undefined || newest === oldest) {
+    return 0;
+  }
+  const ms = availableSinceMs(pet);
+  if (ms === undefined) {
+    return 0;
+  }
+  return (ms - oldest) / (newest - oldest);
+}
+
+function buildReasons(
+  pet: Pet,
+  preferences: TopPickPreferences,
+  prefMatched: boolean,
+  recency: number
+): ReadonlyArray<TopPickReason> {
+  const reasons: TopPickReason[] = [];
+  if (prefMatched) {
+    reasons.push({ kind: 'pref_match', label: 'Matches your preferences' });
+  }
+  const lifestyle = lifestyleReason(pet, preferences.lifestyle);
+  if (lifestyle !== undefined) {
+    reasons.push(lifestyle);
+  }
+  if (recency >= FRESH_CHIP_THRESHOLD) {
+    reasons.push({ kind: 'fresh', label: 'Newly added' });
+  }
+  return reasons;
+}
+
+// Cross-reference the pet's good_with_* flags (carried in extra_json)
+// against the adopter's household. Returns the single most relevant
+// household-fit chip, or undefined when nothing lines up.
+function lifestyleReason(
+  pet: Pet,
+  lifestyle: TopPickPreferences['lifestyle']
+): TopPickReason | undefined {
+  const extra = parseExtra(pet.extraJson);
+
+  if (lifestyle.hasChildren === true && extra.goodWithChildren === true) {
+    return { kind: 'lifestyle', label: 'Good with children' };
+  }
+  if (lifestyle.hasOtherPets === true) {
+    if (lifestyle.otherPetsType === 'dogs' && extra.goodWithDogs === true) {
+      return { kind: 'lifestyle', label: 'Good with dogs' };
+    }
+    if (lifestyle.otherPetsType === 'cats' && extra.goodWithCats === true) {
+      return { kind: 'lifestyle', label: 'Good with cats' };
+    }
+    if (
+      lifestyle.otherPetsType === 'mixed' &&
+      (extra.goodWithDogs === true || extra.goodWithCats === true)
+    ) {
+      return { kind: 'lifestyle', label: 'Good with other pets' };
+    }
+  }
+  return undefined;
+}
+
+type ExtraFlags = {
+  goodWithChildren?: boolean;
+  goodWithDogs?: boolean;
+  goodWithCats?: boolean;
+};
+
+function parseExtra(extraJson: string | undefined): ExtraFlags {
+  if (extraJson === undefined || extraJson === '') {
+    return {};
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(extraJson);
+  } catch {
+    return {};
+  }
+  if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+    return {};
+  }
+  return {
+    goodWithChildren: readBool(parsed, 'goodWithChildren'),
+    goodWithDogs: readBool(parsed, 'goodWithDogs'),
+    goodWithCats: readBool(parsed, 'goodWithCats'),
+  };
+}
+
+function readBool(obj: object, key: string): boolean | undefined {
+  if (!Object.prototype.hasOwnProperty.call(obj, key)) {
+    return undefined;
+  }
+  const value = Object.getOwnPropertyDescriptor(obj, key)?.value;
+  return typeof value === 'boolean' ? value : undefined;
+}
+
+function availableSinceMs(pet: Pet): number | undefined {
+  if (pet.availableSince === undefined || pet.availableSince === '') {
+    return undefined;
+  }
+  const ms = Date.parse(pet.availableSince);
+  return Number.isNaN(ms) ? undefined : ms;
+}


### PR DESCRIPTION
## Why

An audit of `app.client`'s routes against backing service functionality surfaced a broken surface: `TopPicksPage` and `TopPicksHomeModule` call `GET /api/v1/match/top-picks`, which **404s at the gateway** — there was no backing service. This PR builds that endpoint end-to-end and, while there, gives the matching feature a real frontend service client (`lib.matching` was types-only).

## What

### Backend — top-picks (`GET /api/v1/match/top-picks`)
- **proto**: new `GetTopPicks` RPC + `TopPick` / `TopPickReasonChip` messages on `MatchingService`.
- **service.matching**:
  - Pure `scoreTopPicks()` ranker — a preference-match (0.5) / recency (0.3) / promotion (0.2) blend, plus human-readable reason chips (`pref_match`, `lifestyle`, `fresh`). Lifestyle fit is chip-only, never a rank multiplier.
  - `GetTopPicks` handler: reads the adopter's stored match profile, fetches available pets, excludes already-swiped pets (same rule as `Recommend`), scores, and resolves rescue names via a **new `service.rescue` gRPC client** (signed system principal, retry/deadline — mirrors the existing pets client).
  - Shared lowercase-token ⇄ proto-enum tables extracted to `pet-tokens.ts` (de-duped with `recommend-handlers`).
- **gateway**: `MatchingClient.getTopPicks`, the `GET /api/v1/match/top-picks` route (+ rate limit), and a `topPicksToView` adapter that preserves default-valued fields (`score: 0`, empty `rescueName`/`reasons`) the SPA's `MatchTopPick` type requires.

### Frontend — consistency
- **lib.matching**: new `MatchingService` (`getTopPicks` / `getMatchProfile` / `updateMatchProfile`) wrapping the `/api/v1/match/*` surface.
- **app.client**: wire `matchingService` into `libraryServices`, and refactor `TopPicksPage`, `TopPicksHomeModule`, `useMatchPreferences`, and `OnboardingWizardPage` off raw `apiService` calls onto it.

## Testing
All developed TDD. Green suites: `service.matching` (172), `service.gateway` (732), `lib.matching` (10), `app.client` (547). Type-check + prettier + eslint clean.

## Not included
The audit also found `applicationProfileService` (`/apply/:petId` pre-population) calling nonexistent `/api/v1/profile/*` endpoints. That gap needs net-new schema + an auth gRPC client wiring in `service.applications` and is intentionally **out of scope here** — left for a follow-up so this PR stays focused on the top-picks story.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KXLTwu5Lue8SekkbNYZaY1

---
_Generated by [Claude Code](https://claude.ai/code/session_01KXLTwu5Lue8SekkbNYZaY1)_