### PR TITLE
feat: back application defaults pre-population with a real backend

### DIFF
--- a/apps/client/src/components/home/TopPicksHomeModule.test.tsx
+++ b/apps/client/src/components/home/TopPicksHomeModule.test.tsx
@@ -4,7 +4,7 @@ import { TopPicksHomeModule } from './TopPicksHomeModule';
 
 const authState = { isAuthenticated: false };
 const matchPreferencesState = { hasPreferences: false, isLoading: false };
-const apiGet = vi.fn();
+const getTopPicks = vi.fn();
 
 vi.mock('@adopt-dont-shop/lib.auth', async () => {
   const actual = await vi.importActual<typeof import('@adopt-dont-shop/lib.auth')>(
@@ -21,8 +21,8 @@ vi.mock('@/hooks/useMatchPreferences', () => ({
 }));
 
 vi.mock('@/services', () => ({
-  apiService: {
-    get: (...args: unknown[]) => apiGet(...args),
+  matchingService: {
+    getTopPicks: (...args: unknown[]) => getTopPicks(...args),
   },
 }));
 
@@ -30,40 +30,38 @@ beforeEach(() => {
   authState.isAuthenticated = false;
   matchPreferencesState.hasPreferences = false;
   matchPreferencesState.isLoading = false;
-  apiGet.mockReset();
+  getTopPicks.mockReset();
 });
 
 describe('TopPicksHomeModule', () => {
   it('renders nothing for signed-out users', () => {
     const { container } = renderWithProviders(<TopPicksHomeModule />);
     expect(container).toBeEmptyDOMElement();
-    expect(apiGet).not.toHaveBeenCalled();
+    expect(getTopPicks).not.toHaveBeenCalled();
   });
 
   it('renders nothing for signed-in users without preferences', () => {
     authState.isAuthenticated = true;
     const { container } = renderWithProviders(<TopPicksHomeModule />);
     expect(container).toBeEmptyDOMElement();
-    expect(apiGet).not.toHaveBeenCalled();
+    expect(getTopPicks).not.toHaveBeenCalled();
   });
 
   it('shows the Your top picks heading and See all link when preferences exist and picks load', async () => {
     authState.isAuthenticated = true;
     matchPreferencesState.hasPreferences = true;
-    apiGet.mockResolvedValueOnce({
-      data: [
-        {
-          petId: 'pet-1',
-          name: 'Rex',
-          type: 'dog',
-          ageGroup: 'adult',
-          size: 'medium',
-          score: 87,
-          reasons: [],
-          rescueName: 'Happy Rescue',
-        },
-      ],
-    });
+    getTopPicks.mockResolvedValueOnce([
+      {
+        petId: 'pet-1',
+        name: 'Rex',
+        type: 'dog',
+        ageGroup: 'adult',
+        size: 'medium',
+        score: 87,
+        reasons: [],
+        rescueName: 'Happy Rescue',
+      },
+    ]);
     renderWithProviders(<TopPicksHomeModule />);
     await waitFor(() =>
       expect(screen.getByRole('heading', { name: /your top picks/i })).toBeInTheDocument()
@@ -78,9 +76,9 @@ describe('TopPicksHomeModule', () => {
   it('renders nothing when the API returns an empty result', async () => {
     authState.isAuthenticated = true;
     matchPreferencesState.hasPreferences = true;
-    apiGet.mockResolvedValueOnce({ data: [] });
+    getTopPicks.mockResolvedValueOnce([]);
     const { container } = renderWithProviders(<TopPicksHomeModule />);
-    await waitFor(() => expect(apiGet).toHaveBeenCalled());
+    await waitFor(() => expect(getTopPicks).toHaveBeenCalled());
     await waitFor(() => expect(container).toBeEmptyDOMElement());
   });
 });

--- a/apps/client/src/components/home/TopPicksHomeModule.tsx
+++ b/apps/client/src/components/home/TopPicksHomeModule.tsx
@@ -10,7 +10,7 @@ import { PetCardSkeletonGrid } from '@/components/skeletons';
 import { useAuth } from '@adopt-dont-shop/lib.auth';
 import type { MatchTopPick } from '@adopt-dont-shop/lib.matching';
 import { useMatchPreferences } from '@/hooks/useMatchPreferences';
-import { apiService } from '@/services';
+import { matchingService } from '@/services';
 import { resolveFileUrl } from '@/utils/fileUtils';
 import * as styles from './TopPicksHomeModule.css';
 
@@ -55,11 +55,9 @@ export const TopPicksHomeModule: React.FC = () => {
       try {
         setLoading(true);
         setErrored(false);
-        const res = await apiService.get<{ data: MatchTopPick[] }>(
-          '/api/v1/match/top-picks?limit=3'
-        );
+        const data = await matchingService.getTopPicks(3);
         if (!cancelled) {
-          setPicks(res.data ?? []);
+          setPicks(data);
         }
       } catch {
         if (!cancelled) {

--- a/apps/client/src/hooks/useMatchPreferences.test.ts
+++ b/apps/client/src/hooks/useMatchPreferences.test.ts
@@ -14,35 +14,35 @@ vi.mock('@adopt-dont-shop/lib.auth', async () => {
   };
 });
 
-const apiGet = vi.fn();
+const getMatchProfile = vi.fn();
 vi.mock('@/services', () => ({
-  apiService: {
-    get: (...args: unknown[]) => apiGet(...args),
+  matchingService: {
+    getMatchProfile: (...args: unknown[]) => getMatchProfile(...args),
   },
 }));
 
 beforeEach(() => {
   authState.isAuthenticated = false;
-  apiGet.mockReset();
+  getMatchProfile.mockReset();
 });
 
 describe('useMatchPreferences', () => {
   it('reports no preferences for signed-out users and does not call the API', () => {
     const { result } = renderHook(() => useMatchPreferences());
     expect(result.current.hasPreferences).toBe(false);
-    expect(apiGet).not.toHaveBeenCalled();
+    expect(getMatchProfile).not.toHaveBeenCalled();
   });
 
   it('reports preferences when the profile has at least one preferred list populated', async () => {
     authState.isAuthenticated = true;
-    apiGet.mockResolvedValueOnce({ data: { preferred_types: ['dog'] } });
+    getMatchProfile.mockResolvedValueOnce({ preferred_types: ['dog'] });
     const { result } = renderHook(() => useMatchPreferences());
     await waitFor(() => expect(result.current.hasPreferences).toBe(true));
   });
 
   it('reports no preferences when the profile is the empty placeholder', async () => {
     authState.isAuthenticated = true;
-    apiGet.mockResolvedValueOnce({ data: { lifestyle: {} } });
+    getMatchProfile.mockResolvedValueOnce({ lifestyle: {} });
     const { result } = renderHook(() => useMatchPreferences());
     await waitFor(() => expect(result.current.isLoading).toBe(false));
     expect(result.current.hasPreferences).toBe(false);
@@ -50,13 +50,11 @@ describe('useMatchPreferences', () => {
 
   it('treats an empty preferred_types array as no preferences', async () => {
     authState.isAuthenticated = true;
-    apiGet.mockResolvedValueOnce({
-      data: {
-        preferred_types: [],
-        preferred_sizes: [],
-        preferred_age_groups: [],
-        preferred_energy: [],
-      },
+    getMatchProfile.mockResolvedValueOnce({
+      preferred_types: [],
+      preferred_sizes: [],
+      preferred_age_groups: [],
+      preferred_energy: [],
     });
     const { result } = renderHook(() => useMatchPreferences());
     await waitFor(() => expect(result.current.isLoading).toBe(false));
@@ -65,7 +63,7 @@ describe('useMatchPreferences', () => {
 
   it('reports no preferences if the API fails', async () => {
     authState.isAuthenticated = true;
-    apiGet.mockRejectedValueOnce(new Error('boom'));
+    getMatchProfile.mockRejectedValueOnce(new Error('boom'));
     const { result } = renderHook(() => useMatchPreferences());
     await waitFor(() => expect(result.current.isLoading).toBe(false));
     expect(result.current.hasPreferences).toBe(false);

--- a/apps/client/src/hooks/useMatchPreferences.ts
+++ b/apps/client/src/hooks/useMatchPreferences.ts
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 import { useAuth } from '@adopt-dont-shop/lib.auth';
 import type { AdopterMatchProfile } from '@adopt-dont-shop/lib.matching';
-import { apiService } from '@/services';
+import { matchingService } from '@/services';
 
 type UseMatchPreferencesReturn = {
   hasPreferences: boolean;
@@ -46,11 +46,9 @@ export const useMatchPreferences = (): UseMatchPreferencesReturn => {
     const load = async () => {
       try {
         setIsLoading(true);
-        const res = await apiService.get<{ data: Partial<AdopterMatchProfile> }>(
-          '/api/v1/match/profile'
-        );
+        const profile = await matchingService.getMatchProfile();
         if (!cancelled) {
-          setHasPreferences(hasAnyPreference(res.data));
+          setHasPreferences(hasAnyPreference(profile));
         }
       } catch {
         if (!cancelled) {

--- a/apps/client/src/pages/OnboardingWizardPage.test.tsx
+++ b/apps/client/src/pages/OnboardingWizardPage.test.tsx
@@ -17,9 +17,9 @@ const getMock = vi.fn();
 const putMock = vi.fn();
 
 vi.mock('@/services', () => ({
-  apiService: {
-    get: (...args: unknown[]) => getMock(...args),
-    put: (...args: unknown[]) => putMock(...args),
+  matchingService: {
+    getMatchProfile: (...args: unknown[]) => getMock(...args),
+    updateMatchProfile: (...args: unknown[]) => putMock(...args),
   },
 }));
 
@@ -68,17 +68,15 @@ describe('OnboardingWizardPage', () => {
     getMock.mockReset();
     putMock.mockReset();
     getMock.mockResolvedValue({
-      data: {
-        preferred_types: [],
-        preferred_sizes: [],
-        preferred_age_groups: [],
-        preferred_energy: [],
-        lifestyle: {},
-        max_distance_km: null,
-        open_to_special_needs: false,
-        notify_new_matches: false,
-        allergies: null,
-      },
+      preferred_types: [],
+      preferred_sizes: [],
+      preferred_age_groups: [],
+      preferred_energy: [],
+      lifestyle: {},
+      max_distance_km: null,
+      open_to_special_needs: false,
+      notify_new_matches: false,
+      allergies: null,
     });
   });
 
@@ -157,7 +155,7 @@ describe('OnboardingWizardPage', () => {
 
   it('submits all data to PUT /api/v1/match/profile on step 4 and navigates to top-picks', async () => {
     const user = userEvent.setup();
-    putMock.mockResolvedValue({ data: {} });
+    putMock.mockResolvedValue(undefined);
     renderPage();
 
     await waitFor(() => {
@@ -184,8 +182,7 @@ describe('OnboardingWizardPage', () => {
       expect(putMock).toHaveBeenCalledTimes(1);
     });
 
-    const [url, payload] = putMock.mock.calls[0] as [string, Record<string, unknown>];
-    expect(url).toBe('/api/v1/match/profile');
+    const [payload] = putMock.mock.calls[0] as [Record<string, unknown>];
     expect(payload).toHaveProperty('lifestyle');
     expect(payload).toHaveProperty('allergies');
     expect(payload).toHaveProperty('preferred_types');
@@ -221,17 +218,15 @@ describe('OnboardingWizardPage', () => {
 
   it('loads existing match profile data on mount', async () => {
     getMock.mockResolvedValue({
-      data: {
-        preferred_types: ['dog', 'cat'],
-        preferred_sizes: ['medium'],
-        preferred_age_groups: ['adult'],
-        preferred_energy: ['medium'],
-        lifestyle: { housing_type: 'apartment', has_children: false, yard: false },
-        max_distance_km: 25,
-        open_to_special_needs: true,
-        notify_new_matches: true,
-        allergies: 'cats',
-      },
+      preferred_types: ['dog', 'cat'],
+      preferred_sizes: ['medium'],
+      preferred_age_groups: ['adult'],
+      preferred_energy: ['medium'],
+      lifestyle: { housing_type: 'apartment', has_children: false, yard: false },
+      max_distance_km: 25,
+      open_to_special_needs: true,
+      notify_new_matches: true,
+      allergies: 'cats',
     });
 
     renderPage();
@@ -259,17 +254,15 @@ describe('OnboardingWizardPage', () => {
   describe('ADS-688 persistence fixes', () => {
     it('restores the original children_type selection on reload', async () => {
       getMock.mockResolvedValue({
-        data: {
-          preferred_types: [],
-          preferred_sizes: [],
-          preferred_age_groups: [],
-          preferred_energy: [],
-          lifestyle: { children_type: 'older', has_children: true },
-          max_distance_km: null,
-          open_to_special_needs: false,
-          notify_new_matches: false,
-          allergies: null,
-        },
+        preferred_types: [],
+        preferred_sizes: [],
+        preferred_age_groups: [],
+        preferred_energy: [],
+        lifestyle: { children_type: 'older', has_children: true },
+        max_distance_km: null,
+        open_to_special_needs: false,
+        notify_new_matches: false,
+        allergies: null,
       });
 
       renderPage();
@@ -284,17 +277,15 @@ describe('OnboardingWizardPage', () => {
 
     it('restores the original other_pets_type selection on reload', async () => {
       getMock.mockResolvedValue({
-        data: {
-          preferred_types: [],
-          preferred_sizes: [],
-          preferred_age_groups: [],
-          preferred_energy: [],
-          lifestyle: { other_pets_type: 'cats', has_other_pets: true },
-          max_distance_km: null,
-          open_to_special_needs: false,
-          notify_new_matches: false,
-          allergies: null,
-        },
+        preferred_types: [],
+        preferred_sizes: [],
+        preferred_age_groups: [],
+        preferred_energy: [],
+        lifestyle: { other_pets_type: 'cats', has_other_pets: true },
+        max_distance_km: null,
+        open_to_special_needs: false,
+        notify_new_matches: false,
+        allergies: null,
       });
 
       renderPage();
@@ -308,17 +299,15 @@ describe('OnboardingWizardPage', () => {
 
     it('restores "A mix" selection on reload', async () => {
       getMock.mockResolvedValue({
-        data: {
-          preferred_types: [],
-          preferred_sizes: [],
-          preferred_age_groups: [],
-          preferred_energy: [],
-          lifestyle: { other_pets_type: 'mixed', has_other_pets: true },
-          max_distance_km: null,
-          open_to_special_needs: false,
-          notify_new_matches: false,
-          allergies: null,
-        },
+        preferred_types: [],
+        preferred_sizes: [],
+        preferred_age_groups: [],
+        preferred_energy: [],
+        lifestyle: { other_pets_type: 'mixed', has_other_pets: true },
+        max_distance_km: null,
+        open_to_special_needs: false,
+        notify_new_matches: false,
+        allergies: null,
       });
 
       renderPage();
@@ -332,7 +321,7 @@ describe('OnboardingWizardPage', () => {
 
     it('includes activity_level and children_type/other_pets_type in the submitted payload', async () => {
       const user = userEvent.setup();
-      putMock.mockResolvedValue({ data: {} });
+      putMock.mockResolvedValue(undefined);
       renderPage();
 
       await waitFor(() => {
@@ -352,7 +341,7 @@ describe('OnboardingWizardPage', () => {
         expect(putMock).toHaveBeenCalledTimes(1);
       });
 
-      const [, payload] = putMock.mock.calls[0] as [string, { lifestyle: Record<string, unknown> }];
+      const [payload] = putMock.mock.calls[0] as [{ lifestyle: Record<string, unknown> }];
       expect(payload.lifestyle.children_type).toBe('older');
       expect(payload.lifestyle.other_pets_type).toBe('cats');
       expect(payload.lifestyle.activity_level).toBe('high');

--- a/apps/client/src/pages/OnboardingWizardPage.tsx
+++ b/apps/client/src/pages/OnboardingWizardPage.tsx
@@ -3,7 +3,7 @@ import { Alert, Button, Card, Spinner } from '@adopt-dont-shop/lib.components';
 import type { AdopterLifestyle } from '@adopt-dont-shop/lib.matching';
 import React, { useEffect, useState } from 'react';
 import { useNavigate, Link } from 'react-router-dom';
-import { apiService } from '@/services';
+import { matchingService } from '@/services';
 import * as styles from './OnboardingWizardPage.css';
 
 /**
@@ -230,44 +230,33 @@ export const OnboardingWizardPage: React.FC = () => {
     }
     const load = async () => {
       try {
-        const res = await apiService.get<{
-          data: {
-            preferred_types: string[] | null;
-            preferred_sizes: string[] | null;
-            preferred_age_groups: string[] | null;
-            preferred_energy: string[] | null;
-            lifestyle: AdopterLifestyle;
-            max_distance_km: number | null;
-            open_to_special_needs: boolean;
-            notify_new_matches: boolean;
-            allergies: string | null;
-          };
-        }>('/api/v1/match/profile');
-        const p = res.data;
-        // ADS-688: prefer the granular `*_type` field the wizard now persists.
-        // Fall back to the boolean for profiles created before that field
-        // existed (true → first non-"none" choice; false → "none").
-        const restoredChildren =
-          p.lifestyle?.children_type ?? (p.lifestyle?.has_children ? 'young' : 'none');
-        const restoredOtherPets =
-          p.lifestyle?.other_pets_type ?? (p.lifestyle?.has_other_pets ? 'dogs' : 'none');
-        setForm(f => ({
-          ...f,
-          preferred_types: p.preferred_types ?? [],
-          preferred_sizes: p.preferred_sizes ?? [],
-          preferred_age_groups: p.preferred_age_groups ?? [],
-          preferred_energy: p.preferred_energy ?? [],
-          housing_type: p.lifestyle?.housing_type ?? '',
-          has_children: restoredChildren,
-          has_other_pets: restoredOtherPets,
-          activity_level: p.lifestyle?.activity_level ?? '',
-          hours_alone_daily: p.lifestyle?.hours_alone_daily ?? 0,
-          yard: p.lifestyle?.yard ?? false,
-          max_distance_km: p.max_distance_km ?? '',
-          open_to_special_needs: !!p.open_to_special_needs,
-          notify_new_matches: !!p.notify_new_matches,
-          allergies: p.allergies ?? '',
-        }));
+        const p = await matchingService.getMatchProfile();
+        if (p) {
+          // ADS-688: prefer the granular `*_type` field the wizard now persists.
+          // Fall back to the boolean for profiles created before that field
+          // existed (true → first non-"none" choice; false → "none").
+          const restoredChildren =
+            p.lifestyle?.children_type ?? (p.lifestyle?.has_children ? 'young' : 'none');
+          const restoredOtherPets =
+            p.lifestyle?.other_pets_type ?? (p.lifestyle?.has_other_pets ? 'dogs' : 'none');
+          setForm(f => ({
+            ...f,
+            preferred_types: p.preferred_types ?? [],
+            preferred_sizes: p.preferred_sizes ?? [],
+            preferred_age_groups: p.preferred_age_groups ?? [],
+            preferred_energy: p.preferred_energy ?? [],
+            housing_type: p.lifestyle?.housing_type ?? '',
+            has_children: restoredChildren,
+            has_other_pets: restoredOtherPets,
+            activity_level: p.lifestyle?.activity_level ?? '',
+            hours_alone_daily: p.lifestyle?.hours_alone_daily ?? 0,
+            yard: p.lifestyle?.yard ?? false,
+            max_distance_km: p.max_distance_km ?? '',
+            open_to_special_needs: !!p.open_to_special_needs,
+            notify_new_matches: !!p.notify_new_matches,
+            allergies: p.allergies ?? '',
+          }));
+        }
       } catch {
         // First-time load — empty profile is fine.
       } finally {
@@ -361,7 +350,7 @@ export const OnboardingWizardPage: React.FC = () => {
     try {
       setSaving(true);
       setError(null);
-      await apiService.put('/api/v1/match/profile', buildPayload());
+      await matchingService.updateMatchProfile(buildPayload());
       navigate('/match/top-picks');
     } catch (err) {
       console.error('Failed to save match profile', err);

--- a/apps/client/src/pages/TopPicksPage.test.tsx
+++ b/apps/client/src/pages/TopPicksPage.test.tsx
@@ -10,13 +10,13 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { renderWithProviders, screen, waitFor, fireEvent } from '@/test-utils';
 
-const apiGet = vi.fn();
+const getTopPicks = vi.fn();
 const mockNavigate = vi.fn();
 let mockIsAuthenticated = true;
 
 vi.mock('@/services', () => ({
-  apiService: {
-    get: (...args: unknown[]) => apiGet(...args),
+  matchingService: {
+    getTopPicks: (...args: unknown[]) => getTopPicks(...args),
   },
 }));
 
@@ -65,13 +65,13 @@ describe('TopPicksPage (signed out)', () => {
       screen.getByRole('heading', { name: /sign in for your top picks/i })
     ).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /sign in/i })).toBeInTheDocument();
-    expect(apiGet).not.toHaveBeenCalled();
+    expect(getTopPicks).not.toHaveBeenCalled();
   });
 });
 
 describe('TopPicksPage (signed in)', () => {
   it('shows a loading spinner while picks are being fetched', () => {
-    apiGet.mockReturnValue(new Promise(() => {}));
+    getTopPicks.mockReturnValue(new Promise(() => {}));
 
     renderWithProviders(<TopPicksPage />);
 
@@ -79,7 +79,7 @@ describe('TopPicksPage (signed in)', () => {
   });
 
   it('renders an error message when the request fails', async () => {
-    apiGet.mockRejectedValue(new Error('boom'));
+    getTopPicks.mockRejectedValue(new Error('boom'));
 
     renderWithProviders(<TopPicksPage />);
 
@@ -87,7 +87,7 @@ describe('TopPicksPage (signed in)', () => {
   });
 
   it('nudges the user to set preferences when there are no picks', async () => {
-    apiGet.mockResolvedValue({ data: [] });
+    getTopPicks.mockResolvedValue([]);
 
     renderWithProviders(<TopPicksPage />);
 
@@ -96,7 +96,7 @@ describe('TopPicksPage (signed in)', () => {
   });
 
   it('renders the picks grid with the pet name and a match-quality badge', async () => {
-    apiGet.mockResolvedValue({ data: [buildPick({ score: 80 })] });
+    getTopPicks.mockResolvedValue([buildPick({ score: 80 })]);
 
     renderWithProviders(<TopPicksPage />);
 
@@ -106,15 +106,15 @@ describe('TopPicksPage (signed in)', () => {
   });
 
   it('requests the top-picks endpoint with a limit', async () => {
-    apiGet.mockResolvedValue({ data: [] });
+    getTopPicks.mockResolvedValue([]);
 
     renderWithProviders(<TopPicksPage />);
 
-    await waitFor(() => expect(apiGet).toHaveBeenCalledWith('/api/v1/match/top-picks?limit=10'));
+    await waitFor(() => expect(getTopPicks).toHaveBeenCalledWith(10));
   });
 
   it('navigates to the pet details page when a card is activated', async () => {
-    apiGet.mockResolvedValue({ data: [buildPick({ petId: 'pet-42' })] });
+    getTopPicks.mockResolvedValue([buildPick({ petId: 'pet-42' })]);
 
     renderWithProviders(<TopPicksPage />);
 

--- a/apps/client/src/pages/TopPicksPage.tsx
+++ b/apps/client/src/pages/TopPicksPage.tsx
@@ -10,7 +10,7 @@ import {
 import type { MatchTopPick } from '@adopt-dont-shop/lib.matching';
 import React, { useEffect, useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
-import { apiService } from '@/services';
+import { matchingService } from '@/services';
 import { resolveFileUrl } from '@/utils/fileUtils';
 import * as styles from './TopPicksPage.css';
 
@@ -51,11 +51,9 @@ export const TopPicksPage: React.FC = () => {
       try {
         setLoading(true);
         setError(null);
-        const res = await apiService.get<{ data: MatchTopPick[] }>(
-          '/api/v1/match/top-picks?limit=10'
-        );
+        const data = await matchingService.getTopPicks(10);
         if (!cancelled) {
-          setPicks(res.data ?? []);
+          setPicks(data);
         }
       } catch (err) {
         if (!cancelled) {

--- a/apps/client/src/services/index.ts
+++ b/apps/client/src/services/index.ts
@@ -3,6 +3,7 @@ export {
   analyticsService,
   applicationService,
   discoveryService,
+  matchingService,
   petService,
   rescueService,
   authService,

--- a/apps/client/src/services/libraryServices.ts
+++ b/apps/client/src/services/libraryServices.ts
@@ -11,6 +11,7 @@ import { DiscoveryService } from '@adopt-dont-shop/lib.discovery';
 import { PetsService } from '@adopt-dont-shop/lib.pets';
 import { RescueService } from '@adopt-dont-shop/lib.rescue';
 import { ChatService } from '@adopt-dont-shop/lib.chat';
+import { MatchingService } from '@adopt-dont-shop/lib.matching';
 import { SearchService } from '@adopt-dont-shop/lib.search';
 import { NotificationsService } from '@adopt-dont-shop/lib.notifications';
 import { PermissionsService } from '@adopt-dont-shop/lib.permissions';
@@ -43,6 +44,10 @@ export const applicationService = new ApplicationsService(globalApiService, serv
 export const discoveryService = new DiscoveryService(serviceConfig);
 
 export const petService = new PetsService(globalApiService);
+
+// Shares the global apiService so top-picks / match-profile calls carry
+// the same auth + CSRF state as the rest of the app.
+export const matchingService = new MatchingService(globalApiService);
 
 export const rescueService = new RescueService(globalApiService, serviceConfig);
 

--- a/packages/lib.matching/package.json
+++ b/packages/lib.matching/package.json
@@ -37,7 +37,9 @@
   ],
   "author": "Adopt Don't Shop Team",
   "license": "MIT",
-  "dependencies": {},
+  "dependencies": {
+    "@adopt-dont-shop/lib.api": "workspace:*"
+  },
   "devDependencies": {
     "@adopt-dont-shop/eslint-config-base": "workspace:*",
     "@types/node": "^25.9.1"

--- a/packages/lib.matching/src/index.ts
+++ b/packages/lib.matching/src/index.ts
@@ -73,3 +73,5 @@ export type MatchTopPick = {
   breedName?: string | null;
   photoUrl?: string | null;
 };
+
+export { MatchingService } from './matching-service';

--- a/packages/lib.matching/src/matching-service.test.ts
+++ b/packages/lib.matching/src/matching-service.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import type { ApiService } from '@adopt-dont-shop/lib.api';
+
+import { MatchingService } from './matching-service';
+
+type ApiStub = { get?: ReturnType<typeof vi.fn>; put?: ReturnType<typeof vi.fn> };
+
+const makeApi = (stub: ApiStub = {}): ApiService =>
+  ({ get: stub.get ?? vi.fn(), put: stub.put ?? vi.fn() }) as unknown as ApiService;
+
+describe('MatchingService', () => {
+  describe('getTopPicks', () => {
+    it('requests the picks with the given limit and unwraps the data envelope', async () => {
+      const picks = [{ petId: 'p-1', name: 'Bella', reasons: [] }];
+      const get = vi.fn().mockResolvedValue({ data: picks });
+      const service = new MatchingService(makeApi({ get }));
+
+      const result = await service.getTopPicks(5);
+
+      expect(get).toHaveBeenCalledWith('/api/v1/match/top-picks?limit=5');
+      expect(result).toEqual(picks);
+    });
+
+    it('defaults the limit to 10 when none is given', async () => {
+      const get = vi.fn().mockResolvedValue({ data: [] });
+      const service = new MatchingService(makeApi({ get }));
+
+      await service.getTopPicks();
+
+      expect(get).toHaveBeenCalledWith('/api/v1/match/top-picks?limit=10');
+    });
+
+    it('returns an empty array when the response carries no data', async () => {
+      const get = vi.fn().mockResolvedValue({});
+      const service = new MatchingService(makeApi({ get }));
+
+      expect(await service.getTopPicks()).toEqual([]);
+    });
+  });
+
+  describe('getMatchProfile', () => {
+    it('unwraps the profile data envelope', async () => {
+      const profile = { user_id: 'u-1', preferred_types: ['dog'] };
+      const get = vi.fn().mockResolvedValue({ data: profile });
+      const service = new MatchingService(makeApi({ get }));
+
+      const result = await service.getMatchProfile();
+
+      expect(get).toHaveBeenCalledWith('/api/v1/match/profile');
+      expect(result).toEqual(profile);
+    });
+
+    it('returns null when the response carries no profile', async () => {
+      const get = vi.fn().mockResolvedValue({});
+      const service = new MatchingService(makeApi({ get }));
+
+      expect(await service.getMatchProfile()).toBeNull();
+    });
+  });
+
+  describe('updateMatchProfile', () => {
+    it('PUTs the profile payload to the match profile endpoint', async () => {
+      const put = vi.fn().mockResolvedValue({});
+      const service = new MatchingService(makeApi({ put }));
+      const payload = { preferred_types: ['cat'], open_to_special_needs: true };
+
+      await service.updateMatchProfile(payload);
+
+      expect(put).toHaveBeenCalledWith('/api/v1/match/profile', payload);
+    });
+  });
+});

--- a/packages/lib.matching/src/matching-service.ts
+++ b/packages/lib.matching/src/matching-service.ts
@@ -1,0 +1,41 @@
+import { ApiService } from '@adopt-dont-shop/lib.api';
+
+import type { AdopterMatchProfile, MatchTopPick } from './index';
+
+/**
+ * Client for the adopter-matching API surface served by the gateway
+ * (`/api/v1/match/*`). Wraps the top-picks read and the match-profile
+ * read/write so the app.client components stop hand-rolling `apiService`
+ * calls and share one typed contract.
+ */
+export class MatchingService {
+  private readonly apiService: ApiService;
+
+  constructor(apiService: ApiService = new ApiService()) {
+    this.apiService = apiService;
+  }
+
+  /**
+   * Personalised "top picks" scored against the adopter's stored match
+   * profile. Returns an empty list when the user has no picks yet.
+   */
+  async getTopPicks(limit = 10): Promise<MatchTopPick[]> {
+    const res = await this.apiService.get<{ data: MatchTopPick[] }>(
+      `/api/v1/match/top-picks?limit=${limit}`
+    );
+    return res.data ?? [];
+  }
+
+  /** The signed-in adopter's saved match profile, or null when unset. */
+  async getMatchProfile(): Promise<Partial<AdopterMatchProfile> | null> {
+    const res = await this.apiService.get<{ data: Partial<AdopterMatchProfile> }>(
+      '/api/v1/match/profile'
+    );
+    return res.data ?? null;
+  }
+
+  /** Upsert the adopter's match profile (onboarding wizard save). */
+  async updateMatchProfile(profile: Partial<AdopterMatchProfile>): Promise<void> {
+    await this.apiService.put('/api/v1/match/profile', profile);
+  }
+}

--- a/packages/lib.matching/vitest.config.ts
+++ b/packages/lib.matching/vitest.config.ts
@@ -3,9 +3,10 @@ import { defineLibConfig } from '../../vitest.shared.config';
 export default defineLibConfig({
   test: {
     coverage: {
-      // ADS-717: lib.matching only exports type definitions and constants
-      // from index.ts which is excluded from coverage. No coverable
-      // source files exist, so thresholds are held at 0.
+      // ADS-717: index.ts is type definitions + constants (excluded from
+      // coverage). The MatchingService client is the only coverable source
+      // and is fully covered by matching-service.test.ts, but thresholds
+      // are held at 0 to avoid coupling the gate to that single file.
       thresholds: {
         statements: 0,
         branches: 0,

--- a/packages/proto/proto/adopt_dont_shop/applications/v1/application.proto
+++ b/packages/proto/proto/adopt_dont_shop/applications/v1/application.proto
@@ -106,6 +106,19 @@ service ApplicationService {
   // Document metadata — soft-delete one document. Caller MUST hold
   // applications.update for the application's rescue.
   rpc RemoveDocument(RemoveDocumentRequest) returns (RemoveDocumentResponse);
+
+  // Adopter's reusable application defaults (personal info / living
+  // situation / pet experience / references) used to pre-populate new
+  // applications. Always scoped to the calling principal's own
+  // user_id — there is no cross-adopter read or write.
+  rpc GetApplicationDefaults(GetApplicationDefaultsRequest)
+      returns (GetApplicationDefaultsResponse);
+
+  // Deep-merge a partial defaults patch into the adopter's saved
+  // defaults and return the merged result. Top-level keys absent from
+  // the patch are left untouched.
+  rpc UpdateApplicationDefaults(UpdateApplicationDefaultsRequest)
+      returns (UpdateApplicationDefaultsResponse);
 }
 
 // --- ENUMs — value lists mirror the Postgres types verbatim ----------
@@ -399,3 +412,24 @@ message RemoveDocumentRequest {
 }
 
 message RemoveDocumentResponse {}
+
+// --- Application defaults ---------------------------------------------
+
+message GetApplicationDefaultsRequest {}
+
+message GetApplicationDefaultsResponse {
+  // JSON-stringified ApplicationDefaults. Empty string when the adopter
+  // has never saved any defaults.
+  string defaults_json = 1;
+}
+
+message UpdateApplicationDefaultsRequest {
+  // JSON-stringified partial ApplicationDefaults patch, deep-merged
+  // into the stored value.
+  string defaults_patch_json = 1;
+}
+
+message UpdateApplicationDefaultsResponse {
+  // JSON-stringified ApplicationDefaults after the merge.
+  string defaults_json = 1;
+}

--- a/packages/proto/proto/adopt_dont_shop/matching/v1/matching.proto
+++ b/packages/proto/proto/adopt_dont_shop/matching/v1/matching.proto
@@ -78,6 +78,16 @@ service MatchingService {
   // Aggregate swipe counts for a single session. Caller MUST own the
   // session (or be admin).
   rpc GetSessionStats(GetSessionStatsRequest) returns (GetSessionStatsResponse);
+
+  // --- Top picks ---------------------------------------------------------
+
+  // Get a short, personalised "top picks" list for the calling principal —
+  // distinct from Recommend (the swipe-queue feed): top picks reads the
+  // user's STORED match profile (preferred types/sizes/age groups/energy/
+  // temperament) rather than session filters, excludes already-swiped pets,
+  // and attaches reason chips explaining each pick. Stateless — no session
+  // required, no mutation.
+  rpc GetTopPicks(GetTopPicksRequest) returns (GetTopPicksResponse);
 }
 
 // ===== Enums =========================================================
@@ -325,6 +335,50 @@ message UpsertMatchProfileRequest {
 
 message UpsertMatchProfileResponse {
   MatchProfile profile = 1;
+}
+
+// ===== Top picks ======================================================
+
+// A reason chip explaining why a pick was surfaced. `kind` mirrors the
+// SPA's ReasonChipKind vocabulary (pref_match, lifestyle, distance,
+// similar_to_liked, fresh) as a lowercase string rather than an enum —
+// the chip set is presentation-driven and may grow without a proto
+// regen; `label` is the human-readable text the SPA renders verbatim.
+message TopPickReasonChip {
+  string kind = 1;
+  string label = 2;
+}
+
+// TopPick is the top-picks surface's per-pet payload — a superset of
+// PetCandidate's intent but independently shaped since top picks carries
+// size/age_group/reasons/rescue_name that PetCandidate does not.
+message TopPick {
+  string pet_id = 1;
+  string name = 2;
+  // Lowercase species/size/age-group tokens (same vocabulary as the
+  // filters_json the SPA sends elsewhere — e.g. 'dog', 'medium', 'adult').
+  string type = 3;
+  string age_group = 4;
+  string size = 5;
+  // The scorer's result for this pick, on [0.0, 1.0].
+  float score = 6;
+  repeated TopPickReasonChip reasons = 7;
+  string rescue_name = 8;
+  // Pets has no breed NAME (only breed_id) and no photo/image field, so
+  // these stay unset until that data is available — both are optional in
+  // the SPA's MatchTopPick type for exactly this reason.
+  optional string breed_name = 9;
+  optional string photo_url = 10;
+}
+
+message GetTopPicksRequest {
+  // Defaults to 10, max 50 — top picks is a short curated list, not a
+  // paginated feed.
+  uint32 limit = 1;
+}
+
+message GetTopPicksResponse {
+  repeated TopPick picks = 1;
 }
 
 // ===== Swipe statistics ==============================================

--- a/packages/proto/src/generated/proto/adopt_dont_shop/applications/v1/application.ts
+++ b/packages/proto/src/generated/proto/adopt_dont_shop/applications/v1/application.ts
@@ -5,7 +5,7 @@
 // source: proto/adopt_dont_shop/applications/v1/application.proto
 
 /* eslint-disable */
-import { BinaryReader, BinaryWriter } from "@bufbuild/protobuf/wire";
+import { BinaryReader, BinaryWriter } from '@bufbuild/protobuf/wire';
 import {
   type CallOptions,
   type ChannelCredentials,
@@ -17,9 +17,9 @@ import {
   type Metadata,
   type ServiceError,
   type UntypedServiceImplementation,
-} from "@grpc/grpc-js";
+} from '@grpc/grpc-js';
 
-export const protobufPackage = "adopt_dont_shop.applications.v1";
+export const protobufPackage = 'adopt_dont_shop.applications.v1';
 
 export enum ApplicationStatus {
   APPLICATION_STATUS_UNSPECIFIED = 0,
@@ -38,37 +38,37 @@ export enum ApplicationStatus {
 export function applicationStatusFromJSON(object: any): ApplicationStatus {
   switch (object) {
     case 0:
-    case "APPLICATION_STATUS_UNSPECIFIED":
+    case 'APPLICATION_STATUS_UNSPECIFIED':
       return ApplicationStatus.APPLICATION_STATUS_UNSPECIFIED;
     case 1:
-    case "APPLICATION_STATUS_DRAFT":
+    case 'APPLICATION_STATUS_DRAFT':
       return ApplicationStatus.APPLICATION_STATUS_DRAFT;
     case 2:
-    case "APPLICATION_STATUS_SUBMITTED":
+    case 'APPLICATION_STATUS_SUBMITTED':
       return ApplicationStatus.APPLICATION_STATUS_SUBMITTED;
     case 3:
-    case "APPLICATION_STATUS_UNDER_REVIEW":
+    case 'APPLICATION_STATUS_UNDER_REVIEW':
       return ApplicationStatus.APPLICATION_STATUS_UNDER_REVIEW;
     case 4:
-    case "APPLICATION_STATUS_HOME_VISIT_SCHEDULED":
+    case 'APPLICATION_STATUS_HOME_VISIT_SCHEDULED':
       return ApplicationStatus.APPLICATION_STATUS_HOME_VISIT_SCHEDULED;
     case 5:
-    case "APPLICATION_STATUS_HOME_VISIT_COMPLETED":
+    case 'APPLICATION_STATUS_HOME_VISIT_COMPLETED':
       return ApplicationStatus.APPLICATION_STATUS_HOME_VISIT_COMPLETED;
     case 6:
-    case "APPLICATION_STATUS_APPROVED":
+    case 'APPLICATION_STATUS_APPROVED':
       return ApplicationStatus.APPLICATION_STATUS_APPROVED;
     case 7:
-    case "APPLICATION_STATUS_REJECTED":
+    case 'APPLICATION_STATUS_REJECTED':
       return ApplicationStatus.APPLICATION_STATUS_REJECTED;
     case 8:
-    case "APPLICATION_STATUS_WITHDRAWN":
+    case 'APPLICATION_STATUS_WITHDRAWN':
       return ApplicationStatus.APPLICATION_STATUS_WITHDRAWN;
     case 9:
-    case "APPLICATION_STATUS_ADOPTED":
+    case 'APPLICATION_STATUS_ADOPTED':
       return ApplicationStatus.APPLICATION_STATUS_ADOPTED;
     case -1:
-    case "UNRECOGNIZED":
+    case 'UNRECOGNIZED':
     default:
       return ApplicationStatus.UNRECOGNIZED;
   }
@@ -77,28 +77,28 @@ export function applicationStatusFromJSON(object: any): ApplicationStatus {
 export function applicationStatusToJSON(object: ApplicationStatus): string {
   switch (object) {
     case ApplicationStatus.APPLICATION_STATUS_UNSPECIFIED:
-      return "APPLICATION_STATUS_UNSPECIFIED";
+      return 'APPLICATION_STATUS_UNSPECIFIED';
     case ApplicationStatus.APPLICATION_STATUS_DRAFT:
-      return "APPLICATION_STATUS_DRAFT";
+      return 'APPLICATION_STATUS_DRAFT';
     case ApplicationStatus.APPLICATION_STATUS_SUBMITTED:
-      return "APPLICATION_STATUS_SUBMITTED";
+      return 'APPLICATION_STATUS_SUBMITTED';
     case ApplicationStatus.APPLICATION_STATUS_UNDER_REVIEW:
-      return "APPLICATION_STATUS_UNDER_REVIEW";
+      return 'APPLICATION_STATUS_UNDER_REVIEW';
     case ApplicationStatus.APPLICATION_STATUS_HOME_VISIT_SCHEDULED:
-      return "APPLICATION_STATUS_HOME_VISIT_SCHEDULED";
+      return 'APPLICATION_STATUS_HOME_VISIT_SCHEDULED';
     case ApplicationStatus.APPLICATION_STATUS_HOME_VISIT_COMPLETED:
-      return "APPLICATION_STATUS_HOME_VISIT_COMPLETED";
+      return 'APPLICATION_STATUS_HOME_VISIT_COMPLETED';
     case ApplicationStatus.APPLICATION_STATUS_APPROVED:
-      return "APPLICATION_STATUS_APPROVED";
+      return 'APPLICATION_STATUS_APPROVED';
     case ApplicationStatus.APPLICATION_STATUS_REJECTED:
-      return "APPLICATION_STATUS_REJECTED";
+      return 'APPLICATION_STATUS_REJECTED';
     case ApplicationStatus.APPLICATION_STATUS_WITHDRAWN:
-      return "APPLICATION_STATUS_WITHDRAWN";
+      return 'APPLICATION_STATUS_WITHDRAWN';
     case ApplicationStatus.APPLICATION_STATUS_ADOPTED:
-      return "APPLICATION_STATUS_ADOPTED";
+      return 'APPLICATION_STATUS_ADOPTED';
     case ApplicationStatus.UNRECOGNIZED:
     default:
-      return "UNRECOGNIZED";
+      return 'UNRECOGNIZED';
   }
 }
 
@@ -113,19 +113,19 @@ export enum HomeVisitOutcome {
 export function homeVisitOutcomeFromJSON(object: any): HomeVisitOutcome {
   switch (object) {
     case 0:
-    case "HOME_VISIT_OUTCOME_UNSPECIFIED":
+    case 'HOME_VISIT_OUTCOME_UNSPECIFIED':
       return HomeVisitOutcome.HOME_VISIT_OUTCOME_UNSPECIFIED;
     case 1:
-    case "HOME_VISIT_OUTCOME_PASSED":
+    case 'HOME_VISIT_OUTCOME_PASSED':
       return HomeVisitOutcome.HOME_VISIT_OUTCOME_PASSED;
     case 2:
-    case "HOME_VISIT_OUTCOME_FAILED":
+    case 'HOME_VISIT_OUTCOME_FAILED':
       return HomeVisitOutcome.HOME_VISIT_OUTCOME_FAILED;
     case 3:
-    case "HOME_VISIT_OUTCOME_RESCHEDULE":
+    case 'HOME_VISIT_OUTCOME_RESCHEDULE':
       return HomeVisitOutcome.HOME_VISIT_OUTCOME_RESCHEDULE;
     case -1:
-    case "UNRECOGNIZED":
+    case 'UNRECOGNIZED':
     default:
       return HomeVisitOutcome.UNRECOGNIZED;
   }
@@ -134,16 +134,16 @@ export function homeVisitOutcomeFromJSON(object: any): HomeVisitOutcome {
 export function homeVisitOutcomeToJSON(object: HomeVisitOutcome): string {
   switch (object) {
     case HomeVisitOutcome.HOME_VISIT_OUTCOME_UNSPECIFIED:
-      return "HOME_VISIT_OUTCOME_UNSPECIFIED";
+      return 'HOME_VISIT_OUTCOME_UNSPECIFIED';
     case HomeVisitOutcome.HOME_VISIT_OUTCOME_PASSED:
-      return "HOME_VISIT_OUTCOME_PASSED";
+      return 'HOME_VISIT_OUTCOME_PASSED';
     case HomeVisitOutcome.HOME_VISIT_OUTCOME_FAILED:
-      return "HOME_VISIT_OUTCOME_FAILED";
+      return 'HOME_VISIT_OUTCOME_FAILED';
     case HomeVisitOutcome.HOME_VISIT_OUTCOME_RESCHEDULE:
-      return "HOME_VISIT_OUTCOME_RESCHEDULE";
+      return 'HOME_VISIT_OUTCOME_RESCHEDULE';
     case HomeVisitOutcome.UNRECOGNIZED:
     default:
-      return "UNRECOGNIZED";
+      return 'UNRECOGNIZED';
   }
 }
 
@@ -319,16 +319,12 @@ export interface GetApplicationResponse {
 
 export interface ListApplicationsRequest {
   /** Opaque base64-JSON keyset cursor. */
-  cursor?:
-    | string
-    | undefined;
+  cursor?: string | undefined;
   /** Defaults to 20, max 100. */
   limit: number;
   /** Optional filters. UNSPECIFIED in each enum = "no filter". */
   statusFilter: ApplicationStatus;
-  rescueIdFilter?:
-    | string
-    | undefined;
+  rescueIdFilter?: string | undefined;
   /**
    * Adopters can only see their own (the handler enforces scope
    * from principal.userId); admins + super_admin can pass any
@@ -417,18 +413,40 @@ export interface RemoveDocumentRequest {
   documentId: string;
 }
 
-export interface RemoveDocumentResponse {
+export interface RemoveDocumentResponse {}
+
+export interface GetApplicationDefaultsRequest {}
+
+export interface GetApplicationDefaultsResponse {
+  /**
+   * JSON-stringified ApplicationDefaults. Empty string when the adopter
+   * has never saved any defaults.
+   */
+  defaultsJson: string;
+}
+
+export interface UpdateApplicationDefaultsRequest {
+  /**
+   * JSON-stringified partial ApplicationDefaults patch, deep-merged
+   * into the stored value.
+   */
+  defaultsPatchJson: string;
+}
+
+export interface UpdateApplicationDefaultsResponse {
+  /** JSON-stringified ApplicationDefaults after the merge. */
+  defaultsJson: string;
 }
 
 function createBaseApplication(): Application {
   return {
-    applicationId: "",
-    adopterId: "",
-    petId: "",
-    rescueId: "",
+    applicationId: '',
+    adopterId: '',
+    petId: '',
+    rescueId: '',
     status: 0,
-    answersJson: "",
-    referencesJson: "",
+    answersJson: '',
+    referencesJson: '',
     version: 0,
     submittedAt: undefined,
     reviewStartedAt: undefined,
@@ -441,32 +459,32 @@ function createBaseApplication(): Application {
     decisionNotes: undefined,
     rejectionReason: undefined,
     adoptedAt: undefined,
-    createdAt: "",
-    updatedAt: "",
+    createdAt: '',
+    updatedAt: '',
   };
 }
 
 export const Application: MessageFns<Application> = {
   encode(message: Application, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    if (message.applicationId !== "") {
+    if (message.applicationId !== '') {
       writer.uint32(10).string(message.applicationId);
     }
-    if (message.adopterId !== "") {
+    if (message.adopterId !== '') {
       writer.uint32(18).string(message.adopterId);
     }
-    if (message.petId !== "") {
+    if (message.petId !== '') {
       writer.uint32(26).string(message.petId);
     }
-    if (message.rescueId !== "") {
+    if (message.rescueId !== '') {
       writer.uint32(34).string(message.rescueId);
     }
     if (message.status !== 0) {
       writer.uint32(40).int32(message.status);
     }
-    if (message.answersJson !== "") {
+    if (message.answersJson !== '') {
       writer.uint32(50).string(message.answersJson);
     }
-    if (message.referencesJson !== "") {
+    if (message.referencesJson !== '') {
       writer.uint32(58).string(message.referencesJson);
     }
     if (message.version !== 0) {
@@ -505,10 +523,10 @@ export const Application: MessageFns<Application> = {
     if (message.adoptedAt !== undefined) {
       writer.uint32(154).string(message.adoptedAt);
     }
-    if (message.createdAt !== "") {
+    if (message.createdAt !== '') {
       writer.uint32(162).string(message.createdAt);
     }
-    if (message.updatedAt !== "") {
+    if (message.updatedAt !== '') {
       writer.uint32(170).string(message.updatedAt);
     }
     return writer;
@@ -703,124 +721,124 @@ export const Application: MessageFns<Application> = {
       applicationId: isSet(object.applicationId)
         ? globalThis.String(object.applicationId)
         : isSet(object.application_id)
-        ? globalThis.String(object.application_id)
-        : "",
+          ? globalThis.String(object.application_id)
+          : '',
       adopterId: isSet(object.adopterId)
         ? globalThis.String(object.adopterId)
         : isSet(object.adopter_id)
-        ? globalThis.String(object.adopter_id)
-        : "",
+          ? globalThis.String(object.adopter_id)
+          : '',
       petId: isSet(object.petId)
         ? globalThis.String(object.petId)
         : isSet(object.pet_id)
-        ? globalThis.String(object.pet_id)
-        : "",
+          ? globalThis.String(object.pet_id)
+          : '',
       rescueId: isSet(object.rescueId)
         ? globalThis.String(object.rescueId)
         : isSet(object.rescue_id)
-        ? globalThis.String(object.rescue_id)
-        : "",
+          ? globalThis.String(object.rescue_id)
+          : '',
       status: isSet(object.status) ? applicationStatusFromJSON(object.status) : 0,
       answersJson: isSet(object.answersJson)
         ? globalThis.String(object.answersJson)
         : isSet(object.answers_json)
-        ? globalThis.String(object.answers_json)
-        : "",
+          ? globalThis.String(object.answers_json)
+          : '',
       referencesJson: isSet(object.referencesJson)
         ? globalThis.String(object.referencesJson)
         : isSet(object.references_json)
-        ? globalThis.String(object.references_json)
-        : "",
+          ? globalThis.String(object.references_json)
+          : '',
       version: isSet(object.version) ? globalThis.Number(object.version) : 0,
       submittedAt: isSet(object.submittedAt)
         ? globalThis.String(object.submittedAt)
         : isSet(object.submitted_at)
-        ? globalThis.String(object.submitted_at)
-        : undefined,
+          ? globalThis.String(object.submitted_at)
+          : undefined,
       reviewStartedAt: isSet(object.reviewStartedAt)
         ? globalThis.String(object.reviewStartedAt)
         : isSet(object.review_started_at)
-        ? globalThis.String(object.review_started_at)
-        : undefined,
+          ? globalThis.String(object.review_started_at)
+          : undefined,
       homeVisitScheduledAt: isSet(object.homeVisitScheduledAt)
         ? globalThis.String(object.homeVisitScheduledAt)
         : isSet(object.home_visit_scheduled_at)
-        ? globalThis.String(object.home_visit_scheduled_at)
-        : undefined,
+          ? globalThis.String(object.home_visit_scheduled_at)
+          : undefined,
       homeVisitCompletedAt: isSet(object.homeVisitCompletedAt)
         ? globalThis.String(object.homeVisitCompletedAt)
         : isSet(object.home_visit_completed_at)
-        ? globalThis.String(object.home_visit_completed_at)
-        : undefined,
+          ? globalThis.String(object.home_visit_completed_at)
+          : undefined,
       homeVisitOutcome: isSet(object.homeVisitOutcome)
         ? homeVisitOutcomeFromJSON(object.homeVisitOutcome)
         : isSet(object.home_visit_outcome)
-        ? homeVisitOutcomeFromJSON(object.home_visit_outcome)
-        : undefined,
+          ? homeVisitOutcomeFromJSON(object.home_visit_outcome)
+          : undefined,
       homeVisitNotes: isSet(object.homeVisitNotes)
         ? globalThis.String(object.homeVisitNotes)
         : isSet(object.home_visit_notes)
-        ? globalThis.String(object.home_visit_notes)
-        : undefined,
+          ? globalThis.String(object.home_visit_notes)
+          : undefined,
       decidedAt: isSet(object.decidedAt)
         ? globalThis.String(object.decidedAt)
         : isSet(object.decided_at)
-        ? globalThis.String(object.decided_at)
-        : undefined,
+          ? globalThis.String(object.decided_at)
+          : undefined,
       decidedBy: isSet(object.decidedBy)
         ? globalThis.String(object.decidedBy)
         : isSet(object.decided_by)
-        ? globalThis.String(object.decided_by)
-        : undefined,
+          ? globalThis.String(object.decided_by)
+          : undefined,
       decisionNotes: isSet(object.decisionNotes)
         ? globalThis.String(object.decisionNotes)
         : isSet(object.decision_notes)
-        ? globalThis.String(object.decision_notes)
-        : undefined,
+          ? globalThis.String(object.decision_notes)
+          : undefined,
       rejectionReason: isSet(object.rejectionReason)
         ? globalThis.String(object.rejectionReason)
         : isSet(object.rejection_reason)
-        ? globalThis.String(object.rejection_reason)
-        : undefined,
+          ? globalThis.String(object.rejection_reason)
+          : undefined,
       adoptedAt: isSet(object.adoptedAt)
         ? globalThis.String(object.adoptedAt)
         : isSet(object.adopted_at)
-        ? globalThis.String(object.adopted_at)
-        : undefined,
+          ? globalThis.String(object.adopted_at)
+          : undefined,
       createdAt: isSet(object.createdAt)
         ? globalThis.String(object.createdAt)
         : isSet(object.created_at)
-        ? globalThis.String(object.created_at)
-        : "",
+          ? globalThis.String(object.created_at)
+          : '',
       updatedAt: isSet(object.updatedAt)
         ? globalThis.String(object.updatedAt)
         : isSet(object.updated_at)
-        ? globalThis.String(object.updated_at)
-        : "",
+          ? globalThis.String(object.updated_at)
+          : '',
     };
   },
 
   toJSON(message: Application): unknown {
     const obj: any = {};
-    if (message.applicationId !== "") {
+    if (message.applicationId !== '') {
       obj.applicationId = message.applicationId;
     }
-    if (message.adopterId !== "") {
+    if (message.adopterId !== '') {
       obj.adopterId = message.adopterId;
     }
-    if (message.petId !== "") {
+    if (message.petId !== '') {
       obj.petId = message.petId;
     }
-    if (message.rescueId !== "") {
+    if (message.rescueId !== '') {
       obj.rescueId = message.rescueId;
     }
     if (message.status !== 0) {
       obj.status = applicationStatusToJSON(message.status);
     }
-    if (message.answersJson !== "") {
+    if (message.answersJson !== '') {
       obj.answersJson = message.answersJson;
     }
-    if (message.referencesJson !== "") {
+    if (message.referencesJson !== '') {
       obj.referencesJson = message.referencesJson;
     }
     if (message.version !== 0) {
@@ -859,10 +877,10 @@ export const Application: MessageFns<Application> = {
     if (message.adoptedAt !== undefined) {
       obj.adoptedAt = message.adoptedAt;
     }
-    if (message.createdAt !== "") {
+    if (message.createdAt !== '') {
       obj.createdAt = message.createdAt;
     }
-    if (message.updatedAt !== "") {
+    if (message.updatedAt !== '') {
       obj.updatedAt = message.updatedAt;
     }
     return obj;
@@ -873,13 +891,13 @@ export const Application: MessageFns<Application> = {
   },
   fromPartial<I extends Exact<DeepPartial<Application>, I>>(object: I): Application {
     const message = createBaseApplication();
-    message.applicationId = object.applicationId ?? "";
-    message.adopterId = object.adopterId ?? "";
-    message.petId = object.petId ?? "";
-    message.rescueId = object.rescueId ?? "";
+    message.applicationId = object.applicationId ?? '';
+    message.adopterId = object.adopterId ?? '';
+    message.petId = object.petId ?? '';
+    message.rescueId = object.rescueId ?? '';
     message.status = object.status ?? 0;
-    message.answersJson = object.answersJson ?? "";
-    message.referencesJson = object.referencesJson ?? "";
+    message.answersJson = object.answersJson ?? '';
+    message.referencesJson = object.referencesJson ?? '';
     message.version = object.version ?? 0;
     message.submittedAt = object.submittedAt ?? undefined;
     message.reviewStartedAt = object.reviewStartedAt ?? undefined;
@@ -892,30 +910,30 @@ export const Application: MessageFns<Application> = {
     message.decisionNotes = object.decisionNotes ?? undefined;
     message.rejectionReason = object.rejectionReason ?? undefined;
     message.adoptedAt = object.adoptedAt ?? undefined;
-    message.createdAt = object.createdAt ?? "";
-    message.updatedAt = object.updatedAt ?? "";
+    message.createdAt = object.createdAt ?? '';
+    message.updatedAt = object.updatedAt ?? '';
     return message;
   },
 };
 
 function createBaseTimelineEntry(): TimelineEntry {
   return {
-    entryId: "",
-    applicationId: "",
+    entryId: '',
+    applicationId: '',
     fromStatus: 0,
     toStatus: 0,
-    actorUserId: "",
-    occurredAt: "",
+    actorUserId: '',
+    occurredAt: '',
     note: undefined,
   };
 }
 
 export const TimelineEntry: MessageFns<TimelineEntry> = {
   encode(message: TimelineEntry, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    if (message.entryId !== "") {
+    if (message.entryId !== '') {
       writer.uint32(10).string(message.entryId);
     }
-    if (message.applicationId !== "") {
+    if (message.applicationId !== '') {
       writer.uint32(18).string(message.applicationId);
     }
     if (message.fromStatus !== 0) {
@@ -924,10 +942,10 @@ export const TimelineEntry: MessageFns<TimelineEntry> = {
     if (message.toStatus !== 0) {
       writer.uint32(32).int32(message.toStatus);
     }
-    if (message.actorUserId !== "") {
+    if (message.actorUserId !== '') {
       writer.uint32(42).string(message.actorUserId);
     }
-    if (message.occurredAt !== "") {
+    if (message.occurredAt !== '') {
       writer.uint32(50).string(message.occurredAt);
     }
     if (message.note !== undefined) {
@@ -1013,43 +1031,43 @@ export const TimelineEntry: MessageFns<TimelineEntry> = {
       entryId: isSet(object.entryId)
         ? globalThis.String(object.entryId)
         : isSet(object.entry_id)
-        ? globalThis.String(object.entry_id)
-        : "",
+          ? globalThis.String(object.entry_id)
+          : '',
       applicationId: isSet(object.applicationId)
         ? globalThis.String(object.applicationId)
         : isSet(object.application_id)
-        ? globalThis.String(object.application_id)
-        : "",
+          ? globalThis.String(object.application_id)
+          : '',
       fromStatus: isSet(object.fromStatus)
         ? applicationStatusFromJSON(object.fromStatus)
         : isSet(object.from_status)
-        ? applicationStatusFromJSON(object.from_status)
-        : 0,
+          ? applicationStatusFromJSON(object.from_status)
+          : 0,
       toStatus: isSet(object.toStatus)
         ? applicationStatusFromJSON(object.toStatus)
         : isSet(object.to_status)
-        ? applicationStatusFromJSON(object.to_status)
-        : 0,
+          ? applicationStatusFromJSON(object.to_status)
+          : 0,
       actorUserId: isSet(object.actorUserId)
         ? globalThis.String(object.actorUserId)
         : isSet(object.actor_user_id)
-        ? globalThis.String(object.actor_user_id)
-        : "",
+          ? globalThis.String(object.actor_user_id)
+          : '',
       occurredAt: isSet(object.occurredAt)
         ? globalThis.String(object.occurredAt)
         : isSet(object.occurred_at)
-        ? globalThis.String(object.occurred_at)
-        : "",
+          ? globalThis.String(object.occurred_at)
+          : '',
       note: isSet(object.note) ? globalThis.String(object.note) : undefined,
     };
   },
 
   toJSON(message: TimelineEntry): unknown {
     const obj: any = {};
-    if (message.entryId !== "") {
+    if (message.entryId !== '') {
       obj.entryId = message.entryId;
     }
-    if (message.applicationId !== "") {
+    if (message.applicationId !== '') {
       obj.applicationId = message.applicationId;
     }
     if (message.fromStatus !== 0) {
@@ -1058,10 +1076,10 @@ export const TimelineEntry: MessageFns<TimelineEntry> = {
     if (message.toStatus !== 0) {
       obj.toStatus = applicationStatusToJSON(message.toStatus);
     }
-    if (message.actorUserId !== "") {
+    if (message.actorUserId !== '') {
       obj.actorUserId = message.actorUserId;
     }
-    if (message.occurredAt !== "") {
+    if (message.occurredAt !== '') {
       obj.occurredAt = message.occurredAt;
     }
     if (message.note !== undefined) {
@@ -1075,27 +1093,27 @@ export const TimelineEntry: MessageFns<TimelineEntry> = {
   },
   fromPartial<I extends Exact<DeepPartial<TimelineEntry>, I>>(object: I): TimelineEntry {
     const message = createBaseTimelineEntry();
-    message.entryId = object.entryId ?? "";
-    message.applicationId = object.applicationId ?? "";
+    message.entryId = object.entryId ?? '';
+    message.applicationId = object.applicationId ?? '';
     message.fromStatus = object.fromStatus ?? 0;
     message.toStatus = object.toStatus ?? 0;
-    message.actorUserId = object.actorUserId ?? "";
-    message.occurredAt = object.occurredAt ?? "";
+    message.actorUserId = object.actorUserId ?? '';
+    message.occurredAt = object.occurredAt ?? '';
     message.note = object.note ?? undefined;
     return message;
   },
 };
 
 function createBaseStartDraftRequest(): StartDraftRequest {
-  return { adopterId: "", petId: "" };
+  return { adopterId: '', petId: '' };
 }
 
 export const StartDraftRequest: MessageFns<StartDraftRequest> = {
   encode(message: StartDraftRequest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    if (message.adopterId !== "") {
+    if (message.adopterId !== '') {
       writer.uint32(10).string(message.adopterId);
     }
-    if (message.petId !== "") {
+    if (message.petId !== '') {
       writer.uint32(18).string(message.petId);
     }
     return writer;
@@ -1138,22 +1156,22 @@ export const StartDraftRequest: MessageFns<StartDraftRequest> = {
       adopterId: isSet(object.adopterId)
         ? globalThis.String(object.adopterId)
         : isSet(object.adopter_id)
-        ? globalThis.String(object.adopter_id)
-        : "",
+          ? globalThis.String(object.adopter_id)
+          : '',
       petId: isSet(object.petId)
         ? globalThis.String(object.petId)
         : isSet(object.pet_id)
-        ? globalThis.String(object.pet_id)
-        : "",
+          ? globalThis.String(object.pet_id)
+          : '',
     };
   },
 
   toJSON(message: StartDraftRequest): unknown {
     const obj: any = {};
-    if (message.adopterId !== "") {
+    if (message.adopterId !== '') {
       obj.adopterId = message.adopterId;
     }
-    if (message.petId !== "") {
+    if (message.petId !== '') {
       obj.petId = message.petId;
     }
     return obj;
@@ -1164,8 +1182,8 @@ export const StartDraftRequest: MessageFns<StartDraftRequest> = {
   },
   fromPartial<I extends Exact<DeepPartial<StartDraftRequest>, I>>(object: I): StartDraftRequest {
     const message = createBaseStartDraftRequest();
-    message.adopterId = object.adopterId ?? "";
-    message.petId = object.petId ?? "";
+    message.adopterId = object.adopterId ?? '';
+    message.petId = object.petId ?? '';
     return message;
   },
 };
@@ -1207,7 +1225,9 @@ export const StartDraftResponse: MessageFns<StartDraftResponse> = {
   },
 
   fromJSON(object: any): StartDraftResponse {
-    return { application: isSet(object.application) ? Application.fromJSON(object.application) : undefined };
+    return {
+      application: isSet(object.application) ? Application.fromJSON(object.application) : undefined,
+    };
   },
 
   toJSON(message: StartDraftResponse): unknown {
@@ -1223,26 +1243,30 @@ export const StartDraftResponse: MessageFns<StartDraftResponse> = {
   },
   fromPartial<I extends Exact<DeepPartial<StartDraftResponse>, I>>(object: I): StartDraftResponse {
     const message = createBaseStartDraftResponse();
-    message.application = (object.application !== undefined && object.application !== null)
-      ? Application.fromPartial(object.application)
-      : undefined;
+    message.application =
+      object.application !== undefined && object.application !== null
+        ? Application.fromPartial(object.application)
+        : undefined;
     return message;
   },
 };
 
 function createBaseSaveDraftAnswersRequest(): SaveDraftAnswersRequest {
-  return { applicationId: "", expectedVersion: 0, answersPatchJson: "", referencesJson: undefined };
+  return { applicationId: '', expectedVersion: 0, answersPatchJson: '', referencesJson: undefined };
 }
 
 export const SaveDraftAnswersRequest: MessageFns<SaveDraftAnswersRequest> = {
-  encode(message: SaveDraftAnswersRequest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    if (message.applicationId !== "") {
+  encode(
+    message: SaveDraftAnswersRequest,
+    writer: BinaryWriter = new BinaryWriter()
+  ): BinaryWriter {
+    if (message.applicationId !== '') {
       writer.uint32(10).string(message.applicationId);
     }
     if (message.expectedVersion !== 0) {
       writer.uint32(16).uint32(message.expectedVersion);
     }
-    if (message.answersPatchJson !== "") {
+    if (message.answersPatchJson !== '') {
       writer.uint32(26).string(message.answersPatchJson);
     }
     if (message.referencesJson !== undefined) {
@@ -1304,35 +1328,35 @@ export const SaveDraftAnswersRequest: MessageFns<SaveDraftAnswersRequest> = {
       applicationId: isSet(object.applicationId)
         ? globalThis.String(object.applicationId)
         : isSet(object.application_id)
-        ? globalThis.String(object.application_id)
-        : "",
+          ? globalThis.String(object.application_id)
+          : '',
       expectedVersion: isSet(object.expectedVersion)
         ? globalThis.Number(object.expectedVersion)
         : isSet(object.expected_version)
-        ? globalThis.Number(object.expected_version)
-        : 0,
+          ? globalThis.Number(object.expected_version)
+          : 0,
       answersPatchJson: isSet(object.answersPatchJson)
         ? globalThis.String(object.answersPatchJson)
         : isSet(object.answers_patch_json)
-        ? globalThis.String(object.answers_patch_json)
-        : "",
+          ? globalThis.String(object.answers_patch_json)
+          : '',
       referencesJson: isSet(object.referencesJson)
         ? globalThis.String(object.referencesJson)
         : isSet(object.references_json)
-        ? globalThis.String(object.references_json)
-        : undefined,
+          ? globalThis.String(object.references_json)
+          : undefined,
     };
   },
 
   toJSON(message: SaveDraftAnswersRequest): unknown {
     const obj: any = {};
-    if (message.applicationId !== "") {
+    if (message.applicationId !== '') {
       obj.applicationId = message.applicationId;
     }
     if (message.expectedVersion !== 0) {
       obj.expectedVersion = Math.round(message.expectedVersion);
     }
-    if (message.answersPatchJson !== "") {
+    if (message.answersPatchJson !== '') {
       obj.answersPatchJson = message.answersPatchJson;
     }
     if (message.referencesJson !== undefined) {
@@ -1341,14 +1365,18 @@ export const SaveDraftAnswersRequest: MessageFns<SaveDraftAnswersRequest> = {
     return obj;
   },
 
-  create<I extends Exact<DeepPartial<SaveDraftAnswersRequest>, I>>(base?: I): SaveDraftAnswersRequest {
+  create<I extends Exact<DeepPartial<SaveDraftAnswersRequest>, I>>(
+    base?: I
+  ): SaveDraftAnswersRequest {
     return SaveDraftAnswersRequest.fromPartial(base ?? ({} as any));
   },
-  fromPartial<I extends Exact<DeepPartial<SaveDraftAnswersRequest>, I>>(object: I): SaveDraftAnswersRequest {
+  fromPartial<I extends Exact<DeepPartial<SaveDraftAnswersRequest>, I>>(
+    object: I
+  ): SaveDraftAnswersRequest {
     const message = createBaseSaveDraftAnswersRequest();
-    message.applicationId = object.applicationId ?? "";
+    message.applicationId = object.applicationId ?? '';
     message.expectedVersion = object.expectedVersion ?? 0;
-    message.answersPatchJson = object.answersPatchJson ?? "";
+    message.answersPatchJson = object.answersPatchJson ?? '';
     message.referencesJson = object.referencesJson ?? undefined;
     return message;
   },
@@ -1359,7 +1387,10 @@ function createBaseSaveDraftAnswersResponse(): SaveDraftAnswersResponse {
 }
 
 export const SaveDraftAnswersResponse: MessageFns<SaveDraftAnswersResponse> = {
-  encode(message: SaveDraftAnswersResponse, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+  encode(
+    message: SaveDraftAnswersResponse,
+    writer: BinaryWriter = new BinaryWriter()
+  ): BinaryWriter {
     if (message.application !== undefined) {
       Application.encode(message.application, writer.uint32(10).fork()).join();
     }
@@ -1391,7 +1422,9 @@ export const SaveDraftAnswersResponse: MessageFns<SaveDraftAnswersResponse> = {
   },
 
   fromJSON(object: any): SaveDraftAnswersResponse {
-    return { application: isSet(object.application) ? Application.fromJSON(object.application) : undefined };
+    return {
+      application: isSet(object.application) ? Application.fromJSON(object.application) : undefined,
+    };
   },
 
   toJSON(message: SaveDraftAnswersResponse): unknown {
@@ -1402,25 +1435,30 @@ export const SaveDraftAnswersResponse: MessageFns<SaveDraftAnswersResponse> = {
     return obj;
   },
 
-  create<I extends Exact<DeepPartial<SaveDraftAnswersResponse>, I>>(base?: I): SaveDraftAnswersResponse {
+  create<I extends Exact<DeepPartial<SaveDraftAnswersResponse>, I>>(
+    base?: I
+  ): SaveDraftAnswersResponse {
     return SaveDraftAnswersResponse.fromPartial(base ?? ({} as any));
   },
-  fromPartial<I extends Exact<DeepPartial<SaveDraftAnswersResponse>, I>>(object: I): SaveDraftAnswersResponse {
+  fromPartial<I extends Exact<DeepPartial<SaveDraftAnswersResponse>, I>>(
+    object: I
+  ): SaveDraftAnswersResponse {
     const message = createBaseSaveDraftAnswersResponse();
-    message.application = (object.application !== undefined && object.application !== null)
-      ? Application.fromPartial(object.application)
-      : undefined;
+    message.application =
+      object.application !== undefined && object.application !== null
+        ? Application.fromPartial(object.application)
+        : undefined;
     return message;
   },
 };
 
 function createBaseSubmitDraftRequest(): SubmitDraftRequest {
-  return { applicationId: "", expectedVersion: 0 };
+  return { applicationId: '', expectedVersion: 0 };
 }
 
 export const SubmitDraftRequest: MessageFns<SubmitDraftRequest> = {
   encode(message: SubmitDraftRequest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    if (message.applicationId !== "") {
+    if (message.applicationId !== '') {
       writer.uint32(10).string(message.applicationId);
     }
     if (message.expectedVersion !== 0) {
@@ -1466,19 +1504,19 @@ export const SubmitDraftRequest: MessageFns<SubmitDraftRequest> = {
       applicationId: isSet(object.applicationId)
         ? globalThis.String(object.applicationId)
         : isSet(object.application_id)
-        ? globalThis.String(object.application_id)
-        : "",
+          ? globalThis.String(object.application_id)
+          : '',
       expectedVersion: isSet(object.expectedVersion)
         ? globalThis.Number(object.expectedVersion)
         : isSet(object.expected_version)
-        ? globalThis.Number(object.expected_version)
-        : 0,
+          ? globalThis.Number(object.expected_version)
+          : 0,
     };
   },
 
   toJSON(message: SubmitDraftRequest): unknown {
     const obj: any = {};
-    if (message.applicationId !== "") {
+    if (message.applicationId !== '') {
       obj.applicationId = message.applicationId;
     }
     if (message.expectedVersion !== 0) {
@@ -1492,7 +1530,7 @@ export const SubmitDraftRequest: MessageFns<SubmitDraftRequest> = {
   },
   fromPartial<I extends Exact<DeepPartial<SubmitDraftRequest>, I>>(object: I): SubmitDraftRequest {
     const message = createBaseSubmitDraftRequest();
-    message.applicationId = object.applicationId ?? "";
+    message.applicationId = object.applicationId ?? '';
     message.expectedVersion = object.expectedVersion ?? 0;
     return message;
   },
@@ -1535,7 +1573,9 @@ export const SubmitDraftResponse: MessageFns<SubmitDraftResponse> = {
   },
 
   fromJSON(object: any): SubmitDraftResponse {
-    return { application: isSet(object.application) ? Application.fromJSON(object.application) : undefined };
+    return {
+      application: isSet(object.application) ? Application.fromJSON(object.application) : undefined,
+    };
   },
 
   toJSON(message: SubmitDraftResponse): unknown {
@@ -1549,22 +1589,25 @@ export const SubmitDraftResponse: MessageFns<SubmitDraftResponse> = {
   create<I extends Exact<DeepPartial<SubmitDraftResponse>, I>>(base?: I): SubmitDraftResponse {
     return SubmitDraftResponse.fromPartial(base ?? ({} as any));
   },
-  fromPartial<I extends Exact<DeepPartial<SubmitDraftResponse>, I>>(object: I): SubmitDraftResponse {
+  fromPartial<I extends Exact<DeepPartial<SubmitDraftResponse>, I>>(
+    object: I
+  ): SubmitDraftResponse {
     const message = createBaseSubmitDraftResponse();
-    message.application = (object.application !== undefined && object.application !== null)
-      ? Application.fromPartial(object.application)
-      : undefined;
+    message.application =
+      object.application !== undefined && object.application !== null
+        ? Application.fromPartial(object.application)
+        : undefined;
     return message;
   },
 };
 
 function createBaseStartReviewRequest(): StartReviewRequest {
-  return { applicationId: "", note: undefined };
+  return { applicationId: '', note: undefined };
 }
 
 export const StartReviewRequest: MessageFns<StartReviewRequest> = {
   encode(message: StartReviewRequest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    if (message.applicationId !== "") {
+    if (message.applicationId !== '') {
       writer.uint32(10).string(message.applicationId);
     }
     if (message.note !== undefined) {
@@ -1610,15 +1653,15 @@ export const StartReviewRequest: MessageFns<StartReviewRequest> = {
       applicationId: isSet(object.applicationId)
         ? globalThis.String(object.applicationId)
         : isSet(object.application_id)
-        ? globalThis.String(object.application_id)
-        : "",
+          ? globalThis.String(object.application_id)
+          : '',
       note: isSet(object.note) ? globalThis.String(object.note) : undefined,
     };
   },
 
   toJSON(message: StartReviewRequest): unknown {
     const obj: any = {};
-    if (message.applicationId !== "") {
+    if (message.applicationId !== '') {
       obj.applicationId = message.applicationId;
     }
     if (message.note !== undefined) {
@@ -1632,7 +1675,7 @@ export const StartReviewRequest: MessageFns<StartReviewRequest> = {
   },
   fromPartial<I extends Exact<DeepPartial<StartReviewRequest>, I>>(object: I): StartReviewRequest {
     const message = createBaseStartReviewRequest();
-    message.applicationId = object.applicationId ?? "";
+    message.applicationId = object.applicationId ?? '';
     message.note = object.note ?? undefined;
     return message;
   },
@@ -1675,7 +1718,9 @@ export const StartReviewResponse: MessageFns<StartReviewResponse> = {
   },
 
   fromJSON(object: any): StartReviewResponse {
-    return { application: isSet(object.application) ? Application.fromJSON(object.application) : undefined };
+    return {
+      application: isSet(object.application) ? Application.fromJSON(object.application) : undefined,
+    };
   },
 
   toJSON(message: StartReviewResponse): unknown {
@@ -1689,25 +1734,31 @@ export const StartReviewResponse: MessageFns<StartReviewResponse> = {
   create<I extends Exact<DeepPartial<StartReviewResponse>, I>>(base?: I): StartReviewResponse {
     return StartReviewResponse.fromPartial(base ?? ({} as any));
   },
-  fromPartial<I extends Exact<DeepPartial<StartReviewResponse>, I>>(object: I): StartReviewResponse {
+  fromPartial<I extends Exact<DeepPartial<StartReviewResponse>, I>>(
+    object: I
+  ): StartReviewResponse {
     const message = createBaseStartReviewResponse();
-    message.application = (object.application !== undefined && object.application !== null)
-      ? Application.fromPartial(object.application)
-      : undefined;
+    message.application =
+      object.application !== undefined && object.application !== null
+        ? Application.fromPartial(object.application)
+        : undefined;
     return message;
   },
 };
 
 function createBaseScheduleHomeVisitRequest(): ScheduleHomeVisitRequest {
-  return { applicationId: "", scheduledAt: "", note: undefined };
+  return { applicationId: '', scheduledAt: '', note: undefined };
 }
 
 export const ScheduleHomeVisitRequest: MessageFns<ScheduleHomeVisitRequest> = {
-  encode(message: ScheduleHomeVisitRequest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    if (message.applicationId !== "") {
+  encode(
+    message: ScheduleHomeVisitRequest,
+    writer: BinaryWriter = new BinaryWriter()
+  ): BinaryWriter {
+    if (message.applicationId !== '') {
       writer.uint32(10).string(message.applicationId);
     }
-    if (message.scheduledAt !== "") {
+    if (message.scheduledAt !== '') {
       writer.uint32(18).string(message.scheduledAt);
     }
     if (message.note !== undefined) {
@@ -1761,23 +1812,23 @@ export const ScheduleHomeVisitRequest: MessageFns<ScheduleHomeVisitRequest> = {
       applicationId: isSet(object.applicationId)
         ? globalThis.String(object.applicationId)
         : isSet(object.application_id)
-        ? globalThis.String(object.application_id)
-        : "",
+          ? globalThis.String(object.application_id)
+          : '',
       scheduledAt: isSet(object.scheduledAt)
         ? globalThis.String(object.scheduledAt)
         : isSet(object.scheduled_at)
-        ? globalThis.String(object.scheduled_at)
-        : "",
+          ? globalThis.String(object.scheduled_at)
+          : '',
       note: isSet(object.note) ? globalThis.String(object.note) : undefined,
     };
   },
 
   toJSON(message: ScheduleHomeVisitRequest): unknown {
     const obj: any = {};
-    if (message.applicationId !== "") {
+    if (message.applicationId !== '') {
       obj.applicationId = message.applicationId;
     }
-    if (message.scheduledAt !== "") {
+    if (message.scheduledAt !== '') {
       obj.scheduledAt = message.scheduledAt;
     }
     if (message.note !== undefined) {
@@ -1786,13 +1837,17 @@ export const ScheduleHomeVisitRequest: MessageFns<ScheduleHomeVisitRequest> = {
     return obj;
   },
 
-  create<I extends Exact<DeepPartial<ScheduleHomeVisitRequest>, I>>(base?: I): ScheduleHomeVisitRequest {
+  create<I extends Exact<DeepPartial<ScheduleHomeVisitRequest>, I>>(
+    base?: I
+  ): ScheduleHomeVisitRequest {
     return ScheduleHomeVisitRequest.fromPartial(base ?? ({} as any));
   },
-  fromPartial<I extends Exact<DeepPartial<ScheduleHomeVisitRequest>, I>>(object: I): ScheduleHomeVisitRequest {
+  fromPartial<I extends Exact<DeepPartial<ScheduleHomeVisitRequest>, I>>(
+    object: I
+  ): ScheduleHomeVisitRequest {
     const message = createBaseScheduleHomeVisitRequest();
-    message.applicationId = object.applicationId ?? "";
-    message.scheduledAt = object.scheduledAt ?? "";
+    message.applicationId = object.applicationId ?? '';
+    message.scheduledAt = object.scheduledAt ?? '';
     message.note = object.note ?? undefined;
     return message;
   },
@@ -1803,7 +1858,10 @@ function createBaseScheduleHomeVisitResponse(): ScheduleHomeVisitResponse {
 }
 
 export const ScheduleHomeVisitResponse: MessageFns<ScheduleHomeVisitResponse> = {
-  encode(message: ScheduleHomeVisitResponse, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+  encode(
+    message: ScheduleHomeVisitResponse,
+    writer: BinaryWriter = new BinaryWriter()
+  ): BinaryWriter {
     if (message.application !== undefined) {
       Application.encode(message.application, writer.uint32(10).fork()).join();
     }
@@ -1835,7 +1893,9 @@ export const ScheduleHomeVisitResponse: MessageFns<ScheduleHomeVisitResponse> = 
   },
 
   fromJSON(object: any): ScheduleHomeVisitResponse {
-    return { application: isSet(object.application) ? Application.fromJSON(object.application) : undefined };
+    return {
+      application: isSet(object.application) ? Application.fromJSON(object.application) : undefined,
+    };
   },
 
   toJSON(message: ScheduleHomeVisitResponse): unknown {
@@ -1846,25 +1906,33 @@ export const ScheduleHomeVisitResponse: MessageFns<ScheduleHomeVisitResponse> = 
     return obj;
   },
 
-  create<I extends Exact<DeepPartial<ScheduleHomeVisitResponse>, I>>(base?: I): ScheduleHomeVisitResponse {
+  create<I extends Exact<DeepPartial<ScheduleHomeVisitResponse>, I>>(
+    base?: I
+  ): ScheduleHomeVisitResponse {
     return ScheduleHomeVisitResponse.fromPartial(base ?? ({} as any));
   },
-  fromPartial<I extends Exact<DeepPartial<ScheduleHomeVisitResponse>, I>>(object: I): ScheduleHomeVisitResponse {
+  fromPartial<I extends Exact<DeepPartial<ScheduleHomeVisitResponse>, I>>(
+    object: I
+  ): ScheduleHomeVisitResponse {
     const message = createBaseScheduleHomeVisitResponse();
-    message.application = (object.application !== undefined && object.application !== null)
-      ? Application.fromPartial(object.application)
-      : undefined;
+    message.application =
+      object.application !== undefined && object.application !== null
+        ? Application.fromPartial(object.application)
+        : undefined;
     return message;
   },
 };
 
 function createBaseCompleteHomeVisitRequest(): CompleteHomeVisitRequest {
-  return { applicationId: "", outcome: 0, notes: undefined };
+  return { applicationId: '', outcome: 0, notes: undefined };
 }
 
 export const CompleteHomeVisitRequest: MessageFns<CompleteHomeVisitRequest> = {
-  encode(message: CompleteHomeVisitRequest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    if (message.applicationId !== "") {
+  encode(
+    message: CompleteHomeVisitRequest,
+    writer: BinaryWriter = new BinaryWriter()
+  ): BinaryWriter {
+    if (message.applicationId !== '') {
       writer.uint32(10).string(message.applicationId);
     }
     if (message.outcome !== 0) {
@@ -1921,8 +1989,8 @@ export const CompleteHomeVisitRequest: MessageFns<CompleteHomeVisitRequest> = {
       applicationId: isSet(object.applicationId)
         ? globalThis.String(object.applicationId)
         : isSet(object.application_id)
-        ? globalThis.String(object.application_id)
-        : "",
+          ? globalThis.String(object.application_id)
+          : '',
       outcome: isSet(object.outcome) ? homeVisitOutcomeFromJSON(object.outcome) : 0,
       notes: isSet(object.notes) ? globalThis.String(object.notes) : undefined,
     };
@@ -1930,7 +1998,7 @@ export const CompleteHomeVisitRequest: MessageFns<CompleteHomeVisitRequest> = {
 
   toJSON(message: CompleteHomeVisitRequest): unknown {
     const obj: any = {};
-    if (message.applicationId !== "") {
+    if (message.applicationId !== '') {
       obj.applicationId = message.applicationId;
     }
     if (message.outcome !== 0) {
@@ -1942,12 +2010,16 @@ export const CompleteHomeVisitRequest: MessageFns<CompleteHomeVisitRequest> = {
     return obj;
   },
 
-  create<I extends Exact<DeepPartial<CompleteHomeVisitRequest>, I>>(base?: I): CompleteHomeVisitRequest {
+  create<I extends Exact<DeepPartial<CompleteHomeVisitRequest>, I>>(
+    base?: I
+  ): CompleteHomeVisitRequest {
     return CompleteHomeVisitRequest.fromPartial(base ?? ({} as any));
   },
-  fromPartial<I extends Exact<DeepPartial<CompleteHomeVisitRequest>, I>>(object: I): CompleteHomeVisitRequest {
+  fromPartial<I extends Exact<DeepPartial<CompleteHomeVisitRequest>, I>>(
+    object: I
+  ): CompleteHomeVisitRequest {
     const message = createBaseCompleteHomeVisitRequest();
-    message.applicationId = object.applicationId ?? "";
+    message.applicationId = object.applicationId ?? '';
     message.outcome = object.outcome ?? 0;
     message.notes = object.notes ?? undefined;
     return message;
@@ -1959,7 +2031,10 @@ function createBaseCompleteHomeVisitResponse(): CompleteHomeVisitResponse {
 }
 
 export const CompleteHomeVisitResponse: MessageFns<CompleteHomeVisitResponse> = {
-  encode(message: CompleteHomeVisitResponse, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+  encode(
+    message: CompleteHomeVisitResponse,
+    writer: BinaryWriter = new BinaryWriter()
+  ): BinaryWriter {
     if (message.application !== undefined) {
       Application.encode(message.application, writer.uint32(10).fork()).join();
     }
@@ -1991,7 +2066,9 @@ export const CompleteHomeVisitResponse: MessageFns<CompleteHomeVisitResponse> = 
   },
 
   fromJSON(object: any): CompleteHomeVisitResponse {
-    return { application: isSet(object.application) ? Application.fromJSON(object.application) : undefined };
+    return {
+      application: isSet(object.application) ? Application.fromJSON(object.application) : undefined,
+    };
   },
 
   toJSON(message: CompleteHomeVisitResponse): unknown {
@@ -2002,25 +2079,30 @@ export const CompleteHomeVisitResponse: MessageFns<CompleteHomeVisitResponse> = 
     return obj;
   },
 
-  create<I extends Exact<DeepPartial<CompleteHomeVisitResponse>, I>>(base?: I): CompleteHomeVisitResponse {
+  create<I extends Exact<DeepPartial<CompleteHomeVisitResponse>, I>>(
+    base?: I
+  ): CompleteHomeVisitResponse {
     return CompleteHomeVisitResponse.fromPartial(base ?? ({} as any));
   },
-  fromPartial<I extends Exact<DeepPartial<CompleteHomeVisitResponse>, I>>(object: I): CompleteHomeVisitResponse {
+  fromPartial<I extends Exact<DeepPartial<CompleteHomeVisitResponse>, I>>(
+    object: I
+  ): CompleteHomeVisitResponse {
     const message = createBaseCompleteHomeVisitResponse();
-    message.application = (object.application !== undefined && object.application !== null)
-      ? Application.fromPartial(object.application)
-      : undefined;
+    message.application =
+      object.application !== undefined && object.application !== null
+        ? Application.fromPartial(object.application)
+        : undefined;
     return message;
   },
 };
 
 function createBaseApproveRequest(): ApproveRequest {
-  return { applicationId: "", notes: undefined };
+  return { applicationId: '', notes: undefined };
 }
 
 export const ApproveRequest: MessageFns<ApproveRequest> = {
   encode(message: ApproveRequest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    if (message.applicationId !== "") {
+    if (message.applicationId !== '') {
       writer.uint32(10).string(message.applicationId);
     }
     if (message.notes !== undefined) {
@@ -2066,15 +2148,15 @@ export const ApproveRequest: MessageFns<ApproveRequest> = {
       applicationId: isSet(object.applicationId)
         ? globalThis.String(object.applicationId)
         : isSet(object.application_id)
-        ? globalThis.String(object.application_id)
-        : "",
+          ? globalThis.String(object.application_id)
+          : '',
       notes: isSet(object.notes) ? globalThis.String(object.notes) : undefined,
     };
   },
 
   toJSON(message: ApproveRequest): unknown {
     const obj: any = {};
-    if (message.applicationId !== "") {
+    if (message.applicationId !== '') {
       obj.applicationId = message.applicationId;
     }
     if (message.notes !== undefined) {
@@ -2088,7 +2170,7 @@ export const ApproveRequest: MessageFns<ApproveRequest> = {
   },
   fromPartial<I extends Exact<DeepPartial<ApproveRequest>, I>>(object: I): ApproveRequest {
     const message = createBaseApproveRequest();
-    message.applicationId = object.applicationId ?? "";
+    message.applicationId = object.applicationId ?? '';
     message.notes = object.notes ?? undefined;
     return message;
   },
@@ -2131,7 +2213,9 @@ export const ApproveResponse: MessageFns<ApproveResponse> = {
   },
 
   fromJSON(object: any): ApproveResponse {
-    return { application: isSet(object.application) ? Application.fromJSON(object.application) : undefined };
+    return {
+      application: isSet(object.application) ? Application.fromJSON(object.application) : undefined,
+    };
   },
 
   toJSON(message: ApproveResponse): unknown {
@@ -2147,23 +2231,24 @@ export const ApproveResponse: MessageFns<ApproveResponse> = {
   },
   fromPartial<I extends Exact<DeepPartial<ApproveResponse>, I>>(object: I): ApproveResponse {
     const message = createBaseApproveResponse();
-    message.application = (object.application !== undefined && object.application !== null)
-      ? Application.fromPartial(object.application)
-      : undefined;
+    message.application =
+      object.application !== undefined && object.application !== null
+        ? Application.fromPartial(object.application)
+        : undefined;
     return message;
   },
 };
 
 function createBaseRejectRequest(): RejectRequest {
-  return { applicationId: "", reason: "" };
+  return { applicationId: '', reason: '' };
 }
 
 export const RejectRequest: MessageFns<RejectRequest> = {
   encode(message: RejectRequest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    if (message.applicationId !== "") {
+    if (message.applicationId !== '') {
       writer.uint32(10).string(message.applicationId);
     }
-    if (message.reason !== "") {
+    if (message.reason !== '') {
       writer.uint32(18).string(message.reason);
     }
     return writer;
@@ -2206,18 +2291,18 @@ export const RejectRequest: MessageFns<RejectRequest> = {
       applicationId: isSet(object.applicationId)
         ? globalThis.String(object.applicationId)
         : isSet(object.application_id)
-        ? globalThis.String(object.application_id)
-        : "",
-      reason: isSet(object.reason) ? globalThis.String(object.reason) : "",
+          ? globalThis.String(object.application_id)
+          : '',
+      reason: isSet(object.reason) ? globalThis.String(object.reason) : '',
     };
   },
 
   toJSON(message: RejectRequest): unknown {
     const obj: any = {};
-    if (message.applicationId !== "") {
+    if (message.applicationId !== '') {
       obj.applicationId = message.applicationId;
     }
-    if (message.reason !== "") {
+    if (message.reason !== '') {
       obj.reason = message.reason;
     }
     return obj;
@@ -2228,8 +2313,8 @@ export const RejectRequest: MessageFns<RejectRequest> = {
   },
   fromPartial<I extends Exact<DeepPartial<RejectRequest>, I>>(object: I): RejectRequest {
     const message = createBaseRejectRequest();
-    message.applicationId = object.applicationId ?? "";
-    message.reason = object.reason ?? "";
+    message.applicationId = object.applicationId ?? '';
+    message.reason = object.reason ?? '';
     return message;
   },
 };
@@ -2271,7 +2356,9 @@ export const RejectResponse: MessageFns<RejectResponse> = {
   },
 
   fromJSON(object: any): RejectResponse {
-    return { application: isSet(object.application) ? Application.fromJSON(object.application) : undefined };
+    return {
+      application: isSet(object.application) ? Application.fromJSON(object.application) : undefined,
+    };
   },
 
   toJSON(message: RejectResponse): unknown {
@@ -2287,20 +2374,21 @@ export const RejectResponse: MessageFns<RejectResponse> = {
   },
   fromPartial<I extends Exact<DeepPartial<RejectResponse>, I>>(object: I): RejectResponse {
     const message = createBaseRejectResponse();
-    message.application = (object.application !== undefined && object.application !== null)
-      ? Application.fromPartial(object.application)
-      : undefined;
+    message.application =
+      object.application !== undefined && object.application !== null
+        ? Application.fromPartial(object.application)
+        : undefined;
     return message;
   },
 };
 
 function createBaseWithdrawRequest(): WithdrawRequest {
-  return { applicationId: "", reason: undefined };
+  return { applicationId: '', reason: undefined };
 }
 
 export const WithdrawRequest: MessageFns<WithdrawRequest> = {
   encode(message: WithdrawRequest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    if (message.applicationId !== "") {
+    if (message.applicationId !== '') {
       writer.uint32(10).string(message.applicationId);
     }
     if (message.reason !== undefined) {
@@ -2346,15 +2434,15 @@ export const WithdrawRequest: MessageFns<WithdrawRequest> = {
       applicationId: isSet(object.applicationId)
         ? globalThis.String(object.applicationId)
         : isSet(object.application_id)
-        ? globalThis.String(object.application_id)
-        : "",
+          ? globalThis.String(object.application_id)
+          : '',
       reason: isSet(object.reason) ? globalThis.String(object.reason) : undefined,
     };
   },
 
   toJSON(message: WithdrawRequest): unknown {
     const obj: any = {};
-    if (message.applicationId !== "") {
+    if (message.applicationId !== '') {
       obj.applicationId = message.applicationId;
     }
     if (message.reason !== undefined) {
@@ -2368,7 +2456,7 @@ export const WithdrawRequest: MessageFns<WithdrawRequest> = {
   },
   fromPartial<I extends Exact<DeepPartial<WithdrawRequest>, I>>(object: I): WithdrawRequest {
     const message = createBaseWithdrawRequest();
-    message.applicationId = object.applicationId ?? "";
+    message.applicationId = object.applicationId ?? '';
     message.reason = object.reason ?? undefined;
     return message;
   },
@@ -2411,7 +2499,9 @@ export const WithdrawResponse: MessageFns<WithdrawResponse> = {
   },
 
   fromJSON(object: any): WithdrawResponse {
-    return { application: isSet(object.application) ? Application.fromJSON(object.application) : undefined };
+    return {
+      application: isSet(object.application) ? Application.fromJSON(object.application) : undefined,
+    };
   },
 
   toJSON(message: WithdrawResponse): unknown {
@@ -2427,20 +2517,21 @@ export const WithdrawResponse: MessageFns<WithdrawResponse> = {
   },
   fromPartial<I extends Exact<DeepPartial<WithdrawResponse>, I>>(object: I): WithdrawResponse {
     const message = createBaseWithdrawResponse();
-    message.application = (object.application !== undefined && object.application !== null)
-      ? Application.fromPartial(object.application)
-      : undefined;
+    message.application =
+      object.application !== undefined && object.application !== null
+        ? Application.fromPartial(object.application)
+        : undefined;
     return message;
   },
 };
 
 function createBaseMarkAdoptedRequest(): MarkAdoptedRequest {
-  return { applicationId: "" };
+  return { applicationId: '' };
 }
 
 export const MarkAdoptedRequest: MessageFns<MarkAdoptedRequest> = {
   encode(message: MarkAdoptedRequest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    if (message.applicationId !== "") {
+    if (message.applicationId !== '') {
       writer.uint32(10).string(message.applicationId);
     }
     return writer;
@@ -2475,14 +2566,14 @@ export const MarkAdoptedRequest: MessageFns<MarkAdoptedRequest> = {
       applicationId: isSet(object.applicationId)
         ? globalThis.String(object.applicationId)
         : isSet(object.application_id)
-        ? globalThis.String(object.application_id)
-        : "",
+          ? globalThis.String(object.application_id)
+          : '',
     };
   },
 
   toJSON(message: MarkAdoptedRequest): unknown {
     const obj: any = {};
-    if (message.applicationId !== "") {
+    if (message.applicationId !== '') {
       obj.applicationId = message.applicationId;
     }
     return obj;
@@ -2493,7 +2584,7 @@ export const MarkAdoptedRequest: MessageFns<MarkAdoptedRequest> = {
   },
   fromPartial<I extends Exact<DeepPartial<MarkAdoptedRequest>, I>>(object: I): MarkAdoptedRequest {
     const message = createBaseMarkAdoptedRequest();
-    message.applicationId = object.applicationId ?? "";
+    message.applicationId = object.applicationId ?? '';
     return message;
   },
 };
@@ -2535,7 +2626,9 @@ export const MarkAdoptedResponse: MessageFns<MarkAdoptedResponse> = {
   },
 
   fromJSON(object: any): MarkAdoptedResponse {
-    return { application: isSet(object.application) ? Application.fromJSON(object.application) : undefined };
+    return {
+      application: isSet(object.application) ? Application.fromJSON(object.application) : undefined,
+    };
   },
 
   toJSON(message: MarkAdoptedResponse): unknown {
@@ -2549,22 +2642,25 @@ export const MarkAdoptedResponse: MessageFns<MarkAdoptedResponse> = {
   create<I extends Exact<DeepPartial<MarkAdoptedResponse>, I>>(base?: I): MarkAdoptedResponse {
     return MarkAdoptedResponse.fromPartial(base ?? ({} as any));
   },
-  fromPartial<I extends Exact<DeepPartial<MarkAdoptedResponse>, I>>(object: I): MarkAdoptedResponse {
+  fromPartial<I extends Exact<DeepPartial<MarkAdoptedResponse>, I>>(
+    object: I
+  ): MarkAdoptedResponse {
     const message = createBaseMarkAdoptedResponse();
-    message.application = (object.application !== undefined && object.application !== null)
-      ? Application.fromPartial(object.application)
-      : undefined;
+    message.application =
+      object.application !== undefined && object.application !== null
+        ? Application.fromPartial(object.application)
+        : undefined;
     return message;
   },
 };
 
 function createBaseGetApplicationRequest(): GetApplicationRequest {
-  return { applicationId: "", includeTimeline: false };
+  return { applicationId: '', includeTimeline: false };
 }
 
 export const GetApplicationRequest: MessageFns<GetApplicationRequest> = {
   encode(message: GetApplicationRequest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    if (message.applicationId !== "") {
+    if (message.applicationId !== '') {
       writer.uint32(10).string(message.applicationId);
     }
     if (message.includeTimeline !== false) {
@@ -2610,19 +2706,19 @@ export const GetApplicationRequest: MessageFns<GetApplicationRequest> = {
       applicationId: isSet(object.applicationId)
         ? globalThis.String(object.applicationId)
         : isSet(object.application_id)
-        ? globalThis.String(object.application_id)
-        : "",
+          ? globalThis.String(object.application_id)
+          : '',
       includeTimeline: isSet(object.includeTimeline)
         ? globalThis.Boolean(object.includeTimeline)
         : isSet(object.include_timeline)
-        ? globalThis.Boolean(object.include_timeline)
-        : false,
+          ? globalThis.Boolean(object.include_timeline)
+          : false,
     };
   },
 
   toJSON(message: GetApplicationRequest): unknown {
     const obj: any = {};
-    if (message.applicationId !== "") {
+    if (message.applicationId !== '') {
       obj.applicationId = message.applicationId;
     }
     if (message.includeTimeline !== false) {
@@ -2634,9 +2730,11 @@ export const GetApplicationRequest: MessageFns<GetApplicationRequest> = {
   create<I extends Exact<DeepPartial<GetApplicationRequest>, I>>(base?: I): GetApplicationRequest {
     return GetApplicationRequest.fromPartial(base ?? ({} as any));
   },
-  fromPartial<I extends Exact<DeepPartial<GetApplicationRequest>, I>>(object: I): GetApplicationRequest {
+  fromPartial<I extends Exact<DeepPartial<GetApplicationRequest>, I>>(
+    object: I
+  ): GetApplicationRequest {
     const message = createBaseGetApplicationRequest();
-    message.applicationId = object.applicationId ?? "";
+    message.applicationId = object.applicationId ?? '';
     message.includeTimeline = object.includeTimeline ?? false;
     return message;
   },
@@ -2704,30 +2802,44 @@ export const GetApplicationResponse: MessageFns<GetApplicationResponse> = {
       obj.application = Application.toJSON(message.application);
     }
     if (message.timeline?.length) {
-      obj.timeline = message.timeline.map((e) => TimelineEntry.toJSON(e));
+      obj.timeline = message.timeline.map(e => TimelineEntry.toJSON(e));
     }
     return obj;
   },
 
-  create<I extends Exact<DeepPartial<GetApplicationResponse>, I>>(base?: I): GetApplicationResponse {
+  create<I extends Exact<DeepPartial<GetApplicationResponse>, I>>(
+    base?: I
+  ): GetApplicationResponse {
     return GetApplicationResponse.fromPartial(base ?? ({} as any));
   },
-  fromPartial<I extends Exact<DeepPartial<GetApplicationResponse>, I>>(object: I): GetApplicationResponse {
+  fromPartial<I extends Exact<DeepPartial<GetApplicationResponse>, I>>(
+    object: I
+  ): GetApplicationResponse {
     const message = createBaseGetApplicationResponse();
-    message.application = (object.application !== undefined && object.application !== null)
-      ? Application.fromPartial(object.application)
-      : undefined;
-    message.timeline = object.timeline?.map((e) => TimelineEntry.fromPartial(e)) || [];
+    message.application =
+      object.application !== undefined && object.application !== null
+        ? Application.fromPartial(object.application)
+        : undefined;
+    message.timeline = object.timeline?.map(e => TimelineEntry.fromPartial(e)) || [];
     return message;
   },
 };
 
 function createBaseListApplicationsRequest(): ListApplicationsRequest {
-  return { cursor: undefined, limit: 0, statusFilter: 0, rescueIdFilter: undefined, adopterIdFilter: undefined };
+  return {
+    cursor: undefined,
+    limit: 0,
+    statusFilter: 0,
+    rescueIdFilter: undefined,
+    adopterIdFilter: undefined,
+  };
 }
 
 export const ListApplicationsRequest: MessageFns<ListApplicationsRequest> = {
-  encode(message: ListApplicationsRequest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+  encode(
+    message: ListApplicationsRequest,
+    writer: BinaryWriter = new BinaryWriter()
+  ): BinaryWriter {
     if (message.cursor !== undefined) {
       writer.uint32(10).string(message.cursor);
     }
@@ -2809,18 +2921,18 @@ export const ListApplicationsRequest: MessageFns<ListApplicationsRequest> = {
       statusFilter: isSet(object.statusFilter)
         ? applicationStatusFromJSON(object.statusFilter)
         : isSet(object.status_filter)
-        ? applicationStatusFromJSON(object.status_filter)
-        : 0,
+          ? applicationStatusFromJSON(object.status_filter)
+          : 0,
       rescueIdFilter: isSet(object.rescueIdFilter)
         ? globalThis.String(object.rescueIdFilter)
         : isSet(object.rescue_id_filter)
-        ? globalThis.String(object.rescue_id_filter)
-        : undefined,
+          ? globalThis.String(object.rescue_id_filter)
+          : undefined,
       adopterIdFilter: isSet(object.adopterIdFilter)
         ? globalThis.String(object.adopterIdFilter)
         : isSet(object.adopter_id_filter)
-        ? globalThis.String(object.adopter_id_filter)
-        : undefined,
+          ? globalThis.String(object.adopter_id_filter)
+          : undefined,
     };
   },
 
@@ -2844,10 +2956,14 @@ export const ListApplicationsRequest: MessageFns<ListApplicationsRequest> = {
     return obj;
   },
 
-  create<I extends Exact<DeepPartial<ListApplicationsRequest>, I>>(base?: I): ListApplicationsRequest {
+  create<I extends Exact<DeepPartial<ListApplicationsRequest>, I>>(
+    base?: I
+  ): ListApplicationsRequest {
     return ListApplicationsRequest.fromPartial(base ?? ({} as any));
   },
-  fromPartial<I extends Exact<DeepPartial<ListApplicationsRequest>, I>>(object: I): ListApplicationsRequest {
+  fromPartial<I extends Exact<DeepPartial<ListApplicationsRequest>, I>>(
+    object: I
+  ): ListApplicationsRequest {
     const message = createBaseListApplicationsRequest();
     message.cursor = object.cursor ?? undefined;
     message.limit = object.limit ?? 0;
@@ -2863,7 +2979,10 @@ function createBaseListApplicationsResponse(): ListApplicationsResponse {
 }
 
 export const ListApplicationsResponse: MessageFns<ListApplicationsResponse> = {
-  encode(message: ListApplicationsResponse, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+  encode(
+    message: ListApplicationsResponse,
+    writer: BinaryWriter = new BinaryWriter()
+  ): BinaryWriter {
     for (const v of message.applications) {
       Application.encode(v!, writer.uint32(10).fork()).join();
     }
@@ -2913,15 +3032,15 @@ export const ListApplicationsResponse: MessageFns<ListApplicationsResponse> = {
       nextCursor: isSet(object.nextCursor)
         ? globalThis.String(object.nextCursor)
         : isSet(object.next_cursor)
-        ? globalThis.String(object.next_cursor)
-        : undefined,
+          ? globalThis.String(object.next_cursor)
+          : undefined,
     };
   },
 
   toJSON(message: ListApplicationsResponse): unknown {
     const obj: any = {};
     if (message.applications?.length) {
-      obj.applications = message.applications.map((e) => Application.toJSON(e));
+      obj.applications = message.applications.map(e => Application.toJSON(e));
     }
     if (message.nextCursor !== undefined) {
       obj.nextCursor = message.nextCursor;
@@ -2929,12 +3048,16 @@ export const ListApplicationsResponse: MessageFns<ListApplicationsResponse> = {
     return obj;
   },
 
-  create<I extends Exact<DeepPartial<ListApplicationsResponse>, I>>(base?: I): ListApplicationsResponse {
+  create<I extends Exact<DeepPartial<ListApplicationsResponse>, I>>(
+    base?: I
+  ): ListApplicationsResponse {
     return ListApplicationsResponse.fromPartial(base ?? ({} as any));
   },
-  fromPartial<I extends Exact<DeepPartial<ListApplicationsResponse>, I>>(object: I): ListApplicationsResponse {
+  fromPartial<I extends Exact<DeepPartial<ListApplicationsResponse>, I>>(
+    object: I
+  ): ListApplicationsResponse {
     const message = createBaseListApplicationsResponse();
-    message.applications = object.applications?.map((e) => Application.fromPartial(e)) || [];
+    message.applications = object.applications?.map(e => Application.fromPartial(e)) || [];
     message.nextCursor = object.nextCursor ?? undefined;
     return message;
   },
@@ -2992,13 +3115,13 @@ export const GetStatsRequest: MessageFns<GetStatsRequest> = {
       rescueIdFilter: isSet(object.rescueIdFilter)
         ? globalThis.String(object.rescueIdFilter)
         : isSet(object.rescue_id_filter)
-        ? globalThis.String(object.rescue_id_filter)
-        : undefined,
+          ? globalThis.String(object.rescue_id_filter)
+          : undefined,
       adopterIdFilter: isSet(object.adopterIdFilter)
         ? globalThis.String(object.adopterIdFilter)
         : isSet(object.adopter_id_filter)
-        ? globalThis.String(object.adopter_id_filter)
-        : undefined,
+          ? globalThis.String(object.adopter_id_filter)
+          : undefined,
     };
   },
 
@@ -3178,18 +3301,18 @@ export const GetStatsResponse: MessageFns<GetStatsResponse> = {
       underReview: isSet(object.underReview)
         ? globalThis.Number(object.underReview)
         : isSet(object.under_review)
-        ? globalThis.Number(object.under_review)
-        : 0,
+          ? globalThis.Number(object.under_review)
+          : 0,
       homeVisitScheduled: isSet(object.homeVisitScheduled)
         ? globalThis.Number(object.homeVisitScheduled)
         : isSet(object.home_visit_scheduled)
-        ? globalThis.Number(object.home_visit_scheduled)
-        : 0,
+          ? globalThis.Number(object.home_visit_scheduled)
+          : 0,
       homeVisitCompleted: isSet(object.homeVisitCompleted)
         ? globalThis.Number(object.homeVisitCompleted)
         : isSet(object.home_visit_completed)
-        ? globalThis.Number(object.home_visit_completed)
-        : 0,
+          ? globalThis.Number(object.home_visit_completed)
+          : 0,
       approved: isSet(object.approved) ? globalThis.Number(object.approved) : 0,
       rejected: isSet(object.rejected) ? globalThis.Number(object.rejected) : 0,
       withdrawn: isSet(object.withdrawn) ? globalThis.Number(object.withdrawn) : 0,
@@ -3253,32 +3376,32 @@ export const GetStatsResponse: MessageFns<GetStatsResponse> = {
 
 function createBaseDocument(): Document {
   return {
-    documentId: "",
-    applicationId: "",
-    type: "",
-    filename: "",
-    url: "",
+    documentId: '',
+    applicationId: '',
+    type: '',
+    filename: '',
+    url: '',
     size: undefined,
     mimeType: undefined,
-    uploadedAt: "",
+    uploadedAt: '',
   };
 }
 
 export const Document: MessageFns<Document> = {
   encode(message: Document, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    if (message.documentId !== "") {
+    if (message.documentId !== '') {
       writer.uint32(10).string(message.documentId);
     }
-    if (message.applicationId !== "") {
+    if (message.applicationId !== '') {
       writer.uint32(18).string(message.applicationId);
     }
-    if (message.type !== "") {
+    if (message.type !== '') {
       writer.uint32(26).string(message.type);
     }
-    if (message.filename !== "") {
+    if (message.filename !== '') {
       writer.uint32(34).string(message.filename);
     }
-    if (message.url !== "") {
+    if (message.url !== '') {
       writer.uint32(42).string(message.url);
     }
     if (message.size !== undefined) {
@@ -3287,7 +3410,7 @@ export const Document: MessageFns<Document> = {
     if (message.mimeType !== undefined) {
       writer.uint32(58).string(message.mimeType);
     }
-    if (message.uploadedAt !== "") {
+    if (message.uploadedAt !== '') {
       writer.uint32(66).string(message.uploadedAt);
     }
     return writer;
@@ -3378,45 +3501,45 @@ export const Document: MessageFns<Document> = {
       documentId: isSet(object.documentId)
         ? globalThis.String(object.documentId)
         : isSet(object.document_id)
-        ? globalThis.String(object.document_id)
-        : "",
+          ? globalThis.String(object.document_id)
+          : '',
       applicationId: isSet(object.applicationId)
         ? globalThis.String(object.applicationId)
         : isSet(object.application_id)
-        ? globalThis.String(object.application_id)
-        : "",
-      type: isSet(object.type) ? globalThis.String(object.type) : "",
-      filename: isSet(object.filename) ? globalThis.String(object.filename) : "",
-      url: isSet(object.url) ? globalThis.String(object.url) : "",
+          ? globalThis.String(object.application_id)
+          : '',
+      type: isSet(object.type) ? globalThis.String(object.type) : '',
+      filename: isSet(object.filename) ? globalThis.String(object.filename) : '',
+      url: isSet(object.url) ? globalThis.String(object.url) : '',
       size: isSet(object.size) ? globalThis.Number(object.size) : undefined,
       mimeType: isSet(object.mimeType)
         ? globalThis.String(object.mimeType)
         : isSet(object.mime_type)
-        ? globalThis.String(object.mime_type)
-        : undefined,
+          ? globalThis.String(object.mime_type)
+          : undefined,
       uploadedAt: isSet(object.uploadedAt)
         ? globalThis.String(object.uploadedAt)
         : isSet(object.uploaded_at)
-        ? globalThis.String(object.uploaded_at)
-        : "",
+          ? globalThis.String(object.uploaded_at)
+          : '',
     };
   },
 
   toJSON(message: Document): unknown {
     const obj: any = {};
-    if (message.documentId !== "") {
+    if (message.documentId !== '') {
       obj.documentId = message.documentId;
     }
-    if (message.applicationId !== "") {
+    if (message.applicationId !== '') {
       obj.applicationId = message.applicationId;
     }
-    if (message.type !== "") {
+    if (message.type !== '') {
       obj.type = message.type;
     }
-    if (message.filename !== "") {
+    if (message.filename !== '') {
       obj.filename = message.filename;
     }
-    if (message.url !== "") {
+    if (message.url !== '') {
       obj.url = message.url;
     }
     if (message.size !== undefined) {
@@ -3425,7 +3548,7 @@ export const Document: MessageFns<Document> = {
     if (message.mimeType !== undefined) {
       obj.mimeType = message.mimeType;
     }
-    if (message.uploadedAt !== "") {
+    if (message.uploadedAt !== '') {
       obj.uploadedAt = message.uploadedAt;
     }
     return obj;
@@ -3436,34 +3559,41 @@ export const Document: MessageFns<Document> = {
   },
   fromPartial<I extends Exact<DeepPartial<Document>, I>>(object: I): Document {
     const message = createBaseDocument();
-    message.documentId = object.documentId ?? "";
-    message.applicationId = object.applicationId ?? "";
-    message.type = object.type ?? "";
-    message.filename = object.filename ?? "";
-    message.url = object.url ?? "";
+    message.documentId = object.documentId ?? '';
+    message.applicationId = object.applicationId ?? '';
+    message.type = object.type ?? '';
+    message.filename = object.filename ?? '';
+    message.url = object.url ?? '';
     message.size = object.size ?? undefined;
     message.mimeType = object.mimeType ?? undefined;
-    message.uploadedAt = object.uploadedAt ?? "";
+    message.uploadedAt = object.uploadedAt ?? '';
     return message;
   },
 };
 
 function createBaseAddDocumentRequest(): AddDocumentRequest {
-  return { applicationId: "", type: "", filename: "", url: "", size: undefined, mimeType: undefined };
+  return {
+    applicationId: '',
+    type: '',
+    filename: '',
+    url: '',
+    size: undefined,
+    mimeType: undefined,
+  };
 }
 
 export const AddDocumentRequest: MessageFns<AddDocumentRequest> = {
   encode(message: AddDocumentRequest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    if (message.applicationId !== "") {
+    if (message.applicationId !== '') {
       writer.uint32(10).string(message.applicationId);
     }
-    if (message.type !== "") {
+    if (message.type !== '') {
       writer.uint32(18).string(message.type);
     }
-    if (message.filename !== "") {
+    if (message.filename !== '') {
       writer.uint32(26).string(message.filename);
     }
-    if (message.url !== "") {
+    if (message.url !== '') {
       writer.uint32(34).string(message.url);
     }
     if (message.size !== undefined) {
@@ -3544,32 +3674,32 @@ export const AddDocumentRequest: MessageFns<AddDocumentRequest> = {
       applicationId: isSet(object.applicationId)
         ? globalThis.String(object.applicationId)
         : isSet(object.application_id)
-        ? globalThis.String(object.application_id)
-        : "",
-      type: isSet(object.type) ? globalThis.String(object.type) : "",
-      filename: isSet(object.filename) ? globalThis.String(object.filename) : "",
-      url: isSet(object.url) ? globalThis.String(object.url) : "",
+          ? globalThis.String(object.application_id)
+          : '',
+      type: isSet(object.type) ? globalThis.String(object.type) : '',
+      filename: isSet(object.filename) ? globalThis.String(object.filename) : '',
+      url: isSet(object.url) ? globalThis.String(object.url) : '',
       size: isSet(object.size) ? globalThis.Number(object.size) : undefined,
       mimeType: isSet(object.mimeType)
         ? globalThis.String(object.mimeType)
         : isSet(object.mime_type)
-        ? globalThis.String(object.mime_type)
-        : undefined,
+          ? globalThis.String(object.mime_type)
+          : undefined,
     };
   },
 
   toJSON(message: AddDocumentRequest): unknown {
     const obj: any = {};
-    if (message.applicationId !== "") {
+    if (message.applicationId !== '') {
       obj.applicationId = message.applicationId;
     }
-    if (message.type !== "") {
+    if (message.type !== '') {
       obj.type = message.type;
     }
-    if (message.filename !== "") {
+    if (message.filename !== '') {
       obj.filename = message.filename;
     }
-    if (message.url !== "") {
+    if (message.url !== '') {
       obj.url = message.url;
     }
     if (message.size !== undefined) {
@@ -3586,10 +3716,10 @@ export const AddDocumentRequest: MessageFns<AddDocumentRequest> = {
   },
   fromPartial<I extends Exact<DeepPartial<AddDocumentRequest>, I>>(object: I): AddDocumentRequest {
     const message = createBaseAddDocumentRequest();
-    message.applicationId = object.applicationId ?? "";
-    message.type = object.type ?? "";
-    message.filename = object.filename ?? "";
-    message.url = object.url ?? "";
+    message.applicationId = object.applicationId ?? '';
+    message.type = object.type ?? '';
+    message.filename = object.filename ?? '';
+    message.url = object.url ?? '';
     message.size = object.size ?? undefined;
     message.mimeType = object.mimeType ?? undefined;
     return message;
@@ -3647,22 +3777,25 @@ export const AddDocumentResponse: MessageFns<AddDocumentResponse> = {
   create<I extends Exact<DeepPartial<AddDocumentResponse>, I>>(base?: I): AddDocumentResponse {
     return AddDocumentResponse.fromPartial(base ?? ({} as any));
   },
-  fromPartial<I extends Exact<DeepPartial<AddDocumentResponse>, I>>(object: I): AddDocumentResponse {
+  fromPartial<I extends Exact<DeepPartial<AddDocumentResponse>, I>>(
+    object: I
+  ): AddDocumentResponse {
     const message = createBaseAddDocumentResponse();
-    message.document = (object.document !== undefined && object.document !== null)
-      ? Document.fromPartial(object.document)
-      : undefined;
+    message.document =
+      object.document !== undefined && object.document !== null
+        ? Document.fromPartial(object.document)
+        : undefined;
     return message;
   },
 };
 
 function createBaseListDocumentsRequest(): ListDocumentsRequest {
-  return { applicationId: "" };
+  return { applicationId: '' };
 }
 
 export const ListDocumentsRequest: MessageFns<ListDocumentsRequest> = {
   encode(message: ListDocumentsRequest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    if (message.applicationId !== "") {
+    if (message.applicationId !== '') {
       writer.uint32(10).string(message.applicationId);
     }
     return writer;
@@ -3697,14 +3830,14 @@ export const ListDocumentsRequest: MessageFns<ListDocumentsRequest> = {
       applicationId: isSet(object.applicationId)
         ? globalThis.String(object.applicationId)
         : isSet(object.application_id)
-        ? globalThis.String(object.application_id)
-        : "",
+          ? globalThis.String(object.application_id)
+          : '',
     };
   },
 
   toJSON(message: ListDocumentsRequest): unknown {
     const obj: any = {};
-    if (message.applicationId !== "") {
+    if (message.applicationId !== '') {
       obj.applicationId = message.applicationId;
     }
     return obj;
@@ -3713,9 +3846,11 @@ export const ListDocumentsRequest: MessageFns<ListDocumentsRequest> = {
   create<I extends Exact<DeepPartial<ListDocumentsRequest>, I>>(base?: I): ListDocumentsRequest {
     return ListDocumentsRequest.fromPartial(base ?? ({} as any));
   },
-  fromPartial<I extends Exact<DeepPartial<ListDocumentsRequest>, I>>(object: I): ListDocumentsRequest {
+  fromPartial<I extends Exact<DeepPartial<ListDocumentsRequest>, I>>(
+    object: I
+  ): ListDocumentsRequest {
     const message = createBaseListDocumentsRequest();
-    message.applicationId = object.applicationId ?? "";
+    message.applicationId = object.applicationId ?? '';
     return message;
   },
 };
@@ -3767,7 +3902,7 @@ export const ListDocumentsResponse: MessageFns<ListDocumentsResponse> = {
   toJSON(message: ListDocumentsResponse): unknown {
     const obj: any = {};
     if (message.documents?.length) {
-      obj.documents = message.documents.map((e) => Document.toJSON(e));
+      obj.documents = message.documents.map(e => Document.toJSON(e));
     }
     return obj;
   },
@@ -3775,23 +3910,25 @@ export const ListDocumentsResponse: MessageFns<ListDocumentsResponse> = {
   create<I extends Exact<DeepPartial<ListDocumentsResponse>, I>>(base?: I): ListDocumentsResponse {
     return ListDocumentsResponse.fromPartial(base ?? ({} as any));
   },
-  fromPartial<I extends Exact<DeepPartial<ListDocumentsResponse>, I>>(object: I): ListDocumentsResponse {
+  fromPartial<I extends Exact<DeepPartial<ListDocumentsResponse>, I>>(
+    object: I
+  ): ListDocumentsResponse {
     const message = createBaseListDocumentsResponse();
-    message.documents = object.documents?.map((e) => Document.fromPartial(e)) || [];
+    message.documents = object.documents?.map(e => Document.fromPartial(e)) || [];
     return message;
   },
 };
 
 function createBaseRemoveDocumentRequest(): RemoveDocumentRequest {
-  return { applicationId: "", documentId: "" };
+  return { applicationId: '', documentId: '' };
 }
 
 export const RemoveDocumentRequest: MessageFns<RemoveDocumentRequest> = {
   encode(message: RemoveDocumentRequest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    if (message.applicationId !== "") {
+    if (message.applicationId !== '') {
       writer.uint32(10).string(message.applicationId);
     }
-    if (message.documentId !== "") {
+    if (message.documentId !== '') {
       writer.uint32(18).string(message.documentId);
     }
     return writer;
@@ -3834,22 +3971,22 @@ export const RemoveDocumentRequest: MessageFns<RemoveDocumentRequest> = {
       applicationId: isSet(object.applicationId)
         ? globalThis.String(object.applicationId)
         : isSet(object.application_id)
-        ? globalThis.String(object.application_id)
-        : "",
+          ? globalThis.String(object.application_id)
+          : '',
       documentId: isSet(object.documentId)
         ? globalThis.String(object.documentId)
         : isSet(object.document_id)
-        ? globalThis.String(object.document_id)
-        : "",
+          ? globalThis.String(object.document_id)
+          : '',
     };
   },
 
   toJSON(message: RemoveDocumentRequest): unknown {
     const obj: any = {};
-    if (message.applicationId !== "") {
+    if (message.applicationId !== '') {
       obj.applicationId = message.applicationId;
     }
-    if (message.documentId !== "") {
+    if (message.documentId !== '') {
       obj.documentId = message.documentId;
     }
     return obj;
@@ -3858,10 +3995,12 @@ export const RemoveDocumentRequest: MessageFns<RemoveDocumentRequest> = {
   create<I extends Exact<DeepPartial<RemoveDocumentRequest>, I>>(base?: I): RemoveDocumentRequest {
     return RemoveDocumentRequest.fromPartial(base ?? ({} as any));
   },
-  fromPartial<I extends Exact<DeepPartial<RemoveDocumentRequest>, I>>(object: I): RemoveDocumentRequest {
+  fromPartial<I extends Exact<DeepPartial<RemoveDocumentRequest>, I>>(
+    object: I
+  ): RemoveDocumentRequest {
     const message = createBaseRemoveDocumentRequest();
-    message.applicationId = object.applicationId ?? "";
-    message.documentId = object.documentId ?? "";
+    message.applicationId = object.applicationId ?? '';
+    message.documentId = object.documentId ?? '';
     return message;
   },
 };
@@ -3900,11 +4039,278 @@ export const RemoveDocumentResponse: MessageFns<RemoveDocumentResponse> = {
     return obj;
   },
 
-  create<I extends Exact<DeepPartial<RemoveDocumentResponse>, I>>(base?: I): RemoveDocumentResponse {
+  create<I extends Exact<DeepPartial<RemoveDocumentResponse>, I>>(
+    base?: I
+  ): RemoveDocumentResponse {
     return RemoveDocumentResponse.fromPartial(base ?? ({} as any));
   },
-  fromPartial<I extends Exact<DeepPartial<RemoveDocumentResponse>, I>>(_: I): RemoveDocumentResponse {
+  fromPartial<I extends Exact<DeepPartial<RemoveDocumentResponse>, I>>(
+    _: I
+  ): RemoveDocumentResponse {
     const message = createBaseRemoveDocumentResponse();
+    return message;
+  },
+};
+
+function createBaseGetApplicationDefaultsRequest(): GetApplicationDefaultsRequest {
+  return {};
+}
+
+export const GetApplicationDefaultsRequest: MessageFns<GetApplicationDefaultsRequest> = {
+  encode(
+    _: GetApplicationDefaultsRequest,
+    writer: BinaryWriter = new BinaryWriter()
+  ): BinaryWriter {
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): GetApplicationDefaultsRequest {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseGetApplicationDefaultsRequest();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(_: any): GetApplicationDefaultsRequest {
+    return {};
+  },
+
+  toJSON(_: GetApplicationDefaultsRequest): unknown {
+    const obj: any = {};
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<GetApplicationDefaultsRequest>, I>>(
+    base?: I
+  ): GetApplicationDefaultsRequest {
+    return GetApplicationDefaultsRequest.fromPartial(base ?? ({} as any));
+  },
+  fromPartial<I extends Exact<DeepPartial<GetApplicationDefaultsRequest>, I>>(
+    _: I
+  ): GetApplicationDefaultsRequest {
+    const message = createBaseGetApplicationDefaultsRequest();
+    return message;
+  },
+};
+
+function createBaseGetApplicationDefaultsResponse(): GetApplicationDefaultsResponse {
+  return { defaultsJson: '' };
+}
+
+export const GetApplicationDefaultsResponse: MessageFns<GetApplicationDefaultsResponse> = {
+  encode(
+    message: GetApplicationDefaultsResponse,
+    writer: BinaryWriter = new BinaryWriter()
+  ): BinaryWriter {
+    if (message.defaultsJson !== '') {
+      writer.uint32(10).string(message.defaultsJson);
+    }
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): GetApplicationDefaultsResponse {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseGetApplicationDefaultsResponse();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1: {
+          if (tag !== 10) {
+            break;
+          }
+
+          message.defaultsJson = reader.string();
+          continue;
+        }
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): GetApplicationDefaultsResponse {
+    return {
+      defaultsJson: isSet(object.defaultsJson)
+        ? globalThis.String(object.defaultsJson)
+        : isSet(object.defaults_json)
+          ? globalThis.String(object.defaults_json)
+          : '',
+    };
+  },
+
+  toJSON(message: GetApplicationDefaultsResponse): unknown {
+    const obj: any = {};
+    if (message.defaultsJson !== '') {
+      obj.defaultsJson = message.defaultsJson;
+    }
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<GetApplicationDefaultsResponse>, I>>(
+    base?: I
+  ): GetApplicationDefaultsResponse {
+    return GetApplicationDefaultsResponse.fromPartial(base ?? ({} as any));
+  },
+  fromPartial<I extends Exact<DeepPartial<GetApplicationDefaultsResponse>, I>>(
+    object: I
+  ): GetApplicationDefaultsResponse {
+    const message = createBaseGetApplicationDefaultsResponse();
+    message.defaultsJson = object.defaultsJson ?? '';
+    return message;
+  },
+};
+
+function createBaseUpdateApplicationDefaultsRequest(): UpdateApplicationDefaultsRequest {
+  return { defaultsPatchJson: '' };
+}
+
+export const UpdateApplicationDefaultsRequest: MessageFns<UpdateApplicationDefaultsRequest> = {
+  encode(
+    message: UpdateApplicationDefaultsRequest,
+    writer: BinaryWriter = new BinaryWriter()
+  ): BinaryWriter {
+    if (message.defaultsPatchJson !== '') {
+      writer.uint32(10).string(message.defaultsPatchJson);
+    }
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): UpdateApplicationDefaultsRequest {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseUpdateApplicationDefaultsRequest();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1: {
+          if (tag !== 10) {
+            break;
+          }
+
+          message.defaultsPatchJson = reader.string();
+          continue;
+        }
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): UpdateApplicationDefaultsRequest {
+    return {
+      defaultsPatchJson: isSet(object.defaultsPatchJson)
+        ? globalThis.String(object.defaultsPatchJson)
+        : isSet(object.defaults_patch_json)
+          ? globalThis.String(object.defaults_patch_json)
+          : '',
+    };
+  },
+
+  toJSON(message: UpdateApplicationDefaultsRequest): unknown {
+    const obj: any = {};
+    if (message.defaultsPatchJson !== '') {
+      obj.defaultsPatchJson = message.defaultsPatchJson;
+    }
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<UpdateApplicationDefaultsRequest>, I>>(
+    base?: I
+  ): UpdateApplicationDefaultsRequest {
+    return UpdateApplicationDefaultsRequest.fromPartial(base ?? ({} as any));
+  },
+  fromPartial<I extends Exact<DeepPartial<UpdateApplicationDefaultsRequest>, I>>(
+    object: I
+  ): UpdateApplicationDefaultsRequest {
+    const message = createBaseUpdateApplicationDefaultsRequest();
+    message.defaultsPatchJson = object.defaultsPatchJson ?? '';
+    return message;
+  },
+};
+
+function createBaseUpdateApplicationDefaultsResponse(): UpdateApplicationDefaultsResponse {
+  return { defaultsJson: '' };
+}
+
+export const UpdateApplicationDefaultsResponse: MessageFns<UpdateApplicationDefaultsResponse> = {
+  encode(
+    message: UpdateApplicationDefaultsResponse,
+    writer: BinaryWriter = new BinaryWriter()
+  ): BinaryWriter {
+    if (message.defaultsJson !== '') {
+      writer.uint32(10).string(message.defaultsJson);
+    }
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): UpdateApplicationDefaultsResponse {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseUpdateApplicationDefaultsResponse();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1: {
+          if (tag !== 10) {
+            break;
+          }
+
+          message.defaultsJson = reader.string();
+          continue;
+        }
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): UpdateApplicationDefaultsResponse {
+    return {
+      defaultsJson: isSet(object.defaultsJson)
+        ? globalThis.String(object.defaultsJson)
+        : isSet(object.defaults_json)
+          ? globalThis.String(object.defaults_json)
+          : '',
+    };
+  },
+
+  toJSON(message: UpdateApplicationDefaultsResponse): unknown {
+    const obj: any = {};
+    if (message.defaultsJson !== '') {
+      obj.defaultsJson = message.defaultsJson;
+    }
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<UpdateApplicationDefaultsResponse>, I>>(
+    base?: I
+  ): UpdateApplicationDefaultsResponse {
+    return UpdateApplicationDefaultsResponse.fromPartial(base ?? ({} as any));
+  },
+  fromPartial<I extends Exact<DeepPartial<UpdateApplicationDefaultsResponse>, I>>(
+    object: I
+  ): UpdateApplicationDefaultsResponse {
+    const message = createBaseUpdateApplicationDefaultsResponse();
+    message.defaultsJson = object.defaultsJson ?? '';
     return message;
   },
 };
@@ -3939,12 +4345,14 @@ export const ApplicationServiceService = {
    * Publishes `applications.draftCreated` after commit.
    */
   startDraft: {
-    path: "/adopt_dont_shop.applications.v1.ApplicationService/StartDraft" as const,
+    path: '/adopt_dont_shop.applications.v1.ApplicationService/StartDraft' as const,
     requestStream: false as const,
     responseStream: false as const,
-    requestSerialize: (value: StartDraftRequest): Buffer => Buffer.from(StartDraftRequest.encode(value).finish()),
+    requestSerialize: (value: StartDraftRequest): Buffer =>
+      Buffer.from(StartDraftRequest.encode(value).finish()),
     requestDeserialize: (value: Buffer): StartDraftRequest => StartDraftRequest.decode(value),
-    responseSerialize: (value: StartDraftResponse): Buffer => Buffer.from(StartDraftResponse.encode(value).finish()),
+    responseSerialize: (value: StartDraftResponse): Buffer =>
+      Buffer.from(StartDraftResponse.encode(value).finish()),
     responseDeserialize: (value: Buffer): StartDraftResponse => StartDraftResponse.decode(value),
   },
   /**
@@ -3954,15 +4362,17 @@ export const ApplicationServiceService = {
    * super_admin.
    */
   saveDraftAnswers: {
-    path: "/adopt_dont_shop.applications.v1.ApplicationService/SaveDraftAnswers" as const,
+    path: '/adopt_dont_shop.applications.v1.ApplicationService/SaveDraftAnswers' as const,
     requestStream: false as const,
     responseStream: false as const,
     requestSerialize: (value: SaveDraftAnswersRequest): Buffer =>
       Buffer.from(SaveDraftAnswersRequest.encode(value).finish()),
-    requestDeserialize: (value: Buffer): SaveDraftAnswersRequest => SaveDraftAnswersRequest.decode(value),
+    requestDeserialize: (value: Buffer): SaveDraftAnswersRequest =>
+      SaveDraftAnswersRequest.decode(value),
     responseSerialize: (value: SaveDraftAnswersResponse): Buffer =>
       Buffer.from(SaveDraftAnswersResponse.encode(value).finish()),
-    responseDeserialize: (value: Buffer): SaveDraftAnswersResponse => SaveDraftAnswersResponse.decode(value),
+    responseDeserialize: (value: Buffer): SaveDraftAnswersResponse =>
+      SaveDraftAnswersResponse.decode(value),
   },
   /**
    * Transition draft → submitted. Validates that all required core
@@ -3972,12 +4382,14 @@ export const ApplicationServiceService = {
    * and rescue staff.
    */
   submitDraft: {
-    path: "/adopt_dont_shop.applications.v1.ApplicationService/SubmitDraft" as const,
+    path: '/adopt_dont_shop.applications.v1.ApplicationService/SubmitDraft' as const,
     requestStream: false as const,
     responseStream: false as const,
-    requestSerialize: (value: SubmitDraftRequest): Buffer => Buffer.from(SubmitDraftRequest.encode(value).finish()),
+    requestSerialize: (value: SubmitDraftRequest): Buffer =>
+      Buffer.from(SubmitDraftRequest.encode(value).finish()),
     requestDeserialize: (value: Buffer): SubmitDraftRequest => SubmitDraftRequest.decode(value),
-    responseSerialize: (value: SubmitDraftResponse): Buffer => Buffer.from(SubmitDraftResponse.encode(value).finish()),
+    responseSerialize: (value: SubmitDraftResponse): Buffer =>
+      Buffer.from(SubmitDraftResponse.encode(value).finish()),
     responseDeserialize: (value: Buffer): SubmitDraftResponse => SubmitDraftResponse.decode(value),
   },
   /**
@@ -3987,12 +4399,14 @@ export const ApplicationServiceService = {
    * application's rescue.
    */
   startReview: {
-    path: "/adopt_dont_shop.applications.v1.ApplicationService/StartReview" as const,
+    path: '/adopt_dont_shop.applications.v1.ApplicationService/StartReview' as const,
     requestStream: false as const,
     responseStream: false as const,
-    requestSerialize: (value: StartReviewRequest): Buffer => Buffer.from(StartReviewRequest.encode(value).finish()),
+    requestSerialize: (value: StartReviewRequest): Buffer =>
+      Buffer.from(StartReviewRequest.encode(value).finish()),
     requestDeserialize: (value: Buffer): StartReviewRequest => StartReviewRequest.decode(value),
-    responseSerialize: (value: StartReviewResponse): Buffer => Buffer.from(StartReviewResponse.encode(value).finish()),
+    responseSerialize: (value: StartReviewResponse): Buffer =>
+      Buffer.from(StartReviewResponse.encode(value).finish()),
     responseDeserialize: (value: Buffer): StartReviewResponse => StartReviewResponse.decode(value),
   },
   /**
@@ -4001,15 +4415,17 @@ export const ApplicationServiceService = {
    * `applications.homeVisitScheduled`.
    */
   scheduleHomeVisit: {
-    path: "/adopt_dont_shop.applications.v1.ApplicationService/ScheduleHomeVisit" as const,
+    path: '/adopt_dont_shop.applications.v1.ApplicationService/ScheduleHomeVisit' as const,
     requestStream: false as const,
     responseStream: false as const,
     requestSerialize: (value: ScheduleHomeVisitRequest): Buffer =>
       Buffer.from(ScheduleHomeVisitRequest.encode(value).finish()),
-    requestDeserialize: (value: Buffer): ScheduleHomeVisitRequest => ScheduleHomeVisitRequest.decode(value),
+    requestDeserialize: (value: Buffer): ScheduleHomeVisitRequest =>
+      ScheduleHomeVisitRequest.decode(value),
     responseSerialize: (value: ScheduleHomeVisitResponse): Buffer =>
       Buffer.from(ScheduleHomeVisitResponse.encode(value).finish()),
-    responseDeserialize: (value: Buffer): ScheduleHomeVisitResponse => ScheduleHomeVisitResponse.decode(value),
+    responseDeserialize: (value: Buffer): ScheduleHomeVisitResponse =>
+      ScheduleHomeVisitResponse.decode(value),
   },
   /**
    * Transition home_visit_scheduled → home_visit_completed. Carries
@@ -4017,27 +4433,31 @@ export const ApplicationServiceService = {
    * `applications.homeVisitCompleted`.
    */
   completeHomeVisit: {
-    path: "/adopt_dont_shop.applications.v1.ApplicationService/CompleteHomeVisit" as const,
+    path: '/adopt_dont_shop.applications.v1.ApplicationService/CompleteHomeVisit' as const,
     requestStream: false as const,
     responseStream: false as const,
     requestSerialize: (value: CompleteHomeVisitRequest): Buffer =>
       Buffer.from(CompleteHomeVisitRequest.encode(value).finish()),
-    requestDeserialize: (value: Buffer): CompleteHomeVisitRequest => CompleteHomeVisitRequest.decode(value),
+    requestDeserialize: (value: Buffer): CompleteHomeVisitRequest =>
+      CompleteHomeVisitRequest.decode(value),
     responseSerialize: (value: CompleteHomeVisitResponse): Buffer =>
       Buffer.from(CompleteHomeVisitResponse.encode(value).finish()),
-    responseDeserialize: (value: Buffer): CompleteHomeVisitResponse => CompleteHomeVisitResponse.decode(value),
+    responseDeserialize: (value: Buffer): CompleteHomeVisitResponse =>
+      CompleteHomeVisitResponse.decode(value),
   },
   /**
    * Terminal: approve the application. Carries optional notes for
    * the adopter. Publishes `applications.approved`.
    */
   approve: {
-    path: "/adopt_dont_shop.applications.v1.ApplicationService/Approve" as const,
+    path: '/adopt_dont_shop.applications.v1.ApplicationService/Approve' as const,
     requestStream: false as const,
     responseStream: false as const,
-    requestSerialize: (value: ApproveRequest): Buffer => Buffer.from(ApproveRequest.encode(value).finish()),
+    requestSerialize: (value: ApproveRequest): Buffer =>
+      Buffer.from(ApproveRequest.encode(value).finish()),
     requestDeserialize: (value: Buffer): ApproveRequest => ApproveRequest.decode(value),
-    responseSerialize: (value: ApproveResponse): Buffer => Buffer.from(ApproveResponse.encode(value).finish()),
+    responseSerialize: (value: ApproveResponse): Buffer =>
+      Buffer.from(ApproveResponse.encode(value).finish()),
     responseDeserialize: (value: Buffer): ApproveResponse => ApproveResponse.decode(value),
   },
   /**
@@ -4045,12 +4465,14 @@ export const ApplicationServiceService = {
    * `applications.rejected`.
    */
   reject: {
-    path: "/adopt_dont_shop.applications.v1.ApplicationService/Reject" as const,
+    path: '/adopt_dont_shop.applications.v1.ApplicationService/Reject' as const,
     requestStream: false as const,
     responseStream: false as const,
-    requestSerialize: (value: RejectRequest): Buffer => Buffer.from(RejectRequest.encode(value).finish()),
+    requestSerialize: (value: RejectRequest): Buffer =>
+      Buffer.from(RejectRequest.encode(value).finish()),
     requestDeserialize: (value: Buffer): RejectRequest => RejectRequest.decode(value),
-    responseSerialize: (value: RejectResponse): Buffer => Buffer.from(RejectResponse.encode(value).finish()),
+    responseSerialize: (value: RejectResponse): Buffer =>
+      Buffer.from(RejectResponse.encode(value).finish()),
     responseDeserialize: (value: Buffer): RejectResponse => RejectResponse.decode(value),
   },
   /**
@@ -4058,12 +4480,14 @@ export const ApplicationServiceService = {
    * pre-decision state. Publishes `applications.withdrawn`.
    */
   withdraw: {
-    path: "/adopt_dont_shop.applications.v1.ApplicationService/Withdraw" as const,
+    path: '/adopt_dont_shop.applications.v1.ApplicationService/Withdraw' as const,
     requestStream: false as const,
     responseStream: false as const,
-    requestSerialize: (value: WithdrawRequest): Buffer => Buffer.from(WithdrawRequest.encode(value).finish()),
+    requestSerialize: (value: WithdrawRequest): Buffer =>
+      Buffer.from(WithdrawRequest.encode(value).finish()),
     requestDeserialize: (value: Buffer): WithdrawRequest => WithdrawRequest.decode(value),
-    responseSerialize: (value: WithdrawResponse): Buffer => Buffer.from(WithdrawResponse.encode(value).finish()),
+    responseSerialize: (value: WithdrawResponse): Buffer =>
+      Buffer.from(WithdrawResponse.encode(value).finish()),
     responseDeserialize: (value: Buffer): WithdrawResponse => WithdrawResponse.decode(value),
   },
   /**
@@ -4073,12 +4497,14 @@ export const ApplicationServiceService = {
    * `applications.adopted`.
    */
   markAdopted: {
-    path: "/adopt_dont_shop.applications.v1.ApplicationService/MarkAdopted" as const,
+    path: '/adopt_dont_shop.applications.v1.ApplicationService/MarkAdopted' as const,
     requestStream: false as const,
     responseStream: false as const,
-    requestSerialize: (value: MarkAdoptedRequest): Buffer => Buffer.from(MarkAdoptedRequest.encode(value).finish()),
+    requestSerialize: (value: MarkAdoptedRequest): Buffer =>
+      Buffer.from(MarkAdoptedRequest.encode(value).finish()),
     requestDeserialize: (value: Buffer): MarkAdoptedRequest => MarkAdoptedRequest.decode(value),
-    responseSerialize: (value: MarkAdoptedResponse): Buffer => Buffer.from(MarkAdoptedResponse.encode(value).finish()),
+    responseSerialize: (value: MarkAdoptedResponse): Buffer =>
+      Buffer.from(MarkAdoptedResponse.encode(value).finish()),
     responseDeserialize: (value: Buffer): MarkAdoptedResponse => MarkAdoptedResponse.decode(value),
   },
   /**
@@ -4087,15 +4513,17 @@ export const ApplicationServiceService = {
    * deleted.
    */
   get: {
-    path: "/adopt_dont_shop.applications.v1.ApplicationService/Get" as const,
+    path: '/adopt_dont_shop.applications.v1.ApplicationService/Get' as const,
     requestStream: false as const,
     responseStream: false as const,
     requestSerialize: (value: GetApplicationRequest): Buffer =>
       Buffer.from(GetApplicationRequest.encode(value).finish()),
-    requestDeserialize: (value: Buffer): GetApplicationRequest => GetApplicationRequest.decode(value),
+    requestDeserialize: (value: Buffer): GetApplicationRequest =>
+      GetApplicationRequest.decode(value),
     responseSerialize: (value: GetApplicationResponse): Buffer =>
       Buffer.from(GetApplicationResponse.encode(value).finish()),
-    responseDeserialize: (value: Buffer): GetApplicationResponse => GetApplicationResponse.decode(value),
+    responseDeserialize: (value: Buffer): GetApplicationResponse =>
+      GetApplicationResponse.decode(value),
   },
   /**
    * Read-side: keyset paginated list, scoped by status or rescue
@@ -4103,15 +4531,17 @@ export const ApplicationServiceService = {
    * staff see their rescue's; admins see all.
    */
   list: {
-    path: "/adopt_dont_shop.applications.v1.ApplicationService/List" as const,
+    path: '/adopt_dont_shop.applications.v1.ApplicationService/List' as const,
     requestStream: false as const,
     responseStream: false as const,
     requestSerialize: (value: ListApplicationsRequest): Buffer =>
       Buffer.from(ListApplicationsRequest.encode(value).finish()),
-    requestDeserialize: (value: Buffer): ListApplicationsRequest => ListApplicationsRequest.decode(value),
+    requestDeserialize: (value: Buffer): ListApplicationsRequest =>
+      ListApplicationsRequest.decode(value),
     responseSerialize: (value: ListApplicationsResponse): Buffer =>
       Buffer.from(ListApplicationsResponse.encode(value).finish()),
-    responseDeserialize: (value: Buffer): ListApplicationsResponse => ListApplicationsResponse.decode(value),
+    responseDeserialize: (value: Buffer): ListApplicationsResponse =>
+      ListApplicationsResponse.decode(value),
   },
   /**
    * Read-side: application counts grouped by status, scoped the same
@@ -4121,12 +4551,14 @@ export const ApplicationServiceService = {
    * counts — the gateway collapses them to the SPA's 4-state shape.
    */
   getStats: {
-    path: "/adopt_dont_shop.applications.v1.ApplicationService/GetStats" as const,
+    path: '/adopt_dont_shop.applications.v1.ApplicationService/GetStats' as const,
     requestStream: false as const,
     responseStream: false as const,
-    requestSerialize: (value: GetStatsRequest): Buffer => Buffer.from(GetStatsRequest.encode(value).finish()),
+    requestSerialize: (value: GetStatsRequest): Buffer =>
+      Buffer.from(GetStatsRequest.encode(value).finish()),
     requestDeserialize: (value: Buffer): GetStatsRequest => GetStatsRequest.decode(value),
-    responseSerialize: (value: GetStatsResponse): Buffer => Buffer.from(GetStatsResponse.encode(value).finish()),
+    responseSerialize: (value: GetStatsResponse): Buffer =>
+      Buffer.from(GetStatsResponse.encode(value).finish()),
     responseDeserialize: (value: Buffer): GetStatsResponse => GetStatsResponse.decode(value),
   },
   /**
@@ -4136,12 +4568,14 @@ export const ApplicationServiceService = {
    * applications.update for the application's rescue.
    */
   addDocument: {
-    path: "/adopt_dont_shop.applications.v1.ApplicationService/AddDocument" as const,
+    path: '/adopt_dont_shop.applications.v1.ApplicationService/AddDocument' as const,
     requestStream: false as const,
     responseStream: false as const,
-    requestSerialize: (value: AddDocumentRequest): Buffer => Buffer.from(AddDocumentRequest.encode(value).finish()),
+    requestSerialize: (value: AddDocumentRequest): Buffer =>
+      Buffer.from(AddDocumentRequest.encode(value).finish()),
     requestDeserialize: (value: Buffer): AddDocumentRequest => AddDocumentRequest.decode(value),
-    responseSerialize: (value: AddDocumentResponse): Buffer => Buffer.from(AddDocumentResponse.encode(value).finish()),
+    responseSerialize: (value: AddDocumentResponse): Buffer =>
+      Buffer.from(AddDocumentResponse.encode(value).finish()),
     responseDeserialize: (value: Buffer): AddDocumentResponse => AddDocumentResponse.decode(value),
   },
   /**
@@ -4150,29 +4584,70 @@ export const ApplicationServiceService = {
    * staff-of-the-app's-rescue OR admin).
    */
   listDocuments: {
-    path: "/adopt_dont_shop.applications.v1.ApplicationService/ListDocuments" as const,
+    path: '/adopt_dont_shop.applications.v1.ApplicationService/ListDocuments' as const,
     requestStream: false as const,
     responseStream: false as const,
-    requestSerialize: (value: ListDocumentsRequest): Buffer => Buffer.from(ListDocumentsRequest.encode(value).finish()),
+    requestSerialize: (value: ListDocumentsRequest): Buffer =>
+      Buffer.from(ListDocumentsRequest.encode(value).finish()),
     requestDeserialize: (value: Buffer): ListDocumentsRequest => ListDocumentsRequest.decode(value),
     responseSerialize: (value: ListDocumentsResponse): Buffer =>
       Buffer.from(ListDocumentsResponse.encode(value).finish()),
-    responseDeserialize: (value: Buffer): ListDocumentsResponse => ListDocumentsResponse.decode(value),
+    responseDeserialize: (value: Buffer): ListDocumentsResponse =>
+      ListDocumentsResponse.decode(value),
   },
   /**
    * Document metadata — soft-delete one document. Caller MUST hold
    * applications.update for the application's rescue.
    */
   removeDocument: {
-    path: "/adopt_dont_shop.applications.v1.ApplicationService/RemoveDocument" as const,
+    path: '/adopt_dont_shop.applications.v1.ApplicationService/RemoveDocument' as const,
     requestStream: false as const,
     responseStream: false as const,
     requestSerialize: (value: RemoveDocumentRequest): Buffer =>
       Buffer.from(RemoveDocumentRequest.encode(value).finish()),
-    requestDeserialize: (value: Buffer): RemoveDocumentRequest => RemoveDocumentRequest.decode(value),
+    requestDeserialize: (value: Buffer): RemoveDocumentRequest =>
+      RemoveDocumentRequest.decode(value),
     responseSerialize: (value: RemoveDocumentResponse): Buffer =>
       Buffer.from(RemoveDocumentResponse.encode(value).finish()),
-    responseDeserialize: (value: Buffer): RemoveDocumentResponse => RemoveDocumentResponse.decode(value),
+    responseDeserialize: (value: Buffer): RemoveDocumentResponse =>
+      RemoveDocumentResponse.decode(value),
+  },
+  /**
+   * Adopter's reusable application defaults (personal info / living
+   * situation / pet experience / references) used to pre-populate new
+   * applications. Always scoped to the calling principal's own
+   * user_id — there is no cross-adopter read or write.
+   */
+  getApplicationDefaults: {
+    path: '/adopt_dont_shop.applications.v1.ApplicationService/GetApplicationDefaults' as const,
+    requestStream: false as const,
+    responseStream: false as const,
+    requestSerialize: (value: GetApplicationDefaultsRequest): Buffer =>
+      Buffer.from(GetApplicationDefaultsRequest.encode(value).finish()),
+    requestDeserialize: (value: Buffer): GetApplicationDefaultsRequest =>
+      GetApplicationDefaultsRequest.decode(value),
+    responseSerialize: (value: GetApplicationDefaultsResponse): Buffer =>
+      Buffer.from(GetApplicationDefaultsResponse.encode(value).finish()),
+    responseDeserialize: (value: Buffer): GetApplicationDefaultsResponse =>
+      GetApplicationDefaultsResponse.decode(value),
+  },
+  /**
+   * Deep-merge a partial defaults patch into the adopter's saved
+   * defaults and return the merged result. Top-level keys absent from
+   * the patch are left untouched.
+   */
+  updateApplicationDefaults: {
+    path: '/adopt_dont_shop.applications.v1.ApplicationService/UpdateApplicationDefaults' as const,
+    requestStream: false as const,
+    responseStream: false as const,
+    requestSerialize: (value: UpdateApplicationDefaultsRequest): Buffer =>
+      Buffer.from(UpdateApplicationDefaultsRequest.encode(value).finish()),
+    requestDeserialize: (value: Buffer): UpdateApplicationDefaultsRequest =>
+      UpdateApplicationDefaultsRequest.decode(value),
+    responseSerialize: (value: UpdateApplicationDefaultsResponse): Buffer =>
+      Buffer.from(UpdateApplicationDefaultsResponse.encode(value).finish()),
+    responseDeserialize: (value: Buffer): UpdateApplicationDefaultsResponse =>
+      UpdateApplicationDefaultsResponse.decode(value),
   },
 } as const;
 
@@ -4277,6 +4752,25 @@ export interface ApplicationServiceServer extends UntypedServiceImplementation {
    * applications.update for the application's rescue.
    */
   removeDocument: handleUnaryCall<RemoveDocumentRequest, RemoveDocumentResponse>;
+  /**
+   * Adopter's reusable application defaults (personal info / living
+   * situation / pet experience / references) used to pre-populate new
+   * applications. Always scoped to the calling principal's own
+   * user_id — there is no cross-adopter read or write.
+   */
+  getApplicationDefaults: handleUnaryCall<
+    GetApplicationDefaultsRequest,
+    GetApplicationDefaultsResponse
+  >;
+  /**
+   * Deep-merge a partial defaults patch into the adopter's saved
+   * defaults and return the merged result. Top-level keys absent from
+   * the patch are left untouched.
+   */
+  updateApplicationDefaults: handleUnaryCall<
+    UpdateApplicationDefaultsRequest,
+    UpdateApplicationDefaultsResponse
+  >;
 }
 
 export interface ApplicationServiceClient extends Client {
@@ -4287,18 +4781,18 @@ export interface ApplicationServiceClient extends Client {
    */
   startDraft(
     request: StartDraftRequest,
-    callback: (error: ServiceError | null, response: StartDraftResponse) => void,
+    callback: (error: ServiceError | null, response: StartDraftResponse) => void
   ): ClientUnaryCall;
   startDraft(
     request: StartDraftRequest,
     metadata: Metadata,
-    callback: (error: ServiceError | null, response: StartDraftResponse) => void,
+    callback: (error: ServiceError | null, response: StartDraftResponse) => void
   ): ClientUnaryCall;
   startDraft(
     request: StartDraftRequest,
     metadata: Metadata,
     options: Partial<CallOptions>,
-    callback: (error: ServiceError | null, response: StartDraftResponse) => void,
+    callback: (error: ServiceError | null, response: StartDraftResponse) => void
   ): ClientUnaryCall;
   /**
    * Persist answers / reference contacts to an existing draft.
@@ -4308,18 +4802,18 @@ export interface ApplicationServiceClient extends Client {
    */
   saveDraftAnswers(
     request: SaveDraftAnswersRequest,
-    callback: (error: ServiceError | null, response: SaveDraftAnswersResponse) => void,
+    callback: (error: ServiceError | null, response: SaveDraftAnswersResponse) => void
   ): ClientUnaryCall;
   saveDraftAnswers(
     request: SaveDraftAnswersRequest,
     metadata: Metadata,
-    callback: (error: ServiceError | null, response: SaveDraftAnswersResponse) => void,
+    callback: (error: ServiceError | null, response: SaveDraftAnswersResponse) => void
   ): ClientUnaryCall;
   saveDraftAnswers(
     request: SaveDraftAnswersRequest,
     metadata: Metadata,
     options: Partial<CallOptions>,
-    callback: (error: ServiceError | null, response: SaveDraftAnswersResponse) => void,
+    callback: (error: ServiceError | null, response: SaveDraftAnswersResponse) => void
   ): ClientUnaryCall;
   /**
    * Transition draft → submitted. Validates that all required core
@@ -4330,18 +4824,18 @@ export interface ApplicationServiceClient extends Client {
    */
   submitDraft(
     request: SubmitDraftRequest,
-    callback: (error: ServiceError | null, response: SubmitDraftResponse) => void,
+    callback: (error: ServiceError | null, response: SubmitDraftResponse) => void
   ): ClientUnaryCall;
   submitDraft(
     request: SubmitDraftRequest,
     metadata: Metadata,
-    callback: (error: ServiceError | null, response: SubmitDraftResponse) => void,
+    callback: (error: ServiceError | null, response: SubmitDraftResponse) => void
   ): ClientUnaryCall;
   submitDraft(
     request: SubmitDraftRequest,
     metadata: Metadata,
     options: Partial<CallOptions>,
-    callback: (error: ServiceError | null, response: SubmitDraftResponse) => void,
+    callback: (error: ServiceError | null, response: SubmitDraftResponse) => void
   ): ClientUnaryCall;
   /**
    * Transition submitted → under_review (rescue staff opens the
@@ -4351,18 +4845,18 @@ export interface ApplicationServiceClient extends Client {
    */
   startReview(
     request: StartReviewRequest,
-    callback: (error: ServiceError | null, response: StartReviewResponse) => void,
+    callback: (error: ServiceError | null, response: StartReviewResponse) => void
   ): ClientUnaryCall;
   startReview(
     request: StartReviewRequest,
     metadata: Metadata,
-    callback: (error: ServiceError | null, response: StartReviewResponse) => void,
+    callback: (error: ServiceError | null, response: StartReviewResponse) => void
   ): ClientUnaryCall;
   startReview(
     request: StartReviewRequest,
     metadata: Metadata,
     options: Partial<CallOptions>,
-    callback: (error: ServiceError | null, response: StartReviewResponse) => void,
+    callback: (error: ServiceError | null, response: StartReviewResponse) => void
   ): ClientUnaryCall;
   /**
    * Transition under_review → home_visit_scheduled. Carries the
@@ -4371,18 +4865,18 @@ export interface ApplicationServiceClient extends Client {
    */
   scheduleHomeVisit(
     request: ScheduleHomeVisitRequest,
-    callback: (error: ServiceError | null, response: ScheduleHomeVisitResponse) => void,
+    callback: (error: ServiceError | null, response: ScheduleHomeVisitResponse) => void
   ): ClientUnaryCall;
   scheduleHomeVisit(
     request: ScheduleHomeVisitRequest,
     metadata: Metadata,
-    callback: (error: ServiceError | null, response: ScheduleHomeVisitResponse) => void,
+    callback: (error: ServiceError | null, response: ScheduleHomeVisitResponse) => void
   ): ClientUnaryCall;
   scheduleHomeVisit(
     request: ScheduleHomeVisitRequest,
     metadata: Metadata,
     options: Partial<CallOptions>,
-    callback: (error: ServiceError | null, response: ScheduleHomeVisitResponse) => void,
+    callback: (error: ServiceError | null, response: ScheduleHomeVisitResponse) => void
   ): ClientUnaryCall;
   /**
    * Transition home_visit_scheduled → home_visit_completed. Carries
@@ -4391,18 +4885,18 @@ export interface ApplicationServiceClient extends Client {
    */
   completeHomeVisit(
     request: CompleteHomeVisitRequest,
-    callback: (error: ServiceError | null, response: CompleteHomeVisitResponse) => void,
+    callback: (error: ServiceError | null, response: CompleteHomeVisitResponse) => void
   ): ClientUnaryCall;
   completeHomeVisit(
     request: CompleteHomeVisitRequest,
     metadata: Metadata,
-    callback: (error: ServiceError | null, response: CompleteHomeVisitResponse) => void,
+    callback: (error: ServiceError | null, response: CompleteHomeVisitResponse) => void
   ): ClientUnaryCall;
   completeHomeVisit(
     request: CompleteHomeVisitRequest,
     metadata: Metadata,
     options: Partial<CallOptions>,
-    callback: (error: ServiceError | null, response: CompleteHomeVisitResponse) => void,
+    callback: (error: ServiceError | null, response: CompleteHomeVisitResponse) => void
   ): ClientUnaryCall;
   /**
    * Terminal: approve the application. Carries optional notes for
@@ -4410,18 +4904,18 @@ export interface ApplicationServiceClient extends Client {
    */
   approve(
     request: ApproveRequest,
-    callback: (error: ServiceError | null, response: ApproveResponse) => void,
+    callback: (error: ServiceError | null, response: ApproveResponse) => void
   ): ClientUnaryCall;
   approve(
     request: ApproveRequest,
     metadata: Metadata,
-    callback: (error: ServiceError | null, response: ApproveResponse) => void,
+    callback: (error: ServiceError | null, response: ApproveResponse) => void
   ): ClientUnaryCall;
   approve(
     request: ApproveRequest,
     metadata: Metadata,
     options: Partial<CallOptions>,
-    callback: (error: ServiceError | null, response: ApproveResponse) => void,
+    callback: (error: ServiceError | null, response: ApproveResponse) => void
   ): ClientUnaryCall;
   /**
    * Terminal: reject with a reason. Publishes
@@ -4429,18 +4923,18 @@ export interface ApplicationServiceClient extends Client {
    */
   reject(
     request: RejectRequest,
-    callback: (error: ServiceError | null, response: RejectResponse) => void,
+    callback: (error: ServiceError | null, response: RejectResponse) => void
   ): ClientUnaryCall;
   reject(
     request: RejectRequest,
     metadata: Metadata,
-    callback: (error: ServiceError | null, response: RejectResponse) => void,
+    callback: (error: ServiceError | null, response: RejectResponse) => void
   ): ClientUnaryCall;
   reject(
     request: RejectRequest,
     metadata: Metadata,
     options: Partial<CallOptions>,
-    callback: (error: ServiceError | null, response: RejectResponse) => void,
+    callback: (error: ServiceError | null, response: RejectResponse) => void
   ): ClientUnaryCall;
   /**
    * Terminal (adopter-initiated): withdraw an application from any
@@ -4448,18 +4942,18 @@ export interface ApplicationServiceClient extends Client {
    */
   withdraw(
     request: WithdrawRequest,
-    callback: (error: ServiceError | null, response: WithdrawResponse) => void,
+    callback: (error: ServiceError | null, response: WithdrawResponse) => void
   ): ClientUnaryCall;
   withdraw(
     request: WithdrawRequest,
     metadata: Metadata,
-    callback: (error: ServiceError | null, response: WithdrawResponse) => void,
+    callback: (error: ServiceError | null, response: WithdrawResponse) => void
   ): ClientUnaryCall;
   withdraw(
     request: WithdrawRequest,
     metadata: Metadata,
     options: Partial<CallOptions>,
-    callback: (error: ServiceError | null, response: WithdrawResponse) => void,
+    callback: (error: ServiceError | null, response: WithdrawResponse) => void
   ): ClientUnaryCall;
   /**
    * Final-terminal: mark the pet adopted. Triggered when the
@@ -4469,18 +4963,18 @@ export interface ApplicationServiceClient extends Client {
    */
   markAdopted(
     request: MarkAdoptedRequest,
-    callback: (error: ServiceError | null, response: MarkAdoptedResponse) => void,
+    callback: (error: ServiceError | null, response: MarkAdoptedResponse) => void
   ): ClientUnaryCall;
   markAdopted(
     request: MarkAdoptedRequest,
     metadata: Metadata,
-    callback: (error: ServiceError | null, response: MarkAdoptedResponse) => void,
+    callback: (error: ServiceError | null, response: MarkAdoptedResponse) => void
   ): ClientUnaryCall;
   markAdopted(
     request: MarkAdoptedRequest,
     metadata: Metadata,
     options: Partial<CallOptions>,
-    callback: (error: ServiceError | null, response: MarkAdoptedResponse) => void,
+    callback: (error: ServiceError | null, response: MarkAdoptedResponse) => void
   ): ClientUnaryCall;
   /**
    * Read-side: fetch a single application's current projected state
@@ -4489,18 +4983,18 @@ export interface ApplicationServiceClient extends Client {
    */
   get(
     request: GetApplicationRequest,
-    callback: (error: ServiceError | null, response: GetApplicationResponse) => void,
+    callback: (error: ServiceError | null, response: GetApplicationResponse) => void
   ): ClientUnaryCall;
   get(
     request: GetApplicationRequest,
     metadata: Metadata,
-    callback: (error: ServiceError | null, response: GetApplicationResponse) => void,
+    callback: (error: ServiceError | null, response: GetApplicationResponse) => void
   ): ClientUnaryCall;
   get(
     request: GetApplicationRequest,
     metadata: Metadata,
     options: Partial<CallOptions>,
-    callback: (error: ServiceError | null, response: GetApplicationResponse) => void,
+    callback: (error: ServiceError | null, response: GetApplicationResponse) => void
   ): ClientUnaryCall;
   /**
    * Read-side: keyset paginated list, scoped by status or rescue
@@ -4509,18 +5003,18 @@ export interface ApplicationServiceClient extends Client {
    */
   list(
     request: ListApplicationsRequest,
-    callback: (error: ServiceError | null, response: ListApplicationsResponse) => void,
+    callback: (error: ServiceError | null, response: ListApplicationsResponse) => void
   ): ClientUnaryCall;
   list(
     request: ListApplicationsRequest,
     metadata: Metadata,
-    callback: (error: ServiceError | null, response: ListApplicationsResponse) => void,
+    callback: (error: ServiceError | null, response: ListApplicationsResponse) => void
   ): ClientUnaryCall;
   list(
     request: ListApplicationsRequest,
     metadata: Metadata,
     options: Partial<CallOptions>,
-    callback: (error: ServiceError | null, response: ListApplicationsResponse) => void,
+    callback: (error: ServiceError | null, response: ListApplicationsResponse) => void
   ): ClientUnaryCall;
   /**
    * Read-side: application counts grouped by status, scoped the same
@@ -4531,18 +5025,18 @@ export interface ApplicationServiceClient extends Client {
    */
   getStats(
     request: GetStatsRequest,
-    callback: (error: ServiceError | null, response: GetStatsResponse) => void,
+    callback: (error: ServiceError | null, response: GetStatsResponse) => void
   ): ClientUnaryCall;
   getStats(
     request: GetStatsRequest,
     metadata: Metadata,
-    callback: (error: ServiceError | null, response: GetStatsResponse) => void,
+    callback: (error: ServiceError | null, response: GetStatsResponse) => void
   ): ClientUnaryCall;
   getStats(
     request: GetStatsRequest,
     metadata: Metadata,
     options: Partial<CallOptions>,
-    callback: (error: ServiceError | null, response: GetStatsResponse) => void,
+    callback: (error: ServiceError | null, response: GetStatsResponse) => void
   ): ClientUnaryCall;
   /**
    * Document metadata — append a row referencing an already-stored
@@ -4552,18 +5046,18 @@ export interface ApplicationServiceClient extends Client {
    */
   addDocument(
     request: AddDocumentRequest,
-    callback: (error: ServiceError | null, response: AddDocumentResponse) => void,
+    callback: (error: ServiceError | null, response: AddDocumentResponse) => void
   ): ClientUnaryCall;
   addDocument(
     request: AddDocumentRequest,
     metadata: Metadata,
-    callback: (error: ServiceError | null, response: AddDocumentResponse) => void,
+    callback: (error: ServiceError | null, response: AddDocumentResponse) => void
   ): ClientUnaryCall;
   addDocument(
     request: AddDocumentRequest,
     metadata: Metadata,
     options: Partial<CallOptions>,
-    callback: (error: ServiceError | null, response: AddDocumentResponse) => void,
+    callback: (error: ServiceError | null, response: AddDocumentResponse) => void
   ): ClientUnaryCall;
   /**
    * Document metadata — list the non-deleted documents attached to an
@@ -4572,18 +5066,18 @@ export interface ApplicationServiceClient extends Client {
    */
   listDocuments(
     request: ListDocumentsRequest,
-    callback: (error: ServiceError | null, response: ListDocumentsResponse) => void,
+    callback: (error: ServiceError | null, response: ListDocumentsResponse) => void
   ): ClientUnaryCall;
   listDocuments(
     request: ListDocumentsRequest,
     metadata: Metadata,
-    callback: (error: ServiceError | null, response: ListDocumentsResponse) => void,
+    callback: (error: ServiceError | null, response: ListDocumentsResponse) => void
   ): ClientUnaryCall;
   listDocuments(
     request: ListDocumentsRequest,
     metadata: Metadata,
     options: Partial<CallOptions>,
-    callback: (error: ServiceError | null, response: ListDocumentsResponse) => void,
+    callback: (error: ServiceError | null, response: ListDocumentsResponse) => void
   ): ClientUnaryCall;
   /**
    * Document metadata — soft-delete one document. Caller MUST hold
@@ -4591,40 +5085,90 @@ export interface ApplicationServiceClient extends Client {
    */
   removeDocument(
     request: RemoveDocumentRequest,
-    callback: (error: ServiceError | null, response: RemoveDocumentResponse) => void,
+    callback: (error: ServiceError | null, response: RemoveDocumentResponse) => void
   ): ClientUnaryCall;
   removeDocument(
     request: RemoveDocumentRequest,
     metadata: Metadata,
-    callback: (error: ServiceError | null, response: RemoveDocumentResponse) => void,
+    callback: (error: ServiceError | null, response: RemoveDocumentResponse) => void
   ): ClientUnaryCall;
   removeDocument(
     request: RemoveDocumentRequest,
     metadata: Metadata,
     options: Partial<CallOptions>,
-    callback: (error: ServiceError | null, response: RemoveDocumentResponse) => void,
+    callback: (error: ServiceError | null, response: RemoveDocumentResponse) => void
+  ): ClientUnaryCall;
+  /**
+   * Adopter's reusable application defaults (personal info / living
+   * situation / pet experience / references) used to pre-populate new
+   * applications. Always scoped to the calling principal's own
+   * user_id — there is no cross-adopter read or write.
+   */
+  getApplicationDefaults(
+    request: GetApplicationDefaultsRequest,
+    callback: (error: ServiceError | null, response: GetApplicationDefaultsResponse) => void
+  ): ClientUnaryCall;
+  getApplicationDefaults(
+    request: GetApplicationDefaultsRequest,
+    metadata: Metadata,
+    callback: (error: ServiceError | null, response: GetApplicationDefaultsResponse) => void
+  ): ClientUnaryCall;
+  getApplicationDefaults(
+    request: GetApplicationDefaultsRequest,
+    metadata: Metadata,
+    options: Partial<CallOptions>,
+    callback: (error: ServiceError | null, response: GetApplicationDefaultsResponse) => void
+  ): ClientUnaryCall;
+  /**
+   * Deep-merge a partial defaults patch into the adopter's saved
+   * defaults and return the merged result. Top-level keys absent from
+   * the patch are left untouched.
+   */
+  updateApplicationDefaults(
+    request: UpdateApplicationDefaultsRequest,
+    callback: (error: ServiceError | null, response: UpdateApplicationDefaultsResponse) => void
+  ): ClientUnaryCall;
+  updateApplicationDefaults(
+    request: UpdateApplicationDefaultsRequest,
+    metadata: Metadata,
+    callback: (error: ServiceError | null, response: UpdateApplicationDefaultsResponse) => void
+  ): ClientUnaryCall;
+  updateApplicationDefaults(
+    request: UpdateApplicationDefaultsRequest,
+    metadata: Metadata,
+    options: Partial<CallOptions>,
+    callback: (error: ServiceError | null, response: UpdateApplicationDefaultsResponse) => void
   ): ClientUnaryCall;
 }
 
 export const ApplicationServiceClient = makeGenericClientConstructor(
   ApplicationServiceService,
-  "adopt_dont_shop.applications.v1.ApplicationService",
+  'adopt_dont_shop.applications.v1.ApplicationService'
 ) as unknown as {
-  new (address: string, credentials: ChannelCredentials, options?: Partial<ClientOptions>): ApplicationServiceClient;
+  new (
+    address: string,
+    credentials: ChannelCredentials,
+    options?: Partial<ClientOptions>
+  ): ApplicationServiceClient;
   service: typeof ApplicationServiceService;
   serviceName: string;
 };
 
 type Builtin = Date | Function | Uint8Array | string | number | boolean | undefined;
 
-export type DeepPartial<T> = T extends Builtin ? T
-  : T extends globalThis.Array<infer U> ? globalThis.Array<DeepPartial<U>>
-  : T extends ReadonlyArray<infer U> ? ReadonlyArray<DeepPartial<U>>
-  : T extends {} ? { [K in keyof T]?: DeepPartial<T[K]> }
-  : Partial<T>;
+export type DeepPartial<T> = T extends Builtin
+  ? T
+  : T extends globalThis.Array<infer U>
+    ? globalThis.Array<DeepPartial<U>>
+    : T extends ReadonlyArray<infer U>
+      ? ReadonlyArray<DeepPartial<U>>
+      : T extends {}
+        ? { [K in keyof T]?: DeepPartial<T[K]> }
+        : Partial<T>;
 
 type KeysOfUnion<T> = T extends T ? keyof T : never;
-export type Exact<P, I extends P> = P extends Builtin ? P
+export type Exact<P, I extends P> = P extends Builtin
+  ? P
   : P & { [K in keyof P]: Exact<P[K], I[K]> } & { [K in Exclude<keyof I, KeysOfUnion<P>>]: never };
 
 function isSet(value: any): boolean {

--- a/packages/proto/src/generated/proto/adopt_dont_shop/matching/v1/matching.ts
+++ b/packages/proto/src/generated/proto/adopt_dont_shop/matching/v1/matching.ts
@@ -5,7 +5,7 @@
 // source: proto/adopt_dont_shop/matching/v1/matching.proto
 
 /* eslint-disable */
-import { BinaryReader, BinaryWriter } from "@bufbuild/protobuf/wire";
+import { BinaryReader, BinaryWriter } from '@bufbuild/protobuf/wire';
 import {
   type CallOptions,
   type ChannelCredentials,
@@ -17,9 +17,9 @@ import {
   type Metadata,
   type ServiceError,
   type UntypedServiceImplementation,
-} from "@grpc/grpc-js";
+} from '@grpc/grpc-js';
 
-export const protobufPackage = "adopt_dont_shop.matching.v1";
+export const protobufPackage = 'adopt_dont_shop.matching.v1';
 
 export enum SwipeAction {
   SWIPE_ACTION_UNSPECIFIED = 0,
@@ -39,22 +39,22 @@ export enum SwipeAction {
 export function swipeActionFromJSON(object: any): SwipeAction {
   switch (object) {
     case 0:
-    case "SWIPE_ACTION_UNSPECIFIED":
+    case 'SWIPE_ACTION_UNSPECIFIED':
       return SwipeAction.SWIPE_ACTION_UNSPECIFIED;
     case 1:
-    case "SWIPE_ACTION_LIKE":
+    case 'SWIPE_ACTION_LIKE':
       return SwipeAction.SWIPE_ACTION_LIKE;
     case 2:
-    case "SWIPE_ACTION_PASS":
+    case 'SWIPE_ACTION_PASS':
       return SwipeAction.SWIPE_ACTION_PASS;
     case 3:
-    case "SWIPE_ACTION_SUPER_LIKE":
+    case 'SWIPE_ACTION_SUPER_LIKE':
       return SwipeAction.SWIPE_ACTION_SUPER_LIKE;
     case 4:
-    case "SWIPE_ACTION_INFO":
+    case 'SWIPE_ACTION_INFO':
       return SwipeAction.SWIPE_ACTION_INFO;
     case -1:
-    case "UNRECOGNIZED":
+    case 'UNRECOGNIZED':
     default:
       return SwipeAction.UNRECOGNIZED;
   }
@@ -63,18 +63,18 @@ export function swipeActionFromJSON(object: any): SwipeAction {
 export function swipeActionToJSON(object: SwipeAction): string {
   switch (object) {
     case SwipeAction.SWIPE_ACTION_UNSPECIFIED:
-      return "SWIPE_ACTION_UNSPECIFIED";
+      return 'SWIPE_ACTION_UNSPECIFIED';
     case SwipeAction.SWIPE_ACTION_LIKE:
-      return "SWIPE_ACTION_LIKE";
+      return 'SWIPE_ACTION_LIKE';
     case SwipeAction.SWIPE_ACTION_PASS:
-      return "SWIPE_ACTION_PASS";
+      return 'SWIPE_ACTION_PASS';
     case SwipeAction.SWIPE_ACTION_SUPER_LIKE:
-      return "SWIPE_ACTION_SUPER_LIKE";
+      return 'SWIPE_ACTION_SUPER_LIKE';
     case SwipeAction.SWIPE_ACTION_INFO:
-      return "SWIPE_ACTION_INFO";
+      return 'SWIPE_ACTION_INFO';
     case SwipeAction.UNRECOGNIZED:
     default:
-      return "UNRECOGNIZED";
+      return 'UNRECOGNIZED';
   }
 }
 
@@ -90,22 +90,22 @@ export enum DeviceType {
 export function deviceTypeFromJSON(object: any): DeviceType {
   switch (object) {
     case 0:
-    case "DEVICE_TYPE_UNSPECIFIED":
+    case 'DEVICE_TYPE_UNSPECIFIED':
       return DeviceType.DEVICE_TYPE_UNSPECIFIED;
     case 1:
-    case "DEVICE_TYPE_DESKTOP":
+    case 'DEVICE_TYPE_DESKTOP':
       return DeviceType.DEVICE_TYPE_DESKTOP;
     case 2:
-    case "DEVICE_TYPE_MOBILE":
+    case 'DEVICE_TYPE_MOBILE':
       return DeviceType.DEVICE_TYPE_MOBILE;
     case 3:
-    case "DEVICE_TYPE_TABLET":
+    case 'DEVICE_TYPE_TABLET':
       return DeviceType.DEVICE_TYPE_TABLET;
     case 4:
-    case "DEVICE_TYPE_UNKNOWN":
+    case 'DEVICE_TYPE_UNKNOWN':
       return DeviceType.DEVICE_TYPE_UNKNOWN;
     case -1:
-    case "UNRECOGNIZED":
+    case 'UNRECOGNIZED':
     default:
       return DeviceType.UNRECOGNIZED;
   }
@@ -114,18 +114,18 @@ export function deviceTypeFromJSON(object: any): DeviceType {
 export function deviceTypeToJSON(object: DeviceType): string {
   switch (object) {
     case DeviceType.DEVICE_TYPE_UNSPECIFIED:
-      return "DEVICE_TYPE_UNSPECIFIED";
+      return 'DEVICE_TYPE_UNSPECIFIED';
     case DeviceType.DEVICE_TYPE_DESKTOP:
-      return "DEVICE_TYPE_DESKTOP";
+      return 'DEVICE_TYPE_DESKTOP';
     case DeviceType.DEVICE_TYPE_MOBILE:
-      return "DEVICE_TYPE_MOBILE";
+      return 'DEVICE_TYPE_MOBILE';
     case DeviceType.DEVICE_TYPE_TABLET:
-      return "DEVICE_TYPE_TABLET";
+      return 'DEVICE_TYPE_TABLET';
     case DeviceType.DEVICE_TYPE_UNKNOWN:
-      return "DEVICE_TYPE_UNKNOWN";
+      return 'DEVICE_TYPE_UNKNOWN';
     case DeviceType.UNRECOGNIZED:
     default:
-      return "UNRECOGNIZED";
+      return 'UNRECOGNIZED';
   }
 }
 
@@ -167,13 +167,9 @@ export interface PetCandidate {
   age?: string | undefined;
   rescueId: string;
   /** Primary image URL the SPA renders first. */
-  primaryImageUrl?:
-    | string
-    | undefined;
+  primaryImageUrl?: string | undefined;
   /** Short description the swipe card surfaces. */
-  shortDescription?:
-    | string
-    | undefined;
+  shortDescription?: string | undefined;
   /**
    * The recommender's score for this candidate, on [0.0, 1.0].
    * Higher = better fit. SPA may render this as a heart-meter or
@@ -212,9 +208,7 @@ export interface StartSessionRequest {
 }
 
 export interface StartSessionResponse {
-  session?:
-    | SwipeSession
-    | undefined;
+  session?: SwipeSession | undefined;
   /**
    * True when this call created the session; false when an existing
    * active session was returned (idempotency signal).
@@ -268,18 +262,14 @@ export interface RecordSwipeRequest {
 }
 
 export interface RecordSwipeResponse {
-  action?:
-    | SwipeActionRecord
-    | undefined;
+  action?: SwipeActionRecord | undefined;
   /** Echo of the updated session counters for the SPA's HUD. */
   session?: SwipeSession | undefined;
 }
 
 export interface SearchPetsRequest {
   /** Free-text query (matched against pet name + description). */
-  query?:
-    | string
-    | undefined;
+  query?: string | undefined;
   /** Same JSONB filters shape as a session. */
   filtersJson?: string | undefined;
   cursor?: string | undefined;
@@ -338,8 +328,7 @@ export interface MatchProfile {
   updatedAt: string;
 }
 
-export interface GetMatchProfileRequest {
-}
+export interface GetMatchProfileRequest {}
 
 export interface GetMatchProfileResponse {
   profile?: MatchProfile | undefined;
@@ -377,6 +366,58 @@ export interface UpsertMatchProfileResponse {
   profile?: MatchProfile | undefined;
 }
 
+/**
+ * A reason chip explaining why a pick was surfaced. `kind` mirrors the
+ * SPA's ReasonChipKind vocabulary (pref_match, lifestyle, distance,
+ * similar_to_liked, fresh) as a lowercase string rather than an enum —
+ * the chip set is presentation-driven and may grow without a proto
+ * regen; `label` is the human-readable text the SPA renders verbatim.
+ */
+export interface TopPickReasonChip {
+  kind: string;
+  label: string;
+}
+
+/**
+ * TopPick is the top-picks surface's per-pet payload — a superset of
+ * PetCandidate's intent but independently shaped since top picks carries
+ * size/age_group/reasons/rescue_name that PetCandidate does not.
+ */
+export interface TopPick {
+  petId: string;
+  name: string;
+  /**
+   * Lowercase species/size/age-group tokens (same vocabulary as the
+   * filters_json the SPA sends elsewhere — e.g. 'dog', 'medium', 'adult').
+   */
+  type: string;
+  ageGroup: string;
+  size: string;
+  /** The scorer's result for this pick, on [0.0, 1.0]. */
+  score: number;
+  reasons: TopPickReasonChip[];
+  rescueName: string;
+  /**
+   * Pets has no breed NAME (only breed_id) and no photo/image field, so
+   * these stay unset until that data is available — both are optional in
+   * the SPA's MatchTopPick type for exactly this reason.
+   */
+  breedName?: string | undefined;
+  photoUrl?: string | undefined;
+}
+
+export interface GetTopPicksRequest {
+  /**
+   * Defaults to 10, max 50 — top picks is a short curated list, not a
+   * paginated feed.
+   */
+  limit: number;
+}
+
+export interface GetTopPicksResponse {
+  picks: TopPick[];
+}
+
 export interface SwipeStats {
   totalSwipes: number;
   likes: number;
@@ -407,33 +448,33 @@ export interface GetSessionStatsResponse {
 
 function createBaseSwipeSession(): SwipeSession {
   return {
-    sessionId: "",
+    sessionId: '',
     userId: undefined,
-    startTime: "",
+    startTime: '',
     endTime: undefined,
     totalSwipes: 0,
     likes: 0,
     passes: 0,
     superLikes: 0,
-    filtersJson: "",
+    filtersJson: '',
     ipAddress: undefined,
     userAgent: undefined,
     deviceType: 0,
     isActive: false,
-    createdAt: "",
-    updatedAt: "",
+    createdAt: '',
+    updatedAt: '',
   };
 }
 
 export const SwipeSession: MessageFns<SwipeSession> = {
   encode(message: SwipeSession, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    if (message.sessionId !== "") {
+    if (message.sessionId !== '') {
       writer.uint32(10).string(message.sessionId);
     }
     if (message.userId !== undefined) {
       writer.uint32(18).string(message.userId);
     }
-    if (message.startTime !== "") {
+    if (message.startTime !== '') {
       writer.uint32(26).string(message.startTime);
     }
     if (message.endTime !== undefined) {
@@ -451,7 +492,7 @@ export const SwipeSession: MessageFns<SwipeSession> = {
     if (message.superLikes !== 0) {
       writer.uint32(64).uint32(message.superLikes);
     }
-    if (message.filtersJson !== "") {
+    if (message.filtersJson !== '') {
       writer.uint32(74).string(message.filtersJson);
     }
     if (message.ipAddress !== undefined) {
@@ -466,10 +507,10 @@ export const SwipeSession: MessageFns<SwipeSession> = {
     if (message.isActive !== false) {
       writer.uint32(104).bool(message.isActive);
     }
-    if (message.createdAt !== "") {
+    if (message.createdAt !== '') {
       writer.uint32(114).string(message.createdAt);
     }
-    if (message.updatedAt !== "") {
+    if (message.updatedAt !== '') {
       writer.uint32(122).string(message.updatedAt);
     }
     return writer;
@@ -616,82 +657,82 @@ export const SwipeSession: MessageFns<SwipeSession> = {
       sessionId: isSet(object.sessionId)
         ? globalThis.String(object.sessionId)
         : isSet(object.session_id)
-        ? globalThis.String(object.session_id)
-        : "",
+          ? globalThis.String(object.session_id)
+          : '',
       userId: isSet(object.userId)
         ? globalThis.String(object.userId)
         : isSet(object.user_id)
-        ? globalThis.String(object.user_id)
-        : undefined,
+          ? globalThis.String(object.user_id)
+          : undefined,
       startTime: isSet(object.startTime)
         ? globalThis.String(object.startTime)
         : isSet(object.start_time)
-        ? globalThis.String(object.start_time)
-        : "",
+          ? globalThis.String(object.start_time)
+          : '',
       endTime: isSet(object.endTime)
         ? globalThis.String(object.endTime)
         : isSet(object.end_time)
-        ? globalThis.String(object.end_time)
-        : undefined,
+          ? globalThis.String(object.end_time)
+          : undefined,
       totalSwipes: isSet(object.totalSwipes)
         ? globalThis.Number(object.totalSwipes)
         : isSet(object.total_swipes)
-        ? globalThis.Number(object.total_swipes)
-        : 0,
+          ? globalThis.Number(object.total_swipes)
+          : 0,
       likes: isSet(object.likes) ? globalThis.Number(object.likes) : 0,
       passes: isSet(object.passes) ? globalThis.Number(object.passes) : 0,
       superLikes: isSet(object.superLikes)
         ? globalThis.Number(object.superLikes)
         : isSet(object.super_likes)
-        ? globalThis.Number(object.super_likes)
-        : 0,
+          ? globalThis.Number(object.super_likes)
+          : 0,
       filtersJson: isSet(object.filtersJson)
         ? globalThis.String(object.filtersJson)
         : isSet(object.filters_json)
-        ? globalThis.String(object.filters_json)
-        : "",
+          ? globalThis.String(object.filters_json)
+          : '',
       ipAddress: isSet(object.ipAddress)
         ? globalThis.String(object.ipAddress)
         : isSet(object.ip_address)
-        ? globalThis.String(object.ip_address)
-        : undefined,
+          ? globalThis.String(object.ip_address)
+          : undefined,
       userAgent: isSet(object.userAgent)
         ? globalThis.String(object.userAgent)
         : isSet(object.user_agent)
-        ? globalThis.String(object.user_agent)
-        : undefined,
+          ? globalThis.String(object.user_agent)
+          : undefined,
       deviceType: isSet(object.deviceType)
         ? deviceTypeFromJSON(object.deviceType)
         : isSet(object.device_type)
-        ? deviceTypeFromJSON(object.device_type)
-        : 0,
+          ? deviceTypeFromJSON(object.device_type)
+          : 0,
       isActive: isSet(object.isActive)
         ? globalThis.Boolean(object.isActive)
         : isSet(object.is_active)
-        ? globalThis.Boolean(object.is_active)
-        : false,
+          ? globalThis.Boolean(object.is_active)
+          : false,
       createdAt: isSet(object.createdAt)
         ? globalThis.String(object.createdAt)
         : isSet(object.created_at)
-        ? globalThis.String(object.created_at)
-        : "",
+          ? globalThis.String(object.created_at)
+          : '',
       updatedAt: isSet(object.updatedAt)
         ? globalThis.String(object.updatedAt)
         : isSet(object.updated_at)
-        ? globalThis.String(object.updated_at)
-        : "",
+          ? globalThis.String(object.updated_at)
+          : '',
     };
   },
 
   toJSON(message: SwipeSession): unknown {
     const obj: any = {};
-    if (message.sessionId !== "") {
+    if (message.sessionId !== '') {
       obj.sessionId = message.sessionId;
     }
     if (message.userId !== undefined) {
       obj.userId = message.userId;
     }
-    if (message.startTime !== "") {
+    if (message.startTime !== '') {
       obj.startTime = message.startTime;
     }
     if (message.endTime !== undefined) {
@@ -709,7 +750,7 @@ export const SwipeSession: MessageFns<SwipeSession> = {
     if (message.superLikes !== 0) {
       obj.superLikes = Math.round(message.superLikes);
     }
-    if (message.filtersJson !== "") {
+    if (message.filtersJson !== '') {
       obj.filtersJson = message.filtersJson;
     }
     if (message.ipAddress !== undefined) {
@@ -724,10 +765,10 @@ export const SwipeSession: MessageFns<SwipeSession> = {
     if (message.isActive !== false) {
       obj.isActive = message.isActive;
     }
-    if (message.createdAt !== "") {
+    if (message.createdAt !== '') {
       obj.createdAt = message.createdAt;
     }
-    if (message.updatedAt !== "") {
+    if (message.updatedAt !== '') {
       obj.updatedAt = message.updatedAt;
     }
     return obj;
@@ -738,33 +779,33 @@ export const SwipeSession: MessageFns<SwipeSession> = {
   },
   fromPartial<I extends Exact<DeepPartial<SwipeSession>, I>>(object: I): SwipeSession {
     const message = createBaseSwipeSession();
-    message.sessionId = object.sessionId ?? "";
+    message.sessionId = object.sessionId ?? '';
     message.userId = object.userId ?? undefined;
-    message.startTime = object.startTime ?? "";
+    message.startTime = object.startTime ?? '';
     message.endTime = object.endTime ?? undefined;
     message.totalSwipes = object.totalSwipes ?? 0;
     message.likes = object.likes ?? 0;
     message.passes = object.passes ?? 0;
     message.superLikes = object.superLikes ?? 0;
-    message.filtersJson = object.filtersJson ?? "";
+    message.filtersJson = object.filtersJson ?? '';
     message.ipAddress = object.ipAddress ?? undefined;
     message.userAgent = object.userAgent ?? undefined;
     message.deviceType = object.deviceType ?? 0;
     message.isActive = object.isActive ?? false;
-    message.createdAt = object.createdAt ?? "";
-    message.updatedAt = object.updatedAt ?? "";
+    message.createdAt = object.createdAt ?? '';
+    message.updatedAt = object.updatedAt ?? '';
     return message;
   },
 };
 
 function createBasePetCandidate(): PetCandidate {
   return {
-    petId: "",
-    name: "",
-    species: "",
+    petId: '',
+    name: '',
+    species: '',
     breed: undefined,
     age: undefined,
-    rescueId: "",
+    rescueId: '',
     primaryImageUrl: undefined,
     shortDescription: undefined,
     score: 0,
@@ -773,13 +814,13 @@ function createBasePetCandidate(): PetCandidate {
 
 export const PetCandidate: MessageFns<PetCandidate> = {
   encode(message: PetCandidate, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    if (message.petId !== "") {
+    if (message.petId !== '') {
       writer.uint32(10).string(message.petId);
     }
-    if (message.name !== "") {
+    if (message.name !== '') {
       writer.uint32(18).string(message.name);
     }
-    if (message.species !== "") {
+    if (message.species !== '') {
       writer.uint32(26).string(message.species);
     }
     if (message.breed !== undefined) {
@@ -788,7 +829,7 @@ export const PetCandidate: MessageFns<PetCandidate> = {
     if (message.age !== undefined) {
       writer.uint32(42).string(message.age);
     }
-    if (message.rescueId !== "") {
+    if (message.rescueId !== '') {
       writer.uint32(50).string(message.rescueId);
     }
     if (message.primaryImageUrl !== undefined) {
@@ -896,40 +937,40 @@ export const PetCandidate: MessageFns<PetCandidate> = {
       petId: isSet(object.petId)
         ? globalThis.String(object.petId)
         : isSet(object.pet_id)
-        ? globalThis.String(object.pet_id)
-        : "",
-      name: isSet(object.name) ? globalThis.String(object.name) : "",
-      species: isSet(object.species) ? globalThis.String(object.species) : "",
+          ? globalThis.String(object.pet_id)
+          : '',
+      name: isSet(object.name) ? globalThis.String(object.name) : '',
+      species: isSet(object.species) ? globalThis.String(object.species) : '',
       breed: isSet(object.breed) ? globalThis.String(object.breed) : undefined,
       age: isSet(object.age) ? globalThis.String(object.age) : undefined,
       rescueId: isSet(object.rescueId)
         ? globalThis.String(object.rescueId)
         : isSet(object.rescue_id)
-        ? globalThis.String(object.rescue_id)
-        : "",
+          ? globalThis.String(object.rescue_id)
+          : '',
       primaryImageUrl: isSet(object.primaryImageUrl)
         ? globalThis.String(object.primaryImageUrl)
         : isSet(object.primary_image_url)
-        ? globalThis.String(object.primary_image_url)
-        : undefined,
+          ? globalThis.String(object.primary_image_url)
+          : undefined,
       shortDescription: isSet(object.shortDescription)
         ? globalThis.String(object.shortDescription)
         : isSet(object.short_description)
-        ? globalThis.String(object.short_description)
-        : undefined,
+          ? globalThis.String(object.short_description)
+          : undefined,
       score: isSet(object.score) ? globalThis.Number(object.score) : 0,
     };
   },
 
   toJSON(message: PetCandidate): unknown {
     const obj: any = {};
-    if (message.petId !== "") {
+    if (message.petId !== '') {
       obj.petId = message.petId;
     }
-    if (message.name !== "") {
+    if (message.name !== '') {
       obj.name = message.name;
     }
-    if (message.species !== "") {
+    if (message.species !== '') {
       obj.species = message.species;
     }
     if (message.breed !== undefined) {
@@ -938,7 +979,7 @@ export const PetCandidate: MessageFns<PetCandidate> = {
     if (message.age !== undefined) {
       obj.age = message.age;
     }
-    if (message.rescueId !== "") {
+    if (message.rescueId !== '') {
       obj.rescueId = message.rescueId;
     }
     if (message.primaryImageUrl !== undefined) {
@@ -958,12 +999,12 @@ export const PetCandidate: MessageFns<PetCandidate> = {
   },
   fromPartial<I extends Exact<DeepPartial<PetCandidate>, I>>(object: I): PetCandidate {
     const message = createBasePetCandidate();
-    message.petId = object.petId ?? "";
-    message.name = object.name ?? "";
-    message.species = object.species ?? "";
+    message.petId = object.petId ?? '';
+    message.name = object.name ?? '';
+    message.species = object.species ?? '';
     message.breed = object.breed ?? undefined;
     message.age = object.age ?? undefined;
-    message.rescueId = object.rescueId ?? "";
+    message.rescueId = object.rescueId ?? '';
     message.primaryImageUrl = object.primaryImageUrl ?? undefined;
     message.shortDescription = object.shortDescription ?? undefined;
     message.score = object.score ?? 0;
@@ -973,12 +1014,12 @@ export const PetCandidate: MessageFns<PetCandidate> = {
 
 function createBaseSwipeActionRecord(): SwipeActionRecord {
   return {
-    swipeActionId: "",
-    sessionId: "",
-    petId: "",
+    swipeActionId: '',
+    sessionId: '',
+    petId: '',
     userId: undefined,
     action: 0,
-    timestamp: "",
+    timestamp: '',
     responseTime: undefined,
     deviceType: undefined,
   };
@@ -986,13 +1027,13 @@ function createBaseSwipeActionRecord(): SwipeActionRecord {
 
 export const SwipeActionRecord: MessageFns<SwipeActionRecord> = {
   encode(message: SwipeActionRecord, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    if (message.swipeActionId !== "") {
+    if (message.swipeActionId !== '') {
       writer.uint32(10).string(message.swipeActionId);
     }
-    if (message.sessionId !== "") {
+    if (message.sessionId !== '') {
       writer.uint32(18).string(message.sessionId);
     }
-    if (message.petId !== "") {
+    if (message.petId !== '') {
       writer.uint32(26).string(message.petId);
     }
     if (message.userId !== undefined) {
@@ -1001,7 +1042,7 @@ export const SwipeActionRecord: MessageFns<SwipeActionRecord> = {
     if (message.action !== 0) {
       writer.uint32(40).int32(message.action);
     }
-    if (message.timestamp !== "") {
+    if (message.timestamp !== '') {
       writer.uint32(50).string(message.timestamp);
     }
     if (message.responseTime !== undefined) {
@@ -1098,47 +1139,47 @@ export const SwipeActionRecord: MessageFns<SwipeActionRecord> = {
       swipeActionId: isSet(object.swipeActionId)
         ? globalThis.String(object.swipeActionId)
         : isSet(object.swipe_action_id)
-        ? globalThis.String(object.swipe_action_id)
-        : "",
+          ? globalThis.String(object.swipe_action_id)
+          : '',
       sessionId: isSet(object.sessionId)
         ? globalThis.String(object.sessionId)
         : isSet(object.session_id)
-        ? globalThis.String(object.session_id)
-        : "",
+          ? globalThis.String(object.session_id)
+          : '',
       petId: isSet(object.petId)
         ? globalThis.String(object.petId)
         : isSet(object.pet_id)
-        ? globalThis.String(object.pet_id)
-        : "",
+          ? globalThis.String(object.pet_id)
+          : '',
       userId: isSet(object.userId)
         ? globalThis.String(object.userId)
         : isSet(object.user_id)
-        ? globalThis.String(object.user_id)
-        : undefined,
+          ? globalThis.String(object.user_id)
+          : undefined,
       action: isSet(object.action) ? swipeActionFromJSON(object.action) : 0,
-      timestamp: isSet(object.timestamp) ? globalThis.String(object.timestamp) : "",
+      timestamp: isSet(object.timestamp) ? globalThis.String(object.timestamp) : '',
       responseTime: isSet(object.responseTime)
         ? globalThis.Number(object.responseTime)
         : isSet(object.response_time)
-        ? globalThis.Number(object.response_time)
-        : undefined,
+          ? globalThis.Number(object.response_time)
+          : undefined,
       deviceType: isSet(object.deviceType)
         ? globalThis.String(object.deviceType)
         : isSet(object.device_type)
-        ? globalThis.String(object.device_type)
-        : undefined,
+          ? globalThis.String(object.device_type)
+          : undefined,
     };
   },
 
   toJSON(message: SwipeActionRecord): unknown {
     const obj: any = {};
-    if (message.swipeActionId !== "") {
+    if (message.swipeActionId !== '') {
       obj.swipeActionId = message.swipeActionId;
     }
-    if (message.sessionId !== "") {
+    if (message.sessionId !== '') {
       obj.sessionId = message.sessionId;
     }
-    if (message.petId !== "") {
+    if (message.petId !== '') {
       obj.petId = message.petId;
     }
     if (message.userId !== undefined) {
@@ -1147,7 +1188,7 @@ export const SwipeActionRecord: MessageFns<SwipeActionRecord> = {
     if (message.action !== 0) {
       obj.action = swipeActionToJSON(message.action);
     }
-    if (message.timestamp !== "") {
+    if (message.timestamp !== '') {
       obj.timestamp = message.timestamp;
     }
     if (message.responseTime !== undefined) {
@@ -1164,12 +1205,12 @@ export const SwipeActionRecord: MessageFns<SwipeActionRecord> = {
   },
   fromPartial<I extends Exact<DeepPartial<SwipeActionRecord>, I>>(object: I): SwipeActionRecord {
     const message = createBaseSwipeActionRecord();
-    message.swipeActionId = object.swipeActionId ?? "";
-    message.sessionId = object.sessionId ?? "";
-    message.petId = object.petId ?? "";
+    message.swipeActionId = object.swipeActionId ?? '';
+    message.sessionId = object.sessionId ?? '';
+    message.petId = object.petId ?? '';
     message.userId = object.userId ?? undefined;
     message.action = object.action ?? 0;
-    message.timestamp = object.timestamp ?? "";
+    message.timestamp = object.timestamp ?? '';
     message.responseTime = object.responseTime ?? undefined;
     message.deviceType = object.deviceType ?? undefined;
     return message;
@@ -1250,23 +1291,23 @@ export const StartSessionRequest: MessageFns<StartSessionRequest> = {
       filtersJson: isSet(object.filtersJson)
         ? globalThis.String(object.filtersJson)
         : isSet(object.filters_json)
-        ? globalThis.String(object.filters_json)
-        : undefined,
+          ? globalThis.String(object.filters_json)
+          : undefined,
       deviceType: isSet(object.deviceType)
         ? deviceTypeFromJSON(object.deviceType)
         : isSet(object.device_type)
-        ? deviceTypeFromJSON(object.device_type)
-        : 0,
+          ? deviceTypeFromJSON(object.device_type)
+          : 0,
       userAgent: isSet(object.userAgent)
         ? globalThis.String(object.userAgent)
         : isSet(object.user_agent)
-        ? globalThis.String(object.user_agent)
-        : undefined,
+          ? globalThis.String(object.user_agent)
+          : undefined,
       ipAddress: isSet(object.ipAddress)
         ? globalThis.String(object.ipAddress)
         : isSet(object.ip_address)
-        ? globalThis.String(object.ip_address)
-        : undefined,
+          ? globalThis.String(object.ip_address)
+          : undefined,
     };
   },
 
@@ -1290,7 +1331,9 @@ export const StartSessionRequest: MessageFns<StartSessionRequest> = {
   create<I extends Exact<DeepPartial<StartSessionRequest>, I>>(base?: I): StartSessionRequest {
     return StartSessionRequest.fromPartial(base ?? ({} as any));
   },
-  fromPartial<I extends Exact<DeepPartial<StartSessionRequest>, I>>(object: I): StartSessionRequest {
+  fromPartial<I extends Exact<DeepPartial<StartSessionRequest>, I>>(
+    object: I
+  ): StartSessionRequest {
     const message = createBaseStartSessionRequest();
     message.filtersJson = object.filtersJson ?? undefined;
     message.deviceType = object.deviceType ?? 0;
@@ -1368,23 +1411,26 @@ export const StartSessionResponse: MessageFns<StartSessionResponse> = {
   create<I extends Exact<DeepPartial<StartSessionResponse>, I>>(base?: I): StartSessionResponse {
     return StartSessionResponse.fromPartial(base ?? ({} as any));
   },
-  fromPartial<I extends Exact<DeepPartial<StartSessionResponse>, I>>(object: I): StartSessionResponse {
+  fromPartial<I extends Exact<DeepPartial<StartSessionResponse>, I>>(
+    object: I
+  ): StartSessionResponse {
     const message = createBaseStartSessionResponse();
-    message.session = (object.session !== undefined && object.session !== null)
-      ? SwipeSession.fromPartial(object.session)
-      : undefined;
+    message.session =
+      object.session !== undefined && object.session !== null
+        ? SwipeSession.fromPartial(object.session)
+        : undefined;
     message.created = object.created ?? false;
     return message;
   },
 };
 
 function createBaseEndSessionRequest(): EndSessionRequest {
-  return { sessionId: "" };
+  return { sessionId: '' };
 }
 
 export const EndSessionRequest: MessageFns<EndSessionRequest> = {
   encode(message: EndSessionRequest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    if (message.sessionId !== "") {
+    if (message.sessionId !== '') {
       writer.uint32(10).string(message.sessionId);
     }
     return writer;
@@ -1419,14 +1465,14 @@ export const EndSessionRequest: MessageFns<EndSessionRequest> = {
       sessionId: isSet(object.sessionId)
         ? globalThis.String(object.sessionId)
         : isSet(object.session_id)
-        ? globalThis.String(object.session_id)
-        : "",
+          ? globalThis.String(object.session_id)
+          : '',
     };
   },
 
   toJSON(message: EndSessionRequest): unknown {
     const obj: any = {};
-    if (message.sessionId !== "") {
+    if (message.sessionId !== '') {
       obj.sessionId = message.sessionId;
     }
     return obj;
@@ -1437,7 +1483,7 @@ export const EndSessionRequest: MessageFns<EndSessionRequest> = {
   },
   fromPartial<I extends Exact<DeepPartial<EndSessionRequest>, I>>(object: I): EndSessionRequest {
     const message = createBaseEndSessionRequest();
-    message.sessionId = object.sessionId ?? "";
+    message.sessionId = object.sessionId ?? '';
     return message;
   },
 };
@@ -1495,20 +1541,21 @@ export const EndSessionResponse: MessageFns<EndSessionResponse> = {
   },
   fromPartial<I extends Exact<DeepPartial<EndSessionResponse>, I>>(object: I): EndSessionResponse {
     const message = createBaseEndSessionResponse();
-    message.session = (object.session !== undefined && object.session !== null)
-      ? SwipeSession.fromPartial(object.session)
-      : undefined;
+    message.session =
+      object.session !== undefined && object.session !== null
+        ? SwipeSession.fromPartial(object.session)
+        : undefined;
     return message;
   },
 };
 
 function createBaseRecommendRequest(): RecommendRequest {
-  return { sessionId: "", limit: 0, filtersJsonOverride: undefined };
+  return { sessionId: '', limit: 0, filtersJsonOverride: undefined };
 }
 
 export const RecommendRequest: MessageFns<RecommendRequest> = {
   encode(message: RecommendRequest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    if (message.sessionId !== "") {
+    if (message.sessionId !== '') {
       writer.uint32(10).string(message.sessionId);
     }
     if (message.limit !== 0) {
@@ -1565,20 +1612,20 @@ export const RecommendRequest: MessageFns<RecommendRequest> = {
       sessionId: isSet(object.sessionId)
         ? globalThis.String(object.sessionId)
         : isSet(object.session_id)
-        ? globalThis.String(object.session_id)
-        : "",
+          ? globalThis.String(object.session_id)
+          : '',
       limit: isSet(object.limit) ? globalThis.Number(object.limit) : 0,
       filtersJsonOverride: isSet(object.filtersJsonOverride)
         ? globalThis.String(object.filtersJsonOverride)
         : isSet(object.filters_json_override)
-        ? globalThis.String(object.filters_json_override)
-        : undefined,
+          ? globalThis.String(object.filters_json_override)
+          : undefined,
     };
   },
 
   toJSON(message: RecommendRequest): unknown {
     const obj: any = {};
-    if (message.sessionId !== "") {
+    if (message.sessionId !== '') {
       obj.sessionId = message.sessionId;
     }
     if (message.limit !== 0) {
@@ -1595,7 +1642,7 @@ export const RecommendRequest: MessageFns<RecommendRequest> = {
   },
   fromPartial<I extends Exact<DeepPartial<RecommendRequest>, I>>(object: I): RecommendRequest {
     const message = createBaseRecommendRequest();
-    message.sessionId = object.sessionId ?? "";
+    message.sessionId = object.sessionId ?? '';
     message.limit = object.limit ?? 0;
     message.filtersJsonOverride = object.filtersJsonOverride ?? undefined;
     return message;
@@ -1661,7 +1708,7 @@ export const RecommendResponse: MessageFns<RecommendResponse> = {
   toJSON(message: RecommendResponse): unknown {
     const obj: any = {};
     if (message.candidates?.length) {
-      obj.candidates = message.candidates.map((e) => PetCandidate.toJSON(e));
+      obj.candidates = message.candidates.map(e => PetCandidate.toJSON(e));
     }
     if (message.exhausted !== false) {
       obj.exhausted = message.exhausted;
@@ -1674,22 +1721,22 @@ export const RecommendResponse: MessageFns<RecommendResponse> = {
   },
   fromPartial<I extends Exact<DeepPartial<RecommendResponse>, I>>(object: I): RecommendResponse {
     const message = createBaseRecommendResponse();
-    message.candidates = object.candidates?.map((e) => PetCandidate.fromPartial(e)) || [];
+    message.candidates = object.candidates?.map(e => PetCandidate.fromPartial(e)) || [];
     message.exhausted = object.exhausted ?? false;
     return message;
   },
 };
 
 function createBaseRecordSwipeRequest(): RecordSwipeRequest {
-  return { sessionId: "", petId: "", action: 0, responseTime: undefined, deviceType: undefined };
+  return { sessionId: '', petId: '', action: 0, responseTime: undefined, deviceType: undefined };
 }
 
 export const RecordSwipeRequest: MessageFns<RecordSwipeRequest> = {
   encode(message: RecordSwipeRequest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    if (message.sessionId !== "") {
+    if (message.sessionId !== '') {
       writer.uint32(10).string(message.sessionId);
     }
-    if (message.petId !== "") {
+    if (message.petId !== '') {
       writer.uint32(18).string(message.petId);
     }
     if (message.action !== 0) {
@@ -1765,33 +1812,33 @@ export const RecordSwipeRequest: MessageFns<RecordSwipeRequest> = {
       sessionId: isSet(object.sessionId)
         ? globalThis.String(object.sessionId)
         : isSet(object.session_id)
-        ? globalThis.String(object.session_id)
-        : "",
+          ? globalThis.String(object.session_id)
+          : '',
       petId: isSet(object.petId)
         ? globalThis.String(object.petId)
         : isSet(object.pet_id)
-        ? globalThis.String(object.pet_id)
-        : "",
+          ? globalThis.String(object.pet_id)
+          : '',
       action: isSet(object.action) ? swipeActionFromJSON(object.action) : 0,
       responseTime: isSet(object.responseTime)
         ? globalThis.Number(object.responseTime)
         : isSet(object.response_time)
-        ? globalThis.Number(object.response_time)
-        : undefined,
+          ? globalThis.Number(object.response_time)
+          : undefined,
       deviceType: isSet(object.deviceType)
         ? globalThis.String(object.deviceType)
         : isSet(object.device_type)
-        ? globalThis.String(object.device_type)
-        : undefined,
+          ? globalThis.String(object.device_type)
+          : undefined,
     };
   },
 
   toJSON(message: RecordSwipeRequest): unknown {
     const obj: any = {};
-    if (message.sessionId !== "") {
+    if (message.sessionId !== '') {
       obj.sessionId = message.sessionId;
     }
-    if (message.petId !== "") {
+    if (message.petId !== '') {
       obj.petId = message.petId;
     }
     if (message.action !== 0) {
@@ -1811,8 +1858,8 @@ export const RecordSwipeRequest: MessageFns<RecordSwipeRequest> = {
   },
   fromPartial<I extends Exact<DeepPartial<RecordSwipeRequest>, I>>(object: I): RecordSwipeRequest {
     const message = createBaseRecordSwipeRequest();
-    message.sessionId = object.sessionId ?? "";
-    message.petId = object.petId ?? "";
+    message.sessionId = object.sessionId ?? '';
+    message.petId = object.petId ?? '';
     message.action = object.action ?? 0;
     message.responseTime = object.responseTime ?? undefined;
     message.deviceType = object.deviceType ?? undefined;
@@ -1888,14 +1935,18 @@ export const RecordSwipeResponse: MessageFns<RecordSwipeResponse> = {
   create<I extends Exact<DeepPartial<RecordSwipeResponse>, I>>(base?: I): RecordSwipeResponse {
     return RecordSwipeResponse.fromPartial(base ?? ({} as any));
   },
-  fromPartial<I extends Exact<DeepPartial<RecordSwipeResponse>, I>>(object: I): RecordSwipeResponse {
+  fromPartial<I extends Exact<DeepPartial<RecordSwipeResponse>, I>>(
+    object: I
+  ): RecordSwipeResponse {
     const message = createBaseRecordSwipeResponse();
-    message.action = (object.action !== undefined && object.action !== null)
-      ? SwipeActionRecord.fromPartial(object.action)
-      : undefined;
-    message.session = (object.session !== undefined && object.session !== null)
-      ? SwipeSession.fromPartial(object.session)
-      : undefined;
+    message.action =
+      object.action !== undefined && object.action !== null
+        ? SwipeActionRecord.fromPartial(object.action)
+        : undefined;
+    message.session =
+      object.session !== undefined && object.session !== null
+        ? SwipeSession.fromPartial(object.session)
+        : undefined;
     return message;
   },
 };
@@ -1975,8 +2026,8 @@ export const SearchPetsRequest: MessageFns<SearchPetsRequest> = {
       filtersJson: isSet(object.filtersJson)
         ? globalThis.String(object.filtersJson)
         : isSet(object.filters_json)
-        ? globalThis.String(object.filters_json)
-        : undefined,
+          ? globalThis.String(object.filters_json)
+          : undefined,
       cursor: isSet(object.cursor) ? globalThis.String(object.cursor) : undefined,
       limit: isSet(object.limit) ? globalThis.Number(object.limit) : 0,
     };
@@ -2067,15 +2118,15 @@ export const SearchPetsResponse: MessageFns<SearchPetsResponse> = {
       nextCursor: isSet(object.nextCursor)
         ? globalThis.String(object.nextCursor)
         : isSet(object.next_cursor)
-        ? globalThis.String(object.next_cursor)
-        : undefined,
+          ? globalThis.String(object.next_cursor)
+          : undefined,
     };
   },
 
   toJSON(message: SearchPetsResponse): unknown {
     const obj: any = {};
     if (message.results?.length) {
-      obj.results = message.results.map((e) => PetCandidate.toJSON(e));
+      obj.results = message.results.map(e => PetCandidate.toJSON(e));
     }
     if (message.nextCursor !== undefined) {
       obj.nextCursor = message.nextCursor;
@@ -2088,7 +2139,7 @@ export const SearchPetsResponse: MessageFns<SearchPetsResponse> = {
   },
   fromPartial<I extends Exact<DeepPartial<SearchPetsResponse>, I>>(object: I): SearchPetsResponse {
     const message = createBaseSearchPetsResponse();
-    message.results = object.results?.map((e) => PetCandidate.fromPartial(e)) || [];
+    message.results = object.results?.map(e => PetCandidate.fromPartial(e)) || [];
     message.nextCursor = object.nextCursor ?? undefined;
     return message;
   },
@@ -2099,7 +2150,10 @@ function createBaseListSwipeHistoryRequest(): ListSwipeHistoryRequest {
 }
 
 export const ListSwipeHistoryRequest: MessageFns<ListSwipeHistoryRequest> = {
-  encode(message: ListSwipeHistoryRequest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+  encode(
+    message: ListSwipeHistoryRequest,
+    writer: BinaryWriter = new BinaryWriter()
+  ): BinaryWriter {
     if (message.actionFilter !== undefined) {
       writer.uint32(8).int32(message.actionFilter);
     }
@@ -2157,8 +2211,8 @@ export const ListSwipeHistoryRequest: MessageFns<ListSwipeHistoryRequest> = {
       actionFilter: isSet(object.actionFilter)
         ? swipeActionFromJSON(object.actionFilter)
         : isSet(object.action_filter)
-        ? swipeActionFromJSON(object.action_filter)
-        : undefined,
+          ? swipeActionFromJSON(object.action_filter)
+          : undefined,
       cursor: isSet(object.cursor) ? globalThis.String(object.cursor) : undefined,
       limit: isSet(object.limit) ? globalThis.Number(object.limit) : 0,
     };
@@ -2178,10 +2232,14 @@ export const ListSwipeHistoryRequest: MessageFns<ListSwipeHistoryRequest> = {
     return obj;
   },
 
-  create<I extends Exact<DeepPartial<ListSwipeHistoryRequest>, I>>(base?: I): ListSwipeHistoryRequest {
+  create<I extends Exact<DeepPartial<ListSwipeHistoryRequest>, I>>(
+    base?: I
+  ): ListSwipeHistoryRequest {
     return ListSwipeHistoryRequest.fromPartial(base ?? ({} as any));
   },
-  fromPartial<I extends Exact<DeepPartial<ListSwipeHistoryRequest>, I>>(object: I): ListSwipeHistoryRequest {
+  fromPartial<I extends Exact<DeepPartial<ListSwipeHistoryRequest>, I>>(
+    object: I
+  ): ListSwipeHistoryRequest {
     const message = createBaseListSwipeHistoryRequest();
     message.actionFilter = object.actionFilter ?? undefined;
     message.cursor = object.cursor ?? undefined;
@@ -2195,7 +2253,10 @@ function createBaseListSwipeHistoryResponse(): ListSwipeHistoryResponse {
 }
 
 export const ListSwipeHistoryResponse: MessageFns<ListSwipeHistoryResponse> = {
-  encode(message: ListSwipeHistoryResponse, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+  encode(
+    message: ListSwipeHistoryResponse,
+    writer: BinaryWriter = new BinaryWriter()
+  ): BinaryWriter {
     for (const v of message.actions) {
       SwipeActionRecord.encode(v!, writer.uint32(10).fork()).join();
     }
@@ -2245,15 +2306,15 @@ export const ListSwipeHistoryResponse: MessageFns<ListSwipeHistoryResponse> = {
       nextCursor: isSet(object.nextCursor)
         ? globalThis.String(object.nextCursor)
         : isSet(object.next_cursor)
-        ? globalThis.String(object.next_cursor)
-        : undefined,
+          ? globalThis.String(object.next_cursor)
+          : undefined,
     };
   },
 
   toJSON(message: ListSwipeHistoryResponse): unknown {
     const obj: any = {};
     if (message.actions?.length) {
-      obj.actions = message.actions.map((e) => SwipeActionRecord.toJSON(e));
+      obj.actions = message.actions.map(e => SwipeActionRecord.toJSON(e));
     }
     if (message.nextCursor !== undefined) {
       obj.nextCursor = message.nextCursor;
@@ -2261,12 +2322,16 @@ export const ListSwipeHistoryResponse: MessageFns<ListSwipeHistoryResponse> = {
     return obj;
   },
 
-  create<I extends Exact<DeepPartial<ListSwipeHistoryResponse>, I>>(base?: I): ListSwipeHistoryResponse {
+  create<I extends Exact<DeepPartial<ListSwipeHistoryResponse>, I>>(
+    base?: I
+  ): ListSwipeHistoryResponse {
     return ListSwipeHistoryResponse.fromPartial(base ?? ({} as any));
   },
-  fromPartial<I extends Exact<DeepPartial<ListSwipeHistoryResponse>, I>>(object: I): ListSwipeHistoryResponse {
+  fromPartial<I extends Exact<DeepPartial<ListSwipeHistoryResponse>, I>>(
+    object: I
+  ): ListSwipeHistoryResponse {
     const message = createBaseListSwipeHistoryResponse();
-    message.actions = object.actions?.map((e) => SwipeActionRecord.fromPartial(e)) || [];
+    message.actions = object.actions?.map(e => SwipeActionRecord.fromPartial(e)) || [];
     message.nextCursor = object.nextCursor ?? undefined;
     return message;
   },
@@ -2274,47 +2339,47 @@ export const ListSwipeHistoryResponse: MessageFns<ListSwipeHistoryResponse> = {
 
 function createBaseMatchProfile(): MatchProfile {
   return {
-    userId: "",
-    preferredTypesJson: "",
-    preferredSizesJson: "",
-    preferredAgeGroupsJson: "",
-    preferredEnergyJson: "",
-    preferredTemperamentJson: "",
-    lifestyleJson: "",
+    userId: '',
+    preferredTypesJson: '',
+    preferredSizesJson: '',
+    preferredAgeGroupsJson: '',
+    preferredEnergyJson: '',
+    preferredTemperamentJson: '',
+    lifestyleJson: '',
     maxDistanceKm: undefined,
     openToSpecialNeeds: false,
     notifyNewMatches: false,
     minNotificationScore: 0,
     lastNotifiedAt: undefined,
-    inferredPrefsJson: "",
+    inferredPrefsJson: '',
     prefsUpdatedAt: undefined,
     allergies: undefined,
-    createdAt: "",
-    updatedAt: "",
+    createdAt: '',
+    updatedAt: '',
   };
 }
 
 export const MatchProfile: MessageFns<MatchProfile> = {
   encode(message: MatchProfile, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    if (message.userId !== "") {
+    if (message.userId !== '') {
       writer.uint32(10).string(message.userId);
     }
-    if (message.preferredTypesJson !== "") {
+    if (message.preferredTypesJson !== '') {
       writer.uint32(18).string(message.preferredTypesJson);
     }
-    if (message.preferredSizesJson !== "") {
+    if (message.preferredSizesJson !== '') {
       writer.uint32(26).string(message.preferredSizesJson);
     }
-    if (message.preferredAgeGroupsJson !== "") {
+    if (message.preferredAgeGroupsJson !== '') {
       writer.uint32(34).string(message.preferredAgeGroupsJson);
     }
-    if (message.preferredEnergyJson !== "") {
+    if (message.preferredEnergyJson !== '') {
       writer.uint32(42).string(message.preferredEnergyJson);
     }
-    if (message.preferredTemperamentJson !== "") {
+    if (message.preferredTemperamentJson !== '') {
       writer.uint32(50).string(message.preferredTemperamentJson);
     }
-    if (message.lifestyleJson !== "") {
+    if (message.lifestyleJson !== '') {
       writer.uint32(58).string(message.lifestyleJson);
     }
     if (message.maxDistanceKm !== undefined) {
@@ -2332,7 +2397,7 @@ export const MatchProfile: MessageFns<MatchProfile> = {
     if (message.lastNotifiedAt !== undefined) {
       writer.uint32(98).string(message.lastNotifiedAt);
     }
-    if (message.inferredPrefsJson !== "") {
+    if (message.inferredPrefsJson !== '') {
       writer.uint32(106).string(message.inferredPrefsJson);
     }
     if (message.prefsUpdatedAt !== undefined) {
@@ -2341,10 +2406,10 @@ export const MatchProfile: MessageFns<MatchProfile> = {
     if (message.allergies !== undefined) {
       writer.uint32(122).string(message.allergies);
     }
-    if (message.createdAt !== "") {
+    if (message.createdAt !== '') {
       writer.uint32(130).string(message.createdAt);
     }
-    if (message.updatedAt !== "") {
+    if (message.updatedAt !== '') {
       writer.uint32(138).string(message.updatedAt);
     }
     return writer;
@@ -2507,108 +2572,108 @@ export const MatchProfile: MessageFns<MatchProfile> = {
       userId: isSet(object.userId)
         ? globalThis.String(object.userId)
         : isSet(object.user_id)
-        ? globalThis.String(object.user_id)
-        : "",
+          ? globalThis.String(object.user_id)
+          : '',
       preferredTypesJson: isSet(object.preferredTypesJson)
         ? globalThis.String(object.preferredTypesJson)
         : isSet(object.preferred_types_json)
-        ? globalThis.String(object.preferred_types_json)
-        : "",
+          ? globalThis.String(object.preferred_types_json)
+          : '',
       preferredSizesJson: isSet(object.preferredSizesJson)
         ? globalThis.String(object.preferredSizesJson)
         : isSet(object.preferred_sizes_json)
-        ? globalThis.String(object.preferred_sizes_json)
-        : "",
+          ? globalThis.String(object.preferred_sizes_json)
+          : '',
       preferredAgeGroupsJson: isSet(object.preferredAgeGroupsJson)
         ? globalThis.String(object.preferredAgeGroupsJson)
         : isSet(object.preferred_age_groups_json)
-        ? globalThis.String(object.preferred_age_groups_json)
-        : "",
+          ? globalThis.String(object.preferred_age_groups_json)
+          : '',
       preferredEnergyJson: isSet(object.preferredEnergyJson)
         ? globalThis.String(object.preferredEnergyJson)
         : isSet(object.preferred_energy_json)
-        ? globalThis.String(object.preferred_energy_json)
-        : "",
+          ? globalThis.String(object.preferred_energy_json)
+          : '',
       preferredTemperamentJson: isSet(object.preferredTemperamentJson)
         ? globalThis.String(object.preferredTemperamentJson)
         : isSet(object.preferred_temperament_json)
-        ? globalThis.String(object.preferred_temperament_json)
-        : "",
+          ? globalThis.String(object.preferred_temperament_json)
+          : '',
       lifestyleJson: isSet(object.lifestyleJson)
         ? globalThis.String(object.lifestyleJson)
         : isSet(object.lifestyle_json)
-        ? globalThis.String(object.lifestyle_json)
-        : "",
+          ? globalThis.String(object.lifestyle_json)
+          : '',
       maxDistanceKm: isSet(object.maxDistanceKm)
         ? globalThis.Number(object.maxDistanceKm)
         : isSet(object.max_distance_km)
-        ? globalThis.Number(object.max_distance_km)
-        : undefined,
+          ? globalThis.Number(object.max_distance_km)
+          : undefined,
       openToSpecialNeeds: isSet(object.openToSpecialNeeds)
         ? globalThis.Boolean(object.openToSpecialNeeds)
         : isSet(object.open_to_special_needs)
-        ? globalThis.Boolean(object.open_to_special_needs)
-        : false,
+          ? globalThis.Boolean(object.open_to_special_needs)
+          : false,
       notifyNewMatches: isSet(object.notifyNewMatches)
         ? globalThis.Boolean(object.notifyNewMatches)
         : isSet(object.notify_new_matches)
-        ? globalThis.Boolean(object.notify_new_matches)
-        : false,
+          ? globalThis.Boolean(object.notify_new_matches)
+          : false,
       minNotificationScore: isSet(object.minNotificationScore)
         ? globalThis.Number(object.minNotificationScore)
         : isSet(object.min_notification_score)
-        ? globalThis.Number(object.min_notification_score)
-        : 0,
+          ? globalThis.Number(object.min_notification_score)
+          : 0,
       lastNotifiedAt: isSet(object.lastNotifiedAt)
         ? globalThis.String(object.lastNotifiedAt)
         : isSet(object.last_notified_at)
-        ? globalThis.String(object.last_notified_at)
-        : undefined,
+          ? globalThis.String(object.last_notified_at)
+          : undefined,
       inferredPrefsJson: isSet(object.inferredPrefsJson)
         ? globalThis.String(object.inferredPrefsJson)
         : isSet(object.inferred_prefs_json)
-        ? globalThis.String(object.inferred_prefs_json)
-        : "",
+          ? globalThis.String(object.inferred_prefs_json)
+          : '',
       prefsUpdatedAt: isSet(object.prefsUpdatedAt)
         ? globalThis.String(object.prefsUpdatedAt)
         : isSet(object.prefs_updated_at)
-        ? globalThis.String(object.prefs_updated_at)
-        : undefined,
+          ? globalThis.String(object.prefs_updated_at)
+          : undefined,
       allergies: isSet(object.allergies) ? globalThis.String(object.allergies) : undefined,
       createdAt: isSet(object.createdAt)
         ? globalThis.String(object.createdAt)
         : isSet(object.created_at)
-        ? globalThis.String(object.created_at)
-        : "",
+          ? globalThis.String(object.created_at)
+          : '',
       updatedAt: isSet(object.updatedAt)
         ? globalThis.String(object.updatedAt)
         : isSet(object.updated_at)
-        ? globalThis.String(object.updated_at)
-        : "",
+          ? globalThis.String(object.updated_at)
+          : '',
     };
   },
 
   toJSON(message: MatchProfile): unknown {
     const obj: any = {};
-    if (message.userId !== "") {
+    if (message.userId !== '') {
       obj.userId = message.userId;
     }
-    if (message.preferredTypesJson !== "") {
+    if (message.preferredTypesJson !== '') {
       obj.preferredTypesJson = message.preferredTypesJson;
     }
-    if (message.preferredSizesJson !== "") {
+    if (message.preferredSizesJson !== '') {
       obj.preferredSizesJson = message.preferredSizesJson;
     }
-    if (message.preferredAgeGroupsJson !== "") {
+    if (message.preferredAgeGroupsJson !== '') {
       obj.preferredAgeGroupsJson = message.preferredAgeGroupsJson;
     }
-    if (message.preferredEnergyJson !== "") {
+    if (message.preferredEnergyJson !== '') {
       obj.preferredEnergyJson = message.preferredEnergyJson;
     }
-    if (message.preferredTemperamentJson !== "") {
+    if (message.preferredTemperamentJson !== '') {
       obj.preferredTemperamentJson = message.preferredTemperamentJson;
     }
-    if (message.lifestyleJson !== "") {
+    if (message.lifestyleJson !== '') {
       obj.lifestyleJson = message.lifestyleJson;
     }
     if (message.maxDistanceKm !== undefined) {
@@ -2626,7 +2691,7 @@ export const MatchProfile: MessageFns<MatchProfile> = {
     if (message.lastNotifiedAt !== undefined) {
       obj.lastNotifiedAt = message.lastNotifiedAt;
     }
-    if (message.inferredPrefsJson !== "") {
+    if (message.inferredPrefsJson !== '') {
       obj.inferredPrefsJson = message.inferredPrefsJson;
     }
     if (message.prefsUpdatedAt !== undefined) {
@@ -2635,10 +2700,10 @@ export const MatchProfile: MessageFns<MatchProfile> = {
     if (message.allergies !== undefined) {
       obj.allergies = message.allergies;
     }
-    if (message.createdAt !== "") {
+    if (message.createdAt !== '') {
       obj.createdAt = message.createdAt;
     }
-    if (message.updatedAt !== "") {
+    if (message.updatedAt !== '') {
       obj.updatedAt = message.updatedAt;
     }
     return obj;
@@ -2649,23 +2714,23 @@ export const MatchProfile: MessageFns<MatchProfile> = {
   },
   fromPartial<I extends Exact<DeepPartial<MatchProfile>, I>>(object: I): MatchProfile {
     const message = createBaseMatchProfile();
-    message.userId = object.userId ?? "";
-    message.preferredTypesJson = object.preferredTypesJson ?? "";
-    message.preferredSizesJson = object.preferredSizesJson ?? "";
-    message.preferredAgeGroupsJson = object.preferredAgeGroupsJson ?? "";
-    message.preferredEnergyJson = object.preferredEnergyJson ?? "";
-    message.preferredTemperamentJson = object.preferredTemperamentJson ?? "";
-    message.lifestyleJson = object.lifestyleJson ?? "";
+    message.userId = object.userId ?? '';
+    message.preferredTypesJson = object.preferredTypesJson ?? '';
+    message.preferredSizesJson = object.preferredSizesJson ?? '';
+    message.preferredAgeGroupsJson = object.preferredAgeGroupsJson ?? '';
+    message.preferredEnergyJson = object.preferredEnergyJson ?? '';
+    message.preferredTemperamentJson = object.preferredTemperamentJson ?? '';
+    message.lifestyleJson = object.lifestyleJson ?? '';
     message.maxDistanceKm = object.maxDistanceKm ?? undefined;
     message.openToSpecialNeeds = object.openToSpecialNeeds ?? false;
     message.notifyNewMatches = object.notifyNewMatches ?? false;
     message.minNotificationScore = object.minNotificationScore ?? 0;
     message.lastNotifiedAt = object.lastNotifiedAt ?? undefined;
-    message.inferredPrefsJson = object.inferredPrefsJson ?? "";
+    message.inferredPrefsJson = object.inferredPrefsJson ?? '';
     message.prefsUpdatedAt = object.prefsUpdatedAt ?? undefined;
     message.allergies = object.allergies ?? undefined;
-    message.createdAt = object.createdAt ?? "";
-    message.updatedAt = object.updatedAt ?? "";
+    message.createdAt = object.createdAt ?? '';
+    message.updatedAt = object.updatedAt ?? '';
     return message;
   },
 };
@@ -2704,10 +2769,14 @@ export const GetMatchProfileRequest: MessageFns<GetMatchProfileRequest> = {
     return obj;
   },
 
-  create<I extends Exact<DeepPartial<GetMatchProfileRequest>, I>>(base?: I): GetMatchProfileRequest {
+  create<I extends Exact<DeepPartial<GetMatchProfileRequest>, I>>(
+    base?: I
+  ): GetMatchProfileRequest {
     return GetMatchProfileRequest.fromPartial(base ?? ({} as any));
   },
-  fromPartial<I extends Exact<DeepPartial<GetMatchProfileRequest>, I>>(_: I): GetMatchProfileRequest {
+  fromPartial<I extends Exact<DeepPartial<GetMatchProfileRequest>, I>>(
+    _: I
+  ): GetMatchProfileRequest {
     const message = createBaseGetMatchProfileRequest();
     return message;
   },
@@ -2718,7 +2787,10 @@ function createBaseGetMatchProfileResponse(): GetMatchProfileResponse {
 }
 
 export const GetMatchProfileResponse: MessageFns<GetMatchProfileResponse> = {
-  encode(message: GetMatchProfileResponse, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+  encode(
+    message: GetMatchProfileResponse,
+    writer: BinaryWriter = new BinaryWriter()
+  ): BinaryWriter {
     if (message.profile !== undefined) {
       MatchProfile.encode(message.profile, writer.uint32(10).fork()).join();
     }
@@ -2761,31 +2833,36 @@ export const GetMatchProfileResponse: MessageFns<GetMatchProfileResponse> = {
     return obj;
   },
 
-  create<I extends Exact<DeepPartial<GetMatchProfileResponse>, I>>(base?: I): GetMatchProfileResponse {
+  create<I extends Exact<DeepPartial<GetMatchProfileResponse>, I>>(
+    base?: I
+  ): GetMatchProfileResponse {
     return GetMatchProfileResponse.fromPartial(base ?? ({} as any));
   },
-  fromPartial<I extends Exact<DeepPartial<GetMatchProfileResponse>, I>>(object: I): GetMatchProfileResponse {
+  fromPartial<I extends Exact<DeepPartial<GetMatchProfileResponse>, I>>(
+    object: I
+  ): GetMatchProfileResponse {
     const message = createBaseGetMatchProfileResponse();
-    message.profile = (object.profile !== undefined && object.profile !== null)
-      ? MatchProfile.fromPartial(object.profile)
-      : undefined;
+    message.profile =
+      object.profile !== undefined && object.profile !== null
+        ? MatchProfile.fromPartial(object.profile)
+        : undefined;
     return message;
   },
 };
 
 function createBaseUpsertMatchProfileRequest(): UpsertMatchProfileRequest {
   return {
-    preferredTypesJson: "",
+    preferredTypesJson: '',
     setPreferredTypes: false,
-    preferredSizesJson: "",
+    preferredSizesJson: '',
     setPreferredSizes: false,
-    preferredAgeGroupsJson: "",
+    preferredAgeGroupsJson: '',
     setPreferredAgeGroups: false,
-    preferredEnergyJson: "",
+    preferredEnergyJson: '',
     setPreferredEnergy: false,
-    preferredTemperamentJson: "",
+    preferredTemperamentJson: '',
     setPreferredTemperament: false,
-    lifestyleJson: "",
+    lifestyleJson: '',
     setLifestyle: false,
     maxDistanceKm: undefined,
     openToSpecialNeeds: undefined,
@@ -2797,38 +2874,41 @@ function createBaseUpsertMatchProfileRequest(): UpsertMatchProfileRequest {
 }
 
 export const UpsertMatchProfileRequest: MessageFns<UpsertMatchProfileRequest> = {
-  encode(message: UpsertMatchProfileRequest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    if (message.preferredTypesJson !== "") {
+  encode(
+    message: UpsertMatchProfileRequest,
+    writer: BinaryWriter = new BinaryWriter()
+  ): BinaryWriter {
+    if (message.preferredTypesJson !== '') {
       writer.uint32(10).string(message.preferredTypesJson);
     }
     if (message.setPreferredTypes !== false) {
       writer.uint32(16).bool(message.setPreferredTypes);
     }
-    if (message.preferredSizesJson !== "") {
+    if (message.preferredSizesJson !== '') {
       writer.uint32(26).string(message.preferredSizesJson);
     }
     if (message.setPreferredSizes !== false) {
       writer.uint32(32).bool(message.setPreferredSizes);
     }
-    if (message.preferredAgeGroupsJson !== "") {
+    if (message.preferredAgeGroupsJson !== '') {
       writer.uint32(42).string(message.preferredAgeGroupsJson);
     }
     if (message.setPreferredAgeGroups !== false) {
       writer.uint32(48).bool(message.setPreferredAgeGroups);
     }
-    if (message.preferredEnergyJson !== "") {
+    if (message.preferredEnergyJson !== '') {
       writer.uint32(58).string(message.preferredEnergyJson);
     }
     if (message.setPreferredEnergy !== false) {
       writer.uint32(64).bool(message.setPreferredEnergy);
     }
-    if (message.preferredTemperamentJson !== "") {
+    if (message.preferredTemperamentJson !== '') {
       writer.uint32(74).string(message.preferredTemperamentJson);
     }
     if (message.setPreferredTemperament !== false) {
       writer.uint32(80).bool(message.setPreferredTemperament);
     }
-    if (message.lifestyleJson !== "") {
+    if (message.lifestyleJson !== '') {
       writer.uint32(90).string(message.lifestyleJson);
     }
     if (message.setLifestyle !== false) {
@@ -3020,125 +3100,125 @@ export const UpsertMatchProfileRequest: MessageFns<UpsertMatchProfileRequest> = 
       preferredTypesJson: isSet(object.preferredTypesJson)
         ? globalThis.String(object.preferredTypesJson)
         : isSet(object.preferred_types_json)
-        ? globalThis.String(object.preferred_types_json)
-        : "",
+          ? globalThis.String(object.preferred_types_json)
+          : '',
       setPreferredTypes: isSet(object.setPreferredTypes)
         ? globalThis.Boolean(object.setPreferredTypes)
         : isSet(object.set_preferred_types)
-        ? globalThis.Boolean(object.set_preferred_types)
-        : false,
+          ? globalThis.Boolean(object.set_preferred_types)
+          : false,
       preferredSizesJson: isSet(object.preferredSizesJson)
         ? globalThis.String(object.preferredSizesJson)
         : isSet(object.preferred_sizes_json)
-        ? globalThis.String(object.preferred_sizes_json)
-        : "",
+          ? globalThis.String(object.preferred_sizes_json)
+          : '',
       setPreferredSizes: isSet(object.setPreferredSizes)
         ? globalThis.Boolean(object.setPreferredSizes)
         : isSet(object.set_preferred_sizes)
-        ? globalThis.Boolean(object.set_preferred_sizes)
-        : false,
+          ? globalThis.Boolean(object.set_preferred_sizes)
+          : false,
       preferredAgeGroupsJson: isSet(object.preferredAgeGroupsJson)
         ? globalThis.String(object.preferredAgeGroupsJson)
         : isSet(object.preferred_age_groups_json)
-        ? globalThis.String(object.preferred_age_groups_json)
-        : "",
+          ? globalThis.String(object.preferred_age_groups_json)
+          : '',
       setPreferredAgeGroups: isSet(object.setPreferredAgeGroups)
         ? globalThis.Boolean(object.setPreferredAgeGroups)
         : isSet(object.set_preferred_age_groups)
-        ? globalThis.Boolean(object.set_preferred_age_groups)
-        : false,
+          ? globalThis.Boolean(object.set_preferred_age_groups)
+          : false,
       preferredEnergyJson: isSet(object.preferredEnergyJson)
         ? globalThis.String(object.preferredEnergyJson)
         : isSet(object.preferred_energy_json)
-        ? globalThis.String(object.preferred_energy_json)
-        : "",
+          ? globalThis.String(object.preferred_energy_json)
+          : '',
       setPreferredEnergy: isSet(object.setPreferredEnergy)
         ? globalThis.Boolean(object.setPreferredEnergy)
         : isSet(object.set_preferred_energy)
-        ? globalThis.Boolean(object.set_preferred_energy)
-        : false,
+          ? globalThis.Boolean(object.set_preferred_energy)
+          : false,
       preferredTemperamentJson: isSet(object.preferredTemperamentJson)
         ? globalThis.String(object.preferredTemperamentJson)
         : isSet(object.preferred_temperament_json)
-        ? globalThis.String(object.preferred_temperament_json)
-        : "",
+          ? globalThis.String(object.preferred_temperament_json)
+          : '',
       setPreferredTemperament: isSet(object.setPreferredTemperament)
         ? globalThis.Boolean(object.setPreferredTemperament)
         : isSet(object.set_preferred_temperament)
-        ? globalThis.Boolean(object.set_preferred_temperament)
-        : false,
+          ? globalThis.Boolean(object.set_preferred_temperament)
+          : false,
       lifestyleJson: isSet(object.lifestyleJson)
         ? globalThis.String(object.lifestyleJson)
         : isSet(object.lifestyle_json)
-        ? globalThis.String(object.lifestyle_json)
-        : "",
+          ? globalThis.String(object.lifestyle_json)
+          : '',
       setLifestyle: isSet(object.setLifestyle)
         ? globalThis.Boolean(object.setLifestyle)
         : isSet(object.set_lifestyle)
-        ? globalThis.Boolean(object.set_lifestyle)
-        : false,
+          ? globalThis.Boolean(object.set_lifestyle)
+          : false,
       maxDistanceKm: isSet(object.maxDistanceKm)
         ? globalThis.Number(object.maxDistanceKm)
         : isSet(object.max_distance_km)
-        ? globalThis.Number(object.max_distance_km)
-        : undefined,
+          ? globalThis.Number(object.max_distance_km)
+          : undefined,
       openToSpecialNeeds: isSet(object.openToSpecialNeeds)
         ? globalThis.Boolean(object.openToSpecialNeeds)
         : isSet(object.open_to_special_needs)
-        ? globalThis.Boolean(object.open_to_special_needs)
-        : undefined,
+          ? globalThis.Boolean(object.open_to_special_needs)
+          : undefined,
       notifyNewMatches: isSet(object.notifyNewMatches)
         ? globalThis.Boolean(object.notifyNewMatches)
         : isSet(object.notify_new_matches)
-        ? globalThis.Boolean(object.notify_new_matches)
-        : undefined,
+          ? globalThis.Boolean(object.notify_new_matches)
+          : undefined,
       minNotificationScore: isSet(object.minNotificationScore)
         ? globalThis.Number(object.minNotificationScore)
         : isSet(object.min_notification_score)
-        ? globalThis.Number(object.min_notification_score)
-        : undefined,
+          ? globalThis.Number(object.min_notification_score)
+          : undefined,
       allergies: isSet(object.allergies) ? globalThis.String(object.allergies) : undefined,
       setAllergies: isSet(object.setAllergies)
         ? globalThis.Boolean(object.setAllergies)
         : isSet(object.set_allergies)
-        ? globalThis.Boolean(object.set_allergies)
-        : false,
+          ? globalThis.Boolean(object.set_allergies)
+          : false,
     };
   },
 
   toJSON(message: UpsertMatchProfileRequest): unknown {
     const obj: any = {};
-    if (message.preferredTypesJson !== "") {
+    if (message.preferredTypesJson !== '') {
       obj.preferredTypesJson = message.preferredTypesJson;
     }
     if (message.setPreferredTypes !== false) {
       obj.setPreferredTypes = message.setPreferredTypes;
     }
-    if (message.preferredSizesJson !== "") {
+    if (message.preferredSizesJson !== '') {
       obj.preferredSizesJson = message.preferredSizesJson;
     }
     if (message.setPreferredSizes !== false) {
       obj.setPreferredSizes = message.setPreferredSizes;
     }
-    if (message.preferredAgeGroupsJson !== "") {
+    if (message.preferredAgeGroupsJson !== '') {
       obj.preferredAgeGroupsJson = message.preferredAgeGroupsJson;
     }
     if (message.setPreferredAgeGroups !== false) {
       obj.setPreferredAgeGroups = message.setPreferredAgeGroups;
     }
-    if (message.preferredEnergyJson !== "") {
+    if (message.preferredEnergyJson !== '') {
       obj.preferredEnergyJson = message.preferredEnergyJson;
     }
     if (message.setPreferredEnergy !== false) {
       obj.setPreferredEnergy = message.setPreferredEnergy;
     }
-    if (message.preferredTemperamentJson !== "") {
+    if (message.preferredTemperamentJson !== '') {
       obj.preferredTemperamentJson = message.preferredTemperamentJson;
     }
     if (message.setPreferredTemperament !== false) {
       obj.setPreferredTemperament = message.setPreferredTemperament;
     }
-    if (message.lifestyleJson !== "") {
+    if (message.lifestyleJson !== '') {
       obj.lifestyleJson = message.lifestyleJson;
     }
     if (message.setLifestyle !== false) {
@@ -3165,22 +3245,26 @@ export const UpsertMatchProfileRequest: MessageFns<UpsertMatchProfileRequest> = 
     return obj;
   },
 
-  create<I extends Exact<DeepPartial<UpsertMatchProfileRequest>, I>>(base?: I): UpsertMatchProfileRequest {
+  create<I extends Exact<DeepPartial<UpsertMatchProfileRequest>, I>>(
+    base?: I
+  ): UpsertMatchProfileRequest {
     return UpsertMatchProfileRequest.fromPartial(base ?? ({} as any));
   },
-  fromPartial<I extends Exact<DeepPartial<UpsertMatchProfileRequest>, I>>(object: I): UpsertMatchProfileRequest {
+  fromPartial<I extends Exact<DeepPartial<UpsertMatchProfileRequest>, I>>(
+    object: I
+  ): UpsertMatchProfileRequest {
     const message = createBaseUpsertMatchProfileRequest();
-    message.preferredTypesJson = object.preferredTypesJson ?? "";
+    message.preferredTypesJson = object.preferredTypesJson ?? '';
     message.setPreferredTypes = object.setPreferredTypes ?? false;
-    message.preferredSizesJson = object.preferredSizesJson ?? "";
+    message.preferredSizesJson = object.preferredSizesJson ?? '';
     message.setPreferredSizes = object.setPreferredSizes ?? false;
-    message.preferredAgeGroupsJson = object.preferredAgeGroupsJson ?? "";
+    message.preferredAgeGroupsJson = object.preferredAgeGroupsJson ?? '';
     message.setPreferredAgeGroups = object.setPreferredAgeGroups ?? false;
-    message.preferredEnergyJson = object.preferredEnergyJson ?? "";
+    message.preferredEnergyJson = object.preferredEnergyJson ?? '';
     message.setPreferredEnergy = object.setPreferredEnergy ?? false;
-    message.preferredTemperamentJson = object.preferredTemperamentJson ?? "";
+    message.preferredTemperamentJson = object.preferredTemperamentJson ?? '';
     message.setPreferredTemperament = object.setPreferredTemperament ?? false;
-    message.lifestyleJson = object.lifestyleJson ?? "";
+    message.lifestyleJson = object.lifestyleJson ?? '';
     message.setLifestyle = object.setLifestyle ?? false;
     message.maxDistanceKm = object.maxDistanceKm ?? undefined;
     message.openToSpecialNeeds = object.openToSpecialNeeds ?? undefined;
@@ -3197,7 +3281,10 @@ function createBaseUpsertMatchProfileResponse(): UpsertMatchProfileResponse {
 }
 
 export const UpsertMatchProfileResponse: MessageFns<UpsertMatchProfileResponse> = {
-  encode(message: UpsertMatchProfileResponse, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+  encode(
+    message: UpsertMatchProfileResponse,
+    writer: BinaryWriter = new BinaryWriter()
+  ): BinaryWriter {
     if (message.profile !== undefined) {
       MatchProfile.encode(message.profile, writer.uint32(10).fork()).join();
     }
@@ -3240,14 +3327,454 @@ export const UpsertMatchProfileResponse: MessageFns<UpsertMatchProfileResponse> 
     return obj;
   },
 
-  create<I extends Exact<DeepPartial<UpsertMatchProfileResponse>, I>>(base?: I): UpsertMatchProfileResponse {
+  create<I extends Exact<DeepPartial<UpsertMatchProfileResponse>, I>>(
+    base?: I
+  ): UpsertMatchProfileResponse {
     return UpsertMatchProfileResponse.fromPartial(base ?? ({} as any));
   },
-  fromPartial<I extends Exact<DeepPartial<UpsertMatchProfileResponse>, I>>(object: I): UpsertMatchProfileResponse {
+  fromPartial<I extends Exact<DeepPartial<UpsertMatchProfileResponse>, I>>(
+    object: I
+  ): UpsertMatchProfileResponse {
     const message = createBaseUpsertMatchProfileResponse();
-    message.profile = (object.profile !== undefined && object.profile !== null)
-      ? MatchProfile.fromPartial(object.profile)
-      : undefined;
+    message.profile =
+      object.profile !== undefined && object.profile !== null
+        ? MatchProfile.fromPartial(object.profile)
+        : undefined;
+    return message;
+  },
+};
+
+function createBaseTopPickReasonChip(): TopPickReasonChip {
+  return { kind: '', label: '' };
+}
+
+export const TopPickReasonChip: MessageFns<TopPickReasonChip> = {
+  encode(message: TopPickReasonChip, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+    if (message.kind !== '') {
+      writer.uint32(10).string(message.kind);
+    }
+    if (message.label !== '') {
+      writer.uint32(18).string(message.label);
+    }
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): TopPickReasonChip {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseTopPickReasonChip();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1: {
+          if (tag !== 10) {
+            break;
+          }
+
+          message.kind = reader.string();
+          continue;
+        }
+        case 2: {
+          if (tag !== 18) {
+            break;
+          }
+
+          message.label = reader.string();
+          continue;
+        }
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): TopPickReasonChip {
+    return {
+      kind: isSet(object.kind) ? globalThis.String(object.kind) : '',
+      label: isSet(object.label) ? globalThis.String(object.label) : '',
+    };
+  },
+
+  toJSON(message: TopPickReasonChip): unknown {
+    const obj: any = {};
+    if (message.kind !== '') {
+      obj.kind = message.kind;
+    }
+    if (message.label !== '') {
+      obj.label = message.label;
+    }
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<TopPickReasonChip>, I>>(base?: I): TopPickReasonChip {
+    return TopPickReasonChip.fromPartial(base ?? ({} as any));
+  },
+  fromPartial<I extends Exact<DeepPartial<TopPickReasonChip>, I>>(object: I): TopPickReasonChip {
+    const message = createBaseTopPickReasonChip();
+    message.kind = object.kind ?? '';
+    message.label = object.label ?? '';
+    return message;
+  },
+};
+
+function createBaseTopPick(): TopPick {
+  return {
+    petId: '',
+    name: '',
+    type: '',
+    ageGroup: '',
+    size: '',
+    score: 0,
+    reasons: [],
+    rescueName: '',
+    breedName: undefined,
+    photoUrl: undefined,
+  };
+}
+
+export const TopPick: MessageFns<TopPick> = {
+  encode(message: TopPick, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+    if (message.petId !== '') {
+      writer.uint32(10).string(message.petId);
+    }
+    if (message.name !== '') {
+      writer.uint32(18).string(message.name);
+    }
+    if (message.type !== '') {
+      writer.uint32(26).string(message.type);
+    }
+    if (message.ageGroup !== '') {
+      writer.uint32(34).string(message.ageGroup);
+    }
+    if (message.size !== '') {
+      writer.uint32(42).string(message.size);
+    }
+    if (message.score !== 0) {
+      writer.uint32(53).float(message.score);
+    }
+    for (const v of message.reasons) {
+      TopPickReasonChip.encode(v!, writer.uint32(58).fork()).join();
+    }
+    if (message.rescueName !== '') {
+      writer.uint32(66).string(message.rescueName);
+    }
+    if (message.breedName !== undefined) {
+      writer.uint32(74).string(message.breedName);
+    }
+    if (message.photoUrl !== undefined) {
+      writer.uint32(82).string(message.photoUrl);
+    }
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): TopPick {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseTopPick();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1: {
+          if (tag !== 10) {
+            break;
+          }
+
+          message.petId = reader.string();
+          continue;
+        }
+        case 2: {
+          if (tag !== 18) {
+            break;
+          }
+
+          message.name = reader.string();
+          continue;
+        }
+        case 3: {
+          if (tag !== 26) {
+            break;
+          }
+
+          message.type = reader.string();
+          continue;
+        }
+        case 4: {
+          if (tag !== 34) {
+            break;
+          }
+
+          message.ageGroup = reader.string();
+          continue;
+        }
+        case 5: {
+          if (tag !== 42) {
+            break;
+          }
+
+          message.size = reader.string();
+          continue;
+        }
+        case 6: {
+          if (tag !== 53) {
+            break;
+          }
+
+          message.score = reader.float();
+          continue;
+        }
+        case 7: {
+          if (tag !== 58) {
+            break;
+          }
+
+          message.reasons.push(TopPickReasonChip.decode(reader, reader.uint32()));
+          continue;
+        }
+        case 8: {
+          if (tag !== 66) {
+            break;
+          }
+
+          message.rescueName = reader.string();
+          continue;
+        }
+        case 9: {
+          if (tag !== 74) {
+            break;
+          }
+
+          message.breedName = reader.string();
+          continue;
+        }
+        case 10: {
+          if (tag !== 82) {
+            break;
+          }
+
+          message.photoUrl = reader.string();
+          continue;
+        }
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): TopPick {
+    return {
+      petId: isSet(object.petId)
+        ? globalThis.String(object.petId)
+        : isSet(object.pet_id)
+          ? globalThis.String(object.pet_id)
+          : '',
+      name: isSet(object.name) ? globalThis.String(object.name) : '',
+      type: isSet(object.type) ? globalThis.String(object.type) : '',
+      ageGroup: isSet(object.ageGroup)
+        ? globalThis.String(object.ageGroup)
+        : isSet(object.age_group)
+          ? globalThis.String(object.age_group)
+          : '',
+      size: isSet(object.size) ? globalThis.String(object.size) : '',
+      score: isSet(object.score) ? globalThis.Number(object.score) : 0,
+      reasons: globalThis.Array.isArray(object?.reasons)
+        ? object.reasons.map((e: any) => TopPickReasonChip.fromJSON(e))
+        : [],
+      rescueName: isSet(object.rescueName)
+        ? globalThis.String(object.rescueName)
+        : isSet(object.rescue_name)
+          ? globalThis.String(object.rescue_name)
+          : '',
+      breedName: isSet(object.breedName)
+        ? globalThis.String(object.breedName)
+        : isSet(object.breed_name)
+          ? globalThis.String(object.breed_name)
+          : undefined,
+      photoUrl: isSet(object.photoUrl)
+        ? globalThis.String(object.photoUrl)
+        : isSet(object.photo_url)
+          ? globalThis.String(object.photo_url)
+          : undefined,
+    };
+  },
+
+  toJSON(message: TopPick): unknown {
+    const obj: any = {};
+    if (message.petId !== '') {
+      obj.petId = message.petId;
+    }
+    if (message.name !== '') {
+      obj.name = message.name;
+    }
+    if (message.type !== '') {
+      obj.type = message.type;
+    }
+    if (message.ageGroup !== '') {
+      obj.ageGroup = message.ageGroup;
+    }
+    if (message.size !== '') {
+      obj.size = message.size;
+    }
+    if (message.score !== 0) {
+      obj.score = message.score;
+    }
+    if (message.reasons?.length) {
+      obj.reasons = message.reasons.map(e => TopPickReasonChip.toJSON(e));
+    }
+    if (message.rescueName !== '') {
+      obj.rescueName = message.rescueName;
+    }
+    if (message.breedName !== undefined) {
+      obj.breedName = message.breedName;
+    }
+    if (message.photoUrl !== undefined) {
+      obj.photoUrl = message.photoUrl;
+    }
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<TopPick>, I>>(base?: I): TopPick {
+    return TopPick.fromPartial(base ?? ({} as any));
+  },
+  fromPartial<I extends Exact<DeepPartial<TopPick>, I>>(object: I): TopPick {
+    const message = createBaseTopPick();
+    message.petId = object.petId ?? '';
+    message.name = object.name ?? '';
+    message.type = object.type ?? '';
+    message.ageGroup = object.ageGroup ?? '';
+    message.size = object.size ?? '';
+    message.score = object.score ?? 0;
+    message.reasons = object.reasons?.map(e => TopPickReasonChip.fromPartial(e)) || [];
+    message.rescueName = object.rescueName ?? '';
+    message.breedName = object.breedName ?? undefined;
+    message.photoUrl = object.photoUrl ?? undefined;
+    return message;
+  },
+};
+
+function createBaseGetTopPicksRequest(): GetTopPicksRequest {
+  return { limit: 0 };
+}
+
+export const GetTopPicksRequest: MessageFns<GetTopPicksRequest> = {
+  encode(message: GetTopPicksRequest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+    if (message.limit !== 0) {
+      writer.uint32(8).uint32(message.limit);
+    }
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): GetTopPicksRequest {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseGetTopPicksRequest();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1: {
+          if (tag !== 8) {
+            break;
+          }
+
+          message.limit = reader.uint32();
+          continue;
+        }
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): GetTopPicksRequest {
+    return { limit: isSet(object.limit) ? globalThis.Number(object.limit) : 0 };
+  },
+
+  toJSON(message: GetTopPicksRequest): unknown {
+    const obj: any = {};
+    if (message.limit !== 0) {
+      obj.limit = Math.round(message.limit);
+    }
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<GetTopPicksRequest>, I>>(base?: I): GetTopPicksRequest {
+    return GetTopPicksRequest.fromPartial(base ?? ({} as any));
+  },
+  fromPartial<I extends Exact<DeepPartial<GetTopPicksRequest>, I>>(object: I): GetTopPicksRequest {
+    const message = createBaseGetTopPicksRequest();
+    message.limit = object.limit ?? 0;
+    return message;
+  },
+};
+
+function createBaseGetTopPicksResponse(): GetTopPicksResponse {
+  return { picks: [] };
+}
+
+export const GetTopPicksResponse: MessageFns<GetTopPicksResponse> = {
+  encode(message: GetTopPicksResponse, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+    for (const v of message.picks) {
+      TopPick.encode(v!, writer.uint32(10).fork()).join();
+    }
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): GetTopPicksResponse {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseGetTopPicksResponse();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1: {
+          if (tag !== 10) {
+            break;
+          }
+
+          message.picks.push(TopPick.decode(reader, reader.uint32()));
+          continue;
+        }
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): GetTopPicksResponse {
+    return {
+      picks: globalThis.Array.isArray(object?.picks)
+        ? object.picks.map((e: any) => TopPick.fromJSON(e))
+        : [],
+    };
+  },
+
+  toJSON(message: GetTopPicksResponse): unknown {
+    const obj: any = {};
+    if (message.picks?.length) {
+      obj.picks = message.picks.map(e => TopPick.toJSON(e));
+    }
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<GetTopPicksResponse>, I>>(base?: I): GetTopPicksResponse {
+    return GetTopPicksResponse.fromPartial(base ?? ({} as any));
+  },
+  fromPartial<I extends Exact<DeepPartial<GetTopPicksResponse>, I>>(
+    object: I
+  ): GetTopPicksResponse {
+    const message = createBaseGetTopPicksResponse();
+    message.picks = object.picks?.map(e => TopPick.fromPartial(e)) || [];
     return message;
   },
 };
@@ -3337,20 +3864,20 @@ export const SwipeStats: MessageFns<SwipeStats> = {
       totalSwipes: isSet(object.totalSwipes)
         ? globalThis.Number(object.totalSwipes)
         : isSet(object.total_swipes)
-        ? globalThis.Number(object.total_swipes)
-        : 0,
+          ? globalThis.Number(object.total_swipes)
+          : 0,
       likes: isSet(object.likes) ? globalThis.Number(object.likes) : 0,
       passes: isSet(object.passes) ? globalThis.Number(object.passes) : 0,
       superLikes: isSet(object.superLikes)
         ? globalThis.Number(object.superLikes)
         : isSet(object.super_likes)
-        ? globalThis.Number(object.super_likes)
-        : 0,
+          ? globalThis.Number(object.super_likes)
+          : 0,
       infoViews: isSet(object.infoViews)
         ? globalThis.Number(object.infoViews)
         : isSet(object.info_views)
-        ? globalThis.Number(object.info_views)
-        : 0,
+          ? globalThis.Number(object.info_views)
+          : 0,
     };
   },
 
@@ -3393,7 +3920,10 @@ function createBaseGetUserSwipeStatsRequest(): GetUserSwipeStatsRequest {
 }
 
 export const GetUserSwipeStatsRequest: MessageFns<GetUserSwipeStatsRequest> = {
-  encode(message: GetUserSwipeStatsRequest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+  encode(
+    message: GetUserSwipeStatsRequest,
+    writer: BinaryWriter = new BinaryWriter()
+  ): BinaryWriter {
     if (message.userId !== undefined) {
       writer.uint32(10).string(message.userId);
     }
@@ -3429,8 +3959,8 @@ export const GetUserSwipeStatsRequest: MessageFns<GetUserSwipeStatsRequest> = {
       userId: isSet(object.userId)
         ? globalThis.String(object.userId)
         : isSet(object.user_id)
-        ? globalThis.String(object.user_id)
-        : undefined,
+          ? globalThis.String(object.user_id)
+          : undefined,
     };
   },
 
@@ -3442,10 +3972,14 @@ export const GetUserSwipeStatsRequest: MessageFns<GetUserSwipeStatsRequest> = {
     return obj;
   },
 
-  create<I extends Exact<DeepPartial<GetUserSwipeStatsRequest>, I>>(base?: I): GetUserSwipeStatsRequest {
+  create<I extends Exact<DeepPartial<GetUserSwipeStatsRequest>, I>>(
+    base?: I
+  ): GetUserSwipeStatsRequest {
     return GetUserSwipeStatsRequest.fromPartial(base ?? ({} as any));
   },
-  fromPartial<I extends Exact<DeepPartial<GetUserSwipeStatsRequest>, I>>(object: I): GetUserSwipeStatsRequest {
+  fromPartial<I extends Exact<DeepPartial<GetUserSwipeStatsRequest>, I>>(
+    object: I
+  ): GetUserSwipeStatsRequest {
     const message = createBaseGetUserSwipeStatsRequest();
     message.userId = object.userId ?? undefined;
     return message;
@@ -3457,7 +3991,10 @@ function createBaseGetUserSwipeStatsResponse(): GetUserSwipeStatsResponse {
 }
 
 export const GetUserSwipeStatsResponse: MessageFns<GetUserSwipeStatsResponse> = {
-  encode(message: GetUserSwipeStatsResponse, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+  encode(
+    message: GetUserSwipeStatsResponse,
+    writer: BinaryWriter = new BinaryWriter()
+  ): BinaryWriter {
     if (message.stats !== undefined) {
       SwipeStats.encode(message.stats, writer.uint32(10).fork()).join();
     }
@@ -3500,25 +4037,30 @@ export const GetUserSwipeStatsResponse: MessageFns<GetUserSwipeStatsResponse> = 
     return obj;
   },
 
-  create<I extends Exact<DeepPartial<GetUserSwipeStatsResponse>, I>>(base?: I): GetUserSwipeStatsResponse {
+  create<I extends Exact<DeepPartial<GetUserSwipeStatsResponse>, I>>(
+    base?: I
+  ): GetUserSwipeStatsResponse {
     return GetUserSwipeStatsResponse.fromPartial(base ?? ({} as any));
   },
-  fromPartial<I extends Exact<DeepPartial<GetUserSwipeStatsResponse>, I>>(object: I): GetUserSwipeStatsResponse {
+  fromPartial<I extends Exact<DeepPartial<GetUserSwipeStatsResponse>, I>>(
+    object: I
+  ): GetUserSwipeStatsResponse {
     const message = createBaseGetUserSwipeStatsResponse();
-    message.stats = (object.stats !== undefined && object.stats !== null)
-      ? SwipeStats.fromPartial(object.stats)
-      : undefined;
+    message.stats =
+      object.stats !== undefined && object.stats !== null
+        ? SwipeStats.fromPartial(object.stats)
+        : undefined;
     return message;
   },
 };
 
 function createBaseGetSessionStatsRequest(): GetSessionStatsRequest {
-  return { sessionId: "" };
+  return { sessionId: '' };
 }
 
 export const GetSessionStatsRequest: MessageFns<GetSessionStatsRequest> = {
   encode(message: GetSessionStatsRequest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    if (message.sessionId !== "") {
+    if (message.sessionId !== '') {
       writer.uint32(10).string(message.sessionId);
     }
     return writer;
@@ -3553,25 +4095,29 @@ export const GetSessionStatsRequest: MessageFns<GetSessionStatsRequest> = {
       sessionId: isSet(object.sessionId)
         ? globalThis.String(object.sessionId)
         : isSet(object.session_id)
-        ? globalThis.String(object.session_id)
-        : "",
+          ? globalThis.String(object.session_id)
+          : '',
     };
   },
 
   toJSON(message: GetSessionStatsRequest): unknown {
     const obj: any = {};
-    if (message.sessionId !== "") {
+    if (message.sessionId !== '') {
       obj.sessionId = message.sessionId;
     }
     return obj;
   },
 
-  create<I extends Exact<DeepPartial<GetSessionStatsRequest>, I>>(base?: I): GetSessionStatsRequest {
+  create<I extends Exact<DeepPartial<GetSessionStatsRequest>, I>>(
+    base?: I
+  ): GetSessionStatsRequest {
     return GetSessionStatsRequest.fromPartial(base ?? ({} as any));
   },
-  fromPartial<I extends Exact<DeepPartial<GetSessionStatsRequest>, I>>(object: I): GetSessionStatsRequest {
+  fromPartial<I extends Exact<DeepPartial<GetSessionStatsRequest>, I>>(
+    object: I
+  ): GetSessionStatsRequest {
     const message = createBaseGetSessionStatsRequest();
-    message.sessionId = object.sessionId ?? "";
+    message.sessionId = object.sessionId ?? '';
     return message;
   },
 };
@@ -3581,7 +4127,10 @@ function createBaseGetSessionStatsResponse(): GetSessionStatsResponse {
 }
 
 export const GetSessionStatsResponse: MessageFns<GetSessionStatsResponse> = {
-  encode(message: GetSessionStatsResponse, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+  encode(
+    message: GetSessionStatsResponse,
+    writer: BinaryWriter = new BinaryWriter()
+  ): BinaryWriter {
     if (message.stats !== undefined) {
       SwipeStats.encode(message.stats, writer.uint32(10).fork()).join();
     }
@@ -3624,14 +4173,19 @@ export const GetSessionStatsResponse: MessageFns<GetSessionStatsResponse> = {
     return obj;
   },
 
-  create<I extends Exact<DeepPartial<GetSessionStatsResponse>, I>>(base?: I): GetSessionStatsResponse {
+  create<I extends Exact<DeepPartial<GetSessionStatsResponse>, I>>(
+    base?: I
+  ): GetSessionStatsResponse {
     return GetSessionStatsResponse.fromPartial(base ?? ({} as any));
   },
-  fromPartial<I extends Exact<DeepPartial<GetSessionStatsResponse>, I>>(object: I): GetSessionStatsResponse {
+  fromPartial<I extends Exact<DeepPartial<GetSessionStatsResponse>, I>>(
+    object: I
+  ): GetSessionStatsResponse {
     const message = createBaseGetSessionStatsResponse();
-    message.stats = (object.stats !== undefined && object.stats !== null)
-      ? SwipeStats.fromPartial(object.stats)
-      : undefined;
+    message.stats =
+      object.stats !== undefined && object.stats !== null
+        ? SwipeStats.fromPartial(object.stats)
+        : undefined;
     return message;
   },
 };
@@ -3662,26 +4216,30 @@ export const MatchingServiceService = {
    * filters here.
    */
   startSession: {
-    path: "/adopt_dont_shop.matching.v1.MatchingService/StartSession" as const,
+    path: '/adopt_dont_shop.matching.v1.MatchingService/StartSession' as const,
     requestStream: false as const,
     responseStream: false as const,
-    requestSerialize: (value: StartSessionRequest): Buffer => Buffer.from(StartSessionRequest.encode(value).finish()),
+    requestSerialize: (value: StartSessionRequest): Buffer =>
+      Buffer.from(StartSessionRequest.encode(value).finish()),
     requestDeserialize: (value: Buffer): StartSessionRequest => StartSessionRequest.decode(value),
     responseSerialize: (value: StartSessionResponse): Buffer =>
       Buffer.from(StartSessionResponse.encode(value).finish()),
-    responseDeserialize: (value: Buffer): StartSessionResponse => StartSessionResponse.decode(value),
+    responseDeserialize: (value: Buffer): StartSessionResponse =>
+      StartSessionResponse.decode(value),
   },
   /**
    * Close an open session. Marks is_active=false and stamps end_time.
    * Idempotent on already-closed sessions.
    */
   endSession: {
-    path: "/adopt_dont_shop.matching.v1.MatchingService/EndSession" as const,
+    path: '/adopt_dont_shop.matching.v1.MatchingService/EndSession' as const,
     requestStream: false as const,
     responseStream: false as const,
-    requestSerialize: (value: EndSessionRequest): Buffer => Buffer.from(EndSessionRequest.encode(value).finish()),
+    requestSerialize: (value: EndSessionRequest): Buffer =>
+      Buffer.from(EndSessionRequest.encode(value).finish()),
     requestDeserialize: (value: Buffer): EndSessionRequest => EndSessionRequest.decode(value),
-    responseSerialize: (value: EndSessionResponse): Buffer => Buffer.from(EndSessionResponse.encode(value).finish()),
+    responseSerialize: (value: EndSessionResponse): Buffer =>
+      Buffer.from(EndSessionResponse.encode(value).finish()),
     responseDeserialize: (value: Buffer): EndSessionResponse => EndSessionResponse.decode(value),
   },
   /**
@@ -3693,12 +4251,14 @@ export const MatchingServiceService = {
    * the queue runs low.
    */
   recommend: {
-    path: "/adopt_dont_shop.matching.v1.MatchingService/Recommend" as const,
+    path: '/adopt_dont_shop.matching.v1.MatchingService/Recommend' as const,
     requestStream: false as const,
     responseStream: false as const,
-    requestSerialize: (value: RecommendRequest): Buffer => Buffer.from(RecommendRequest.encode(value).finish()),
+    requestSerialize: (value: RecommendRequest): Buffer =>
+      Buffer.from(RecommendRequest.encode(value).finish()),
     requestDeserialize: (value: Buffer): RecommendRequest => RecommendRequest.decode(value),
-    responseSerialize: (value: RecommendResponse): Buffer => Buffer.from(RecommendResponse.encode(value).finish()),
+    responseSerialize: (value: RecommendResponse): Buffer =>
+      Buffer.from(RecommendResponse.encode(value).finish()),
     responseDeserialize: (value: Buffer): RecommendResponse => RecommendResponse.decode(value),
   },
   /**
@@ -3709,12 +4269,14 @@ export const MatchingServiceService = {
    * surface "user X super-liked your pet" notifications.
    */
   recordSwipe: {
-    path: "/adopt_dont_shop.matching.v1.MatchingService/RecordSwipe" as const,
+    path: '/adopt_dont_shop.matching.v1.MatchingService/RecordSwipe' as const,
     requestStream: false as const,
     responseStream: false as const,
-    requestSerialize: (value: RecordSwipeRequest): Buffer => Buffer.from(RecordSwipeRequest.encode(value).finish()),
+    requestSerialize: (value: RecordSwipeRequest): Buffer =>
+      Buffer.from(RecordSwipeRequest.encode(value).finish()),
     requestDeserialize: (value: Buffer): RecordSwipeRequest => RecordSwipeRequest.decode(value),
-    responseSerialize: (value: RecordSwipeResponse): Buffer => Buffer.from(RecordSwipeResponse.encode(value).finish()),
+    responseSerialize: (value: RecordSwipeResponse): Buffer =>
+      Buffer.from(RecordSwipeResponse.encode(value).finish()),
     responseDeserialize: (value: Buffer): RecordSwipeResponse => RecordSwipeResponse.decode(value),
   },
   /**
@@ -3725,12 +4287,14 @@ export const MatchingServiceService = {
    * service.pets via gRPC; matching service is stateless on this RPC.
    */
   searchPets: {
-    path: "/adopt_dont_shop.matching.v1.MatchingService/SearchPets" as const,
+    path: '/adopt_dont_shop.matching.v1.MatchingService/SearchPets' as const,
     requestStream: false as const,
     responseStream: false as const,
-    requestSerialize: (value: SearchPetsRequest): Buffer => Buffer.from(SearchPetsRequest.encode(value).finish()),
+    requestSerialize: (value: SearchPetsRequest): Buffer =>
+      Buffer.from(SearchPetsRequest.encode(value).finish()),
     requestDeserialize: (value: Buffer): SearchPetsRequest => SearchPetsRequest.decode(value),
-    responseSerialize: (value: SearchPetsResponse): Buffer => Buffer.from(SearchPetsResponse.encode(value).finish()),
+    responseSerialize: (value: SearchPetsResponse): Buffer =>
+      Buffer.from(SearchPetsResponse.encode(value).finish()),
     responseDeserialize: (value: Buffer): SearchPetsResponse => SearchPetsResponse.decode(value),
   },
   /**
@@ -3739,30 +4303,34 @@ export const MatchingServiceService = {
    * in the SPA. Filterable by action type.
    */
   listSwipeHistory: {
-    path: "/adopt_dont_shop.matching.v1.MatchingService/ListSwipeHistory" as const,
+    path: '/adopt_dont_shop.matching.v1.MatchingService/ListSwipeHistory' as const,
     requestStream: false as const,
     responseStream: false as const,
     requestSerialize: (value: ListSwipeHistoryRequest): Buffer =>
       Buffer.from(ListSwipeHistoryRequest.encode(value).finish()),
-    requestDeserialize: (value: Buffer): ListSwipeHistoryRequest => ListSwipeHistoryRequest.decode(value),
+    requestDeserialize: (value: Buffer): ListSwipeHistoryRequest =>
+      ListSwipeHistoryRequest.decode(value),
     responseSerialize: (value: ListSwipeHistoryResponse): Buffer =>
       Buffer.from(ListSwipeHistoryResponse.encode(value).finish()),
-    responseDeserialize: (value: Buffer): ListSwipeHistoryResponse => ListSwipeHistoryResponse.decode(value),
+    responseDeserialize: (value: Buffer): ListSwipeHistoryResponse =>
+      ListSwipeHistoryResponse.decode(value),
   },
   /**
    * Read the calling principal's match profile, returning empty defaults
    * when the row doesn't exist yet (the SPA renders an empty form).
    */
   getMatchProfile: {
-    path: "/adopt_dont_shop.matching.v1.MatchingService/GetMatchProfile" as const,
+    path: '/adopt_dont_shop.matching.v1.MatchingService/GetMatchProfile' as const,
     requestStream: false as const,
     responseStream: false as const,
     requestSerialize: (value: GetMatchProfileRequest): Buffer =>
       Buffer.from(GetMatchProfileRequest.encode(value).finish()),
-    requestDeserialize: (value: Buffer): GetMatchProfileRequest => GetMatchProfileRequest.decode(value),
+    requestDeserialize: (value: Buffer): GetMatchProfileRequest =>
+      GetMatchProfileRequest.decode(value),
     responseSerialize: (value: GetMatchProfileResponse): Buffer =>
       Buffer.from(GetMatchProfileResponse.encode(value).finish()),
-    responseDeserialize: (value: Buffer): GetMatchProfileResponse => GetMatchProfileResponse.decode(value),
+    responseDeserialize: (value: Buffer): GetMatchProfileResponse =>
+      GetMatchProfileResponse.decode(value),
   },
   /**
    * Create-or-update the calling principal's match profile. Only the
@@ -3770,15 +4338,17 @@ export const MatchingServiceService = {
    * current value (or the column default on first insert).
    */
   upsertMatchProfile: {
-    path: "/adopt_dont_shop.matching.v1.MatchingService/UpsertMatchProfile" as const,
+    path: '/adopt_dont_shop.matching.v1.MatchingService/UpsertMatchProfile' as const,
     requestStream: false as const,
     responseStream: false as const,
     requestSerialize: (value: UpsertMatchProfileRequest): Buffer =>
       Buffer.from(UpsertMatchProfileRequest.encode(value).finish()),
-    requestDeserialize: (value: Buffer): UpsertMatchProfileRequest => UpsertMatchProfileRequest.decode(value),
+    requestDeserialize: (value: Buffer): UpsertMatchProfileRequest =>
+      UpsertMatchProfileRequest.decode(value),
     responseSerialize: (value: UpsertMatchProfileResponse): Buffer =>
       Buffer.from(UpsertMatchProfileResponse.encode(value).finish()),
-    responseDeserialize: (value: Buffer): UpsertMatchProfileResponse => UpsertMatchProfileResponse.decode(value),
+    responseDeserialize: (value: Buffer): UpsertMatchProfileResponse =>
+      UpsertMatchProfileResponse.decode(value),
   },
   /**
    * Aggregate swipe counts for a user (total / likes / passes /
@@ -3786,30 +4356,53 @@ export const MatchingServiceService = {
    * via swipes:read:any.
    */
   getUserSwipeStats: {
-    path: "/adopt_dont_shop.matching.v1.MatchingService/GetUserSwipeStats" as const,
+    path: '/adopt_dont_shop.matching.v1.MatchingService/GetUserSwipeStats' as const,
     requestStream: false as const,
     responseStream: false as const,
     requestSerialize: (value: GetUserSwipeStatsRequest): Buffer =>
       Buffer.from(GetUserSwipeStatsRequest.encode(value).finish()),
-    requestDeserialize: (value: Buffer): GetUserSwipeStatsRequest => GetUserSwipeStatsRequest.decode(value),
+    requestDeserialize: (value: Buffer): GetUserSwipeStatsRequest =>
+      GetUserSwipeStatsRequest.decode(value),
     responseSerialize: (value: GetUserSwipeStatsResponse): Buffer =>
       Buffer.from(GetUserSwipeStatsResponse.encode(value).finish()),
-    responseDeserialize: (value: Buffer): GetUserSwipeStatsResponse => GetUserSwipeStatsResponse.decode(value),
+    responseDeserialize: (value: Buffer): GetUserSwipeStatsResponse =>
+      GetUserSwipeStatsResponse.decode(value),
   },
   /**
    * Aggregate swipe counts for a single session. Caller MUST own the
    * session (or be admin).
    */
   getSessionStats: {
-    path: "/adopt_dont_shop.matching.v1.MatchingService/GetSessionStats" as const,
+    path: '/adopt_dont_shop.matching.v1.MatchingService/GetSessionStats' as const,
     requestStream: false as const,
     responseStream: false as const,
     requestSerialize: (value: GetSessionStatsRequest): Buffer =>
       Buffer.from(GetSessionStatsRequest.encode(value).finish()),
-    requestDeserialize: (value: Buffer): GetSessionStatsRequest => GetSessionStatsRequest.decode(value),
+    requestDeserialize: (value: Buffer): GetSessionStatsRequest =>
+      GetSessionStatsRequest.decode(value),
     responseSerialize: (value: GetSessionStatsResponse): Buffer =>
       Buffer.from(GetSessionStatsResponse.encode(value).finish()),
-    responseDeserialize: (value: Buffer): GetSessionStatsResponse => GetSessionStatsResponse.decode(value),
+    responseDeserialize: (value: Buffer): GetSessionStatsResponse =>
+      GetSessionStatsResponse.decode(value),
+  },
+  /**
+   * Get a short, personalised "top picks" list for the calling principal —
+   * distinct from Recommend (the swipe-queue feed): top picks reads the
+   * user's STORED match profile (preferred types/sizes/age groups/energy/
+   * temperament) rather than session filters, excludes already-swiped pets,
+   * and attaches reason chips explaining each pick. Stateless — no session
+   * required, no mutation.
+   */
+  getTopPicks: {
+    path: '/adopt_dont_shop.matching.v1.MatchingService/GetTopPicks' as const,
+    requestStream: false as const,
+    responseStream: false as const,
+    requestSerialize: (value: GetTopPicksRequest): Buffer =>
+      Buffer.from(GetTopPicksRequest.encode(value).finish()),
+    requestDeserialize: (value: Buffer): GetTopPicksRequest => GetTopPicksRequest.decode(value),
+    responseSerialize: (value: GetTopPicksResponse): Buffer =>
+      Buffer.from(GetTopPicksResponse.encode(value).finish()),
+    responseDeserialize: (value: Buffer): GetTopPicksResponse => GetTopPicksResponse.decode(value),
   },
 } as const;
 
@@ -3880,6 +4473,15 @@ export interface MatchingServiceServer extends UntypedServiceImplementation {
    * session (or be admin).
    */
   getSessionStats: handleUnaryCall<GetSessionStatsRequest, GetSessionStatsResponse>;
+  /**
+   * Get a short, personalised "top picks" list for the calling principal —
+   * distinct from Recommend (the swipe-queue feed): top picks reads the
+   * user's STORED match profile (preferred types/sizes/age groups/energy/
+   * temperament) rather than session filters, excludes already-swiped pets,
+   * and attaches reason chips explaining each pick. Stateless — no session
+   * required, no mutation.
+   */
+  getTopPicks: handleUnaryCall<GetTopPicksRequest, GetTopPicksResponse>;
 }
 
 export interface MatchingServiceClient extends Client {
@@ -3892,18 +4494,18 @@ export interface MatchingServiceClient extends Client {
    */
   startSession(
     request: StartSessionRequest,
-    callback: (error: ServiceError | null, response: StartSessionResponse) => void,
+    callback: (error: ServiceError | null, response: StartSessionResponse) => void
   ): ClientUnaryCall;
   startSession(
     request: StartSessionRequest,
     metadata: Metadata,
-    callback: (error: ServiceError | null, response: StartSessionResponse) => void,
+    callback: (error: ServiceError | null, response: StartSessionResponse) => void
   ): ClientUnaryCall;
   startSession(
     request: StartSessionRequest,
     metadata: Metadata,
     options: Partial<CallOptions>,
-    callback: (error: ServiceError | null, response: StartSessionResponse) => void,
+    callback: (error: ServiceError | null, response: StartSessionResponse) => void
   ): ClientUnaryCall;
   /**
    * Close an open session. Marks is_active=false and stamps end_time.
@@ -3911,18 +4513,18 @@ export interface MatchingServiceClient extends Client {
    */
   endSession(
     request: EndSessionRequest,
-    callback: (error: ServiceError | null, response: EndSessionResponse) => void,
+    callback: (error: ServiceError | null, response: EndSessionResponse) => void
   ): ClientUnaryCall;
   endSession(
     request: EndSessionRequest,
     metadata: Metadata,
-    callback: (error: ServiceError | null, response: EndSessionResponse) => void,
+    callback: (error: ServiceError | null, response: EndSessionResponse) => void
   ): ClientUnaryCall;
   endSession(
     request: EndSessionRequest,
     metadata: Metadata,
     options: Partial<CallOptions>,
-    callback: (error: ServiceError | null, response: EndSessionResponse) => void,
+    callback: (error: ServiceError | null, response: EndSessionResponse) => void
   ): ClientUnaryCall;
   /**
    * Get the top-K recommendations for the calling principal. Reads
@@ -3934,18 +4536,18 @@ export interface MatchingServiceClient extends Client {
    */
   recommend(
     request: RecommendRequest,
-    callback: (error: ServiceError | null, response: RecommendResponse) => void,
+    callback: (error: ServiceError | null, response: RecommendResponse) => void
   ): ClientUnaryCall;
   recommend(
     request: RecommendRequest,
     metadata: Metadata,
-    callback: (error: ServiceError | null, response: RecommendResponse) => void,
+    callback: (error: ServiceError | null, response: RecommendResponse) => void
   ): ClientUnaryCall;
   recommend(
     request: RecommendRequest,
     metadata: Metadata,
     options: Partial<CallOptions>,
-    callback: (error: ServiceError | null, response: RecommendResponse) => void,
+    callback: (error: ServiceError | null, response: RecommendResponse) => void
   ): ClientUnaryCall;
   /**
    * Record a swipe action and tick the session's counters
@@ -3956,18 +4558,18 @@ export interface MatchingServiceClient extends Client {
    */
   recordSwipe(
     request: RecordSwipeRequest,
-    callback: (error: ServiceError | null, response: RecordSwipeResponse) => void,
+    callback: (error: ServiceError | null, response: RecordSwipeResponse) => void
   ): ClientUnaryCall;
   recordSwipe(
     request: RecordSwipeRequest,
     metadata: Metadata,
-    callback: (error: ServiceError | null, response: RecordSwipeResponse) => void,
+    callback: (error: ServiceError | null, response: RecordSwipeResponse) => void
   ): ClientUnaryCall;
   recordSwipe(
     request: RecordSwipeRequest,
     metadata: Metadata,
     options: Partial<CallOptions>,
-    callback: (error: ServiceError | null, response: RecordSwipeResponse) => void,
+    callback: (error: ServiceError | null, response: RecordSwipeResponse) => void
   ): ClientUnaryCall;
   /**
    * Search pets — the explicit search surface that absorbs the
@@ -3978,18 +4580,18 @@ export interface MatchingServiceClient extends Client {
    */
   searchPets(
     request: SearchPetsRequest,
-    callback: (error: ServiceError | null, response: SearchPetsResponse) => void,
+    callback: (error: ServiceError | null, response: SearchPetsResponse) => void
   ): ClientUnaryCall;
   searchPets(
     request: SearchPetsRequest,
     metadata: Metadata,
-    callback: (error: ServiceError | null, response: SearchPetsResponse) => void,
+    callback: (error: ServiceError | null, response: SearchPetsResponse) => void
   ): ClientUnaryCall;
   searchPets(
     request: SearchPetsRequest,
     metadata: Metadata,
     options: Partial<CallOptions>,
-    callback: (error: ServiceError | null, response: SearchPetsResponse) => void,
+    callback: (error: ServiceError | null, response: SearchPetsResponse) => void
   ): ClientUnaryCall;
   /**
    * List the calling principal's swipe history — what they liked,
@@ -3998,18 +4600,18 @@ export interface MatchingServiceClient extends Client {
    */
   listSwipeHistory(
     request: ListSwipeHistoryRequest,
-    callback: (error: ServiceError | null, response: ListSwipeHistoryResponse) => void,
+    callback: (error: ServiceError | null, response: ListSwipeHistoryResponse) => void
   ): ClientUnaryCall;
   listSwipeHistory(
     request: ListSwipeHistoryRequest,
     metadata: Metadata,
-    callback: (error: ServiceError | null, response: ListSwipeHistoryResponse) => void,
+    callback: (error: ServiceError | null, response: ListSwipeHistoryResponse) => void
   ): ClientUnaryCall;
   listSwipeHistory(
     request: ListSwipeHistoryRequest,
     metadata: Metadata,
     options: Partial<CallOptions>,
-    callback: (error: ServiceError | null, response: ListSwipeHistoryResponse) => void,
+    callback: (error: ServiceError | null, response: ListSwipeHistoryResponse) => void
   ): ClientUnaryCall;
   /**
    * Read the calling principal's match profile, returning empty defaults
@@ -4017,18 +4619,18 @@ export interface MatchingServiceClient extends Client {
    */
   getMatchProfile(
     request: GetMatchProfileRequest,
-    callback: (error: ServiceError | null, response: GetMatchProfileResponse) => void,
+    callback: (error: ServiceError | null, response: GetMatchProfileResponse) => void
   ): ClientUnaryCall;
   getMatchProfile(
     request: GetMatchProfileRequest,
     metadata: Metadata,
-    callback: (error: ServiceError | null, response: GetMatchProfileResponse) => void,
+    callback: (error: ServiceError | null, response: GetMatchProfileResponse) => void
   ): ClientUnaryCall;
   getMatchProfile(
     request: GetMatchProfileRequest,
     metadata: Metadata,
     options: Partial<CallOptions>,
-    callback: (error: ServiceError | null, response: GetMatchProfileResponse) => void,
+    callback: (error: ServiceError | null, response: GetMatchProfileResponse) => void
   ): ClientUnaryCall;
   /**
    * Create-or-update the calling principal's match profile. Only the
@@ -4037,18 +4639,18 @@ export interface MatchingServiceClient extends Client {
    */
   upsertMatchProfile(
     request: UpsertMatchProfileRequest,
-    callback: (error: ServiceError | null, response: UpsertMatchProfileResponse) => void,
+    callback: (error: ServiceError | null, response: UpsertMatchProfileResponse) => void
   ): ClientUnaryCall;
   upsertMatchProfile(
     request: UpsertMatchProfileRequest,
     metadata: Metadata,
-    callback: (error: ServiceError | null, response: UpsertMatchProfileResponse) => void,
+    callback: (error: ServiceError | null, response: UpsertMatchProfileResponse) => void
   ): ClientUnaryCall;
   upsertMatchProfile(
     request: UpsertMatchProfileRequest,
     metadata: Metadata,
     options: Partial<CallOptions>,
-    callback: (error: ServiceError | null, response: UpsertMatchProfileResponse) => void,
+    callback: (error: ServiceError | null, response: UpsertMatchProfileResponse) => void
   ): ClientUnaryCall;
   /**
    * Aggregate swipe counts for a user (total / likes / passes /
@@ -4057,18 +4659,18 @@ export interface MatchingServiceClient extends Client {
    */
   getUserSwipeStats(
     request: GetUserSwipeStatsRequest,
-    callback: (error: ServiceError | null, response: GetUserSwipeStatsResponse) => void,
+    callback: (error: ServiceError | null, response: GetUserSwipeStatsResponse) => void
   ): ClientUnaryCall;
   getUserSwipeStats(
     request: GetUserSwipeStatsRequest,
     metadata: Metadata,
-    callback: (error: ServiceError | null, response: GetUserSwipeStatsResponse) => void,
+    callback: (error: ServiceError | null, response: GetUserSwipeStatsResponse) => void
   ): ClientUnaryCall;
   getUserSwipeStats(
     request: GetUserSwipeStatsRequest,
     metadata: Metadata,
     options: Partial<CallOptions>,
-    callback: (error: ServiceError | null, response: GetUserSwipeStatsResponse) => void,
+    callback: (error: ServiceError | null, response: GetUserSwipeStatsResponse) => void
   ): ClientUnaryCall;
   /**
    * Aggregate swipe counts for a single session. Caller MUST own the
@@ -4076,40 +4678,72 @@ export interface MatchingServiceClient extends Client {
    */
   getSessionStats(
     request: GetSessionStatsRequest,
-    callback: (error: ServiceError | null, response: GetSessionStatsResponse) => void,
+    callback: (error: ServiceError | null, response: GetSessionStatsResponse) => void
   ): ClientUnaryCall;
   getSessionStats(
     request: GetSessionStatsRequest,
     metadata: Metadata,
-    callback: (error: ServiceError | null, response: GetSessionStatsResponse) => void,
+    callback: (error: ServiceError | null, response: GetSessionStatsResponse) => void
   ): ClientUnaryCall;
   getSessionStats(
     request: GetSessionStatsRequest,
     metadata: Metadata,
     options: Partial<CallOptions>,
-    callback: (error: ServiceError | null, response: GetSessionStatsResponse) => void,
+    callback: (error: ServiceError | null, response: GetSessionStatsResponse) => void
+  ): ClientUnaryCall;
+  /**
+   * Get a short, personalised "top picks" list for the calling principal —
+   * distinct from Recommend (the swipe-queue feed): top picks reads the
+   * user's STORED match profile (preferred types/sizes/age groups/energy/
+   * temperament) rather than session filters, excludes already-swiped pets,
+   * and attaches reason chips explaining each pick. Stateless — no session
+   * required, no mutation.
+   */
+  getTopPicks(
+    request: GetTopPicksRequest,
+    callback: (error: ServiceError | null, response: GetTopPicksResponse) => void
+  ): ClientUnaryCall;
+  getTopPicks(
+    request: GetTopPicksRequest,
+    metadata: Metadata,
+    callback: (error: ServiceError | null, response: GetTopPicksResponse) => void
+  ): ClientUnaryCall;
+  getTopPicks(
+    request: GetTopPicksRequest,
+    metadata: Metadata,
+    options: Partial<CallOptions>,
+    callback: (error: ServiceError | null, response: GetTopPicksResponse) => void
   ): ClientUnaryCall;
 }
 
 export const MatchingServiceClient = makeGenericClientConstructor(
   MatchingServiceService,
-  "adopt_dont_shop.matching.v1.MatchingService",
+  'adopt_dont_shop.matching.v1.MatchingService'
 ) as unknown as {
-  new (address: string, credentials: ChannelCredentials, options?: Partial<ClientOptions>): MatchingServiceClient;
+  new (
+    address: string,
+    credentials: ChannelCredentials,
+    options?: Partial<ClientOptions>
+  ): MatchingServiceClient;
   service: typeof MatchingServiceService;
   serviceName: string;
 };
 
 type Builtin = Date | Function | Uint8Array | string | number | boolean | undefined;
 
-export type DeepPartial<T> = T extends Builtin ? T
-  : T extends globalThis.Array<infer U> ? globalThis.Array<DeepPartial<U>>
-  : T extends ReadonlyArray<infer U> ? ReadonlyArray<DeepPartial<U>>
-  : T extends {} ? { [K in keyof T]?: DeepPartial<T[K]> }
-  : Partial<T>;
+export type DeepPartial<T> = T extends Builtin
+  ? T
+  : T extends globalThis.Array<infer U>
+    ? globalThis.Array<DeepPartial<U>>
+    : T extends ReadonlyArray<infer U>
+      ? ReadonlyArray<DeepPartial<U>>
+      : T extends {}
+        ? { [K in keyof T]?: DeepPartial<T[K]> }
+        : Partial<T>;
 
 type KeysOfUnion<T> = T extends T ? keyof T : never;
-export type Exact<P, I extends P> = P extends Builtin ? P
+export type Exact<P, I extends P> = P extends Builtin
+  ? P
   : P & { [K in keyof P]: Exact<P[K], I[K]> } & { [K in Exclude<keyof I, KeysOfUnion<P>>]: never };
 
 function isSet(value: any): boolean {

--- a/packages/proto/src/index.ts
+++ b/packages/proto/src/index.ts
@@ -292,6 +292,10 @@ export type {
   ListDocumentsResponse,
   RemoveDocumentRequest,
   RemoveDocumentResponse,
+  GetApplicationDefaultsRequest,
+  GetApplicationDefaultsResponse,
+  UpdateApplicationDefaultsRequest,
+  UpdateApplicationDefaultsResponse,
   ApplicationServiceServer,
   ApplicationServiceClient,
 } from './generated/proto/adopt_dont_shop/applications/v1/application.js';

--- a/packages/proto/src/index.ts
+++ b/packages/proto/src/index.ts
@@ -355,6 +355,10 @@ export type {
   GetUserSwipeStatsResponse,
   GetSessionStatsRequest,
   GetSessionStatsResponse,
+  TopPick,
+  TopPickReasonChip,
+  GetTopPicksRequest,
+  GetTopPicksResponse,
   MatchingServiceServer,
   MatchingServiceClient,
 } from './generated/proto/adopt_dont_shop/matching/v1/matching.js';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1268,6 +1268,9 @@ importers:
 
   packages/lib.matching:
     dependencies:
+      '@adopt-dont-shop/lib.api':
+        specifier: workspace:*
+        version: link:../lib.api
       typescript:
         specifier: ^6.0.0
         version: 6.0.3

--- a/services/applications/src/grpc/application-defaults-handlers.test.ts
+++ b/services/applications/src/grpc/application-defaults-handlers.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { HandlerError, type HandlerDeps } from './adapter.js';
+import {
+  getApplicationDefaults,
+  updateApplicationDefaults,
+} from './application-defaults-handlers.js';
+
+function makePrincipal(
+  overrides: Partial<{ userId: string; roles: string[]; permissions: string[] }> = {}
+) {
+  return {
+    userId: overrides.userId ?? 'usr-1',
+    roles: overrides.roles ?? ['adopter'],
+    permissions: overrides.permissions ?? ['applications.read', 'applications.update'],
+  } as unknown as Parameters<typeof getApplicationDefaults>[1];
+}
+
+function makeDeps(): { deps: HandlerDeps; query: ReturnType<typeof vi.fn> } {
+  const query = vi.fn();
+  const pool = { query } as unknown as HandlerDeps['pool'];
+  return { deps: { pool, nats: {} } as unknown as HandlerDeps, query };
+}
+
+describe('getApplicationDefaults', () => {
+  it('throws PERMISSION_DENIED without applications.read', async () => {
+    const { deps } = makeDeps();
+    await expect(
+      getApplicationDefaults(deps, makePrincipal({ permissions: [] }), {})
+    ).rejects.toBeInstanceOf(HandlerError);
+  });
+
+  it('returns an empty defaults_json when the adopter has no saved row', async () => {
+    const { deps, query } = makeDeps();
+    query.mockResolvedValueOnce({ rows: [] });
+
+    const res = await getApplicationDefaults(deps, makePrincipal(), {});
+
+    expect(res.defaultsJson).toBe('');
+  });
+
+  it('returns the stored defaults as a JSON string', async () => {
+    const { deps, query } = makeDeps();
+    query.mockResolvedValueOnce({ rows: [{ data: { personalInfo: { firstName: 'Ada' } } }] });
+
+    const res = await getApplicationDefaults(deps, makePrincipal(), {});
+
+    expect(JSON.parse(res.defaultsJson)).toEqual({ personalInfo: { firstName: 'Ada' } });
+  });
+
+  it('scopes the read to the calling principal, not a request-supplied id', async () => {
+    const { deps, query } = makeDeps();
+    query.mockResolvedValueOnce({ rows: [] });
+
+    await getApplicationDefaults(deps, makePrincipal({ userId: 'usr-9' }), {});
+
+    expect(query.mock.calls[0][1]).toEqual(['usr-9']);
+  });
+});
+
+describe('updateApplicationDefaults', () => {
+  it('throws PERMISSION_DENIED without applications.update', async () => {
+    const { deps } = makeDeps();
+    await expect(
+      updateApplicationDefaults(deps, makePrincipal({ permissions: ['applications.read'] }), {
+        defaultsPatchJson: '{}',
+      })
+    ).rejects.toBeInstanceOf(HandlerError);
+  });
+
+  it('throws INVALID_ARGUMENT when the patch is not valid JSON', async () => {
+    const { deps, query } = makeDeps();
+    await expect(
+      updateApplicationDefaults(deps, makePrincipal(), { defaultsPatchJson: 'not json' })
+    ).rejects.toBeInstanceOf(HandlerError);
+    expect(query).not.toHaveBeenCalled();
+  });
+
+  it('throws INVALID_ARGUMENT when the patch is not a JSON object', async () => {
+    const { deps } = makeDeps();
+    await expect(
+      updateApplicationDefaults(deps, makePrincipal(), { defaultsPatchJson: '[1,2]' })
+    ).rejects.toBeInstanceOf(HandlerError);
+  });
+
+  it('deep-merges the patch into the existing stored defaults and upserts the result', async () => {
+    const { deps, query } = makeDeps();
+    query
+      .mockResolvedValueOnce({
+        rows: [{ data: { personalInfo: { firstName: 'Ada', lastName: 'Lovelace' } } }],
+      })
+      .mockResolvedValueOnce({ rows: [] });
+
+    const res = await updateApplicationDefaults(deps, makePrincipal(), {
+      defaultsPatchJson: JSON.stringify({ personalInfo: { firstName: 'Grace' } }),
+    });
+
+    expect(JSON.parse(res.defaultsJson)).toEqual({
+      personalInfo: { firstName: 'Grace', lastName: 'Lovelace' },
+    });
+    const [upsertSql, upsertParams] = query.mock.calls[1];
+    expect(upsertSql).toContain('INSERT INTO application_defaults');
+    expect(upsertParams[0]).toBe('usr-1');
+    expect(JSON.parse(upsertParams[1])).toEqual({
+      personalInfo: { firstName: 'Grace', lastName: 'Lovelace' },
+    });
+  });
+
+  it('treats a missing saved row as an empty base', async () => {
+    const { deps, query } = makeDeps();
+    query.mockResolvedValueOnce({ rows: [] }).mockResolvedValueOnce({ rows: [] });
+
+    const res = await updateApplicationDefaults(deps, makePrincipal(), {
+      defaultsPatchJson: JSON.stringify({ personalInfo: { firstName: 'Grace' } }),
+    });
+
+    expect(JSON.parse(res.defaultsJson)).toEqual({ personalInfo: { firstName: 'Grace' } });
+  });
+
+  it('scopes the write to the calling principal', async () => {
+    const { deps, query } = makeDeps();
+    query.mockResolvedValueOnce({ rows: [] }).mockResolvedValueOnce({ rows: [] });
+
+    await updateApplicationDefaults(deps, makePrincipal({ userId: 'usr-9' }), {
+      defaultsPatchJson: '{}',
+    });
+
+    expect(query.mock.calls[0][1]).toEqual(['usr-9']);
+    expect(query.mock.calls[1][1][0]).toBe('usr-9');
+  });
+});

--- a/services/applications/src/grpc/application-defaults-handlers.ts
+++ b/services/applications/src/grpc/application-defaults-handlers.ts
@@ -1,0 +1,87 @@
+// gRPC handlers — adopter application defaults (read + merge-write).
+//
+// Reusable personal-info / living-situation / pet-experience / references
+// data the SPA uses to pre-populate new applications. Always scoped to
+// the calling principal's own user_id — there is no cross-adopter read
+// or write, so unlike document-handlers.ts there's no owner row to load
+// first. Both run OUTSIDE a transaction (straight off deps.pool) — a
+// single SELECT, or a SELECT + upsert for the merge-write.
+
+import { requirePermission, type Principal } from '@adopt-dont-shop/authz';
+import { APPLICATIONS_UPDATE, APPLICATIONS_VIEW } from '@adopt-dont-shop/lib.types';
+import type {
+  GetApplicationDefaultsRequest,
+  GetApplicationDefaultsResponse,
+  UpdateApplicationDefaultsRequest,
+  UpdateApplicationDefaultsResponse,
+} from '@adopt-dont-shop/proto';
+
+import { HandlerError, type HandlerDeps } from './adapter.js';
+import { mergeJson, type JsonObject } from './json-merge.js';
+
+type DefaultsRow = {
+  data: JsonObject;
+};
+
+async function fetchStoredDefaults(
+  deps: HandlerDeps,
+  userId: string
+): Promise<JsonObject | undefined> {
+  const { rows } = await deps.pool.query<DefaultsRow>(
+    `SELECT data FROM application_defaults WHERE user_id = $1`,
+    [userId]
+  );
+  return rows[0]?.data;
+}
+
+export async function getApplicationDefaults(
+  deps: HandlerDeps,
+  principal: Principal,
+  _req: GetApplicationDefaultsRequest
+): Promise<GetApplicationDefaultsResponse> {
+  if (!requirePermission(principal, APPLICATIONS_VIEW)) {
+    throw new HandlerError('PERMISSION_DENIED', `'${APPLICATIONS_VIEW}' required`);
+  }
+
+  const stored = await fetchStoredDefaults(deps, principal.userId);
+  return { defaultsJson: stored === undefined ? '' : JSON.stringify(stored) };
+}
+
+export async function updateApplicationDefaults(
+  deps: HandlerDeps,
+  principal: Principal,
+  req: UpdateApplicationDefaultsRequest
+): Promise<UpdateApplicationDefaultsResponse> {
+  if (!requirePermission(principal, APPLICATIONS_UPDATE)) {
+    throw new HandlerError('PERMISSION_DENIED', `'${APPLICATIONS_UPDATE}' required`);
+  }
+
+  const patch = parsePatch(req.defaultsPatchJson);
+  const existing = (await fetchStoredDefaults(deps, principal.userId)) ?? {};
+  const merged = mergeJson(existing, patch) as JsonObject;
+
+  await deps.pool.query(
+    `INSERT INTO application_defaults (user_id, data, updated_at)
+     VALUES ($1, $2, now())
+     ON CONFLICT (user_id) DO UPDATE SET data = $2, updated_at = now()`,
+    [principal.userId, JSON.stringify(merged)]
+  );
+
+  return { defaultsJson: JSON.stringify(merged) };
+}
+
+function parsePatch(raw: string): JsonObject {
+  if (raw === '') {
+    return {};
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    throw new HandlerError('INVALID_ARGUMENT', 'defaults_patch_json must be valid JSON');
+  }
+  if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+    throw new HandlerError('INVALID_ARGUMENT', 'defaults_patch_json must be a JSON object');
+  }
+  return parsed as JsonObject;
+}

--- a/services/applications/src/grpc/json-merge.test.ts
+++ b/services/applications/src/grpc/json-merge.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+
+import { mergeJson } from './json-merge.js';
+
+describe('mergeJson', () => {
+  it('merges a top-level key absent from the base into the result', () => {
+    expect(mergeJson({ a: 1 }, { b: 2 })).toEqual({ a: 1, b: 2 });
+  });
+
+  it('overwrites a scalar value at a shared key', () => {
+    expect(mergeJson({ a: 1 }, { a: 2 })).toEqual({ a: 2 });
+  });
+
+  it('recursively merges nested objects instead of replacing the whole section', () => {
+    const base = { personalInfo: { firstName: 'Ada', lastName: 'Lovelace' } };
+    const patch = { personalInfo: { firstName: 'Grace' } };
+    expect(mergeJson(base, patch)).toEqual({
+      personalInfo: { firstName: 'Grace', lastName: 'Lovelace' },
+    });
+  });
+
+  it('leaves top-level keys absent from the patch untouched', () => {
+    const base = { personalInfo: { firstName: 'Ada' }, livingSituation: { housingType: 'house' } };
+    const patch = { personalInfo: { firstName: 'Grace' } };
+    expect(mergeJson(base, patch)).toEqual({
+      personalInfo: { firstName: 'Grace' },
+      livingSituation: { housingType: 'house' },
+    });
+  });
+
+  it('replaces an array wholesale rather than merging element-by-element', () => {
+    const base = { references: { personal: [{ name: 'Old' }] } };
+    const patch = { references: { personal: [{ name: 'New' }] } };
+    expect(mergeJson(base, patch)).toEqual({ references: { personal: [{ name: 'New' }] } });
+  });
+
+  it('replaces a value when its type changes between base and patch', () => {
+    expect(mergeJson({ a: { nested: true } }, { a: 'now a string' })).toEqual({
+      a: 'now a string',
+    });
+  });
+
+  it('replaces null over an object and vice versa', () => {
+    expect(mergeJson({ a: { nested: true } }, { a: null })).toEqual({ a: null });
+    expect(mergeJson({ a: null }, { a: { nested: true } })).toEqual({ a: { nested: true } });
+  });
+
+  it('returns the patch unchanged when the base is not a plain object', () => {
+    expect(mergeJson(null, { a: 1 })).toEqual({ a: 1 });
+    expect(mergeJson([1, 2], { a: 1 })).toEqual({ a: 1 });
+  });
+});

--- a/services/applications/src/grpc/json-merge.ts
+++ b/services/applications/src/grpc/json-merge.ts
@@ -1,0 +1,27 @@
+// Pure recursive JSON merge backing UpdateApplicationDefaults — no I/O,
+// fully unit-testable.
+//
+// Plain objects merge key-by-key, recursing into shared keys that are
+// themselves plain objects on both sides. Anything else (arrays,
+// scalars, null, or a type mismatch between base and patch) takes the
+// patch's value wholesale — this matches the SPA's expectation that
+// sending a new `references.personal` array replaces the old one
+// rather than splicing it.
+
+export type JsonValue = string | number | boolean | null | JsonValue[] | JsonObject;
+export type JsonObject = { [key: string]: JsonValue };
+
+function isPlainObject(value: JsonValue): value is JsonObject {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+export function mergeJson(base: JsonValue, patch: JsonValue): JsonValue {
+  if (!isPlainObject(base) || !isPlainObject(patch)) {
+    return patch;
+  }
+  const result: JsonObject = { ...base };
+  for (const [key, value] of Object.entries(patch)) {
+    result[key] = key in base ? mergeJson(base[key], value) : value;
+  }
+  return result;
+}

--- a/services/applications/src/grpc/server.ts
+++ b/services/applications/src/grpc/server.ts
@@ -17,6 +17,10 @@ import { ApplicationsV1 } from '@adopt-dont-shop/proto';
 import type { ApplicationsConfig } from '../config.js';
 
 import { adapt } from './adapter.js';
+import {
+  getApplicationDefaults,
+  updateApplicationDefaults,
+} from './application-defaults-handlers.js';
 import { makeStartDraft, saveDraftAnswers, submitDraft } from './handlers.js';
 import { createPetsClient, type PetsClient } from './pets-client.js';
 import { addDocument, listDocuments, removeDocument } from './document-handlers.js';
@@ -74,6 +78,9 @@ export const createGrpcServer = (opts: CreateGrpcServerOptions): Server => {
     addDocument: adapt(addDocument, { deps, logger }),
     listDocuments: adapt(listDocuments, { deps, logger }),
     removeDocument: adapt(removeDocument, { deps, logger }),
+    // Application defaults (application-defaults-handlers.ts)
+    getApplicationDefaults: adapt(getApplicationDefaults, { deps, logger }),
+    updateApplicationDefaults: adapt(updateApplicationDefaults, { deps, logger }),
   });
 
   logger.info('gRPC ApplicationService registered', {
@@ -94,6 +101,8 @@ export const createGrpcServer = (opts: CreateGrpcServerOptions): Server => {
       'addDocument',
       'listDocuments',
       'removeDocument',
+      'getApplicationDefaults',
+      'updateApplicationDefaults',
     ],
     grpcPort: config.grpcPort,
   });

--- a/services/applications/src/migrations/009_create_application_defaults.ts
+++ b/services/applications/src/migrations/009_create_application_defaults.ts
@@ -1,0 +1,25 @@
+import type { MigrationBuilder } from 'node-pg-migrate';
+
+// Per-table baseline — application_defaults.
+//
+// One row per adopter holding the reusable personal/living-situation/
+// pet-experience/references data used to pre-populate new applications.
+// user_id is a cross-schema soft pointer (auth.users) — no DB REFERENCES
+// per the schema-per-service rule. The whole defaults blob is stored as
+// a single JSONB column; the gRPC surface (GetApplicationDefaults /
+// UpdateApplicationDefaults) reads/merges it as JSON rather than
+// exploding it into columns, since its shape is owned by the SPA, not
+// this service.
+
+export const up = async (pgm: MigrationBuilder): Promise<void> => {
+  pgm.createTable('application_defaults', {
+    user_id: { type: 'uuid', primaryKey: true },
+    data: { type: 'jsonb', notNull: true, default: pgm.func("'{}'::jsonb") },
+    created_at: { type: 'timestamptz', notNull: true, default: pgm.func('now()') },
+    updated_at: { type: 'timestamptz', notNull: true, default: pgm.func('now()') },
+  });
+};
+
+export const down = async (pgm: MigrationBuilder): Promise<void> => {
+  pgm.dropTable('application_defaults');
+};

--- a/services/applications/src/migrations/migrations.test.ts
+++ b/services/applications/src/migrations/migrations.test.ts
@@ -47,6 +47,7 @@ describe('applications migrations', () => {
     '006_install_home_visit_status_propagation_trigger.ts',
     '007_create_application_drafts.ts',
     '008_create_application_documents.ts',
+    '009_create_application_defaults.ts',
   ])('%s exports `up` and `down` functions', async filename => {
     const mod = (await import(`./${filename}`)) as {
       up: unknown;

--- a/services/gateway/src/grpc-clients/applications-client.contract.test.ts
+++ b/services/gateway/src/grpc-clients/applications-client.contract.test.ts
@@ -62,6 +62,8 @@ const makeHandlers = (
   addDocument: unimplemented,
   listDocuments: unimplemented,
   removeDocument: unimplemented,
+  getApplicationDefaults: unimplemented,
+  updateApplicationDefaults: unimplemented,
   ...overrides,
 });
 

--- a/services/gateway/src/grpc-clients/applications-client.ts
+++ b/services/gateway/src/grpc-clients/applications-client.ts
@@ -17,6 +17,8 @@ import {
   type ApproveResponse,
   type CompleteHomeVisitRequest,
   type CompleteHomeVisitResponse,
+  type GetApplicationDefaultsRequest,
+  type GetApplicationDefaultsResponse,
   type GetApplicationRequest,
   type GetApplicationResponse,
   type GetStatsRequest,
@@ -41,6 +43,8 @@ import {
   type StartReviewResponse,
   type SubmitDraftRequest,
   type SubmitDraftResponse,
+  type UpdateApplicationDefaultsRequest,
+  type UpdateApplicationDefaultsResponse,
   type WithdrawRequest,
   type WithdrawResponse,
 } from '@adopt-dont-shop/proto';
@@ -75,6 +79,14 @@ export type ApplicationsClient = {
   addDocument(req: AddDocumentRequest, metadata: Metadata): Promise<AddDocumentResponse>;
   listDocuments(req: ListDocumentsRequest, metadata: Metadata): Promise<ListDocumentsResponse>;
   removeDocument(req: RemoveDocumentRequest, metadata: Metadata): Promise<RemoveDocumentResponse>;
+  getApplicationDefaults(
+    req: GetApplicationDefaultsRequest,
+    metadata: Metadata
+  ): Promise<GetApplicationDefaultsResponse>;
+  updateApplicationDefaults(
+    req: UpdateApplicationDefaultsRequest,
+    metadata: Metadata
+  ): Promise<UpdateApplicationDefaultsResponse>;
   close(): void;
 };
 
@@ -155,11 +167,15 @@ export const createApplicationsClient = (
     markAdopted: (req, metadata) => callUnary(stub.markAdopted, req, metadata, false),
     addDocument: (req, metadata) => callUnary(stub.addDocument, req, metadata, false),
     removeDocument: (req, metadata) => callUnary(stub.removeDocument, req, metadata, false),
+    updateApplicationDefaults: (req, metadata) =>
+      callUnary(stub.updateApplicationDefaults, req, metadata, false),
     // ── Idempotent (reads) ───────────────────────────────────────────
     get: (req, metadata) => callUnary(stub.get, req, metadata, true),
     list: (req, metadata) => callUnary(stub.list, req, metadata, true),
     getStats: (req, metadata) => callUnary(stub.getStats, req, metadata, true),
     listDocuments: (req, metadata) => callUnary(stub.listDocuments, req, metadata, true),
+    getApplicationDefaults: (req, metadata) =>
+      callUnary(stub.getApplicationDefaults, req, metadata, true),
     close: () => stub.close(),
   };
 };

--- a/services/gateway/src/grpc-clients/matching-client.ts
+++ b/services/gateway/src/grpc-clients/matching-client.ts
@@ -21,6 +21,8 @@ import {
   type GetMatchProfileResponse,
   type GetSessionStatsRequest,
   type GetSessionStatsResponse,
+  type GetTopPicksRequest,
+  type GetTopPicksResponse,
   type GetUserSwipeStatsRequest,
   type GetUserSwipeStatsResponse,
   type ListSwipeHistoryRequest,
@@ -67,6 +69,7 @@ export type MatchingClient = {
     req: GetSessionStatsRequest,
     metadata: Metadata
   ): Promise<GetSessionStatsResponse>;
+  getTopPicks(req: GetTopPicksRequest, metadata: Metadata): Promise<GetTopPicksResponse>;
   close(): void;
 };
 
@@ -141,6 +144,7 @@ export const createMatchingClient = (opts: CreateMatchingClientOptions): Matchin
     getMatchProfile: (req, metadata) => callUnary(stub.getMatchProfile, req, metadata, true),
     getUserSwipeStats: (req, metadata) => callUnary(stub.getUserSwipeStats, req, metadata, true),
     getSessionStats: (req, metadata) => callUnary(stub.getSessionStats, req, metadata, true),
+    getTopPicks: (req, metadata) => callUnary(stub.getTopPicks, req, metadata, true),
     close: () => stub.close(),
   };
 };

--- a/services/gateway/src/routes/applications.test.ts
+++ b/services/gateway/src/routes/applications.test.ts
@@ -42,6 +42,8 @@ function makeClient(): {
     'get',
     'list',
     'getStats',
+    'getApplicationDefaults',
+    'updateApplicationDefaults',
   ]) {
     mocks[m] = vi.fn();
   }
@@ -414,6 +416,64 @@ describe('applications routes', () => {
       headers: ADOPTER,
     });
     expect(missing.statusCode).toBe(404);
+  });
+
+  it('GET /api/v1/profile/application-defaults returns the parsed defaults in { data }', async () => {
+    mocks.getApplicationDefaults.mockResolvedValue({
+      defaultsJson: JSON.stringify({ personalInfo: { firstName: 'Jo' } }),
+    });
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/v1/profile/application-defaults',
+      headers: ADOPTER,
+    });
+    expect(res.statusCode).toBe(200);
+    expect((res.json() as { data: unknown }).data).toEqual({
+      personalInfo: { firstName: 'Jo' },
+    });
+    expect(mocks.getApplicationDefaults.mock.calls[0][0]).toEqual({});
+  });
+
+  it('GET /api/v1/profile/application-defaults returns {} when the adopter has no saved row', async () => {
+    mocks.getApplicationDefaults.mockResolvedValue({ defaultsJson: '' });
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/v1/profile/application-defaults',
+      headers: ADOPTER,
+    });
+    expect((res.json() as { data: unknown }).data).toEqual({});
+  });
+
+  it('PUT /api/v1/profile/application-defaults sends the patch and returns the merged result', async () => {
+    mocks.updateApplicationDefaults.mockResolvedValue({
+      defaultsJson: JSON.stringify({ personalInfo: { firstName: 'Grace', lastName: 'Hopper' } }),
+    });
+    const res = await app.inject({
+      method: 'PUT',
+      url: '/api/v1/profile/application-defaults',
+      headers: ADOPTER,
+      payload: { applicationDefaults: { personalInfo: { firstName: 'Grace' } } },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(mocks.updateApplicationDefaults.mock.calls[0][0]).toEqual({
+      defaultsPatchJson: JSON.stringify({ personalInfo: { firstName: 'Grace' } }),
+    });
+    expect((res.json() as { data: unknown }).data).toEqual({
+      personalInfo: { firstName: 'Grace', lastName: 'Hopper' },
+    });
+  });
+
+  it('maps PERMISSION_DENIED on GET /api/v1/profile/application-defaults → 403', async () => {
+    mocks.getApplicationDefaults.mockRejectedValue({
+      code: grpcStatus.PERMISSION_DENIED,
+      details: 'nope',
+    });
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/v1/profile/application-defaults',
+      headers: ADOPTER,
+    });
+    expect(res.statusCode).toBe(403);
   });
 
   it('threads x-user-* metadata to the gRPC client', async () => {

--- a/services/gateway/src/routes/applications.ts
+++ b/services/gateway/src/routes/applications.ts
@@ -526,6 +526,55 @@ export const registerApplicationsRoutes = async (
       }
     }
   );
+
+  // ---------- Adopter application defaults ----------
+  //
+  // Reusable personal-info / living-situation / pet-experience / references
+  // data the SPA uses to pre-populate new applications (applicationProfileService.ts).
+  // Always scoped to the caller via x-user-id metadata — no id in the URL or body.
+
+  app.get(
+    '/api/v1/profile/application-defaults',
+    {
+      config: { rateLimit: RL_READ },
+      schema: {
+        tags: ['applications'],
+        summary: "Get the caller's saved application defaults",
+      },
+    },
+    async (req, reply) => {
+      try {
+        const res = await client.getApplicationDefaults({}, buildMetadata(req));
+        return reply.send({ data: res.defaultsJson === '' ? {} : JSON.parse(res.defaultsJson) });
+      } catch (err) {
+        return handleGrpcError(err, reply);
+      }
+    }
+  );
+
+  app.put(
+    '/api/v1/profile/application-defaults',
+    {
+      config: { rateLimit: RL_WRITE },
+      schema: {
+        tags: ['applications'],
+        summary: "Deep-merge a patch into the caller's saved application defaults",
+      },
+    },
+    async (req, reply) => {
+      const b = (req.body ?? {}) as Record<string, unknown>;
+      const patch = b.applicationDefaults ?? {};
+      try {
+        const res = await client.updateApplicationDefaults(
+          { defaultsPatchJson: JSON.stringify(patch) },
+          buildMetadata(req)
+        );
+        return reply.send({ data: JSON.parse(res.defaultsJson) });
+      } catch (err) {
+        return handleGrpcError(err, reply);
+      }
+    }
+  );
 };
 
 // --- Helpers ---------------------------------------------------------

--- a/services/gateway/src/routes/matching-view.test.ts
+++ b/services/gateway/src/routes/matching-view.test.ts
@@ -1,8 +1,18 @@
 import { describe, expect, it } from 'vitest';
 
-import type { PetCandidate, RecommendResponse, SearchPetsResponse } from '@adopt-dont-shop/proto';
+import type {
+  GetTopPicksResponse,
+  PetCandidate,
+  RecommendResponse,
+  SearchPetsResponse,
+} from '@adopt-dont-shop/proto';
 
-import { petCandidateToView, recommendToQueue, searchToView } from './matching-view.js';
+import {
+  petCandidateToView,
+  recommendToQueue,
+  searchToView,
+  topPicksToView,
+} from './matching-view.js';
 
 function makeCandidate(overrides: Partial<PetCandidate> = {}): PetCandidate {
   return {
@@ -89,5 +99,77 @@ describe('searchToView', () => {
   it('omits next_cursor when absent or empty', () => {
     const env = searchToView({ results: [], nextCursor: '' } as SearchPetsResponse);
     expect('next_cursor' in env).toBe(false);
+  });
+});
+
+describe('topPicksToView', () => {
+  it('maps proto TopPicks to the SPA MatchTopPick shape, preserving default fields', () => {
+    const view = topPicksToView({
+      picks: [
+        {
+          petId: 'pet-1',
+          name: 'Bella',
+          type: 'cat',
+          ageGroup: 'baby',
+          size: 'small',
+          score: 0.74,
+          reasons: [{ kind: 'pref_match', label: 'Matches your preferences' }],
+          rescueName: 'Happy Tails',
+        },
+      ],
+    } as GetTopPicksResponse);
+
+    expect(view).toEqual([
+      {
+        petId: 'pet-1',
+        name: 'Bella',
+        type: 'cat',
+        ageGroup: 'baby',
+        size: 'small',
+        score: 0.74,
+        reasons: [{ kind: 'pref_match', label: 'Matches your preferences' }],
+        rescueName: 'Happy Tails',
+      },
+    ]);
+  });
+
+  it('keeps zero score, empty rescue name and empty reasons rather than dropping them', () => {
+    const view = topPicksToView({
+      picks: [
+        {
+          petId: 'pet-2',
+          name: 'Rex',
+          type: 'dog',
+          ageGroup: 'adult',
+          size: 'medium',
+          score: 0,
+          reasons: [],
+          rescueName: '',
+        },
+      ],
+    } as GetTopPicksResponse);
+
+    expect(view[0]).toMatchObject({ petId: 'pet-2', score: 0, rescueName: '', reasons: [] });
+  });
+
+  it('forwards breedName and photoUrl when present', () => {
+    const view = topPicksToView({
+      picks: [
+        {
+          petId: 'pet-3',
+          name: 'Max',
+          type: 'dog',
+          ageGroup: 'young',
+          size: 'large',
+          score: 0.5,
+          reasons: [],
+          rescueName: 'Rescue',
+          breedName: 'Labrador',
+          photoUrl: '/uploads/pets/pet-3.jpg',
+        },
+      ],
+    } as GetTopPicksResponse);
+
+    expect(view[0]).toMatchObject({ breedName: 'Labrador', photoUrl: '/uploads/pets/pet-3.jpg' });
   });
 });

--- a/services/gateway/src/routes/matching-view.ts
+++ b/services/gateway/src/routes/matching-view.ts
@@ -13,7 +13,13 @@
 // Both surfaces are read-only, so the adapter is one-directional: proto
 // PetCandidate → frontend pet view, then build the per-route envelope.
 
-import type { PetCandidate, RecommendResponse, SearchPetsResponse } from '@adopt-dont-shop/proto';
+import type {
+  GetTopPicksResponse,
+  PetCandidate,
+  RecommendResponse,
+  SearchPetsResponse,
+  TopPick,
+} from '@adopt-dont-shop/proto';
 
 export type DiscoveryPetView = {
   pet_id: string;
@@ -92,4 +98,46 @@ export function searchToView(res: SearchPetsResponse): SearchPetsView {
     view.next_cursor = res.nextCursor;
   }
   return view;
+}
+
+// proto TopPick → the SPA's MatchTopPick (lib.matching). The shapes are
+// camelCase-identical, but we build the object explicitly rather than
+// using TopPick.toJSON so default-valued fields (score 0, empty
+// rescueName, empty reasons) survive — the SPA's MatchTopPick type
+// requires them.
+export type TopPickView = {
+  petId: string;
+  name: string;
+  type: string;
+  ageGroup: string;
+  size: string;
+  score: number;
+  reasons: ReadonlyArray<{ kind: string; label: string }>;
+  rescueName: string;
+  breedName?: string;
+  photoUrl?: string;
+};
+
+function topPickToView(pick: TopPick): TopPickView {
+  const view: TopPickView = {
+    petId: pick.petId,
+    name: pick.name,
+    type: pick.type,
+    ageGroup: pick.ageGroup,
+    size: pick.size,
+    score: pick.score,
+    reasons: pick.reasons.map(r => ({ kind: r.kind, label: r.label })),
+    rescueName: pick.rescueName,
+  };
+  if (pick.breedName !== undefined) {
+    view.breedName = pick.breedName;
+  }
+  if (pick.photoUrl !== undefined) {
+    view.photoUrl = pick.photoUrl;
+  }
+  return view;
+}
+
+export function topPicksToView(res: GetTopPicksResponse): TopPickView[] {
+  return res.picks.map(topPickToView);
 }

--- a/services/gateway/src/routes/matching.test.ts
+++ b/services/gateway/src/routes/matching.test.ts
@@ -28,6 +28,7 @@ function makeClient(): {
   upsertMatchProfileMock: ReturnType<typeof vi.fn>;
   getUserSwipeStatsMock: ReturnType<typeof vi.fn>;
   getSessionStatsMock: ReturnType<typeof vi.fn>;
+  getTopPicksMock: ReturnType<typeof vi.fn>;
 } {
   const startSessionMock = vi.fn();
   const endSessionMock = vi.fn();
@@ -39,6 +40,7 @@ function makeClient(): {
   const upsertMatchProfileMock = vi.fn();
   const getUserSwipeStatsMock = vi.fn();
   const getSessionStatsMock = vi.fn();
+  const getTopPicksMock = vi.fn();
   const client: MatchingClient = {
     startSession: startSessionMock,
     endSession: endSessionMock,
@@ -50,6 +52,7 @@ function makeClient(): {
     upsertMatchProfile: upsertMatchProfileMock,
     getUserSwipeStats: getUserSwipeStatsMock,
     getSessionStats: getSessionStatsMock,
+    getTopPicks: getTopPicksMock,
     close: vi.fn(),
   };
   return {
@@ -64,6 +67,7 @@ function makeClient(): {
     upsertMatchProfileMock,
     getUserSwipeStatsMock,
     getSessionStatsMock,
+    getTopPicksMock,
   };
 }
 
@@ -642,6 +646,86 @@ describe('match profile + swipe stats', () => {
       const res = await app.inject({
         method: 'GET',
         url: '/api/v1/discovery/swipe/stats/usr-other',
+        headers: ADOPTER_HEADERS,
+      });
+      expect(res.statusCode).toBe(403);
+    } finally {
+      await app.close();
+    }
+  });
+});
+
+describe('GET /api/v1/match/top-picks (GetTopPicks)', () => {
+  it('returns the SPA-shaped top picks under a data envelope', async () => {
+    const m = makeClient();
+    m.getTopPicksMock.mockResolvedValue({
+      picks: [
+        {
+          petId: 'pet-1',
+          name: 'Bella',
+          type: 'cat',
+          ageGroup: 'baby',
+          size: 'small',
+          score: 0.74,
+          reasons: [{ kind: 'pref_match', label: 'Matches your preferences' }],
+          rescueName: 'Happy Tails',
+        },
+      ],
+    });
+    const app = await makeApp(m.client);
+    try {
+      const res = await app.inject({
+        method: 'GET',
+        url: '/api/v1/match/top-picks?limit=3',
+        headers: ADOPTER_HEADERS,
+      });
+      expect(res.statusCode).toBe(200);
+      const body = JSON.parse(res.body) as { success: boolean; data: unknown[] };
+      expect(body.success).toBe(true);
+      expect(body.data).toEqual([
+        {
+          petId: 'pet-1',
+          name: 'Bella',
+          type: 'cat',
+          ageGroup: 'baby',
+          size: 'small',
+          score: 0.74,
+          reasons: [{ kind: 'pref_match', label: 'Matches your preferences' }],
+          rescueName: 'Happy Tails',
+        },
+      ]);
+      // The query limit is forwarded to the gRPC request.
+      expect(m.getTopPicksMock.mock.calls[0][0]).toEqual({ limit: 3 });
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('defaults the limit to 10 when the query param is absent', async () => {
+    const m = makeClient();
+    m.getTopPicksMock.mockResolvedValue({ picks: [] });
+    const app = await makeApp(m.client);
+    try {
+      const res = await app.inject({
+        method: 'GET',
+        url: '/api/v1/match/top-picks',
+        headers: ADOPTER_HEADERS,
+      });
+      expect(res.statusCode).toBe(200);
+      expect(m.getTopPicksMock.mock.calls[0][0]).toEqual({ limit: 10 });
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('maps an upstream PERMISSION_DENIED to 403', async () => {
+    const m = makeClient();
+    m.getTopPicksMock.mockRejectedValue({ code: grpcStatus.PERMISSION_DENIED, details: 'no' });
+    const app = await makeApp(m.client);
+    try {
+      const res = await app.inject({
+        method: 'GET',
+        url: '/api/v1/match/top-picks',
         headers: ADOPTER_HEADERS,
       });
       expect(res.statusCode).toBe(403);

--- a/services/gateway/src/routes/matching.ts
+++ b/services/gateway/src/routes/matching.ts
@@ -30,6 +30,7 @@ import type { FastifyInstance, FastifyRequest } from 'fastify';
 import {
   MatchingV1,
   type EndSessionRequest,
+  type GetTopPicksRequest,
   type ListSwipeHistoryRequest,
   type RecommendRequest,
   type RecordSwipeRequest,
@@ -39,7 +40,7 @@ import {
 
 import type { MatchingClient } from '../grpc-clients/matching-client.js';
 
-import { recommendToQueue, searchToView } from './matching-view.js';
+import { recommendToQueue, searchToView, topPicksToView } from './matching-view.js';
 import { buildMetadata } from '../middleware/metadata.js';
 import { handleGrpcError } from '../middleware/grpc-error.js';
 import { parsePagination } from '../middleware/pagination.js';
@@ -61,6 +62,8 @@ const MATCHING_RATE_LIMITS = {
   // Discovery + search are the chatty browse paths.
   recommend: { max: 120, timeWindow: '1 minute' },
   search: { max: 120, timeWindow: '1 minute' },
+  // Top picks is a curated read the SPA loads on the home + picks pages.
+  topPicks: { max: 60, timeWindow: '1 minute' },
 } as const;
 
 type StartSessionBody = {
@@ -345,6 +348,28 @@ export const registerMatchingRoutes = async (
     }
   );
 
+  // ---- Top picks ---------------------------------------------------
+  // GET /api/v1/match/top-picks?limit=N — a short, personalised picks
+  // list scored against the adopter's stored match profile. Returns the
+  // SPA's MatchTopPick[] under a { success, data } envelope.
+  app.get(
+    '/api/v1/match/top-picks',
+    {
+      config: { rateLimit: MATCHING_RATE_LIMITS.topPicks },
+      schema: { tags: ['matching'] },
+    },
+    async (req, reply) => {
+      const query = req.query as Record<string, string | undefined>;
+      const grpcReq: GetTopPicksRequest = { limit: parseTopPicksLimit(query.limit) };
+      try {
+        const res = await client.getTopPicks(grpcReq, buildMetadata(req));
+        return reply.send({ success: true, data: topPicksToView(res) });
+      } catch (err) {
+        return handleGrpcError(err, reply);
+      }
+    }
+  );
+
   // ---- Swipe statistics --------------------------------------------
   // GET /api/v1/discovery/swipe/stats/:userId
   app.get<{ Params: { userId: string } }>(
@@ -480,6 +505,17 @@ function clampLimit(raw: number | undefined): number {
     return 20;
   }
   return Math.min(Math.max(Math.trunc(raw), 1), 100);
+}
+
+// Top picks is a short curated list: default 10, capped at 50. An absent
+// or unparseable query param falls back to the default. The matching
+// service re-clamps with the same bounds as defence-in-depth.
+function parseTopPicksLimit(raw: string | undefined): number {
+  const parsed = raw === undefined ? NaN : Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return 10;
+  }
+  return Math.min(parsed, 50);
 }
 
 // Implicit-session helper: when the SPA doesn't carry a sessionId on

--- a/services/matching/src/config.test.ts
+++ b/services/matching/src/config.test.ts
@@ -11,6 +11,7 @@ describe('loadConfig', () => {
     expect(config.grpcPort).toBe(6008);
     expect(config.schema).toBe('matching');
     expect(config.petsGrpcUrl).toBe('service-pets:6003');
+    expect(config.rescueGrpcUrl).toBe('service-rescue:6004');
   });
 
   it('honours all env overrides when set', () => {
@@ -23,11 +24,13 @@ describe('loadConfig', () => {
       DATABASE_URL: 'postgres://x',
       NATS_URL: 'nats://nats.internal:4222',
       PETS_GRPC_URL: 'pets.internal:6003',
+      RESCUE_GRPC_URL: 'rescue.internal:6004',
     });
     expect(config.port).toBe(5500);
     expect(config.grpcPort).toBe(6500);
     expect(config.schema).toBe('matching_test');
     expect(config.petsGrpcUrl).toBe('pets.internal:6003');
+    expect(config.rescueGrpcUrl).toBe('rescue.internal:6004');
   });
 
   it('rejects a non-numeric MATCHING_PORT', () => {

--- a/services/matching/src/config.ts
+++ b/services/matching/src/config.ts
@@ -27,6 +27,10 @@ export type MatchingConfig = {
   // stateless compute, not a denormalised projection of pets).
   // Defaults to the same service-pets:6003 address the gateway uses.
   petsGrpcUrl: string;
+  // service.rescue gRPC URL — GetTopPicks resolves each pick's rescue
+  // name via RescueService.Get. Defaults to the same service-rescue:6004
+  // address the gateway uses.
+  rescueGrpcUrl: string;
 };
 
 const DEFAULT_PORT = 5008;
@@ -35,6 +39,7 @@ const DEFAULT_HOST = '0.0.0.0';
 const DEFAULT_SCHEMA = 'matching';
 const DEFAULT_NATS_URL = 'nats://nats:4222';
 const DEFAULT_PETS_GRPC_URL = 'service-pets:6003';
+const DEFAULT_RESCUE_GRPC_URL = 'service-rescue:6004';
 
 export const loadConfig = (env: NodeJS.ProcessEnv = process.env): MatchingConfig => {
   const port = parsePort(env.MATCHING_PORT, DEFAULT_PORT, 'MATCHING_PORT');
@@ -51,5 +56,6 @@ export const loadConfig = (env: NodeJS.ProcessEnv = process.env): MatchingConfig
     schema: env.MATCHING_SCHEMA?.trim() || DEFAULT_SCHEMA,
     natsUrl: env.NATS_URL?.trim() || DEFAULT_NATS_URL,
     petsGrpcUrl: env.PETS_GRPC_URL?.trim() || DEFAULT_PETS_GRPC_URL,
+    rescueGrpcUrl: env.RESCUE_GRPC_URL?.trim() || DEFAULT_RESCUE_GRPC_URL,
   };
 };

--- a/services/matching/src/grpc/pet-tokens.ts
+++ b/services/matching/src/grpc/pet-tokens.ts
@@ -1,0 +1,75 @@
+// Shared lowercase-token <-> proto-enum lookup tables for the pets
+// PetType / PetSize / PetAgeGroup enums. Both the filters_json the SPA
+// sends (Recommend, SearchPets) and the lowercase tokens the top-picks
+// surface returns (TopPick.type/size/age_group) use this exact
+// vocabulary, so the tables live here once rather than duplicated per
+// handler file.
+
+import { PetsV1 } from '@adopt-dont-shop/proto';
+
+export const SPECIES_TO_TYPE: Record<string, PetsV1.PetType> = {
+  dog: PetsV1.PetType.PET_TYPE_DOG,
+  cat: PetsV1.PetType.PET_TYPE_CAT,
+  rabbit: PetsV1.PetType.PET_TYPE_RABBIT,
+  bird: PetsV1.PetType.PET_TYPE_BIRD,
+  reptile: PetsV1.PetType.PET_TYPE_REPTILE,
+  small_mammal: PetsV1.PetType.PET_TYPE_SMALL_MAMMAL,
+  fish: PetsV1.PetType.PET_TYPE_FISH,
+  other: PetsV1.PetType.PET_TYPE_OTHER,
+};
+
+export const SIZE_TO_ENUM: Record<string, PetsV1.PetSize> = {
+  extra_small: PetsV1.PetSize.PET_SIZE_EXTRA_SMALL,
+  small: PetsV1.PetSize.PET_SIZE_SMALL,
+  medium: PetsV1.PetSize.PET_SIZE_MEDIUM,
+  large: PetsV1.PetSize.PET_SIZE_LARGE,
+  extra_large: PetsV1.PetSize.PET_SIZE_EXTRA_LARGE,
+};
+
+export const AGE_GROUP_TO_ENUM: Record<string, PetsV1.PetAgeGroup> = {
+  baby: PetsV1.PetAgeGroup.PET_AGE_GROUP_BABY,
+  young: PetsV1.PetAgeGroup.PET_AGE_GROUP_YOUNG,
+  adult: PetsV1.PetAgeGroup.PET_AGE_GROUP_ADULT,
+  senior: PetsV1.PetAgeGroup.PET_AGE_GROUP_SENIOR,
+};
+
+// PetType enum → the lowercase species token PetCandidate.species /
+// TopPick.type carry. UNSPECIFIED / UNRECOGNIZED fall back to 'unknown'.
+export const TYPE_TO_SPECIES: Record<PetsV1.PetType, string> = {
+  [PetsV1.PetType.PET_TYPE_UNSPECIFIED]: 'unknown',
+  [PetsV1.PetType.PET_TYPE_DOG]: 'dog',
+  [PetsV1.PetType.PET_TYPE_CAT]: 'cat',
+  [PetsV1.PetType.PET_TYPE_RABBIT]: 'rabbit',
+  [PetsV1.PetType.PET_TYPE_BIRD]: 'bird',
+  [PetsV1.PetType.PET_TYPE_REPTILE]: 'reptile',
+  [PetsV1.PetType.PET_TYPE_SMALL_MAMMAL]: 'small_mammal',
+  [PetsV1.PetType.PET_TYPE_FISH]: 'fish',
+  [PetsV1.PetType.PET_TYPE_OTHER]: 'other',
+  [PetsV1.PetType.UNRECOGNIZED]: 'unknown',
+};
+
+export const SIZE_TO_TOKEN: Record<PetsV1.PetSize, string> = {
+  [PetsV1.PetSize.PET_SIZE_UNSPECIFIED]: 'unknown',
+  [PetsV1.PetSize.PET_SIZE_EXTRA_SMALL]: 'extra_small',
+  [PetsV1.PetSize.PET_SIZE_SMALL]: 'small',
+  [PetsV1.PetSize.PET_SIZE_MEDIUM]: 'medium',
+  [PetsV1.PetSize.PET_SIZE_LARGE]: 'large',
+  [PetsV1.PetSize.PET_SIZE_EXTRA_LARGE]: 'extra_large',
+  [PetsV1.PetSize.UNRECOGNIZED]: 'unknown',
+};
+
+export const AGE_GROUP_TO_TOKEN: Record<PetsV1.PetAgeGroup, string> = {
+  [PetsV1.PetAgeGroup.PET_AGE_GROUP_UNSPECIFIED]: 'unknown',
+  [PetsV1.PetAgeGroup.PET_AGE_GROUP_BABY]: 'baby',
+  [PetsV1.PetAgeGroup.PET_AGE_GROUP_YOUNG]: 'young',
+  [PetsV1.PetAgeGroup.PET_AGE_GROUP_ADULT]: 'adult',
+  [PetsV1.PetAgeGroup.PET_AGE_GROUP_SENIOR]: 'senior',
+  [PetsV1.PetAgeGroup.UNRECOGNIZED]: 'unknown',
+};
+
+export function lookupToken<T>(value: unknown, table: Record<string, T>): T | undefined {
+  if (typeof value !== 'string') {
+    return undefined;
+  }
+  return table[value.trim().toLowerCase()];
+}

--- a/services/matching/src/grpc/recommend-handlers.ts
+++ b/services/matching/src/grpc/recommend-handlers.ts
@@ -27,6 +27,13 @@ import {
 } from '@adopt-dont-shop/proto';
 
 import { HandlerError, type HandlerDeps } from './adapter.js';
+import {
+  AGE_GROUP_TO_ENUM,
+  lookupToken,
+  SIZE_TO_ENUM,
+  SPECIES_TO_TYPE,
+  TYPE_TO_SPECIES,
+} from './pet-tokens.js';
 import type { PetsClient } from './pets-client.js';
 import { principalToMetadata } from './principal.js';
 import { scoreCandidates, type RecommendPreferences } from './recommend-scoring.js';
@@ -176,7 +183,8 @@ async function listPetsResponse(
 // — where the same pet can have many rows from repeat swipes — collapses
 // to one exclusion per pet. 'info' actions are trace views, not
 // decisions, so they don't exclude a pet from future recommendations.
-async function fetchSwipedPetIds(deps: HandlerDeps, userId: string): Promise<Set<string>> {
+// Exported so GetTopPicks applies the exact same exclusion rule.
+export async function fetchSwipedPetIds(deps: HandlerDeps, userId: string): Promise<Set<string>> {
   const { rows } = await deps.pool.query<{ pet_id: string }>(
     `SELECT DISTINCT pet_id
        FROM matching.swipe_actions
@@ -223,32 +231,6 @@ function readField(obj: object, key: string): unknown {
     : undefined;
 }
 
-const SPECIES_TO_TYPE: Record<string, PetsV1.PetType> = {
-  dog: PetsV1.PetType.PET_TYPE_DOG,
-  cat: PetsV1.PetType.PET_TYPE_CAT,
-  rabbit: PetsV1.PetType.PET_TYPE_RABBIT,
-  bird: PetsV1.PetType.PET_TYPE_BIRD,
-  reptile: PetsV1.PetType.PET_TYPE_REPTILE,
-  small_mammal: PetsV1.PetType.PET_TYPE_SMALL_MAMMAL,
-  fish: PetsV1.PetType.PET_TYPE_FISH,
-  other: PetsV1.PetType.PET_TYPE_OTHER,
-};
-
-const SIZE_TO_ENUM: Record<string, PetsV1.PetSize> = {
-  extra_small: PetsV1.PetSize.PET_SIZE_EXTRA_SMALL,
-  small: PetsV1.PetSize.PET_SIZE_SMALL,
-  medium: PetsV1.PetSize.PET_SIZE_MEDIUM,
-  large: PetsV1.PetSize.PET_SIZE_LARGE,
-  extra_large: PetsV1.PetSize.PET_SIZE_EXTRA_LARGE,
-};
-
-const AGE_GROUP_TO_ENUM: Record<string, PetsV1.PetAgeGroup> = {
-  baby: PetsV1.PetAgeGroup.PET_AGE_GROUP_BABY,
-  young: PetsV1.PetAgeGroup.PET_AGE_GROUP_YOUNG,
-  adult: PetsV1.PetAgeGroup.PET_AGE_GROUP_ADULT,
-  senior: PetsV1.PetAgeGroup.PET_AGE_GROUP_SENIOR,
-};
-
 function mapSpecies(value: unknown): PetsV1.PetType | undefined {
   return lookupToken(value, SPECIES_TO_TYPE);
 }
@@ -260,28 +242,6 @@ function mapSize(value: unknown): PetsV1.PetSize | undefined {
 function mapAgeGroup(value: unknown): PetsV1.PetAgeGroup | undefined {
   return lookupToken(value, AGE_GROUP_TO_ENUM);
 }
-
-function lookupToken<T>(value: unknown, table: Record<string, T>): T | undefined {
-  if (typeof value !== 'string') {
-    return undefined;
-  }
-  return table[value.trim().toLowerCase()];
-}
-
-// PetType enum → the lowercase species token PetCandidate.species
-// carries. UNSPECIFIED / UNRECOGNIZED fall back to 'unknown'.
-const TYPE_TO_SPECIES: Record<PetsV1.PetType, string> = {
-  [PetsV1.PetType.PET_TYPE_UNSPECIFIED]: 'unknown',
-  [PetsV1.PetType.PET_TYPE_DOG]: 'dog',
-  [PetsV1.PetType.PET_TYPE_CAT]: 'cat',
-  [PetsV1.PetType.PET_TYPE_RABBIT]: 'rabbit',
-  [PetsV1.PetType.PET_TYPE_BIRD]: 'bird',
-  [PetsV1.PetType.PET_TYPE_REPTILE]: 'reptile',
-  [PetsV1.PetType.PET_TYPE_SMALL_MAMMAL]: 'small_mammal',
-  [PetsV1.PetType.PET_TYPE_FISH]: 'fish',
-  [PetsV1.PetType.PET_TYPE_OTHER]: 'other',
-  [PetsV1.PetType.UNRECOGNIZED]: 'unknown',
-};
 
 // Pet (pets vertical) → PetCandidate (matching's swipe-card subset).
 // The pets Pet message has no plain `breed` name (only breedId) nor an

--- a/services/matching/src/grpc/rescue-client.test.ts
+++ b/services/matching/src/grpc/rescue-client.test.ts
@@ -1,0 +1,167 @@
+// Behaviour tests for the matching rescue-client. Mirrors
+// services/notifications/src/grpc/rescue-client.test.ts: a real
+// @grpc/grpc-js Server bound to 127.0.0.1:0, torn down in afterEach.
+
+import {
+  Metadata,
+  Server,
+  ServerCredentials,
+  ServerUnaryCall,
+  sendUnaryData,
+  ServiceError,
+  status,
+} from '@grpc/grpc-js';
+
+import { RescueV1, type GetRescueRequest, type GetRescueResponse } from '@adopt-dont-shop/proto';
+import {
+  PRINCIPAL_TOKEN_HEADER,
+  resetDefaultPrincipalSigningKeyForTests,
+  verifyPrincipalToken,
+} from '@adopt-dont-shop/service-bootstrap';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { createRescueClient } from './rescue-client.js';
+
+const makeServiceError = (code: number, details: string): ServiceError => {
+  const err = new Error(details) as ServiceError;
+  err.code = code;
+  err.details = details;
+  err.metadata = new Metadata();
+  return err;
+};
+
+describe('createRescueClient — rescue name lookup', () => {
+  let server: Server;
+  let port: number;
+
+  beforeEach(() => {
+    server = new Server();
+  });
+
+  afterEach(async () => {
+    await new Promise<void>(resolve => server.tryShutdown(() => resolve()));
+  });
+
+  const startServer = async (): Promise<number> =>
+    new Promise<number>((resolve, reject) => {
+      server.bindAsync('127.0.0.1:0', ServerCredentials.createInsecure(), (err, boundPort) =>
+        err ? reject(err) : resolve(boundPort)
+      );
+    });
+
+  it('returns the rescue name from Get', async () => {
+    server.addService(RescueV1.RescueServiceService, {
+      get: (
+        _call: ServerUnaryCall<GetRescueRequest, GetRescueResponse>,
+        cb: sendUnaryData<GetRescueResponse>
+      ) => {
+        cb(null, {
+          rescue: RescueV1.Rescue.fromPartial({ rescueId: 'res-1', name: 'Happy Tails' }),
+        });
+      },
+    });
+
+    port = await startServer();
+    const client = createRescueClient({ address: `127.0.0.1:${port}`, deadlineMs: 2_000 });
+    try {
+      expect(await client.getRescueName('res-1')).toBe('Happy Tails');
+    } finally {
+      client.close();
+    }
+  });
+
+  it('returns null when the rescue has no name set', async () => {
+    server.addService(RescueV1.RescueServiceService, {
+      get: (
+        _call: ServerUnaryCall<GetRescueRequest, GetRescueResponse>,
+        cb: sendUnaryData<GetRescueResponse>
+      ) => {
+        cb(null, { rescue: undefined });
+      },
+    });
+
+    port = await startServer();
+    const client = createRescueClient({ address: `127.0.0.1:${port}`, deadlineMs: 2_000 });
+    try {
+      expect(await client.getRescueName('res-missing')).toBeNull();
+    } finally {
+      client.close();
+    }
+  });
+
+  it('retries Get on a transient UNAVAILABLE', async () => {
+    let callCount = 0;
+    server.addService(RescueV1.RescueServiceService, {
+      get: (
+        _call: ServerUnaryCall<GetRescueRequest, GetRescueResponse>,
+        cb: sendUnaryData<GetRescueResponse>
+      ) => {
+        callCount += 1;
+        if (callCount === 1) {
+          cb(makeServiceError(status.UNAVAILABLE, 'service unavailable'), null);
+        } else {
+          cb(null, { rescue: RescueV1.Rescue.fromPartial({ rescueId: 'res-1', name: 'Retried' }) });
+        }
+      },
+    });
+
+    port = await startServer();
+    const client = createRescueClient({ address: `127.0.0.1:${port}`, deadlineMs: 2_000 });
+    try {
+      expect(await client.getRescueName('res-1')).toBe('Retried');
+      expect(callCount).toBe(2);
+    } finally {
+      client.close();
+    }
+  });
+});
+
+describe('createRescueClient — signed system principal', () => {
+  const SIGNING_KEY = 'matching-test-signing-key';
+  let server: Server;
+
+  beforeEach(() => {
+    server = new Server();
+  });
+
+  afterEach(async () => {
+    delete process.env.PRINCIPAL_SIGNING_KEY;
+    resetDefaultPrincipalSigningKeyForTests();
+    await new Promise<void>(resolve => server.tryShutdown(() => resolve()));
+  });
+
+  it('stamps a super_admin principal carrying rescues.read so it can read any rescue', async () => {
+    process.env.PRINCIPAL_SIGNING_KEY = SIGNING_KEY;
+    resetDefaultPrincipalSigningKeyForTests();
+
+    const captured: Metadata[] = [];
+    server.addService(RescueV1.RescueServiceService, {
+      get: (
+        call: ServerUnaryCall<GetRescueRequest, GetRescueResponse>,
+        cb: sendUnaryData<GetRescueResponse>
+      ) => {
+        captured.push(call.metadata);
+        cb(null, { rescue: undefined });
+      },
+    });
+    const port = await new Promise<number>((resolve, reject) => {
+      server.bindAsync('127.0.0.1:0', ServerCredentials.createInsecure(), (err, boundPort) =>
+        err ? reject(err) : resolve(boundPort)
+      );
+    });
+
+    const client = createRescueClient({ address: `127.0.0.1:${port}` });
+    try {
+      await client.getRescueName('res-1');
+      expect(captured).toHaveLength(1);
+      const token = String(captured[0].get(PRINCIPAL_TOKEN_HEADER)[0]);
+      const principal = verifyPrincipalToken(token, SIGNING_KEY);
+      expect(principal.userId).toBe('svc-matching');
+      expect(principal.roles).toEqual(['super_admin']);
+      expect(principal.permissions).toEqual(['rescues.read']);
+    } finally {
+      client.close();
+    }
+  });
+});

--- a/services/matching/src/grpc/rescue-client.ts
+++ b/services/matching/src/grpc/rescue-client.ts
@@ -1,0 +1,121 @@
+// Service-to-service gRPC client for service.rescue — GetTopPicks
+// resolves each pick's rescue name via RescueService.Get. Mirrors
+// services/notifications/src/grpc/rescue-client.ts (signed system
+// principal, retry on UNAVAILABLE / DEADLINE_EXCEEDED, a per-call
+// deadline), trimmed to just the lookup top-picks needs.
+
+import { credentials, status, type CallOptions, Metadata } from '@grpc/grpc-js';
+
+import { RescueV1, type GetRescueRequest, type GetRescueResponse } from '@adopt-dont-shop/proto';
+import {
+  getDefaultPrincipalSigningKey,
+  PRINCIPAL_TOKEN_HEADER,
+  signPrincipalToken,
+} from '@adopt-dont-shop/service-bootstrap';
+
+export type CreateRescueClientOptions = {
+  address: string;
+  // System principal metadata. RescueService.Get gates on `rescues.read`.
+  systemUserId?: string;
+  systemRoles?: string;
+  systemPermissions?: string;
+  deadlineMs?: number;
+  maxRetries?: number;
+};
+
+const DEFAULT_DEADLINE_MS = 5_000;
+const DEFAULT_MAX_RETRIES = 2;
+const RETRYABLE_CODES = new Set([status.UNAVAILABLE, status.DEADLINE_EXCEEDED]);
+
+const isRetryableError = (err: unknown): boolean => {
+  if (err === null || typeof err !== 'object') {
+    return false;
+  }
+  const code = (err as { code?: unknown }).code;
+  return typeof code === 'number' && RETRYABLE_CODES.has(code);
+};
+
+const sleep = (ms: number): Promise<void> => new Promise(resolve => setTimeout(resolve, ms));
+
+const splitList = (raw: string): string[] =>
+  raw
+    .split(',')
+    .map(s => s.trim())
+    .filter(Boolean);
+
+const jitteredBackoff = (attempt: number, baseMs: number): number => {
+  const base = baseMs * Math.pow(2, attempt - 1);
+  return base * (0.75 + Math.random() * 0.5);
+};
+
+export type RescueNameClient = {
+  getRescueName: (rescueId: string) => Promise<string | null>;
+  close(): void;
+};
+
+export function createRescueClient(opts: CreateRescueClientOptions): RescueNameClient {
+  const stub = new RescueV1.RescueServiceClient(opts.address, credentials.createInsecure());
+  const deadlineMs = opts.deadlineMs ?? DEFAULT_DEADLINE_MS;
+  const maxRetries = opts.maxRetries ?? DEFAULT_MAX_RETRIES;
+
+  const systemPrincipal = {
+    userId: opts.systemUserId ?? 'svc-matching',
+    roles: splitList(opts.systemRoles ?? 'super_admin'),
+    permissions: splitList(opts.systemPermissions ?? 'rescues.read'),
+  };
+
+  const buildSystemMetadata = (): Metadata => {
+    const meta = new Metadata();
+    meta.set('x-user-id', systemPrincipal.userId);
+    meta.set('x-user-roles', systemPrincipal.roles.join(','));
+    meta.set('x-user-permissions', systemPrincipal.permissions.join(','));
+    const signingKey = getDefaultPrincipalSigningKey();
+    if (signingKey) {
+      meta.set(PRINCIPAL_TOKEN_HEADER, signPrincipalToken(systemPrincipal, signingKey));
+    }
+    return meta;
+  };
+
+  const callWithRetry = <Req, Res>(
+    fn: (
+      req: Req,
+      metadata: Metadata,
+      options: Partial<CallOptions>,
+      cb: (err: unknown, res: Res) => void
+    ) => unknown,
+    req: Req
+  ): Promise<Res> => {
+    const attempt = (remaining: number): Promise<Res> =>
+      new Promise<Res>((resolve, reject) => {
+        const options: Partial<CallOptions> = {
+          deadline: new Date(Date.now() + deadlineMs),
+        };
+        fn.call(stub, req, buildSystemMetadata(), options, (err: unknown, res: Res) => {
+          if (err) {
+            if (remaining > 0 && isRetryableError(err)) {
+              const retryIndex = maxRetries - remaining + 1;
+              sleep(jitteredBackoff(retryIndex, 100))
+                .then(() => attempt(remaining - 1))
+                .then(resolve, reject);
+            } else {
+              reject(err);
+            }
+            return;
+          }
+          resolve(res);
+        });
+      });
+
+    return attempt(maxRetries);
+  };
+
+  return {
+    getRescueName: async (rescueId: string): Promise<string | null> => {
+      const res = await callWithRetry<GetRescueRequest, GetRescueResponse>(stub.get, {
+        rescueId,
+      });
+      return res.rescue?.name ?? null;
+    },
+    close: () => stub.close(),
+  };
+}

--- a/services/matching/src/grpc/server.test.ts
+++ b/services/matching/src/grpc/server.test.ts
@@ -25,20 +25,32 @@ const config: MatchingConfig = {
   schema: 'matching',
   natsUrl: 'nats://localhost:4222',
   petsGrpcUrl: 'service-pets:6003',
+  rescueGrpcUrl: 'service-rescue:6004',
 };
 
 const pool = {} as unknown as Pool;
 const nats = {} as unknown as NatsConnection;
-// Inject a stub pets client so the test doesn't construct a real gRPC
-// channel just to assert handler registration.
+// Inject stub downstream clients so the test doesn't construct real gRPC
+// channels just to assert handler registration.
 const petsClient = {
   listPets: () => Promise.reject(new Error('not used')),
   close: () => undefined,
 } as unknown as Parameters<typeof createGrpcServer>[0]['petsClient'];
+const rescueClient = {
+  getRescueName: () => Promise.reject(new Error('not used')),
+  close: () => undefined,
+} as unknown as Parameters<typeof createGrpcServer>[0]['rescueClient'];
 
 describe('createGrpcServer', () => {
   it('registers all six MatchingService methods on the grpc.Server', () => {
-    const server = createGrpcServer({ config, pool, nats, logger: quietLogger, petsClient });
+    const server = createGrpcServer({
+      config,
+      pool,
+      nats,
+      logger: quietLogger,
+      petsClient,
+      rescueClient,
+    });
     const handlers = (server as unknown as { handlers: Map<string, unknown> }).handlers;
 
     expect(handlers.has('/adopt_dont_shop.matching.v1.MatchingService/StartSession')).toBe(true);
@@ -55,7 +67,14 @@ describe('createGrpcServer', () => {
     const definition = MatchingV1.MatchingServiceService;
     const expectedPaths = Object.values(definition).map(d => (d as { path: string }).path);
 
-    const server = createGrpcServer({ config, pool, nats, logger: quietLogger, petsClient });
+    const server = createGrpcServer({
+      config,
+      pool,
+      nats,
+      logger: quietLogger,
+      petsClient,
+      rescueClient,
+    });
     const handlers = (server as unknown as { handlers: Map<string, unknown> }).handlers;
 
     for (const p of expectedPaths) {

--- a/services/matching/src/grpc/server.ts
+++ b/services/matching/src/grpc/server.ts
@@ -26,6 +26,8 @@ import {
   upsertMatchProfile,
 } from './profile-stats-handlers.js';
 import { makeRecommend, makeSearchPets } from './recommend-handlers.js';
+import { createRescueClient, type RescueNameClient } from './rescue-client.js';
+import { makeGetTopPicks } from './top-picks-handlers.js';
 
 export type CreateGrpcServerOptions = {
   config: MatchingConfig;
@@ -37,6 +39,10 @@ export type CreateGrpcServerOptions = {
   // client is built from config.petsGrpcUrl. startGrpcServer always
   // builds + owns one so it can close it on shutdown.
   petsClient?: PetsClient;
+  // Injected for GetTopPicks's rescue-name resolution. Same lifecycle as
+  // petsClient: optional for direct/test construction, built + owned by
+  // startGrpcServer from config.rescueGrpcUrl in production.
+  rescueClient?: RescueNameClient;
 };
 
 export type { RunningGrpcServer };
@@ -45,6 +51,7 @@ export const createGrpcServer = (opts: CreateGrpcServerOptions): Server => {
   const { config, pool, nats, logger } = opts;
   const deps = { pool, nats };
   const petsClient = opts.petsClient ?? createPetsClient({ address: config.petsGrpcUrl });
+  const rescueClient = opts.rescueClient ?? createRescueClient({ address: config.rescueGrpcUrl });
   const server = new Server();
 
   server.addService(MatchingV1.MatchingServiceService, {
@@ -58,6 +65,7 @@ export const createGrpcServer = (opts: CreateGrpcServerOptions): Server => {
     upsertMatchProfile: adapt(upsertMatchProfile, { deps, logger }),
     getUserSwipeStats: adapt(getUserSwipeStats, { deps, logger }),
     getSessionStats: adapt(getSessionStats, { deps, logger }),
+    getTopPicks: adapt(makeGetTopPicks(petsClient, rescueClient), { deps, logger }),
   });
 
   logger.info('gRPC MatchingService registered', {
@@ -72,6 +80,7 @@ export const createGrpcServer = (opts: CreateGrpcServerOptions): Server => {
       'upsertMatchProfile',
       'getUserSwipeStats',
       'getSessionStats',
+      'getTopPicks',
     ],
     grpcPort: config.grpcPort,
   });
@@ -83,9 +92,10 @@ export const startGrpcServer = async (
   opts: CreateGrpcServerOptions
 ): Promise<RunningGrpcServer> => {
   const { config, logger } = opts;
-  // Build + own the pets client here so it's closed on shutdown.
+  // Build + own the downstream clients here so they're closed on shutdown.
   const petsClient = opts.petsClient ?? createPetsClient({ address: config.petsGrpcUrl });
-  const server = createGrpcServer({ ...opts, petsClient });
+  const rescueClient = opts.rescueClient ?? createRescueClient({ address: config.rescueGrpcUrl });
+  const server = createGrpcServer({ ...opts, petsClient, rescueClient });
   const running = await startGrpcServerShared(server, config, logger);
 
   return {
@@ -96,10 +106,15 @@ export const startGrpcServer = async (
           if (err) {
             logger.error('gRPC server shutdown error', { err });
           }
-          try {
-            petsClient.close();
-          } catch (closeErr) {
-            logger.error('pets client close error', { err: closeErr });
+          for (const [name, client] of [
+            ['pets', petsClient],
+            ['rescue', rescueClient],
+          ] as const) {
+            try {
+              client.close();
+            } catch (closeErr) {
+              logger.error(`${name} client close error`, { err: closeErr });
+            }
           }
           resolve();
         });

--- a/services/matching/src/grpc/top-picks-handlers.test.ts
+++ b/services/matching/src/grpc/top-picks-handlers.test.ts
@@ -1,0 +1,289 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  PetsV1,
+  type ListPetsResponse,
+  type Pet,
+  type GetTopPicksRequest,
+} from '@adopt-dont-shop/proto';
+
+import type { HandlerDeps } from './adapter.js';
+import type { PetsClient } from './pets-client.js';
+import type { RescueNameClient } from './rescue-client.js';
+import { makeGetTopPicks } from './top-picks-handlers.js';
+
+function makePrincipal(
+  overrides: Partial<{ userId: string; permissions: string[]; roles: string[] }> = {}
+) {
+  return {
+    userId: overrides.userId ?? 'usr-1',
+    roles: overrides.roles ?? ['adopter'],
+    permissions: overrides.permissions ?? ['pets.read'],
+    rescueId: undefined,
+  } as unknown as Parameters<ReturnType<typeof makeGetTopPicks>>[1];
+}
+
+type ProfileRow = {
+  preferred_types: unknown[] | null;
+  preferred_sizes: unknown[] | null;
+  preferred_age_groups: unknown[] | null;
+  lifestyle: Record<string, unknown>;
+};
+
+// A pool stub that answers the two reads the handler makes — the match
+// profile SELECT and the swipe-history exclusion — by branching on the
+// SQL text. `profile: null` simulates an adopter with no saved profile.
+function makeDeps(opts: { profile?: ProfileRow | null; swiped?: string[] } = {}): HandlerDeps {
+  const query = vi.fn((sql: string) => {
+    if (sql.includes('adopter_match_profiles')) {
+      const noProfile = opts.profile === null || opts.profile === undefined;
+      return Promise.resolve({ rows: noProfile ? [] : [opts.profile] });
+    }
+    if (sql.includes('swipe_actions')) {
+      return Promise.resolve({ rows: (opts.swiped ?? []).map(pet_id => ({ pet_id })) });
+    }
+    return Promise.resolve({ rows: [] });
+  });
+  return { pool: { query } } as unknown as HandlerDeps;
+}
+
+function makePetsClient(listPets: ReturnType<typeof vi.fn>): PetsClient {
+  return { listPets, close: vi.fn() } as unknown as PetsClient;
+}
+
+function makeRescueClient(
+  getRescueName: ReturnType<typeof vi.fn> = vi.fn().mockResolvedValue('A Rescue')
+): RescueNameClient {
+  return { getRescueName, close: vi.fn() };
+}
+
+function makePet(overrides: Partial<Pet> & { petId: string }): Pet {
+  return {
+    name: 'Rex',
+    type: PetsV1.PetType.PET_TYPE_DOG,
+    status: PetsV1.PetStatus.PET_STATUS_AVAILABLE,
+    gender: PetsV1.PetGender.PET_GENDER_UNSPECIFIED,
+    size: PetsV1.PetSize.PET_SIZE_MEDIUM,
+    ageGroup: PetsV1.PetAgeGroup.PET_AGE_GROUP_ADULT,
+    archived: false,
+    featured: false,
+    priorityListing: false,
+    specialNeeds: false,
+    houseTrained: false,
+    temperamentJson: '[]',
+    tagsJson: '[]',
+    extraJson: '{}',
+    viewCount: 0,
+    favoriteCount: 0,
+    applicationCount: 0,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+const listResponse = (pets: Pet[]): ListPetsResponse => ({ pets });
+const req = (limit = 10): GetTopPicksRequest => ({ limit });
+
+describe('makeGetTopPicks', () => {
+  it('throws PERMISSION_DENIED without pets.read', async () => {
+    const getTopPicks = makeGetTopPicks(makePetsClient(vi.fn()), makeRescueClient());
+    await expect(
+      getTopPicks(makeDeps(), makePrincipal({ permissions: [] }), req())
+    ).rejects.toMatchObject({ code: 'PERMISSION_DENIED' });
+  });
+
+  it('only requests available pets from service.pets', async () => {
+    const listPets = vi.fn().mockResolvedValue(listResponse([]));
+    const getTopPicks = makeGetTopPicks(makePetsClient(listPets), makeRescueClient());
+
+    await getTopPicks(makeDeps(), makePrincipal(), req());
+
+    expect(listPets.mock.calls[0][0].statusFilter).toBe(PetsV1.PetStatus.PET_STATUS_AVAILABLE);
+  });
+
+  it('returns scored picks with lowercase tokens and a resolved rescue name', async () => {
+    const listPets = vi.fn().mockResolvedValue(
+      listResponse([
+        makePet({
+          petId: 'p-1',
+          name: 'Bella',
+          rescueId: 'rsc-1',
+          type: PetsV1.PetType.PET_TYPE_CAT,
+          size: PetsV1.PetSize.PET_SIZE_SMALL,
+          ageGroup: PetsV1.PetAgeGroup.PET_AGE_GROUP_BABY,
+        }),
+      ])
+    );
+    const getRescueName = vi.fn().mockResolvedValue('Happy Tails');
+    const getTopPicks = makeGetTopPicks(makePetsClient(listPets), makeRescueClient(getRescueName));
+
+    const res = await getTopPicks(makeDeps(), makePrincipal(), req());
+
+    expect(res.picks).toHaveLength(1);
+    expect(res.picks[0]).toMatchObject({
+      petId: 'p-1',
+      name: 'Bella',
+      type: 'cat',
+      size: 'small',
+      ageGroup: 'baby',
+      rescueName: 'Happy Tails',
+    });
+    expect(res.picks[0].score).toBeGreaterThanOrEqual(0);
+    expect(res.picks[0].score).toBeLessThanOrEqual(1);
+  });
+
+  it('ranks a pet matching the stored profile above a non-matching one', async () => {
+    const listPets = vi
+      .fn()
+      .mockResolvedValue(
+        listResponse([
+          makePet({ petId: 'cat', rescueId: 'rsc-1', type: PetsV1.PetType.PET_TYPE_CAT }),
+          makePet({ petId: 'dog', rescueId: 'rsc-1', type: PetsV1.PetType.PET_TYPE_DOG }),
+        ])
+      );
+    const getTopPicks = makeGetTopPicks(makePetsClient(listPets), makeRescueClient());
+
+    const res = await getTopPicks(
+      makeDeps({
+        profile: {
+          preferred_types: ['dog'],
+          preferred_sizes: null,
+          preferred_age_groups: null,
+          lifestyle: {},
+        },
+      }),
+      makePrincipal(),
+      req()
+    );
+
+    expect(res.picks[0].petId).toBe('dog');
+    expect(res.picks[0].reasons.some(r => r.kind === 'pref_match')).toBe(true);
+  });
+
+  it('excludes pets the caller has already swiped', async () => {
+    const listPets = vi
+      .fn()
+      .mockResolvedValue(
+        listResponse([
+          makePet({ petId: 'seen', rescueId: 'rsc-1' }),
+          makePet({ petId: 'fresh', rescueId: 'rsc-1' }),
+        ])
+      );
+    const getTopPicks = makeGetTopPicks(makePetsClient(listPets), makeRescueClient());
+
+    const res = await getTopPicks(makeDeps({ swiped: ['seen'] }), makePrincipal(), req());
+
+    const ids = res.picks.map(p => p.petId);
+    expect(ids).toContain('fresh');
+    expect(ids).not.toContain('seen');
+  });
+
+  it('caps the result at the requested limit', async () => {
+    const pets = Array.from({ length: 5 }, (_, i) =>
+      makePet({ petId: `p-${i}`, rescueId: 'rsc-1' })
+    );
+    const listPets = vi.fn().mockResolvedValue(listResponse(pets));
+    const getTopPicks = makeGetTopPicks(makePetsClient(listPets), makeRescueClient());
+
+    const res = await getTopPicks(makeDeps(), makePrincipal(), req(2));
+
+    expect(res.picks).toHaveLength(2);
+  });
+
+  it('resolves each distinct rescue exactly once even across many picks', async () => {
+    const listPets = vi
+      .fn()
+      .mockResolvedValue(
+        listResponse([
+          makePet({ petId: 'a', rescueId: 'rsc-1' }),
+          makePet({ petId: 'b', rescueId: 'rsc-1' }),
+          makePet({ petId: 'c', rescueId: 'rsc-2' }),
+        ])
+      );
+    const getRescueName = vi.fn().mockResolvedValue('Some Rescue');
+    const getTopPicks = makeGetTopPicks(makePetsClient(listPets), makeRescueClient(getRescueName));
+
+    await getTopPicks(makeDeps(), makePrincipal(), req());
+
+    expect(getRescueName).toHaveBeenCalledTimes(2);
+    expect(getRescueName.mock.calls.map(c => c[0]).sort()).toEqual(['rsc-1', 'rsc-2']);
+  });
+
+  it('leaves rescueName empty when the rescue lookup yields nothing', async () => {
+    const listPets = vi
+      .fn()
+      .mockResolvedValue(listResponse([makePet({ petId: 'p-1', rescueId: 'rsc-1' })]));
+    const getRescueName = vi.fn().mockResolvedValue(null);
+    const getTopPicks = makeGetTopPicks(makePetsClient(listPets), makeRescueClient(getRescueName));
+
+    const res = await getTopPicks(makeDeps(), makePrincipal(), req());
+
+    expect(res.picks[0].rescueName).toBe('');
+  });
+
+  it('still returns picks when the adopter has no saved profile', async () => {
+    const listPets = vi
+      .fn()
+      .mockResolvedValue(listResponse([makePet({ petId: 'p-1', rescueId: 'rsc-1' })]));
+    const getTopPicks = makeGetTopPicks(makePetsClient(listPets), makeRescueClient());
+
+    const res = await getTopPicks(makeDeps({ profile: null }), makePrincipal(), req());
+
+    expect(res.picks).toHaveLength(1);
+    expect(res.picks[0].reasons.some(r => r.kind === 'pref_match')).toBe(false);
+  });
+
+  it('surfaces a lifestyle chip when a child-friendly pet meets a household with children', async () => {
+    const listPets = vi.fn().mockResolvedValue(
+      listResponse([
+        makePet({
+          petId: 'p-1',
+          rescueId: 'rsc-1',
+          extraJson: JSON.stringify({ goodWithChildren: true }),
+        }),
+      ])
+    );
+    const getTopPicks = makeGetTopPicks(makePetsClient(listPets), makeRescueClient());
+
+    const res = await getTopPicks(
+      makeDeps({
+        profile: {
+          preferred_types: null,
+          preferred_sizes: null,
+          preferred_age_groups: null,
+          lifestyle: { has_children: true },
+        },
+      }),
+      makePrincipal(),
+      req()
+    );
+
+    expect(res.picks[0].reasons.some(r => r.kind === 'lifestyle')).toBe(true);
+  });
+
+  it('forwards the caller identity to service.pets as metadata', async () => {
+    const listPets = vi.fn().mockResolvedValue(listResponse([]));
+    const getTopPicks = makeGetTopPicks(makePetsClient(listPets), makeRescueClient());
+
+    await getTopPicks(makeDeps(), makePrincipal({ userId: 'usr-9' }), req());
+
+    expect(listPets.mock.calls[0][1].get('x-user-id')).toEqual(['usr-9']);
+  });
+
+  it('maps a pets PERMISSION_DENIED (grpc code 7) onto PERMISSION_DENIED', async () => {
+    const listPets = vi.fn().mockRejectedValue({ code: 7 });
+    const getTopPicks = makeGetTopPicks(makePetsClient(listPets), makeRescueClient());
+    await expect(getTopPicks(makeDeps(), makePrincipal(), req())).rejects.toMatchObject({
+      code: 'PERMISSION_DENIED',
+    });
+  });
+
+  it('maps an unexpected pets error onto INTERNAL', async () => {
+    const listPets = vi.fn().mockRejectedValue(new Error('boom'));
+    const getTopPicks = makeGetTopPicks(makePetsClient(listPets), makeRescueClient());
+    await expect(getTopPicks(makeDeps(), makePrincipal(), req())).rejects.toMatchObject({
+      code: 'INTERNAL',
+    });
+  });
+});

--- a/services/matching/src/grpc/top-picks-handlers.ts
+++ b/services/matching/src/grpc/top-picks-handlers.ts
@@ -1,0 +1,224 @@
+// gRPC handler for MatchingService.GetTopPicks — a short, personalised
+// "top picks" list distinct from Recommend's swipe feed.
+//
+// Unlike Recommend (which scores against the session's transient
+// filters), top picks reads the adopter's STORED match profile
+// (preferred types / sizes / age groups + lifestyle) from
+// matching.adopter_match_profiles, scores the available pets against it
+// with the pure scorer in top-picks-scoring.ts, excludes already-swiped
+// pets (same rule as Recommend), and resolves each pick's rescue name
+// over gRPC. Stateless — no swipe session required, no mutation.
+
+import { requirePermission, type Principal } from '@adopt-dont-shop/authz';
+import { PETS_VIEW } from '@adopt-dont-shop/lib.types';
+import {
+  PetsV1,
+  type GetTopPicksRequest,
+  type GetTopPicksResponse,
+  type ListPetsRequest,
+  type Pet,
+  type TopPick,
+} from '@adopt-dont-shop/proto';
+
+import { HandlerError, type HandlerDeps } from './adapter.js';
+import {
+  AGE_GROUP_TO_ENUM,
+  AGE_GROUP_TO_TOKEN,
+  lookupToken,
+  SIZE_TO_ENUM,
+  SIZE_TO_TOKEN,
+  SPECIES_TO_TYPE,
+  TYPE_TO_SPECIES,
+} from './pet-tokens.js';
+import type { PetsClient } from './pets-client.js';
+import { principalToMetadata } from './principal.js';
+import { fetchSwipedPetIds } from './recommend-handlers.js';
+import type { RescueNameClient } from './rescue-client.js';
+import { scoreTopPicks, type TopPickPreferences } from './top-picks-scoring.js';
+
+// grpc-js PERMISSION_DENIED, returned by service.pets' List gate.
+const PETS_GRPC_PERMISSION_DENIED = 7;
+
+const DEFAULT_LIMIT = 10;
+const MAX_LIMIT = 50;
+// service.pets caps List at 100/page; pull the max so the scorer ranks a
+// real pool rather than a single SPA page before slicing to the top-K.
+const CANDIDATE_FETCH = 100;
+
+export function makeGetTopPicks(
+  petsClient: PetsClient,
+  rescueClient: RescueNameClient
+): (
+  deps: HandlerDeps,
+  principal: Principal,
+  req: GetTopPicksRequest
+) => Promise<GetTopPicksResponse> {
+  return async (deps, principal, req) => {
+    if (!requirePermission(principal, PETS_VIEW)) {
+      throw new HandlerError('PERMISSION_DENIED', `'${PETS_VIEW}' required`);
+    }
+
+    const limit = clamp(req.limit, DEFAULT_LIMIT, MAX_LIMIT);
+    const preferences = await loadPreferences(deps, principal.userId);
+
+    const listReq: ListPetsRequest = {
+      limit: CANDIDATE_FETCH,
+      statusFilter: PetsV1.PetStatus.PET_STATUS_AVAILABLE,
+      typeFilter: PetsV1.PetType.PET_TYPE_UNSPECIFIED,
+      sizeFilter: PetsV1.PetSize.PET_SIZE_UNSPECIFIED,
+    };
+    const pets = await listAvailablePets(petsClient, principal, listReq);
+
+    const swiped = await fetchSwipedPetIds(deps, principal.userId);
+    const fresh = pets.filter(pet => !swiped.has(pet.petId));
+
+    const ranked = scoreTopPicks(fresh, preferences).slice(0, limit);
+
+    const rescueNames = await resolveRescueNames(
+      rescueClient,
+      ranked.map(r => r.pet)
+    );
+    const picks = ranked.map(({ pet, score, reasons }) =>
+      toTopPick(pet, score, reasons, rescueNames)
+    );
+
+    return { picks };
+  };
+}
+
+function clamp(raw: number, fallback: number, max: number): number {
+  if (!Number.isFinite(raw) || raw <= 0) {
+    return fallback;
+  }
+  return Math.min(Math.trunc(raw), max);
+}
+
+type ProfileRow = {
+  preferred_types: unknown[] | null;
+  preferred_sizes: unknown[] | null;
+  preferred_age_groups: unknown[] | null;
+  lifestyle: Record<string, unknown> | null;
+};
+
+// Read the adopter's stored match profile and map its lowercase token
+// arrays onto the proto enum sets the scorer needs. A missing profile
+// yields empty preferences — every candidate then scores purely on
+// recency + promotion (no preference signal to discriminate on).
+async function loadPreferences(deps: HandlerDeps, userId: string): Promise<TopPickPreferences> {
+  const { rows } = await deps.pool.query<ProfileRow>(
+    `SELECT preferred_types, preferred_sizes, preferred_age_groups, lifestyle
+       FROM matching.adopter_match_profiles
+      WHERE user_id = $1
+      LIMIT 1`,
+    [userId]
+  );
+  const row = rows[0];
+  if (row === undefined) {
+    return emptyPreferences();
+  }
+  return {
+    preferredTypes: tokensToEnumSet(row.preferred_types, SPECIES_TO_TYPE),
+    preferredSizes: tokensToEnumSet(row.preferred_sizes, SIZE_TO_ENUM),
+    preferredAgeGroups: tokensToEnumSet(row.preferred_age_groups, AGE_GROUP_TO_ENUM),
+    lifestyle: parseLifestyle(row.lifestyle),
+  };
+}
+
+function emptyPreferences(): TopPickPreferences {
+  return {
+    preferredTypes: new Set(),
+    preferredSizes: new Set(),
+    preferredAgeGroups: new Set(),
+    lifestyle: {},
+  };
+}
+
+function tokensToEnumSet<T>(tokens: unknown[] | null, table: Record<string, T>): ReadonlySet<T> {
+  const set = new Set<T>();
+  if (tokens === null) {
+    return set;
+  }
+  for (const token of tokens) {
+    const enumValue = lookupToken(token, table);
+    if (enumValue !== undefined) {
+      set.add(enumValue);
+    }
+  }
+  return set;
+}
+
+function parseLifestyle(
+  lifestyle: Record<string, unknown> | null
+): TopPickPreferences['lifestyle'] {
+  if (lifestyle === null) {
+    return {};
+  }
+  return {
+    hasChildren: readBool(lifestyle, 'has_children'),
+    hasOtherPets: readBool(lifestyle, 'has_other_pets'),
+    otherPetsType: readOtherPetsType(lifestyle),
+  };
+}
+
+function readBool(obj: Record<string, unknown>, key: string): boolean | undefined {
+  const value = obj[key];
+  return typeof value === 'boolean' ? value : undefined;
+}
+
+function readOtherPetsType(
+  obj: Record<string, unknown>
+): TopPickPreferences['lifestyle']['otherPetsType'] {
+  const value = obj['other_pets_type'];
+  if (value === 'none' || value === 'dogs' || value === 'cats' || value === 'mixed') {
+    return value;
+  }
+  return undefined;
+}
+
+async function listAvailablePets(
+  petsClient: PetsClient,
+  principal: Principal,
+  req: ListPetsRequest
+): Promise<ReadonlyArray<Pet>> {
+  try {
+    const res = await petsClient.listPets(req, principalToMetadata(principal));
+    return res.pets;
+  } catch (err) {
+    const code = (err as { code?: number }).code;
+    if (code === PETS_GRPC_PERMISSION_DENIED) {
+      throw new HandlerError('PERMISSION_DENIED', 'not allowed to read pets');
+    }
+    throw new HandlerError('INTERNAL', 'failed to read candidate pets');
+  }
+}
+
+// Resolve the rescue name for every distinct rescue in the pick set in
+// one batch, deduping so a rescue with several picks is fetched once.
+async function resolveRescueNames(
+  rescueClient: RescueNameClient,
+  pets: ReadonlyArray<Pet>
+): Promise<Map<string, string>> {
+  const ids = [...new Set(pets.map(pet => pet.rescueId).filter((id): id is string => !!id))];
+  const entries = await Promise.all(
+    ids.map(async id => [id, (await rescueClient.getRescueName(id)) ?? ''] as const)
+  );
+  return new Map(entries);
+}
+
+function toTopPick(
+  pet: Pet,
+  score: number,
+  reasons: ReadonlyArray<{ kind: string; label: string }>,
+  rescueNames: Map<string, string>
+): TopPick {
+  return {
+    petId: pet.petId,
+    name: pet.name,
+    type: TYPE_TO_SPECIES[pet.type] ?? 'unknown',
+    ageGroup: AGE_GROUP_TO_TOKEN[pet.ageGroup] ?? 'unknown',
+    size: SIZE_TO_TOKEN[pet.size] ?? 'unknown',
+    score,
+    reasons: reasons.map(r => ({ kind: r.kind, label: r.label })),
+    rescueName: (pet.rescueId && rescueNames.get(pet.rescueId)) || '',
+  };
+}

--- a/services/matching/src/grpc/top-picks-scoring.test.ts
+++ b/services/matching/src/grpc/top-picks-scoring.test.ts
@@ -1,0 +1,204 @@
+import { describe, expect, it } from 'vitest';
+
+import { PetsV1, type Pet } from '@adopt-dont-shop/proto';
+
+import { scoreTopPicks, type TopPickPreferences } from './top-picks-scoring.js';
+
+// Minimal Pet factory — only the fields the scorer reads matter; the
+// rest take harmless defaults.
+function makePet(overrides: Partial<Pet> & { petId: string }): Pet {
+  return {
+    name: 'Rex',
+    type: PetsV1.PetType.PET_TYPE_DOG,
+    status: PetsV1.PetStatus.PET_STATUS_AVAILABLE,
+    gender: PetsV1.PetGender.PET_GENDER_UNSPECIFIED,
+    size: PetsV1.PetSize.PET_SIZE_MEDIUM,
+    ageGroup: PetsV1.PetAgeGroup.PET_AGE_GROUP_ADULT,
+    archived: false,
+    featured: false,
+    priorityListing: false,
+    specialNeeds: false,
+    houseTrained: false,
+    temperamentJson: '[]',
+    tagsJson: '[]',
+    extraJson: '{}',
+    viewCount: 0,
+    favoriteCount: 0,
+    applicationCount: 0,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+const NO_PREFERENCES: TopPickPreferences = {
+  preferredTypes: new Set(),
+  preferredSizes: new Set(),
+  preferredAgeGroups: new Set(),
+  lifestyle: {},
+};
+
+describe('scoreTopPicks', () => {
+  it('returns an empty list for no candidates', () => {
+    expect(scoreTopPicks([], NO_PREFERENCES)).toEqual([]);
+  });
+
+  it('produces scores within [0, 1] for every candidate', () => {
+    const result = scoreTopPicks(
+      [
+        makePet({ petId: 'a', availableSince: '2026-06-01T00:00:00.000Z', featured: true }),
+        makePet({ petId: 'b', availableSince: '2026-01-01T00:00:00.000Z' }),
+      ],
+      NO_PREFERENCES
+    );
+    for (const { score } of result) {
+      expect(score).toBeGreaterThanOrEqual(0);
+      expect(score).toBeLessThanOrEqual(1);
+    }
+  });
+
+  it('ranks a pet matching the stored type/size/age preferences above a non-matching one', () => {
+    const when = '2026-03-01T00:00:00.000Z';
+    const result = scoreTopPicks(
+      [
+        makePet({
+          petId: 'mismatch',
+          availableSince: when,
+          type: PetsV1.PetType.PET_TYPE_CAT,
+          size: PetsV1.PetSize.PET_SIZE_LARGE,
+          ageGroup: PetsV1.PetAgeGroup.PET_AGE_GROUP_SENIOR,
+        }),
+        makePet({
+          petId: 'match',
+          availableSince: when,
+          type: PetsV1.PetType.PET_TYPE_DOG,
+          size: PetsV1.PetSize.PET_SIZE_SMALL,
+          ageGroup: PetsV1.PetAgeGroup.PET_AGE_GROUP_BABY,
+        }),
+      ],
+      {
+        preferredTypes: new Set([PetsV1.PetType.PET_TYPE_DOG]),
+        preferredSizes: new Set([PetsV1.PetSize.PET_SIZE_SMALL]),
+        preferredAgeGroups: new Set([PetsV1.PetAgeGroup.PET_AGE_GROUP_BABY]),
+        lifestyle: {},
+      }
+    );
+    expect(result[0].pet.petId).toBe('match');
+    expect(result[0].score).toBeGreaterThan(result[1].score);
+  });
+
+  it('attaches a pref_match reason chip only to pets matching a stored preference', () => {
+    const when = '2026-03-01T00:00:00.000Z';
+    const result = scoreTopPicks(
+      [
+        makePet({ petId: 'dog', availableSince: when, type: PetsV1.PetType.PET_TYPE_DOG }),
+        makePet({ petId: 'cat', availableSince: when, type: PetsV1.PetType.PET_TYPE_CAT }),
+      ],
+      {
+        preferredTypes: new Set([PetsV1.PetType.PET_TYPE_DOG]),
+        preferredSizes: new Set(),
+        preferredAgeGroups: new Set(),
+        lifestyle: {},
+      }
+    );
+    const byId = new Map(result.map(r => [r.pet.petId, r]));
+    expect(byId.get('dog')?.reasons.some(r => r.kind === 'pref_match')).toBe(true);
+    expect(byId.get('cat')?.reasons.some(r => r.kind === 'pref_match')).toBe(false);
+  });
+
+  it('never emits a pref_match chip when the adopter set no preferences', () => {
+    const result = scoreTopPicks(
+      [makePet({ petId: 'a', availableSince: '2026-03-01T00:00:00.000Z' })],
+      NO_PREFERENCES
+    );
+    expect(result[0].reasons.some(r => r.kind === 'pref_match')).toBe(false);
+  });
+
+  it('attaches a lifestyle chip when a child-friendly pet meets a household with children', () => {
+    const result = scoreTopPicks(
+      [
+        makePet({
+          petId: 'kid-safe',
+          availableSince: '2026-03-01T00:00:00.000Z',
+          extraJson: JSON.stringify({ goodWithChildren: true }),
+        }),
+      ],
+      { ...NO_PREFERENCES, lifestyle: { hasChildren: true } }
+    );
+    expect(result[0].reasons.some(r => r.kind === 'lifestyle')).toBe(true);
+  });
+
+  it('omits the lifestyle chip when the household has no children even if the pet is child-friendly', () => {
+    const result = scoreTopPicks(
+      [
+        makePet({
+          petId: 'kid-safe',
+          availableSince: '2026-03-01T00:00:00.000Z',
+          extraJson: JSON.stringify({ goodWithChildren: true }),
+        }),
+      ],
+      { ...NO_PREFERENCES, lifestyle: { hasChildren: false } }
+    );
+    expect(result[0].reasons.some(r => r.kind === 'lifestyle')).toBe(false);
+  });
+
+  it('matches a dog-friendly pet against a household with dogs', () => {
+    const result = scoreTopPicks(
+      [
+        makePet({
+          petId: 'dog-ok',
+          availableSince: '2026-03-01T00:00:00.000Z',
+          extraJson: JSON.stringify({ goodWithDogs: true }),
+        }),
+      ],
+      { ...NO_PREFERENCES, lifestyle: { hasOtherPets: true, otherPetsType: 'dogs' } }
+    );
+    expect(result[0].reasons.some(r => r.kind === 'lifestyle')).toBe(true);
+  });
+
+  it('attaches a fresh chip to the most recently available pet', () => {
+    const result = scoreTopPicks(
+      [
+        makePet({ petId: 'old', availableSince: '2026-01-01T00:00:00.000Z' }),
+        makePet({ petId: 'new', availableSince: '2026-06-01T00:00:00.000Z' }),
+      ],
+      NO_PREFERENCES
+    );
+    const byId = new Map(result.map(r => [r.pet.petId, r]));
+    expect(byId.get('new')?.reasons.some(r => r.kind === 'fresh')).toBe(true);
+    expect(byId.get('old')?.reasons.some(r => r.kind === 'fresh')).toBe(false);
+  });
+
+  it('boosts a featured pet over a plain one of equal recency and preference fit', () => {
+    const when = '2026-03-01T00:00:00.000Z';
+    const result = scoreTopPicks(
+      [
+        makePet({ petId: 'plain', availableSince: when }),
+        makePet({ petId: 'promoted', availableSince: when, featured: true }),
+      ],
+      NO_PREFERENCES
+    );
+    expect(result[0].pet.petId).toBe('promoted');
+  });
+
+  it('breaks score ties deterministically on petId ascending', () => {
+    const when = '2026-03-01T00:00:00.000Z';
+    const result = scoreTopPicks(
+      [
+        makePet({ petId: 'z', availableSince: when }),
+        makePet({ petId: 'a', availableSince: when }),
+      ],
+      NO_PREFERENCES
+    );
+    expect(result.map(r => r.pet.petId)).toEqual(['a', 'z']);
+  });
+
+  it('tolerates an unparseable extra_json without throwing', () => {
+    const result = scoreTopPicks(
+      [makePet({ petId: 'a', availableSince: '2026-03-01T00:00:00.000Z', extraJson: 'not json' })],
+      { ...NO_PREFERENCES, lifestyle: { hasChildren: true } }
+    );
+    expect(result).toHaveLength(1);
+    expect(result[0].reasons.some(r => r.kind === 'lifestyle')).toBe(false);
+  });
+});

--- a/services/matching/src/grpc/top-picks-scoring.ts
+++ b/services/matching/src/grpc/top-picks-scoring.ts
@@ -1,0 +1,222 @@
+// Pure ranking for GetTopPicks — no I/O, fully unit-testable.
+//
+// Top picks differs from Recommend's swipe feed: it scores a candidate
+// set against the adopter's STORED match profile (preferred types /
+// sizes / age groups + lifestyle) rather than transient session filters,
+// and attaches human-readable "reason chips" explaining each pick.
+//
+// score ∈ [0, 1] is a weighted blend of three signals:
+//
+//   1. Preference match (weight 0.5) — the share of the adopter's SET
+//      preference dimensions (type / size / age group) the pet satisfies.
+//      Dimensions the adopter left empty don't discriminate; when the
+//      adopter set NO preferences at all the axis collapses to 1.0.
+//
+//   2. Recency (weight 0.3) — freshly-listed pets surface first.
+//      Normalised linearly against the freshest availableSince in the
+//      set (newest 1.0, oldest 0.0); unknown freshness scores 0.
+//
+//   3. Promotion (weight 0.2) — the rescue's `featured` / priorityListing
+//      boost flags.
+//
+// Lifestyle does NOT carry its own scoring weight — household fit is a
+// soft, presentational signal surfaced only as a reason chip, never a
+// rank multiplier (a child-friendly pet shouldn't outrank a better
+// preference match just because the adopter has kids).
+//
+// Weights sum to 1.0 so the blend stays within [0, 1].
+
+import { PetsV1, type Pet } from '@adopt-dont-shop/proto';
+
+const PREF_MATCH_WEIGHT = 0.5;
+const RECENCY_WEIGHT = 0.3;
+const PROMOTION_WEIGHT = 0.2;
+
+// A recency component at or above this surfaces the "fresh" chip.
+const FRESH_CHIP_THRESHOLD = 0.8;
+
+// The adopter's stored match profile, pre-mapped to proto enums by the
+// handler. Empty sets mean "no preference on this dimension".
+export type TopPickPreferences = {
+  preferredTypes: ReadonlySet<PetsV1.PetType>;
+  preferredSizes: ReadonlySet<PetsV1.PetSize>;
+  preferredAgeGroups: ReadonlySet<PetsV1.PetAgeGroup>;
+  lifestyle: {
+    hasChildren?: boolean;
+    hasOtherPets?: boolean;
+    otherPetsType?: 'none' | 'dogs' | 'cats' | 'mixed';
+  };
+};
+
+export type TopPickReason = {
+  kind: string;
+  label: string;
+};
+
+export type ScoredTopPick = {
+  pet: Pet;
+  score: number;
+  reasons: ReadonlyArray<TopPickReason>;
+};
+
+export function scoreTopPicks(
+  candidates: ReadonlyArray<Pet>,
+  preferences: TopPickPreferences
+): ReadonlyArray<ScoredTopPick> {
+  if (candidates.length === 0) {
+    return [];
+  }
+
+  const timestamps = candidates
+    .map(pet => availableSinceMs(pet))
+    .filter((ms): ms is number => ms !== undefined);
+  const newest = timestamps.length > 0 ? Math.max(...timestamps) : undefined;
+  const oldest = timestamps.length > 0 ? Math.min(...timestamps) : undefined;
+
+  const scored = candidates.map(pet => {
+    const recency = recencyScore(pet, newest, oldest);
+    const prefMatch = preferenceMatchScore(pet, preferences);
+    const promotion = pet.featured || pet.priorityListing ? 1 : 0;
+
+    const raw =
+      prefMatch.score * PREF_MATCH_WEIGHT + recency * RECENCY_WEIGHT + promotion * PROMOTION_WEIGHT;
+    const score = Math.min(1, Math.max(0, raw));
+
+    return { pet, score, reasons: buildReasons(pet, preferences, prefMatch.matched, recency) };
+  });
+
+  return [...scored].sort((a, b) => {
+    if (b.score !== a.score) {
+      return b.score - a.score;
+    }
+    return a.pet.petId < b.pet.petId ? -1 : a.pet.petId > b.pet.petId ? 1 : 0;
+  });
+}
+
+type PreferenceMatch = {
+  // Mean satisfaction across the SET dimensions (1.0 when none set).
+  score: number;
+  // True when at least one set dimension was satisfied.
+  matched: boolean;
+};
+
+function preferenceMatchScore(pet: Pet, preferences: TopPickPreferences): PreferenceMatch {
+  const dimensions: boolean[] = [];
+  if (preferences.preferredTypes.size > 0) {
+    dimensions.push(preferences.preferredTypes.has(pet.type));
+  }
+  if (preferences.preferredSizes.size > 0) {
+    dimensions.push(preferences.preferredSizes.has(pet.size));
+  }
+  if (preferences.preferredAgeGroups.size > 0) {
+    dimensions.push(preferences.preferredAgeGroups.has(pet.ageGroup));
+  }
+
+  if (dimensions.length === 0) {
+    return { score: 1, matched: false };
+  }
+  const hits = dimensions.filter(Boolean).length;
+  return { score: hits / dimensions.length, matched: hits > 0 };
+}
+
+function recencyScore(pet: Pet, newest: number | undefined, oldest: number | undefined): number {
+  if (newest === undefined || oldest === undefined || newest === oldest) {
+    return 0;
+  }
+  const ms = availableSinceMs(pet);
+  if (ms === undefined) {
+    return 0;
+  }
+  return (ms - oldest) / (newest - oldest);
+}
+
+function buildReasons(
+  pet: Pet,
+  preferences: TopPickPreferences,
+  prefMatched: boolean,
+  recency: number
+): ReadonlyArray<TopPickReason> {
+  const reasons: TopPickReason[] = [];
+  if (prefMatched) {
+    reasons.push({ kind: 'pref_match', label: 'Matches your preferences' });
+  }
+  const lifestyle = lifestyleReason(pet, preferences.lifestyle);
+  if (lifestyle !== undefined) {
+    reasons.push(lifestyle);
+  }
+  if (recency >= FRESH_CHIP_THRESHOLD) {
+    reasons.push({ kind: 'fresh', label: 'Newly added' });
+  }
+  return reasons;
+}
+
+// Cross-reference the pet's good_with_* flags (carried in extra_json)
+// against the adopter's household. Returns the single most relevant
+// household-fit chip, or undefined when nothing lines up.
+function lifestyleReason(
+  pet: Pet,
+  lifestyle: TopPickPreferences['lifestyle']
+): TopPickReason | undefined {
+  const extra = parseExtra(pet.extraJson);
+
+  if (lifestyle.hasChildren === true && extra.goodWithChildren === true) {
+    return { kind: 'lifestyle', label: 'Good with children' };
+  }
+  if (lifestyle.hasOtherPets === true) {
+    if (lifestyle.otherPetsType === 'dogs' && extra.goodWithDogs === true) {
+      return { kind: 'lifestyle', label: 'Good with dogs' };
+    }
+    if (lifestyle.otherPetsType === 'cats' && extra.goodWithCats === true) {
+      return { kind: 'lifestyle', label: 'Good with cats' };
+    }
+    if (
+      lifestyle.otherPetsType === 'mixed' &&
+      (extra.goodWithDogs === true || extra.goodWithCats === true)
+    ) {
+      return { kind: 'lifestyle', label: 'Good with other pets' };
+    }
+  }
+  return undefined;
+}
+
+type ExtraFlags = {
+  goodWithChildren?: boolean;
+  goodWithDogs?: boolean;
+  goodWithCats?: boolean;
+};
+
+function parseExtra(extraJson: string | undefined): ExtraFlags {
+  if (extraJson === undefined || extraJson === '') {
+    return {};
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(extraJson);
+  } catch {
+    return {};
+  }
+  if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+    return {};
+  }
+  return {
+    goodWithChildren: readBool(parsed, 'goodWithChildren'),
+    goodWithDogs: readBool(parsed, 'goodWithDogs'),
+    goodWithCats: readBool(parsed, 'goodWithCats'),
+  };
+}
+
+function readBool(obj: object, key: string): boolean | undefined {
+  if (!Object.prototype.hasOwnProperty.call(obj, key)) {
+    return undefined;
+  }
+  const value = Object.getOwnPropertyDescriptor(obj, key)?.value;
+  return typeof value === 'boolean' ? value : undefined;
+}
+
+function availableSinceMs(pet: Pet): number | undefined {
+  if (pet.availableSince === undefined || pet.availableSince === '') {
+    return undefined;
+  }
+  const ms = Date.parse(pet.availableSince);
+  return Number.isNaN(ms) ? undefined : ms;
+}


### PR DESCRIPTION
## Why

Follow-up to #1130's route audit of `app.client`. `ApplicationPage` pre-populates new applications via `applicationProfileService.getApplicationDefaults()` / `updateApplicationDefaults()`, which call `/api/v1/profile/application-defaults` — but the gateway had no route and no backing service for it. This PR implements just that slice (not the full `applicationProfileService` surface — `preferences`/`completion`/`pre-population`/`quick-application` remain unbacked and out of scope).

## What

- **proto**: `GetApplicationDefaults` / `UpdateApplicationDefaults` RPCs on `ApplicationService`, JSON-stringified payload (mirrors `answers_json`/`references_json`).
- **service.applications**:
  - New `application_defaults` table (one row per adopter, opaque `jsonb` blob — shape is SPA-owned).
  - Direct-pool CRUD handlers (`application-defaults-handlers.ts`), same pattern as `document-handlers.ts` — no event sourcing, since this is profile data with no lifecycle. Always scoped to `principal.userId` (no id field in the request — can't read/write another adopter's data).
  - Pure `mergeJson()` deep-merge util so a partial patch (e.g. only `personalInfo.occupation`) doesn't clobber untouched sibling fields (e.g. `personalInfo.lastName`).
- **gateway**: `GET`/`PUT /api/v1/profile/application-defaults`, wired through the existing `applications-client.ts`.

## Testing

TDD throughout. Green suites: `service.applications` (254), `service.gateway` (736). Type-check + lint clean. `apps/client`'s existing `applicationProfileService.test.ts` (13 tests, unchanged) confirms the frontend contract this backend now satisfies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KXLTwu5Lue8SekkbNYZaY1


---
_Generated by [Claude Code](https://claude.ai/code/session_01KXLTwu5Lue8SekkbNYZaY1)_