### PR TITLE
feat(gateway): implement applications bulk-update endpoint (ADS-874)

### DIFF
--- a/services/gateway/src/routes/applications.test.ts
+++ b/services/gateway/src/routes/applications.test.ts
@@ -488,4 +488,180 @@ describe('applications routes', () => {
     expect(metadata.get('x-user-id')).toEqual(['staff-1']);
     expect(metadata.get('x-rescue-id')).toEqual(['rsc-1']);
   });
+
+  describe('PATCH /api/v1/applications/bulk-update', () => {
+    it('requires a non-empty applicationIds array', async () => {
+      const res = await app.inject({
+        method: 'PATCH',
+        url: '/api/v1/applications/bulk-update',
+        headers: STAFF,
+        payload: { applicationIds: [], updates: { status: 'approved' } },
+      });
+      expect(res.statusCode).toBe(400);
+    });
+
+    it('status: approved → Approve for every id, reporting an all-success summary', async () => {
+      mocks.approve.mockResolvedValue({ application: SUBMITTED });
+      const res = await app.inject({
+        method: 'PATCH',
+        url: '/api/v1/applications/bulk-update',
+        headers: STAFF,
+        payload: {
+          applicationIds: ['app-1', 'app-2'],
+          updates: { status: 'approved', notes: 'great home' },
+        },
+      });
+      expect(res.statusCode).toBe(200);
+      expect(mocks.approve).toHaveBeenCalledTimes(2);
+      expect(mocks.approve.mock.calls[0][0]).toMatchObject({
+        applicationId: 'app-1',
+        notes: 'great home',
+      });
+      expect(mocks.approve.mock.calls[1][0]).toMatchObject({ applicationId: 'app-2' });
+      expect(res.json()).toEqual({ data: { successCount: 2, failureCount: 0, failures: [] } });
+    });
+
+    it('status: rejected → Reject, preferring rejectionReason over notes', async () => {
+      mocks.reject.mockResolvedValue({ application: SUBMITTED });
+      await app.inject({
+        method: 'PATCH',
+        url: '/api/v1/applications/bulk-update',
+        headers: STAFF,
+        payload: {
+          applicationIds: ['app-1'],
+          updates: { status: 'rejected', notes: 'fallback', rejectionReason: 'no yard' },
+        },
+      });
+      expect(mocks.reject.mock.calls[0][0]).toMatchObject({
+        applicationId: 'app-1',
+        reason: 'no yard',
+      });
+    });
+
+    it('status: withdrawn → Withdraw with withdrawalReason', async () => {
+      mocks.withdraw.mockResolvedValue({ application: SUBMITTED });
+      await app.inject({
+        method: 'PATCH',
+        url: '/api/v1/applications/bulk-update',
+        headers: ADOPTER,
+        payload: {
+          applicationIds: ['app-1'],
+          updates: { status: 'withdrawn', withdrawalReason: 'found another pet' },
+        },
+      });
+      expect(mocks.withdraw.mock.calls[0][0]).toMatchObject({
+        applicationId: 'app-1',
+        reason: 'found another pet',
+      });
+    });
+
+    it('stage: reviewing → StartReview (single-row stage transition, ADS-642)', async () => {
+      mocks.startReview.mockResolvedValue({ application: SUBMITTED });
+      await app.inject({
+        method: 'PATCH',
+        url: '/api/v1/applications/bulk-update',
+        headers: STAFF,
+        payload: { applicationIds: ['app-1'], updates: { stage: 'reviewing' } },
+      });
+      expect(mocks.startReview.mock.calls[0][0]).toMatchObject({ applicationId: 'app-1' });
+    });
+
+    it('stage: visiting → ScheduleHomeVisit, requires scheduledAt', async () => {
+      mocks.scheduleHomeVisit.mockResolvedValue({ application: SUBMITTED });
+      const ok = await app.inject({
+        method: 'PATCH',
+        url: '/api/v1/applications/bulk-update',
+        headers: STAFF,
+        payload: {
+          applicationIds: ['app-1'],
+          updates: { stage: 'visiting', scheduledAt: '2026-07-01T10:00:00.000Z' },
+        },
+      });
+      expect(mocks.scheduleHomeVisit.mock.calls[0][0]).toMatchObject({
+        applicationId: 'app-1',
+        scheduledAt: '2026-07-01T10:00:00.000Z',
+      });
+      expect((ok.json() as { data: { successCount: number } }).data.successCount).toBe(1);
+
+      const missingDate = await app.inject({
+        method: 'PATCH',
+        url: '/api/v1/applications/bulk-update',
+        headers: STAFF,
+        payload: { applicationIds: ['app-2'], updates: { stage: 'visiting' } },
+      });
+      const body = missingDate.json() as { data: { failureCount: number } };
+      expect(body.data.failureCount).toBe(1);
+    });
+
+    it('stage: deciding → CompleteHomeVisit with the parsed outcome', async () => {
+      mocks.completeHomeVisit.mockResolvedValue({ application: SUBMITTED });
+      await app.inject({
+        method: 'PATCH',
+        url: '/api/v1/applications/bulk-update',
+        headers: STAFF,
+        payload: {
+          applicationIds: ['app-1'],
+          updates: { stage: 'deciding', outcome: 'passed', notes: 'all good' },
+        },
+      });
+      expect(mocks.completeHomeVisit.mock.calls[0][0]).toMatchObject({
+        applicationId: 'app-1',
+        outcome: ApplicationsV1.HomeVisitOutcome.HOME_VISIT_OUTCOME_PASSED,
+        notes: 'all good',
+      });
+    });
+
+    it('an unrecognised updates shape is a per-item failure, not a 400', async () => {
+      const res = await app.inject({
+        method: 'PATCH',
+        url: '/api/v1/applications/bulk-update',
+        headers: STAFF,
+        payload: { applicationIds: ['app-1'], updates: { foo: 'bar' } },
+      });
+      expect(res.statusCode).toBe(200);
+      const body = res.json() as { data: { failureCount: number; failures: unknown[] } };
+      expect(body.data.failureCount).toBe(1);
+      expect(body.data.failures).toEqual([
+        {
+          applicationId: 'app-1',
+          error: 'updates must include a recognised status or stage transition',
+        },
+      ]);
+    });
+
+    it('one failing id does not block the others from succeeding', async () => {
+      mocks.approve.mockResolvedValueOnce({ application: SUBMITTED }).mockRejectedValueOnce({
+        code: grpcStatus.FAILED_PRECONDITION,
+        details: 'already decided',
+      });
+      const res = await app.inject({
+        method: 'PATCH',
+        url: '/api/v1/applications/bulk-update',
+        headers: STAFF,
+        payload: { applicationIds: ['app-1', 'app-2'], updates: { status: 'approved' } },
+      });
+      const body = res.json() as {
+        data: {
+          successCount: number;
+          failureCount: number;
+          failures: Array<{ applicationId: string; error: string }>;
+        };
+      };
+      expect(body.data.successCount).toBe(1);
+      expect(body.data.failureCount).toBe(1);
+      expect(body.data.failures).toEqual([{ applicationId: 'app-2', error: 'already decided' }]);
+    });
+
+    it('a server-side (5xx) failure is reported generically, not with internal details', async () => {
+      mocks.approve.mockRejectedValue({ code: grpcStatus.INTERNAL, details: 'db connection lost' });
+      const res = await app.inject({
+        method: 'PATCH',
+        url: '/api/v1/applications/bulk-update',
+        headers: STAFF,
+        payload: { applicationIds: ['app-1'], updates: { status: 'approved' } },
+      });
+      const body = res.json() as { data: { failures: Array<{ error: string }> } };
+      expect(body.data.failures[0].error).toBe('internal_error');
+    });
+  });
 });

--- a/services/gateway/src/routes/applications.ts
+++ b/services/gateway/src/routes/applications.ts
@@ -27,6 +27,7 @@
 // whenever the applications service client is wired — see server.ts.
 
 import rateLimit from '@fastify/rate-limit';
+import type { Metadata } from '@grpc/grpc-js';
 import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
 
 import {
@@ -47,7 +48,7 @@ import type { ApplicationsClient } from '../grpc-clients/applications-client.js'
 
 import { applicationToView, statsToView, type ApplicationView } from './applications-view.js';
 import { buildMetadata } from '../middleware/metadata.js';
-import { handleGrpcError } from '../middleware/grpc-error.js';
+import { GRPC_TO_HTTP, handleGrpcError } from '../middleware/grpc-error.js';
 import { parsePagination } from '../middleware/pagination.js';
 
 export type ApplicationsRoutesOptions = {
@@ -263,6 +264,55 @@ export const registerApplicationsRoutes = async (
       } catch (err) {
         return handleGrpcError(err, reply);
       }
+    }
+  );
+
+  // ---------- Bulk update (ADS-874) ----------
+  //
+  // ADS-642 (frontend): single-row stage transitions AND the multi-select
+  // BulkActionBar both dispatch through this one endpoint — there is no
+  // dedicated stage-transition route. `updates` is a free-form patch; we
+  // translate the fields the SPA actually sends (status / stage / notes /
+  // rejectionReason / withdrawalReason / scheduledAt / outcome) onto the
+  // matching service command per application. A batch can mix valid and
+  // invalid rows, so a single item's failure doesn't abort the others.
+  app.patch(
+    '/api/v1/applications/bulk-update',
+    {
+      config: { rateLimit: RL_WRITE },
+      schema: {
+        tags: ['applications'],
+        summary: 'Apply the same status/stage transition to a batch of applications',
+      },
+    },
+    async (req, reply) => {
+      const b = (req.body ?? {}) as Record<string, unknown>;
+      const applicationIds = Array.isArray(b.applicationIds)
+        ? b.applicationIds.filter((id): id is string => typeof id === 'string')
+        : [];
+      const updates = (b.updates ?? {}) as Record<string, unknown>;
+
+      if (applicationIds.length === 0) {
+        return reply.code(400).send({ error: 'applicationIds must be a non-empty array' });
+      }
+
+      const meta = buildMetadata(req);
+      const failures: Array<{ applicationId: string; error: string }> = [];
+      for (const applicationId of applicationIds) {
+        try {
+          await applyBulkUpdate(client, applicationId, updates, meta);
+        } catch (err) {
+          failures.push({ applicationId, error: describeGrpcError(err) });
+        }
+      }
+
+      return reply.send({
+        data: {
+          successCount: applicationIds.length - failures.length,
+          failureCount: failures.length,
+          failures,
+        },
+      });
     }
   );
 
@@ -652,4 +702,85 @@ function parseHomeVisitOutcome(raw: string | undefined): ApplicationsV1.HomeVisi
     ApplicationsV1.HomeVisitOutcome.UNRECOGNIZED,
     raw
   );
+}
+
+// Bulk-update's per-item command dispatch (ADS-874). `status` (a terminal
+// decision) wins when present; otherwise `stage` drives the matching
+// workflow command. The frontend's 5-stage model (PENDING/REVIEWING/
+// VISITING/DECIDING/RESOLVED) is coarser than the service's 9-state
+// lifecycle, so `stage` maps onto the closest matching command — an
+// out-of-order transition (e.g. `visiting` while still a draft) surfaces
+// as the service's own FAILED_PRECONDITION rather than being pre-validated
+// here.
+async function applyBulkUpdate(
+  client: ApplicationsClient,
+  applicationId: string,
+  updates: Record<string, unknown>,
+  meta: Metadata
+): Promise<void> {
+  const status = updates.status as string | undefined;
+  const notes = updates.notes as string | undefined;
+
+  if (status === 'approved') {
+    await client.approve({ applicationId, notes }, meta);
+    return;
+  }
+  if (status === 'rejected') {
+    await client.reject(
+      { applicationId, reason: (updates.rejectionReason as string | undefined) ?? notes ?? '' },
+      meta
+    );
+    return;
+  }
+  if (status === 'withdrawn') {
+    await client.withdraw(
+      { applicationId, reason: (updates.withdrawalReason as string | undefined) ?? notes },
+      meta
+    );
+    return;
+  }
+
+  const stage = (updates.stage as string | undefined)?.toLowerCase();
+  if (stage === 'reviewing') {
+    await client.startReview({ applicationId, note: notes }, meta);
+    return;
+  }
+  if (stage === 'visiting') {
+    const scheduledAt = (updates.scheduledAt ?? updates.scheduledDate) as string | undefined;
+    if (!scheduledAt) {
+      throw new Error('scheduledAt is required to move an application to the visiting stage');
+    }
+    await client.scheduleHomeVisit({ applicationId, scheduledAt, note: notes }, meta);
+    return;
+  }
+  if (stage === 'deciding') {
+    await client.completeHomeVisit(
+      {
+        applicationId,
+        outcome: parseHomeVisitOutcome(updates.outcome as string | undefined),
+        notes,
+      },
+      meta
+    );
+    return;
+  }
+
+  throw new Error('updates must include a recognised status or stage transition');
+}
+
+// Per-item error message for the bulk-update response body. A gRPC error
+// (has a `code`) mirrors handleGrpcError's 4xx-vs-5xx split — don't leak
+// internal error text for server-side failures. A plain Error (no `code`)
+// is one applyBulkUpdate raised itself before calling the client (e.g. a
+// missing scheduledAt) — its message is ours to show, so surface it as-is.
+function describeGrpcError(err: unknown): string {
+  const grpcErr = err as { code?: number; details?: string; message?: string };
+  if (grpcErr?.code === undefined) {
+    return grpcErr?.message ?? 'internal_error';
+  }
+  const httpStatus = GRPC_TO_HTTP[grpcErr.code] || 500;
+  if (httpStatus >= 500) {
+    return 'internal_error';
+  }
+  return grpcErr?.details ?? grpcErr?.message ?? 'internal_error';
 }


### PR DESCRIPTION
## Summary

First slice of [ADS-874](https://linear.app/ideasquared/issue/ADS-874): `PATCH /api/v1/applications/bulk-update` was entirely missing from the gateway, 404ing both:

- the rescue dashboard's multi-select `BulkActionBar`
- **every single-row stage transition** (ADS-642 routes `transitionStage` through this same endpoint — there's no dedicated stage-transition route), so this gap affected normal single-application review, not just bulk actions.

This change implements the endpoint by translating the frontend's free-form `{ applicationIds, updates }` payload onto the existing per-application gRPC commands:

| `updates` shape | Dispatched command |
|---|---|
| `status: 'approved'` | `Approve` |
| `status: 'rejected'` | `Reject` (reason: `rejectionReason` ?? `notes`) |
| `status: 'withdrawn'` | `Withdraw` (reason: `withdrawalReason` ?? `notes`) |
| `stage: 'reviewing'` | `StartReview` |
| `stage: 'visiting'` | `ScheduleHomeVisit` (requires `scheduledAt`) |
| `stage: 'deciding'` | `CompleteHomeVisit` (parses `outcome`) |

Each application ID is dispatched independently and failures are collected per-item (`{ successCount, failureCount, failures: [{ applicationId, error }] }`) so one invalid row in a batch doesn't fail the others. Server-side (5xx) failures are reported generically to avoid leaking internal error details, matching the existing `handleGrpcError` convention.

## Scope note

ADS-874 also covers three other missing endpoint groups (application timeline CRUD, reference-check updates, and home-visit list/get/update-by-id). Those require new proto RPCs against the event-sourced applications domain model (the current `Reference`/`HomeVisit` shapes are plain JSON blobs, not addressable entities) and are intentionally left for follow-up PRs rather than bundled here.

## Test plan

- [x] `pnpm vitest run src/routes/applications.test.ts` — 36/36 passing (10 new cases covering status + stage dispatch, validation, partial-batch failure, and 5xx redaction)
- [x] Full gateway suite: 793/793 passing
- [x] `tsc --noEmit` and `eslint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018QZfkvptD4UxZwnwMvMw5D)_