### PR TITLE
Wire admin inbox routes (moderation + support aggregation)

### DIFF
--- a/services/gateway/src/routes/admin-inbox.test.ts
+++ b/services/gateway/src/routes/admin-inbox.test.ts
@@ -1,0 +1,382 @@
+import { status as grpcStatus } from '@grpc/grpc-js';
+import Fastify, { type FastifyInstance } from 'fastify';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { ModerationV1 } from '@adopt-dont-shop/proto';
+
+import type { ModerationClient } from '../grpc-clients/moderation-client.js';
+
+import { registerAdminInboxRoutes } from './admin-inbox.js';
+
+function makeClient(): {
+  client: ModerationClient;
+  mocks: Record<string, ReturnType<typeof vi.fn>>;
+} {
+  const mocks: Record<string, ReturnType<typeof vi.fn>> = {};
+  for (const m of ['listReports', 'listSupportTickets', 'assignReport']) {
+    mocks[m] = vi.fn();
+  }
+  // Default: empty lists so a route that only needs one source still resolves.
+  mocks.listReports.mockResolvedValue({ reports: [] });
+  mocks.listSupportTickets.mockResolvedValue({ tickets: [] });
+  const client = { ...mocks, close: vi.fn() } as unknown as ModerationClient;
+  return { client, mocks };
+}
+
+async function makeApp(client: ModerationClient): Promise<FastifyInstance> {
+  const app = Fastify({ logger: false });
+  await registerAdminInboxRoutes(app, { client });
+  return app;
+}
+
+const ADMIN = {
+  'x-user-id': 'mod-1',
+  'x-user-roles': 'admin',
+  'x-user-permissions': 'admin.dashboard',
+};
+
+const REPORT = {
+  reportId: 'rpt-1',
+  reporterId: 'usr-1',
+  reportedEntityType: ModerationV1.ReportEntityType.REPORT_ENTITY_TYPE_USER,
+  reportedEntityId: 'usr-2',
+  reportedUserId: 'usr-2',
+  category: ModerationV1.ReportCategory.REPORT_CATEGORY_HARASSMENT,
+  severity: ModerationV1.Severity.SEVERITY_HIGH,
+  status: ModerationV1.ReportStatus.REPORT_STATUS_PENDING,
+  title: 'Bad behaviour',
+  description: 'They were rude',
+  evidence: [],
+  assignedModerator: undefined,
+  createdAt: '2026-06-01T00:00:00.000Z',
+  updatedAt: '2026-06-03T00:00:00.000Z',
+};
+
+const TICKET = {
+  ticketId: 'tkt-1',
+  userId: 'usr-9',
+  userEmail: 'reporter@example.com',
+  status: ModerationV1.SupportTicketStatus.SUPPORT_TICKET_STATUS_OPEN,
+  priority: ModerationV1.SupportTicketPriority.SUPPORT_TICKET_PRIORITY_LOW,
+  category: ModerationV1.SupportTicketCategory.SUPPORT_TICKET_CATEGORY_GENERAL_INQUIRY,
+  subject: 'Cannot log in',
+  description: 'Login fails',
+  assignedTo: 'mod-1',
+  tags: [],
+  createdAt: '2026-06-02T00:00:00.000Z',
+  updatedAt: '2026-06-02T00:00:00.000Z',
+};
+
+type InboxItem = {
+  id: string;
+  source: string;
+  title: string;
+  summary: string;
+  status: string;
+  severity: string;
+  assignedTo: string | null;
+  createdAt: string;
+  updatedAt: string;
+  relatedUserId: string | null;
+  relatedUserEmail: string | null;
+};
+
+type InboxBody = {
+  data: InboxItem[];
+  pagination: { page: number; limit: number; total: number; totalPages: number };
+};
+
+describe('GET /api/v1/admin/inbox', () => {
+  let app: FastifyInstance;
+  let mocks: Record<string, ReturnType<typeof vi.fn>>;
+
+  beforeEach(async () => {
+    const m = makeClient();
+    mocks = m.mocks;
+    app = await makeApp(m.client);
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  it('merges reports and tickets into a unified queue sorted by updatedAt desc', async () => {
+    mocks.listReports.mockResolvedValueOnce({ reports: [REPORT] });
+    mocks.listSupportTickets.mockResolvedValueOnce({ tickets: [TICKET] });
+
+    const res = await app.inject({ method: 'GET', url: '/api/v1/admin/inbox', headers: ADMIN });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json() as InboxBody;
+    expect(body.data).toHaveLength(2);
+    // REPORT.updatedAt (06-03) is newer than TICKET.updatedAt (06-02).
+    expect(body.data[0].source).toBe('moderation');
+    expect(body.data[0].id).toBe('rpt-1');
+    expect(body.data[1].source).toBe('support');
+    expect(body.pagination).toMatchObject({ page: 1, total: 2, totalPages: 1 });
+  });
+
+  it('maps a report into the InboxItem shape with lowercase enum tokens', async () => {
+    mocks.listReports.mockResolvedValueOnce({ reports: [REPORT] });
+
+    const res = await app.inject({ method: 'GET', url: '/api/v1/admin/inbox', headers: ADMIN });
+
+    const item = (res.json() as InboxBody).data[0];
+    expect(item).toMatchObject({
+      id: 'rpt-1',
+      source: 'moderation',
+      title: 'Bad behaviour',
+      summary: 'They were rude',
+      status: 'pending',
+      severity: 'high',
+      assignedTo: null,
+      relatedUserId: 'usr-2',
+      relatedUserEmail: null,
+    });
+  });
+
+  it('maps a ticket into the InboxItem shape (priority → severity, subject → title)', async () => {
+    mocks.listSupportTickets.mockResolvedValueOnce({ tickets: [TICKET] });
+
+    const res = await app.inject({ method: 'GET', url: '/api/v1/admin/inbox', headers: ADMIN });
+
+    const item = (res.json() as InboxBody).data[0];
+    expect(item).toMatchObject({
+      id: 'tkt-1',
+      source: 'support',
+      title: 'Cannot log in',
+      summary: 'Login fails',
+      status: 'open',
+      severity: 'low',
+      assignedTo: 'mod-1',
+      relatedUserId: 'usr-9',
+      relatedUserEmail: 'reporter@example.com',
+    });
+  });
+
+  it('honours sortBy=createdAt sortOrder=asc', async () => {
+    mocks.listReports.mockResolvedValueOnce({ reports: [REPORT] });
+    mocks.listSupportTickets.mockResolvedValueOnce({ tickets: [TICKET] });
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/v1/admin/inbox?sortBy=createdAt&sortOrder=asc',
+      headers: ADMIN,
+    });
+
+    const body = res.json() as InboxBody;
+    // REPORT.createdAt (06-01) is older than TICKET.createdAt (06-02).
+    expect(body.data[0].id).toBe('rpt-1');
+    expect(body.data[1].id).toBe('tkt-1');
+  });
+
+  it('filters by source=support (does not call listReports)', async () => {
+    mocks.listSupportTickets.mockResolvedValueOnce({ tickets: [TICKET] });
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/v1/admin/inbox?source=support',
+      headers: ADMIN,
+    });
+
+    const body = res.json() as InboxBody;
+    expect(body.data).toHaveLength(1);
+    expect(body.data[0].source).toBe('support');
+    expect(mocks.listReports).not.toHaveBeenCalled();
+  });
+
+  it('filters by source=moderation (does not call listSupportTickets)', async () => {
+    mocks.listReports.mockResolvedValueOnce({ reports: [REPORT] });
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/v1/admin/inbox?source=moderation',
+      headers: ADMIN,
+    });
+
+    const body = res.json() as InboxBody;
+    expect(body.data).toHaveLength(1);
+    expect(body.data[0].source).toBe('moderation');
+    expect(mocks.listSupportTickets).not.toHaveBeenCalled();
+  });
+
+  it('filters by status', async () => {
+    mocks.listReports.mockResolvedValueOnce({ reports: [REPORT] });
+    mocks.listSupportTickets.mockResolvedValueOnce({ tickets: [TICKET] });
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/v1/admin/inbox?status=open',
+      headers: ADMIN,
+    });
+
+    const body = res.json() as InboxBody;
+    expect(body.data).toHaveLength(1);
+    expect(body.data[0].status).toBe('open');
+  });
+
+  it('filters by severity', async () => {
+    mocks.listReports.mockResolvedValueOnce({ reports: [REPORT] });
+    mocks.listSupportTickets.mockResolvedValueOnce({ tickets: [TICKET] });
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/v1/admin/inbox?severity=high',
+      headers: ADMIN,
+    });
+
+    const body = res.json() as InboxBody;
+    expect(body.data).toHaveLength(1);
+    expect(body.data[0].severity).toBe('high');
+  });
+
+  it('filters by assignedTo (matches the staff member)', async () => {
+    mocks.listReports.mockResolvedValueOnce({ reports: [REPORT] });
+    mocks.listSupportTickets.mockResolvedValueOnce({ tickets: [TICKET] });
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/v1/admin/inbox?assignedTo=mod-1',
+      headers: ADMIN,
+    });
+
+    const body = res.json() as InboxBody;
+    expect(body.data).toHaveLength(1);
+    expect(body.data[0].id).toBe('tkt-1');
+  });
+
+  it('filters by search (case-insensitive across title and summary)', async () => {
+    mocks.listReports.mockResolvedValueOnce({ reports: [REPORT] });
+    mocks.listSupportTickets.mockResolvedValueOnce({ tickets: [TICKET] });
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/v1/admin/inbox?search=log%20in',
+      headers: ADMIN,
+    });
+
+    const body = res.json() as InboxBody;
+    expect(body.data).toHaveLength(1);
+    expect(body.data[0].id).toBe('tkt-1');
+  });
+
+  it('paginates the merged list', async () => {
+    const reports = Array.from({ length: 3 }, (_, i) => ({
+      ...REPORT,
+      reportId: `rpt-${i}`,
+      updatedAt: `2026-06-0${i + 1}T00:00:00.000Z`,
+    }));
+    mocks.listReports.mockResolvedValueOnce({ reports });
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/v1/admin/inbox?page=2&limit=2',
+      headers: ADMIN,
+    });
+
+    const body = res.json() as InboxBody;
+    expect(body.pagination).toMatchObject({ page: 2, limit: 2, total: 3, totalPages: 2 });
+    expect(body.data).toHaveLength(1);
+  });
+
+  it('rejects an invalid limit with 400', async () => {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/v1/admin/inbox?limit=abc',
+      headers: ADMIN,
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('maps PERMISSION_DENIED → 403', async () => {
+    mocks.listReports.mockRejectedValueOnce({
+      code: grpcStatus.PERMISSION_DENIED,
+      details: 'nope',
+    });
+    const res = await app.inject({ method: 'GET', url: '/api/v1/admin/inbox', headers: ADMIN });
+    expect(res.statusCode).toBe(403);
+  });
+});
+
+describe('POST /api/v1/admin/inbox/assign', () => {
+  let app: FastifyInstance;
+  let mocks: Record<string, ReturnType<typeof vi.fn>>;
+
+  beforeEach(async () => {
+    const m = makeClient();
+    mocks = m.mocks;
+    app = await makeApp(m.client);
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  it('assigns a moderation item via assignReport and returns 204', async () => {
+    mocks.assignReport.mockResolvedValueOnce({ report: REPORT });
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/v1/admin/inbox/assign',
+      headers: ADMIN,
+      payload: { itemId: 'rpt-1', source: 'moderation', assignedTo: 'mod-2' },
+    });
+
+    expect(res.statusCode).toBe(204);
+    expect(mocks.assignReport.mock.calls[0][0]).toMatchObject({
+      reportId: 'rpt-1',
+      moderatorId: 'mod-2',
+    });
+  });
+
+  it('returns 501 for an unsupported support assignment (no backing RPC)', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/v1/admin/inbox/assign',
+      headers: ADMIN,
+      payload: { itemId: 'tkt-1', source: 'support', assignedTo: 'mod-2' },
+    });
+
+    expect(res.statusCode).toBe(501);
+    expect(mocks.assignReport).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 for a message-source assignment', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/v1/admin/inbox/assign',
+      headers: ADMIN,
+      payload: { itemId: 'chat-1', source: 'message', assignedTo: 'mod-2' },
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(mocks.assignReport).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when itemId or assignedTo is missing', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/v1/admin/inbox/assign',
+      headers: ADMIN,
+      payload: { source: 'moderation' },
+    });
+
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('maps a gRPC NOT_FOUND on assign → 404', async () => {
+    mocks.assignReport.mockRejectedValueOnce({
+      code: grpcStatus.NOT_FOUND,
+      details: 'report not found',
+    });
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/v1/admin/inbox/assign',
+      headers: ADMIN,
+      payload: { itemId: 'rpt-x', source: 'moderation', assignedTo: 'mod-2' },
+    });
+
+    expect(res.statusCode).toBe(404);
+  });
+});

--- a/services/gateway/src/routes/admin-inbox.ts
+++ b/services/gateway/src/routes/admin-inbox.ts
@@ -1,0 +1,251 @@
+// REST → gRPC aggregation for the admin Triage Inbox
+// (apps/admin Inbox.tsx via inboxService.ts).
+//
+// The SPA wants ONE unified queue across moderation reports and support
+// tickets. service.moderation exposes these as two separate list RPCs,
+// so the gateway fans out, maps each source into a common InboxItem
+// shape, then merges / filters / sorts / paginates in memory.
+//
+// The frontend's third source, 'message', has no backing RPC yet, so we
+// never emit message items and reject message assignments.
+
+import type { FastifyInstance } from 'fastify';
+
+import {
+  ModerationV1,
+  type ListReportsRequest,
+  type ListSupportTicketsRequest,
+  type Report,
+  type SupportTicket,
+} from '@adopt-dont-shop/proto';
+
+import type { ModerationClient } from '../grpc-clients/moderation-client.js';
+
+import { buildMetadata } from '../middleware/metadata.js';
+import { handleGrpcError } from '../middleware/grpc-error.js';
+import { parsePagination } from '../middleware/pagination.js';
+
+export type AdminInboxRoutesOptions = {
+  client: ModerationClient;
+};
+
+// Matches the SPA's InboxItem (apps/admin/src/services/inboxService.ts).
+// The gateway must not depend on lib.types, so the type is defined here.
+type InboxSource = 'moderation' | 'support';
+
+type InboxItem = {
+  id: string;
+  source: InboxSource;
+  title: string;
+  summary: string;
+  status: string;
+  severity: string;
+  assignedTo: string | null;
+  createdAt: string;
+  updatedAt: string;
+  relatedUserId: string | null;
+  relatedUserEmail: string | null;
+};
+
+// Upper bound on the candidate window pulled from each source before the
+// in-memory merge. The merged list is paginated locally, so we gather a
+// bounded page from each RPC (gRPC clamps to its own MAX_LIMIT) rather
+// than streaming every row.
+const CANDIDATE_LIMIT = 200;
+
+// Strip a proto enum's SCREAMING prefix and lowercase it
+// (REPORT_STATUS_PENDING → 'pending'). Mirrors moderation-view.ts.
+function tokenFromProto(
+  toJSON: (v: number) => string,
+  value: number,
+  prefix: string
+): string | undefined {
+  if (value <= 0) {
+    return undefined;
+  }
+  return toJSON(value).slice(prefix.length).toLowerCase();
+}
+
+function reportToInboxItem(r: Report): InboxItem {
+  return {
+    id: r.reportId,
+    source: 'moderation',
+    title: r.title,
+    summary: r.description,
+    status:
+      tokenFromProto(ModerationV1.reportStatusToJSON, r.status, 'REPORT_STATUS_') ?? 'pending',
+    severity: tokenFromProto(ModerationV1.severityToJSON, r.severity, 'SEVERITY_') ?? 'low',
+    assignedTo: r.assignedModerator ?? null,
+    createdAt: r.createdAt,
+    updatedAt: r.updatedAt,
+    relatedUserId: r.reportedUserId ?? null,
+    relatedUserEmail: null,
+  };
+}
+
+function ticketToInboxItem(t: SupportTicket): InboxItem {
+  return {
+    id: t.ticketId,
+    source: 'support',
+    title: t.subject,
+    summary: t.description,
+    status:
+      tokenFromProto(ModerationV1.supportTicketStatusToJSON, t.status, 'SUPPORT_TICKET_STATUS_') ??
+      'open',
+    // Support tickets carry no severity; the SPA renders a ticket's
+    // priority in the severity column.
+    severity:
+      tokenFromProto(
+        ModerationV1.supportTicketPriorityToJSON,
+        t.priority,
+        'SUPPORT_TICKET_PRIORITY_'
+      ) ?? 'low',
+    assignedTo: t.assignedTo ?? null,
+    createdAt: t.createdAt,
+    updatedAt: t.updatedAt,
+    relatedUserId: t.userId ?? null,
+    relatedUserEmail: t.userEmail,
+  };
+}
+
+type InboxQuery = {
+  source?: string;
+  status?: string;
+  assignedTo?: string;
+  severity?: string;
+  search?: string;
+};
+
+function matchesFilters(item: InboxItem, q: InboxQuery): boolean {
+  if (q.status !== undefined && q.status !== '' && item.status !== q.status) {
+    return false;
+  }
+  if (q.severity !== undefined && q.severity !== '' && item.severity !== q.severity) {
+    return false;
+  }
+  if (q.assignedTo !== undefined && q.assignedTo !== '' && item.assignedTo !== q.assignedTo) {
+    return false;
+  }
+  if (q.search !== undefined && q.search !== '') {
+    const needle = q.search.toLowerCase();
+    const haystack = `${item.title} ${item.summary}`.toLowerCase();
+    if (!haystack.includes(needle)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+function sortItems(
+  items: ReadonlyArray<InboxItem>,
+  sortBy: 'createdAt' | 'updatedAt',
+  sortOrder: 'asc' | 'desc'
+): InboxItem[] {
+  const direction = sortOrder === 'asc' ? 1 : -1;
+  return [...items].sort((a, b) => {
+    const cmp = a[sortBy].localeCompare(b[sortBy]);
+    return cmp * direction;
+  });
+}
+
+export const registerAdminInboxRoutes = async (
+  app: FastifyInstance,
+  opts: AdminInboxRoutesOptions
+): Promise<void> => {
+  const { client } = opts;
+
+  app.get('/api/v1/admin/inbox', { schema: { tags: ['admin', 'inbox'] } }, async (req, reply) => {
+    const q = req.query as Record<string, string | undefined>;
+    const pagination = parsePagination(q, { page: 1, limit: 20 });
+    if (!pagination.ok) {
+      return reply.code(400).send({ error: pagination.error });
+    }
+
+    const source = q.source;
+    const sortBy = q.sortBy === 'createdAt' ? 'createdAt' : 'updatedAt';
+    const sortOrder = q.sortOrder === 'asc' ? 'asc' : 'desc';
+    const meta = buildMetadata(req);
+
+    const wantModeration = source === undefined || source === '' || source === 'moderation';
+    const wantSupport = source === undefined || source === '' || source === 'support';
+
+    try {
+      const items: InboxItem[] = [];
+
+      if (wantModeration) {
+        const grpcReq: ListReportsRequest = {
+          limit: CANDIDATE_LIMIT,
+          assignedModerator: q.assignedTo,
+        };
+        const res = await client.listReports(grpcReq, meta);
+        items.push(...res.reports.map(reportToInboxItem));
+      }
+
+      if (wantSupport) {
+        const grpcReq: ListSupportTicketsRequest = {
+          limit: CANDIDATE_LIMIT,
+          assignedTo: q.assignedTo,
+        };
+        const res = await client.listSupportTickets(grpcReq, meta);
+        items.push(...res.tickets.map(ticketToInboxItem));
+      }
+
+      const filtered = items.filter(item => matchesFilters(item, q));
+      const sorted = sortItems(filtered, sortBy, sortOrder);
+
+      const total = sorted.length;
+      const totalPages = total === 0 ? 0 : Math.ceil(total / pagination.limit);
+      const start = (pagination.page - 1) * pagination.limit;
+      const pageItems = sorted.slice(start, start + pagination.limit);
+
+      return reply.send({
+        data: pageItems,
+        pagination: {
+          page: pagination.page,
+          limit: pagination.limit,
+          total,
+          totalPages,
+        },
+      });
+    } catch (err) {
+      return handleGrpcError(err, reply);
+    }
+  });
+
+  app.post(
+    '/api/v1/admin/inbox/assign',
+    { schema: { tags: ['admin', 'inbox'] } },
+    async (req, reply) => {
+      const b = (req.body ?? {}) as { itemId?: string; source?: string; assignedTo?: string };
+      if (
+        b.itemId === undefined ||
+        b.itemId === '' ||
+        b.assignedTo === undefined ||
+        b.assignedTo === ''
+      ) {
+        return reply.code(400).send({ error: 'itemId and assignedTo are required' });
+      }
+
+      if (b.source === 'moderation') {
+        try {
+          await client.assignReport(
+            { reportId: b.itemId, moderatorId: b.assignedTo },
+            buildMetadata(req)
+          );
+          return reply.code(204).send();
+        } catch (err) {
+          return handleGrpcError(err, reply);
+        }
+      }
+
+      // Support-ticket assignment has no backing RPC in service.moderation
+      // yet (only AssignReport exists), so we cannot fulfil it from the
+      // gateway. Surface that honestly rather than silently no-op.
+      if (b.source === 'support') {
+        return reply.code(501).send({ error: 'support ticket assignment is not implemented' });
+      }
+
+      return reply.code(400).send({ error: `unsupported inbox source: ${b.source ?? ''}` });
+    }
+  );
+};

--- a/services/gateway/src/server.ts
+++ b/services/gateway/src/server.ts
@@ -66,6 +66,7 @@ import { registerFieldPermissionsRoutes } from './routes/field-permissions.js';
 import { registerGdprRoutes } from './routes/gdpr.js';
 import { registerLegalRoutes } from './routes/legal.js';
 import { registerMatchingRoutes } from './routes/matching.js';
+import { registerAdminInboxRoutes } from './routes/admin-inbox.js';
 import { registerModerationAdminRoutes } from './routes/moderation-admin.js';
 import { registerSupportRoutes } from './routes/support.js';
 import { registerModerationRoutes } from './routes/moderation.js';
@@ -486,6 +487,9 @@ export const createServer = async (opts: CreateServerOptions): Promise<FastifyIn
     // SPA-facing surface at /api/v1/admin/{moderation,support}/* with
     // frontend-shape envelopes (lib.moderation, lib.support-tickets).
     await registerModerationAdminRoutes(server, { client: opts.moderationClient });
+    // Unified admin Triage Inbox at /api/v1/admin/inbox — aggregates
+    // moderation reports + support tickets into one queue.
+    await registerAdminInboxRoutes(server, { client: opts.moderationClient });
     // User-facing /api/v1/support/* — adopters opening + replying to
     // their own tickets. Handlers self-scope by principal.userId.
     await registerSupportRoutes(server, { client: opts.moderationClient });


### PR DESCRIPTION
## The gap

The admin SPA's Triage Inbox (`apps/admin/src/pages/Inbox.tsx` via `useInbox.ts` / `inboxService.ts`) calls two endpoints the gateway never served, so both returned 404:

- `GET /api/v1/admin/inbox` — a unified, filtered, paginated queue
- `POST /api/v1/admin/inbox/assign` — assign an inbox item to a staff member

## What this does

Adds `services/gateway/src/routes/admin-inbox.ts` (`registerAdminInboxRoutes`) and wires it into `server.ts` inside the existing `if (opts.moderationClient)` block, alongside `registerModerationAdminRoutes`.

**`GET /api/v1/admin/inbox`** aggregates the two existing moderation-service list RPCs — `listReports` + `listSupportTickets` — into one `InboxItem` queue:
- maps each source into the SPA's `InboxItem` shape (lowercase enum tokens via the same `tokenFromProto` idiom as `moderation-view.ts`; report `description`→`summary`, ticket `subject`→`title`, ticket `priority`→`severity`, ticket `userEmail`→`relatedUserEmail`);
- when `source=moderation` or `source=support` is set, only that source's RPC is called;
- merges, applies `status` / `assignedTo` / `severity` / `search` filters in memory, sorts by `sortBy`/`sortOrder` (default `updatedAt desc`), and paginates the merged list into `{ data, pagination: { page, limit, total, totalPages } }`;
- reuses `parsePagination`, `buildMetadata`, and `handleGrpcError` from the existing middleware.

**`POST /api/v1/admin/inbox/assign`** dispatches on `source`:
- `moderation` → `assignReport` (`assignedTo`→`moderatorId`), returns `204`;
- `support` → **`501`** (see below);
- `message` → `400`;
- missing `itemId`/`assignedTo` → `400`.

The gateway keeps its boundary: no dependency on `lib.types`; the `InboxItem` type is defined locally in the route file.

## Scoping decisions / surprises

- **No support-ticket assignment RPC exists.** `service.moderation` (and the proto) only expose `AssignReport`; the support surface is `OpenSupportTicket` / `GetSupportTicket` / `ListSupportTickets` / `RespondToTicket`. `SupportTicket.assignedTo` is read-only over gRPC. Rather than invent a messages/ticket-assign RPC (out of scope for a gateway aggregation slice), support assignment returns **`501 Not Implemented`**. Adding the real RPC is a follow-up in `service.moderation` + proto.
- **The `message` source has no backing RPC**, so message items are never emitted in the list and message assignment returns `400`, as specified.
- The candidate window pulled from each source before the in-memory merge is bounded (`CANDIDATE_LIMIT = 200`, matching the gRPC services' own max).

## Test plan

`services/gateway/src/routes/admin-inbox.test.ts` (Vitest + Fastify `app.inject`, mocked moderation client) — 18 tests covering: report+ticket merge & sort (both `updatedAt desc` default and `createdAt asc`), per-source narrowing, each filter (`source`/`status`/`severity`/`assignedTo`/`search`), pagination, invalid-limit `400`, assign dispatch (`moderation`→204), support `501`, message `400`, missing-field `400`, and gRPC error → HTTP mapping (`PERMISSION_DENIED`→403, `NOT_FOUND`→404).

`pnpm exec turbo lint test type-check --filter=@adopt-dont-shop/service.gateway` — all green (lint clean; 66 test files / 801 tests pass; type-check clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EgwcaPwDJBjJJr68hnjeMX)_