### PR TITLE
docs: align backend docs + runbooks + skills with microservices architecture

### DIFF
--- a/.claude/skills/backend-endpoint/SKILL.md
+++ b/.claude/skills/backend-endpoint/SKILL.md
@@ -1,228 +1,290 @@
 ---
 name: backend-endpoint
 description: >
-  Add a new REST endpoint to service.backend. Use when the user asks to create a new
-  API route, expose a controller action, or add CRUD endpoints. Walks through routes,
-  controllers, services, validation, RBAC, and audit hookup.
+  Add a new REST endpoint backed by a gRPC microservice. Use when the
+  user asks to create a new API route, expose a domain action, or add
+  CRUD endpoints. Walks through the proto contract, the gRPC handler,
+  the gateway REST translation, validation, RBAC, and audit hookup.
 disable-model-invocation: true
 ---
 
 # Adding a Backend REST Endpoint
 
-The backend follows a strict layering: **Route → Controller → Service → Model**. Each
-layer has one job. Skipping or merging layers fights the codebase.
+The backend is a Fastify gateway fronting a fleet of Node.js gRPC
+microservices. Every public HTTP route lives in the gateway and
+delegates to a gRPC method on a backing service. There is **no**
+monolithic `service.backend` with Express controllers + Sequelize
+models; if a doc / skill tells you to create files under
+`src/controllers/` or `src/models/`, it describes the deleted
+architecture — don't follow it.
 
 | Layer | Responsibility | Lives in |
-|-------|---------------|----------|
-| Route | Wire middleware (auth, RBAC, validation, audit), forward to controller | `src/routes/` |
-| Controller | Parse req, call service, return response. **No business logic.** | `src/controllers/` |
-| Service | Business rules, DB writes, audit, transactions | `src/services/` |
-| Model | Sequelize schema, associations, hooks | `src/models/` |
+|-------|----------------|----------|
+| Proto contract | Request / response types and the RPC signature | `packages/proto/proto/<domain>.v1.proto` |
+| gRPC handler   | Business logic, DB writes, audit, transactions | `services/<name>/src/grpc/` |
+| Gateway route  | REST → gRPC translation, auth/RBAC/rate limits | `services/gateway/src/routes/` |
 
-## Step 1 — Define the request/response schema (Zod first)
+Validation lives in `lib.validation` (Zod schemas) where the SPA and
+the gateway share one source of truth.
 
-Schemas live in `lib.validation` so frontends and backend share one source of truth.
+## Step 1 — Define the proto contract
 
-```typescript
-// lib.validation/src/<feature>.ts
-import { z } from 'zod';
+Add the request / response message + the RPC method to the owning
+domain's proto.
 
-export const CreateThingRequestSchema = z.object({
-  name: z.string().min(1).max(120),
-  description: z.string().max(2000).optional(),
-});
+```proto
+// packages/proto/proto/things.v1.proto
+service ThingsService {
+  rpc CreateThing (CreateThingRequest) returns (CreateThingResponse);
+  rpc GetThing (GetThingRequest) returns (GetThingResponse);
+}
 
-export type CreateThingRequest = z.infer<typeof CreateThingRequestSchema>;
-```
+message CreateThingRequest {
+  string name = 1;
+  string description = 2;
+}
 
-Re-export from `lib.validation/src/index.ts`. Rebuild lib.validation
-(`cd lib.validation && pnpm build`) so service.backend resolves the new export.
+message CreateThingResponse {
+  Thing thing = 1;
+}
 
-## Step 2 — Add validation in the controller
-
-Use `validateBody` / `validateParams` / `validateQuery` from `middleware/zod-validate`,
-**not** express-validator. (Existing routes still use express-validator; new code
-should prefer Zod.)
-
-```typescript
-// src/controllers/thing.controller.ts
-import { Request, Response } from 'express';
-import { z } from 'zod';
-import { CreateThingRequestSchema } from '@adopt-dont-shop/lib.validation';
-import { validateBody, validateParams } from '../middleware/zod-validate';
-import { BaseController } from './base.controller';
-import { ThingService } from '../services/thing.service';
-import { AuthenticatedRequest } from '../types';
-
-const ThingIdParamSchema = z.object({
-  thingId: z.string().uuid('Valid thing ID is required'),
-});
-
-export class ThingController extends BaseController {
-  static validateCreate = [validateBody(CreateThingRequestSchema)];
-  static validateById = [validateParams(ThingIdParamSchema)];
-
-  static async create(req: AuthenticatedRequest, res: Response) {
-    const userId = req.user!.userId;
-    const thing = await ThingService.create(req.body, userId);
-    return res.status(201).json({ data: thing });
-  }
-
-  static async getById(req: AuthenticatedRequest, res: Response) {
-    const thing = await ThingService.getById(req.params.thingId);
-    return res.status(200).json({ data: thing });
-  }
+message Thing {
+  string thing_id = 1;
+  string name = 2;
+  string description = 3;
 }
 ```
 
-**Controllers must not contain business rules.** They only:
-- Pull values off the request (already validated)
-- Call a service method
-- Choose the success status code
-- Return `{ data: ... }` (or `{ data, pagination }` for lists)
+Regenerate the TypeScript clients:
 
-Errors propagate to the error-handler middleware automatically — never write
-`try/catch` in a controller just to translate to HTTP. See the `error-handling` skill.
+```bash
+pnpm exec turbo build --filter=@adopt-dont-shop/proto
+```
 
-## Step 3 — Implement the service
+The generated types appear under
+`@adopt-dont-shop/proto`'s `<Domain>V1` namespace.
+
+## Step 2 — Implement the gRPC handler
+
+Handlers live next to their tests. Pattern:
+`services/<name>/src/grpc/<feature>-handlers.ts` +
+`<feature>-handlers.test.ts`. Read an existing handler in the same
+service (e.g. `services/pets/src/grpc/favorite-handlers.ts`) for the
+local conventions before writing yours.
 
 ```typescript
-// src/services/thing.service.ts
-import sequelize from '../sequelize';
-import Thing from '../models/Thing';
-import { NotFoundError } from '../middleware/error-handler';
-import { AuditLogService } from './auditLog.service';
-import { CreateThingRequest } from '@adopt-dont-shop/lib.validation';
+// services/things/src/grpc/thing-handlers.ts
+import { randomUUID } from 'node:crypto';
 
-export class ThingService {
-  static async create(payload: CreateThingRequest, actorUserId: string): Promise<Thing> {
-    return sequelize.transaction(async t => {
-      const thing = await Thing.create({ ...payload, createdBy: actorUserId }, { transaction: t });
+import type { Principal } from '@adopt-dont-shop/authz';
+import {
+  type CreateThingRequest,
+  type CreateThingResponse,
+} from '@adopt-dont-shop/proto';
 
-      // Audit inside the transaction — commits atomically with the write.
-      await AuditLogService.log({
-        userId: actorUserId,
-        action: 'CREATE',
-        entity: 'Thing',
-        entityId: thing.thingId,
-        details: { name: thing.name },
-        transaction: t,
-      });
+import { HandlerError, type HandlerDeps } from './handlers.js';
 
-      return thing;
-    });
+export async function createThing(
+  deps: HandlerDeps,
+  principal: Principal | null,
+  req: CreateThingRequest,
+): Promise<CreateThingResponse> {
+  if (!principal?.userId) {
+    throw new HandlerError('UNAUTHENTICATED', 'authentication required');
+  }
+  if (!req.name) {
+    throw new HandlerError('INVALID_ARGUMENT', 'name is required');
   }
 
-  static async getById(thingId: string): Promise<Thing> {
-    const thing = await Thing.findByPk(thingId);
-    if (!thing) {
-      throw new NotFoundError('Thing not found');
-    }
-    return thing;
-  }
+  const thingId = randomUUID();
+  await deps.pool.query(
+    `INSERT INTO things.things (thing_id, name, description, created_by, created_at, updated_at)
+     VALUES ($1, $2, $3, $4, now(), now())`,
+    [thingId, req.name, req.description ?? null, principal.userId],
+  );
+
+  // Audit (see the audit-logging skill for the full pattern).
+  await deps.audit.log({
+    actorUserId: principal.userId,
+    action: 'CREATE',
+    entity: 'Thing',
+    entityId: thingId,
+    details: { name: req.name },
+  });
+
+  return { thing: { thingId, name: req.name, description: req.description ?? '' } };
 }
 ```
 
-See the `audit-logging` skill for when to use `AuditLogService.log()` inside a
-transaction vs the route-level `auditRoute()` middleware. Don't combine both.
+Key points:
 
-## Step 4 — Wire the route
+- Use direct parameterised SQL via `deps.pool` (a `pg.Pool` from
+  `@adopt-dont-shop/db`). There is no ORM.
+- `HandlerError` carries the gRPC status code + a human message; the
+  gateway translates these to HTTP status codes via
+  `handleGrpcError`.
+- Transactions: pull a client from the pool, `BEGIN` / `COMMIT` /
+  `ROLLBACK` explicitly. Read an existing multi-write handler
+  (e.g. service-rescue's invitation handlers) for the local pattern.
+- Permission checks beyond authentication go in the handler — the
+  authz package's `Principal` carries the resolved roles.
 
-```typescript
-// src/routes/thing.routes.ts
-import express from 'express';
-import { authenticateToken } from '../middleware/auth';
-import { requirePermission } from '../middleware/rbac';
-import { fieldMask, fieldWriteGuard } from '../middleware/field-permissions';
-import { ThingController } from '../controllers/thing.controller';
-import { PERMISSIONS } from '../types';
+Register the new handler in the service's gRPC server wiring
+(`services/<name>/src/grpc/server.ts`).
 
-const router = express.Router();
+## Step 3 — Add the gateway REST route
 
-router.use(authenticateToken);
-
-router.post('/',
-  requirePermission(PERMISSIONS.THING_CREATE),
-  ...ThingController.validateCreate,
-  // fieldWriteGuard('things', { audit: true }),    // only if 'things' is a field-permissioned resource
-  ThingController.create
-);
-
-router.get('/:thingId',
-  requirePermission(PERMISSIONS.THING_READ),
-  ...ThingController.validateById,
-  // fieldMask('things', { audit: true, resourceIdParam: 'thingId' }),
-  ThingController.getById
-);
-
-export default router;
-```
-
-**Middleware order matters** — see the `field-permissions` skill:
-
-```
-authenticateToken → requirePermission → validate* → fieldMask/fieldWriteGuard → controller
-```
-
-## Step 5 — Mount the router
-
-In `src/index.ts` (or wherever routes are mounted):
+Routes live in `services/gateway/src/routes/<domain>.ts`. The gateway
+is Fastify; routes register on an `app: FastifyInstance` passed into
+the plugin function.
 
 ```typescript
-import thingRoutes from './routes/thing.routes';
-app.use('/api/v1/things', thingRoutes);
+// services/gateway/src/routes/things.ts
+import type { FastifyInstance } from 'fastify';
+
+import {
+  type CreateThingRequest as GrpcCreateThingRequest,
+} from '@adopt-dont-shop/proto';
+
+import type { ThingsClient } from '../grpc-clients/things-client.js';
+import { buildMetadata } from '../middleware/metadata.js';
+import { handleGrpcError } from '../middleware/grpc-error.js';
+
+export type ThingsRoutesOptions = {
+  client: ThingsClient;
+};
+
+export function registerThingsRoutes(
+  app: FastifyInstance,
+  opts: ThingsRoutesOptions,
+): void {
+  const { client } = opts;
+
+  app.post<{ Body: { name: string; description?: string } }>(
+    '/api/v1/things',
+    {
+      schema: {
+        tags: ['things'],
+        summary: 'Create a thing',
+        body: {
+          type: 'object',
+          required: ['name'],
+          properties: {
+            name: { type: 'string', minLength: 1, maxLength: 120 },
+            description: { type: 'string', maxLength: 2000 },
+          },
+        },
+      },
+    },
+    async (req, reply) => {
+      const grpcReq: GrpcCreateThingRequest = {
+        name: req.body.name,
+        description: req.body.description ?? '',
+      };
+      try {
+        const res = await client.createThing(grpcReq, buildMetadata(req));
+        return reply.code(201).send({ success: true, data: res.thing });
+      } catch (err) {
+        return handleGrpcError(err, reply);
+      }
+    },
+  );
+}
 ```
+
+Wire the plugin in `services/gateway/src/server.ts` (look for the
+existing per-domain `register…Routes(app, …)` calls).
+
+`buildMetadata(req)` forwards the request id, the verified principal
+token, and the per-request locale onto the gRPC call. `handleGrpcError`
+translates `HandlerError` status codes into HTTP responses
+(`UNAUTHENTICATED` → 401, `PERMISSION_DENIED` → 403,
+`INVALID_ARGUMENT` → 400, `NOT_FOUND` → 404, etc.).
+
+For shared request validation across the SPA + gateway, define a Zod
+schema in `lib.validation/src/schemas/<feature>.ts` and reuse it on
+both ends. The gateway can call the Zod schema with `safeParse` before
+forwarding to gRPC.
+
+## Step 4 — Auth + RBAC + rate limits
+
+The gateway exposes hooks for these:
+
+- **Authentication**: requests carrying a valid JWT get a populated
+  principal automatically (see `services/gateway/src/middleware/authenticate.ts`).
+  Routes that don't need auth set `config: { public: true }` or live
+  under the public route prefix.
+- **Permission gates**: use the `requirePermission(...)` hook from
+  `@adopt-dont-shop/authz` (read an existing route — admin routes are
+  the canonical example).
+- **Rate limits**: a global plugin caps every route; override
+  per-route via `config: { rateLimit: { max, timeWindow } }`. The
+  `email-rate-limiter.ts` route shows the pattern.
+
+## Step 5 — Audit
+
+See the `audit-logging` skill for the full pattern. Quick rules:
+
+- Audit inside the gRPC handler when the action runs in a single
+  transaction with the DB write.
+- Audit at the gateway via the `auditRoute(...)` hook for read-only
+  / no-transaction CRUD routes that have nothing meaningful to do
+  inside a transaction.
+- **Never** combine both — it produces duplicate audit rows and
+  breaks transactional atomicity.
 
 ## Step 6 — Write tests (TDD)
 
-Tests come BEFORE implementation per CLAUDE.md. See the `backend-test` skill for the
-mock setup and behaviour-focused patterns.
+Tests are colocated, no `__tests__/` directory. See the `backend-test`
+skill for the Vitest + behaviour-driven patterns.
 
-- Service tests: `src/__tests__/services/thing.service.test.ts`
-- Controller tests: `src/__tests__/controllers/thing.controller.test.ts` (sparingly —
-  most logic should be covered at the service layer)
-- Route tests: `src/__tests__/routes/thing.routes.test.ts` (integration-style with
-  supertest)
+- gRPC handler tests:
+  `services/<name>/src/grpc/<feature>-handlers.test.ts` — stub the
+  pool with a mock `query`, assert the SQL + the response.
+- Gateway route tests:
+  `services/gateway/src/routes/<domain>.test.ts` — inject the route
+  into a Fastify instance, stub the gRPC client, exercise the HTTP
+  surface with `app.inject({ method, url, payload })`.
 
 ## Step 7 — Field permissions (if applicable)
 
-If the resource is one of `users`, `rescues`, `pets`, `applications` — or you're adding
-a new one — read the `field-permissions` skill. You must:
+If the resource is one of `users`, `rescues`, `pets`, `applications` —
+or you're adding a new one — read the `field-permissions` skill. You
+must register field defaults and apply the field-mask / field-write
+hooks on the gateway route.
 
-1. Add field defaults in `lib.types/src/config/field-permission-defaults.ts` (all 4 roles)
-2. Apply `fieldMask()` to GET routes and `fieldWriteGuard()` to write routes
-3. Add sensitive fields to `SENSITIVE_FIELD_DENYLIST`
+## Step 8 — Document the route shape
 
-## Step 8 — Swagger / OpenAPI
-
-Existing routes document each endpoint with JSDoc `@swagger` blocks above the route
-handler. Match that pattern so the generated docs stay complete. See
-`application.routes.ts` for a comprehensive example.
+Fastify generates the OpenAPI surface from the `schema:` block on
+each route — make sure `tags`, `summary`, and the body / params /
+querystring schemas reflect the real shape so the generated
+`generated-openapi.json` stays accurate.
 
 ## Conventions checklist
 
-- [ ] Schema-first: Zod schema in `lib.validation`, type derived via `z.infer`
-- [ ] Validation in the controller via `validateBody/Params/Query` (Zod) for new code
-- [ ] Controller has no `try/catch`, no business logic — just request/response shape
-- [ ] Service holds all business rules, runs DB writes in a transaction when multiple
-      tables change
-- [ ] Audit hookup: inside the transaction (`AuditLogService.log({ transaction: t })`)
-      OR via `auditRoute()` middleware — never both
-- [ ] RBAC via `requirePermission` / `requireRole` / `requirePermissionOrOwnership`
-- [ ] Field permissions on routes for users/rescues/pets/applications
-- [ ] Response shape: `{ data: ... }` on success, errors handled by error middleware
-- [ ] Swagger JSDoc on each route
+- [ ] Proto contract added + clients regenerated
+- [ ] gRPC handler in `services/<name>/src/grpc/` with a colocated
+      `*.test.ts`
+- [ ] Gateway route in `services/gateway/src/routes/<domain>.ts`,
+      registered in `server.ts`
+- [ ] Authentication / permission hook applied where appropriate
+- [ ] Audit hookup: inside the handler (transactional writes) OR via
+      `auditRoute()` on the gateway — never both
+- [ ] Field permissions wired if the resource is field-permissioned
+- [ ] Fastify `schema:` block populated for OpenAPI generation
 - [ ] Tests first, behaviour-focused
 
 ## Common mistakes
 
-- Putting business logic in the controller (validation, DB queries, audit calls)
-- `try/catch` in the controller that swallows the error or returns a custom shape —
-  let it bubble to the error handler
-- Skipping `requirePermission` because "auth is enough" — auth is identity, RBAC is
-  what they can do
-- Forgetting `await` on `AuditLogService.log()` inside a transaction — the audit row
-  won't be in the tx
-- Mixing express-validator and Zod on the same route (pick one — prefer Zod for new code)
-- Forgetting to re-export the new Zod schema from `lib.validation/src/index.ts` and
-  rebuild the lib
+- Reaching for Express controllers / Sequelize models — neither exists
+  in the current architecture. Read an existing handler + route
+  before writing yours.
+- Skipping `handleGrpcError` and writing custom catch blocks per route
+  — the helper centralises the gRPC-status → HTTP-status mapping.
+- Mixing audit-in-handler and audit-on-route — pick one per action.
+- Forgetting to register the new route plugin in `server.ts` — the
+  route never mounts and the SPA gets 404.
+- Using `app.get`/`app.post` without the type param (`<{ Body … }>`)
+  and then `as`-casting `req.body` — annotate the generic instead.
+- Direct DB access from the gateway — the gateway owns no tables.
+  Always go through a gRPC call.

--- a/.claude/skills/backend-test/SKILL.md
+++ b/.claude/skills/backend-test/SKILL.md
@@ -1,36 +1,47 @@
 ---
 name: backend-test
 description: >
-  Patterns for writing tests in service.backend. Apply when adding or modifying any
-  service, controller, route, or middleware test. Covers Vitest setup, mock patterns,
-  behaviour-focused assertions, and TDD.
+  Patterns for writing tests in the backend services (services/gateway
+  and services/<name>). Apply when adding or modifying any gRPC handler
+  test, gateway route test, or pure unit test. Covers Vitest setup,
+  mock patterns, behaviour-focused assertions, and TDD.
 ---
 
 # Backend Testing Patterns
 
-The backend uses **Vitest** (not Jest) with the setup in
-`service.backend/src/setup-tests.ts`. Tests favour behaviour over implementation.
+Every backend service in `services/*` uses **Vitest** (not Jest) with
+the config in `services/<name>/vitest.config.ts`. Tests favour
+behaviour over implementation.
 
 ## Test layout
 
+Tests are **colocated** with the source file they cover — no
+`__tests__/` directory and no per-layer split. The vitest config
+picks up `**/*.test.ts` automatically.
+
 ```
-service.backend/src/__tests__/
-  services/<name>.service.test.ts        # Most logic lives here
-  controllers/<name>.controller.test.ts  # Sparingly — HTTP shape only
-  routes/<name>.routes.test.ts           # Integration via supertest
-  middleware/<name>.test.ts              # For new middleware
-  integration/                           # Cross-layer scenarios
-  models/                                # Validation/hooks only — not CRUD
+services/gateway/src/
+  routes/things.ts
+  routes/things.test.ts          # Fastify route → mocked gRPC client
+
+services/things/src/grpc/
+  thing-handlers.ts
+  thing-handlers.test.ts         # gRPC handler → stubbed pool/audit
+  adapter.ts
+  adapter.test.ts                # pure mapping helpers
 ```
 
-Run all backend tests:
+Run all tests for a service:
+
 ```bash
-cd service.backend && pnpm test
+pnpm exec turbo test --filter=@adopt-dont-shop/service.things
 ```
 
 Run a single file (fast feedback loop):
+
 ```bash
-cd service.backend && pnpm test -- src/__tests__/services/thing.service.test.ts
+cd services/things && pnpm test handlers
+# Vitest takes a substring filter, no need to spell the full path.
 ```
 
 ## TDD loop (per CLAUDE.md)
@@ -40,11 +51,12 @@ cd service.backend && pnpm test -- src/__tests__/services/thing.service.test.ts
 3. **Refactor** — clean up with tests green
 
 State the success criteria before you start:
-> "Create returns the new Thing and writes one audit row with action=CREATE"
+> "createThing returns the new thing id and writes one audit row with action=CREATE"
 
 ## What to test
 
-**Test behaviour through public APIs only.** Internals must be invisible.
+**Test behaviour through public APIs only.** Internals must be
+invisible.
 
 | Good | Bad |
 |------|-----|
@@ -52,7 +64,8 @@ State the success criteria before you start:
 | "POST /things 201s and returns the new id" | "Controller calls ThingService.create" |
 | "Rejecting an application emits a notification" | "spy was called with NotificationType.REJECTED" |
 
-A test that breaks every time you refactor is testing implementation, not behaviour.
+A test that breaks every time you refactor is testing implementation,
+not behaviour.
 
 ## Vitest imports
 
@@ -60,140 +73,142 @@ A test that breaks every time you refactor is testing implementation, not behavi
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 ```
 
-Use `vi.fn()`, `vi.mock()`, `vi.spyOn()`. **Never** `jest.*` — this project does not
-use Jest.
+Use `vi.fn()`, `vi.mock()`, `vi.spyOn()`. **Never** `jest.*` — this
+project does not use Jest.
 
-## Mock setup pattern (services)
+## gRPC handler test pattern
 
-`setup-tests.ts` already mocks the logger, encryption keys, and JWT/CSRF secrets.
-Mock anything external your service touches:
+Stub the pool, principal, and any cross-service clients in `deps`.
+Assert on the SQL the handler ran and the response shape it produced.
 
 ```typescript
-import { vi } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 
-// External services — mock at the top of the file before importing the SUT.
-vi.mock('../../services/notification.service', () => ({
-  NotificationService: {
-    createNotification: vi.fn().mockResolvedValue(undefined),
-  },
-}));
+import { createThing } from './thing-handlers.js';
+import type { HandlerDeps } from './handlers.js';
 
-vi.mock('../../services/email.service', () => ({
-  default: {
-    sendEmail: vi.fn().mockResolvedValue('email-id-1'),
-    queueEmail: vi.fn().mockResolvedValue(undefined),
-  },
-}));
+const makeDeps = (overrides: Partial<HandlerDeps> = {}): HandlerDeps => ({
+  pool: { query: vi.fn().mockResolvedValue({ rows: [] }) } as never,
+  audit: { log: vi.fn().mockResolvedValue(undefined) } as never,
+  ...overrides,
+});
 
-// Socket emits — capture without a live IO server.
-vi.mock('../../socket/socket-registry', () => ({
-  emitToUser: vi.fn(),
-  emitToRescue: vi.fn(),
-}));
+describe('createThing', () => {
+  it('inserts the row + writes an audit log', async () => {
+    const deps = makeDeps();
+    const res = await createThing(
+      deps,
+      { userId: 'u-1', roles: [] },
+      { name: 'Buddy', description: '' },
+    );
 
-import { ThingService } from '../../services/thing.service';
-import { NotificationService } from '../../services/notification.service';
-
-describe('ThingService — Business Logic', () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
+    expect(res.thing.name).toBe('Buddy');
+    expect(deps.pool.query).toHaveBeenCalledWith(
+      expect.stringContaining('INSERT INTO things.things'),
+      expect.any(Array),
+    );
+    expect(deps.audit.log).toHaveBeenCalledWith(
+      expect.objectContaining({ action: 'CREATE', entity: 'Thing' }),
+    );
   });
 
-  it('creates a thing and notifies the owner', async () => {
-    const thing = await ThingService.create({ name: 'Buddy' }, 'user-1');
-
-    expect(thing.thingId).toBeDefined();
-    expect(NotificationService.createNotification).toHaveBeenCalledTimes(1);
+  it('rejects unauthenticated callers', async () => {
+    await expect(
+      createThing(makeDeps(), null, { name: 'X', description: '' }),
+    ).rejects.toMatchObject({ code: 'UNAUTHENTICATED' });
   });
+});
+```
+
+## Gateway route test pattern
+
+Use Fastify's `app.inject({ ... })` against a stubbed gRPC client —
+no live HTTP server, no supertest. Read an existing
+`services/gateway/src/routes/*.test.ts` for the canonical setup
+(building a `FastifyInstance`, registering the route, stubbing the
+client, calling `inject`).
+
+```typescript
+import Fastify from 'fastify';
+import { describe, it, expect, vi } from 'vitest';
+
+import { registerThingsRoutes } from './things.js';
+
+const makeApp = (clientOverrides: Partial<ThingsClient> = {}) => {
+  const app = Fastify({ logger: false });
+  const client = {
+    createThing: vi.fn().mockResolvedValue({
+      thing: { thingId: 't-1', name: 'Buddy', description: '' },
+    }),
+    ...clientOverrides,
+  } as never;
+  registerThingsRoutes(app, { client });
+  return { app, client };
+};
+
+it('POST /api/v1/things returns 201 + the created thing', async () => {
+  const { app } = makeApp();
+  const res = await app.inject({
+    method: 'POST',
+    url: '/api/v1/things',
+    payload: { name: 'Buddy' },
+  });
+  expect(res.statusCode).toBe(201);
+  expect(res.json()).toMatchObject({ success: true, data: { name: 'Buddy' } });
 });
 ```
 
 ## Database in tests
 
-Tests run against a real in-memory SQLite (configured in `setup-tests.ts`), so model
-behaviour is tested accurately. You don't mock Sequelize models — you let them write
-to the in-memory DB and assert the resulting state.
-
-If a test needs a clean DB, truncate inside `beforeEach`:
-
-```typescript
-beforeEach(async () => {
-  await Thing.destroy({ where: {}, truncate: true });
-});
-```
-
-Avoid `sequelize.sync({ force: true })` per-test — slow and unnecessary.
-
-## Controller tests
-
-Use `supertest` for route/controller integration. Spin up an Express app with just the
-router under test rather than booting the whole `index.ts`:
-
-```typescript
-import express from 'express';
-import request from 'supertest';
-import thingRoutes from '../../routes/thing.routes';
-
-const app = express();
-app.use(express.json());
-app.use('/api/v1/things', thingRoutes);
-
-it('rejects unauthenticated requests', async () => {
-  const res = await request(app).post('/api/v1/things').send({ name: 'X' });
-  expect(res.status).toBe(401);
-});
-```
+There is no in-memory test database. The pattern is to stub the
+`pool.query` call with `vi.fn()` and assert on the SQL string + the
+returned shape. If you need true round-trip behaviour, set up a
+disposable Postgres in the test (`pg-mem` is sometimes appropriate
+for migration tests) — but most handler tests don't need it.
 
 ## Auditing assertions
 
-Don't assert on `AuditLogService.log` call args by mocking it — that tests
-implementation. Instead, query the `audit_logs` table after the operation:
+Don't assert on the contents of audit calls by mocking
+`AuditLogService.log` in production code paths and snapshotting the
+args — that tests implementation. Instead, assert the action +
+entity + entityId fields you actually care about:
 
 ```typescript
-import { AuditLog } from '../../models/AuditLog';
-
-it('records an audit row on create', async () => {
-  await ThingService.create({ name: 'Buddy' }, 'user-1');
-
-  const rows = await AuditLog.findAll({ where: { entity: 'Thing' } });
-  expect(rows).toHaveLength(1);
-  expect(rows[0].action).toBe('CREATE');
-});
+expect(deps.audit.log).toHaveBeenCalledWith(
+  expect.objectContaining({ action: 'CREATE', entity: 'Thing', entityId: 't-1' }),
+);
 ```
 
 ## Error path coverage
 
-Each `throw` in a service is a branch. Cover it:
+Each `throw HandlerError(...)` in a handler is a branch. Cover it:
 
 ```typescript
-it('throws NotFoundError when the thing is missing', async () => {
-  await expect(ThingService.getById('missing-id')).rejects.toThrow('Thing not found');
+it('rejects unknown pets', async () => {
+  const deps = makeDeps({
+    pool: { query: vi.fn().mockRejectedValue({ code: '23503' }) } as never,
+  });
+  await expect(
+    addFavorite(deps, { userId: 'u-1' } as never, { petId: 'missing' }),
+  ).rejects.toMatchObject({ code: 'NOT_FOUND' });
 });
-```
-
-Test the error TYPE, not the message string, when downstream code branches on it:
-
-```typescript
-import { NotFoundError } from '../../middleware/error-handler';
-
-await expect(ThingService.getById('x')).rejects.toBeInstanceOf(NotFoundError);
 ```
 
 ## What to skip
 
-- Don't snapshot test JSON responses — they break on every field add. Assert on specific fields.
-- Don't test that the logger was called. Logger output is operational, not behaviour.
-- Don't test Sequelize internals (e.g. `findByPk` was called). Test the OBSERVABLE result.
-
-## Coverage
-
-CLAUDE.md targets 100% coverage but ONLY of meaningful business behaviour. Don't
-add tests to lift coverage on lines that don't matter. If a line can't be reached by
-realistic input, the line is dead code — delete it instead.
+- Don't snapshot test JSON responses — they break on every field add.
+  Assert on specific fields.
+- Don't test that the logger was called. Logger output is
+  operational, not behaviour.
+- Don't test the internals of `@adopt-dont-shop/db` or proto-generated
+  types. They're external dependencies for the purposes of your test.
 
 ## TypeScript rules (apply to tests too)
 
-- No `any` — use `unknown` or `vi.MockedFunction<typeof fn>`
+- No `any` — use `unknown` or `vi.MockedFunction<typeof fn>`. The
+  `as never` casts in the patterns above are deliberate ergonomics
+  for fully-typed third-party shapes; prefer `Partial<…>` overrides
+  when you can.
 - No `as` assertions without a comment explaining why
 - No `@ts-ignore`/`@ts-expect-error` — fix the type
 - Tests are first-class TypeScript code
@@ -201,10 +216,11 @@ realistic input, the line is dead code — delete it instead.
 ## Common mistakes
 
 - `jest.fn()` instead of `vi.fn()` — wrong test framework
-- Mocking `AuditLogService` to assert log calls — test the resulting audit row instead
-- Snapshotting full responses — brittle, doesn't describe behaviour
-- Testing private methods via casting — refactor so the behaviour is visible publicly
-- `sequelize.sync({ force: true })` in every test — slow; truncate the tables you touch
-- Asserting against the mocked logger — operational signal, not behaviour
-- Skipping the `beforeEach(() => vi.clearAllMocks())` reset — call-count assertions
-  leak across tests
+- Reaching for `supertest` or `express` — the gateway is Fastify;
+  `app.inject(...)` is the equivalent in this codebase
+- Reaching for Sequelize models / `sequelize.sync({ force: true })` —
+  no ORM. Stub `pool.query` instead
+- Asserting on internal call counts of helpers (`buildMetadata`,
+  `handleGrpcError`) — they're implementation details
+- Skipping `beforeEach(() => vi.clearAllMocks())` when sharing mocks
+  across tests — call-count assertions leak between cases

--- a/.claude/skills/db-migration/SKILL.md
+++ b/.claude/skills/db-migration/SKILL.md
@@ -1,181 +1,218 @@
 ---
 name: db-migration
 description: >
-  Create a Sequelize migration for service.backend. Use when the user asks to add a
-  column, table, index, enum value, or any schema change. Covers numbering,
-  idempotency, transactions, and up/down symmetry.
+  Create a node-pg-migrate migration in a schema-owning service. Use when
+  the user asks to add a column, table, index, enum value, or any schema
+  change. Covers naming, idempotency, up/down symmetry, and where the
+  migration runs.
 disable-model-invocation: true
 ---
 
 # Adding a Database Migration
 
-Migrations live in `service.backend/src/migrations/` and run sequentially by filename.
-NEVER modify an existing migration — create a new one.
+Each schema-owning service ships its own migrations under
+`services/<name>/src/migrations/` and runs them on container boot via
+`node-pg-migrate` wrapped by `@adopt-dont-shop/db` (entry point:
+`services/<name>/src/db/migrate.ts`). The runner records applied
+migrations in a `pgmigrations` table inside that service's owning
+Postgres schema (one per service: `auth`, `pets`, `rescue`,
+`applications`, `chat`, `notifications`, `moderation`, `matching`,
+`cms`, `audit`). There is no `sequelize-cli`, no Umzug, and no
+`SequelizeMeta` table — those describe the deleted monolith.
 
-## Current latest migration
-!`ls /home/user/adopt-dont-shop/service.backend/src/migrations/ 2>/dev/null | grep -v "^_" | sort | tail -5`
+**NEVER modify an existing migration.** Migrations are append-only
+history.
 
-## Step 1 — Pick the filename
+## Step 1 — Pick the right service
 
-Format: `<NN>-<kebab-case-summary>.ts` where `NN` is the next integer in the existing
-series.
+Migrations live in the schema-owning service. If you're adding a
+column to `pets.pets`, the migration goes in
+`services/pets/src/migrations/`. Schema ownership:
 
-- Baseline migrations (`00-baseline-*`) are the per-model bootstrap — never add to
-  this series.
-- Increment from the highest numeric prefix. If the last is `10-migrate-quiz-data`,
-  yours becomes `11-<your-change>`.
-- Keep the summary short and descriptive: `09-add-allergies-to-adopter-match-profile.ts`,
-  `06-add-audit-logs-login-failures-index.ts`.
+| Service                | Schema                          |
+|------------------------|---------------------------------|
+| `services/auth/`       | `auth.*`                        |
+| `services/pets/`       | `pets.*`                        |
+| `services/rescue/`     | `rescue.*`                      |
+| `services/applications/` | `applications.*`              |
+| `services/chat/`       | `chat.*`                        |
+| `services/notifications/` | `notifications.*`            |
+| `services/moderation/` | `moderation.*`                  |
+| `services/matching/`   | `matching.*`                    |
+| `services/cms/`        | `cms.*`                         |
+| `services/audit/`      | `audit.*`                       |
 
-## Step 2 — Use the helpers
+## Step 2 — Pick the filename
 
-`src/migrations/_helpers.ts` provides:
+Format: `<NNN>_<snake_case_summary>.ts` where `<NNN>` is the next
+zero-padded integer after the highest existing prefix in that
+service's migrations directory. `node-pg-migrate` orders by filename,
+so the prefix is load-bearing.
 
-| Helper | Purpose |
-|--------|---------|
-| `runInTransaction(queryInterface, fn)` | Wraps the body in a transaction — required for multi-step DDL |
-| `columnExists(queryInterface, table, col)` | Idempotency guard before `addColumn` |
-| `dropEnumTypeIfExists(queryInterface, name)` | Cleanly drop a Postgres ENUM in `down` |
-| `assertDestructiveDownAcknowledged()` | Guard for destructive `down` (data-loss) |
-
-Idempotency matters because `00-baseline-*` migrations create the schema via
-`sequelize.sync()` on a fresh DB, and the model definitions already include columns
-declared in later migrations. Without an `if (columnExists)` guard, a fresh install
-re-tries to add a column that's already there → migration failure.
+Examples:
+- `007_pets_list_keyset_index.ts`
+- `012_add_favourite_colour_to_pets.ts`
 
 ## Step 3 — Write the migration
+
+Migrations export `up` and `down` functions that take a
+`MigrationBuilder`. `node-pg-migrate` already wraps each migration
+in a transaction by default — don't add another one yourself.
 
 ### Add a column
 
 ```typescript
-// 11-add-favourite-colour-to-pets.ts
-import { DataTypes, type QueryInterface } from 'sequelize';
-import { columnExists, runInTransaction } from './_helpers';
+import type { MigrationBuilder } from 'node-pg-migrate';
 
-export default {
-  up: async (queryInterface: QueryInterface) => {
-    if (await columnExists(queryInterface, 'pets', 'favourite_colour')) {
-      return;
-    }
-    await runInTransaction(queryInterface, async transaction => {
-      await queryInterface.addColumn(
-        'pets',
-        'favourite_colour',
-        { type: DataTypes.STRING(50), allowNull: true, defaultValue: null },
-        { transaction }
-      );
-    });
-  },
+export const up = async (pgm: MigrationBuilder): Promise<void> => {
+  pgm.addColumn('pets', {
+    favourite_colour: { type: 'varchar(50)', notNull: false, default: null },
+  });
+};
 
-  down: async (queryInterface: QueryInterface) => {
-    await runInTransaction(queryInterface, async transaction => {
-      await queryInterface.removeColumn('pets', 'favourite_colour', { transaction });
-    });
-  },
+export const down = async (pgm: MigrationBuilder): Promise<void> => {
+  pgm.dropColumn('pets', 'favourite_colour');
 };
 ```
 
 ### Add an index
 
 ```typescript
-export default {
-  up: async (queryInterface: QueryInterface) => {
-    await runInTransaction(queryInterface, async transaction => {
-      await queryInterface.addIndex('audit_logs', ['user_id', 'action'], {
-        name: 'idx_audit_logs_user_action',
-        transaction,
-      });
-    });
-  },
+import type { MigrationBuilder } from 'node-pg-migrate';
 
-  down: async (queryInterface: QueryInterface) => {
-    await runInTransaction(queryInterface, async transaction => {
-      await queryInterface.removeIndex('audit_logs', 'idx_audit_logs_user_action', {
-        transaction,
-      });
-    });
-  },
+export const up = async (pgm: MigrationBuilder): Promise<void> => {
+  pgm.createIndex('audit_logs', ['user_id', 'action'], {
+    name: 'audit_logs_user_action_idx',
+  });
+};
+
+export const down = async (pgm: MigrationBuilder): Promise<void> => {
+  pgm.dropIndex('audit_logs', ['user_id', 'action'], {
+    name: 'audit_logs_user_action_idx',
+  });
 };
 ```
 
 ### Add an ENUM value
 
-Postgres ENUMs require a special path — `ALTER TYPE ... ADD VALUE` cannot run inside
-a transaction.
+Postgres ENUMs require `ALTER TYPE ... ADD VALUE`, which cannot run
+inside a transaction. Tell `node-pg-migrate` to skip the transaction
+wrapper by exporting `shorthands` / using raw SQL with `IF NOT EXISTS`.
 
 ```typescript
-export default {
-  up: async (queryInterface: QueryInterface) => {
-    await queryInterface.sequelize.query(
-      `ALTER TYPE "enum_notifications_type" ADD VALUE IF NOT EXISTS 'NEW_VALUE'`
-    );
-  },
+import type { MigrationBuilder } from 'node-pg-migrate';
 
-  down: async () => {
-    // Postgres can't remove enum values cleanly.
-    // Leave as a no-op or assertDestructiveDownAcknowledged().
-  },
+// Run outside a transaction — required for ADD VALUE.
+export const shorthands = undefined;
+
+export const up = async (pgm: MigrationBuilder): Promise<void> => {
+  pgm.sql(
+    `ALTER TYPE "notifications"."notification_type" ADD VALUE IF NOT EXISTS 'NEW_VALUE'`,
+  );
+};
+
+export const down = async (): Promise<void> => {
+  // Postgres can't cleanly remove an enum value. Leave as a no-op
+  // unless you've planned a full table-rewrite path.
 };
 ```
 
-## Step 4 — Update the Sequelize model
+### Create a table
 
-If you added a column, the model in `src/models/<Model>.ts` must declare it too. Two
-places to update:
+Use schema-qualified names where ambiguity matters; `@adopt-dont-shop/db`
+sets `search_path` to the service's schema, so unqualified table names
+also work for the owning service. Postgres extensions belong in
+`public` and need `CREATE EXTENSION IF NOT EXISTS` if not already
+present.
 
-1. The `XxxAttributes` interface
-2. The `Xxx.init({...})` call
+```typescript
+import type { MigrationBuilder } from 'node-pg-migrate';
 
-The model is the source of truth for `sequelize.sync()` (clean-DB bootstrap), so a
-missing model declaration means a freshly synced dev DB won't have the new column.
+export const up = async (pgm: MigrationBuilder): Promise<void> => {
+  pgm.createTable('things', {
+    thing_id: { type: 'uuid', primaryKey: true },
+    name: { type: 'varchar(128)', notNull: true },
+    created_at: { type: 'timestamptz', notNull: true, default: pgm.func('now()') },
+    updated_at: { type: 'timestamptz', notNull: true, default: pgm.func('now()') },
+  });
+  pgm.createIndex('things', 'name', { name: 'things_name_idx' });
+};
 
-## Step 5 — `down` symmetry
+export const down = async (pgm: MigrationBuilder): Promise<void> => {
+  pgm.dropTable('things');
+};
+```
 
-Every `up` must have a matching `down` that returns the schema to its prior state.
-This is enforced by the migration runner in CI for non-destructive changes.
+## Step 4 — `down` symmetry
 
-For destructive `down` (drops a column with data, drops a table) — use
-`assertDestructiveDownAcknowledged()` so it only runs when explicitly approved via the
-documented env var.
+Every `up` must have a matching `down` that returns the schema to its
+prior state. The migration test suite (see Step 6) enforces this.
+
+There is **no `pnpm db:migrate:undo` script** — the runner is
+`up`-only. `down` is exercised by the test suite and is the canonical
+recipe for the corrective migration you'd write to reverse a forward
+change in production. See [`docs/runbooks/migration-failure.md`](../../../docs/runbooks/migration-failure.md)
+for the operational recovery sequence.
+
+## Step 5 — Update the gRPC handlers
+
+There is no ORM. The service's gRPC handlers in
+`services/<name>/src/grpc/` read/write the new schema via direct
+parameterised SQL using the connection from `@adopt-dont-shop/db`.
+Update those queries to use the new column / table.
 
 ## Step 6 — Run and verify
 
 ```bash
-# Inside the backend container
-docker exec adopt-dont-shop-service-backend-1 pnpm db:migrate
+# Restart the owning service — its boot CMD runs db:migrate.
+docker compose restart service-pets
 
-# Inspect the result
-docker exec adopt-dont-shop-database-1 \
-  psql -U adopt_user -d adopt_dont_shop_dev \
-  -c "\d+ pets"
+# Or run db:migrate by hand (the runner is idempotent).
+docker compose exec service-pets pnpm db:migrate
 
-# Roll back to verify down
-docker exec adopt-dont-shop-service-backend-1 pnpm db:migrate:undo
+# Inspect the result.
+docker compose exec database \
+  psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" \
+  -c '\d+ pets.pets'
+
+# Confirm the migration is recorded.
+docker compose exec database \
+  psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" \
+  -c 'SELECT name FROM pets.pgmigrations ORDER BY id DESC LIMIT 5;'
 ```
-
-For the local (non-Docker) path: `pnpm db:migrate` from `service.backend/`.
 
 ## Step 7 — Add a migration test
 
-`src/__tests__/migrations/` contains per-migration tests that exercise up + down
-against a fresh DB. Match the style of an existing test for the same change shape.
+Each schema-owning service has a `services/<name>/src/migrations/migrations.test.ts`
+that loops over every migration up + down and asserts the schema state.
+If you've added a new migration, the existing test usually covers it
+automatically — read the test header to confirm. For unusual migrations
+(e.g. data backfills) add a dedicated assertion.
 
 ## Conventions checklist
 
-- [ ] Filename uses next integer prefix, kebab-case summary
-- [ ] `columnExists()` guard on every `addColumn` (or equivalent for other ops)
-- [ ] Body wrapped in `runInTransaction` (except ENUM ADD VALUE)
-- [ ] `down` reverses `up` (or is acknowledged-destructive)
-- [ ] Model file updated to match
-- [ ] Brief JSDoc header explaining WHY the change (ticket ref, motivation)
-- [ ] Migration test added
+- [ ] Filename uses next zero-padded prefix + `snake_case_summary`
+- [ ] `up` + `down` both implemented (or `down` deliberately a no-op
+      for unrecoverable ENUM ADD VALUE)
+- [ ] gRPC handlers updated to use the new column / table
+- [ ] Migration test in the service's `migrations.test.ts` still passes
+- [ ] Brief comment header explaining WHY the change (ticket ref,
+      motivation)
 
 ## Common mistakes
 
-- Modifying an existing migration — never. Migrations are append-only history
-- Skipping `columnExists` → migration fails on fresh DBs where `sync()` already added it
-- Running ENUM `ADD VALUE` inside `runInTransaction` → Postgres rejects it
-- Forgetting to update the model → fresh `sync()` skips the column
-- `down` that destroys data without `assertDestructiveDownAcknowledged()`
-- Adding a NOT NULL column without a default → fails on tables with existing rows.
-  Use nullable + default in step 1, backfill in step 2, then tighten if needed.
+- Modifying an existing migration — never. They're append-only.
+- Wrapping the body in a transaction — `node-pg-migrate` already does
+  this by default; nesting can break.
+- Trying to run `ALTER TYPE ... ADD VALUE` inside the default
+  transaction — Postgres rejects it. Use `pgm.sql(...)` with
+  `IF NOT EXISTS` and let the runner pick up the no-transaction hint.
+- Reaching for `pnpm db:migrate:undo` — the script doesn't exist. To
+  reverse a forward change, author a new migration that performs the
+  reverse DDL.
+- Adding a `NOT NULL` column without a default → fails on tables with
+  existing rows. Use nullable + default in step 1, backfill in step 2,
+  tighten in step 3.
+- Putting the migration in the wrong service — the runner only sees
+  files under `services/<name>/src/migrations/`, so a misplaced
+  migration silently never runs.

--- a/docs/README.md
+++ b/docs/README.md
@@ -50,7 +50,7 @@ Documentation for the adopt-don't-shop monorepo, organized by audience. The root
 - [ADR — sticky sessions for Socket.IO](./architecture/adr-socket-sticky-sessions.md) — connection-cap mitigation for the WebSocket edge
 - [Frontend technical architecture](./frontend/technical-architecture.md) — app shells, routing, state, styling
 - [Backend implementation guide](./backend/implementation-guide.md) — gateway routes → gRPC handlers → services wiring
-- [Backend service PRD](./backend/service-backend-prd.md) — backend product requirements
+- [Backend service PRD](./backend/service-backend-prd.md) — backend product requirements (architecture section is historical — see banner at the top)
 - [Backend deployment](./backend/deployment.md) — how the backend is built and shipped
 - [Microservices standards](./infrastructure/MICROSERVICES-STANDARDS.md) — boundaries, contracts, ownership
 - [Dependency graph](./dependency-graph.md) — Turbo build/dependency graph reference

--- a/docs/SECRETS-MANAGEMENT.md
+++ b/docs/SECRETS-MANAGEMENT.md
@@ -436,8 +436,8 @@ ls -la secrets/
 printf '%s' "actual-secret-value" > secrets/jwt_secret
 chmod 600 secrets/jwt_secret
 
-# Restart the affected service
-docker compose -f docker-compose.prod.yml --env-file .env up -d service-backend
+# Restart the affected service (substitute the service that consumes the secret)
+docker compose -f docker-compose.prod.yml --env-file .env up -d service-auth
 ```
 
 ## Additional Resources

--- a/docs/architecture/adr-socket-sticky-sessions.md
+++ b/docs/architecture/adr-socket-sticky-sessions.md
@@ -172,19 +172,20 @@ WebSocket stickiness before this assumption holds. Concretely:
 ### nginx (current production proxy)
 
 Add `ip_hash;` (or `hash $http_authorization consistent;`) to the
-backend upstream block in `nginx/nginx.prod.conf`:
+gateway upstream block in `nginx/nginx.prod.conf` (the gateway is
+the Socket.IO server — `services/gateway/src/ws/`):
 
 ```nginx
-upstream service_backend {
+upstream service_gateway {
     ip_hash;
-    server service-backend-1:3000;
-    server service-backend-2:3000;
+    server service-gateway-1:4000;
+    server service-gateway-2:4000;
     # ...
 }
 ```
 
 Place the directive at the top of the upstream block. With a single
-backend replica (current default) the directive is a no-op but is
+gateway replica (current default) the directive is a no-op but is
 harmless and future-proofs the config.
 
 ### Validation

--- a/docs/backend/implementation-guide.md
+++ b/docs/backend/implementation-guide.md
@@ -37,21 +37,21 @@ From the repository root the typical workflow uses Docker — the container boot
 
 4. **Initialize the database (first run, or after `docker:reset`)**
 
-   Each service runs its own migrations from `services/<name>/src/migrations/` on startup (the project does not use `sequelize-cli`). Seeds are split into reference / demo / fixtures with no "do everything" alias — pick the right one for what you're doing.
+   Each service runs its own migrations from `services/<name>/src/migrations/` on container start (the dev `CMD` in `Dockerfile.service` runs `pnpm run --if-present db:migrate && pnpm run --if-present db:seed && pnpm run dev`), so the typical workflow is "start the stack and it's ready". The runner is `node-pg-migrate` wrapped by `@adopt-dont-shop/db`, which tracks applied migrations in a `pgmigrations` table per schema and retries on the cross-service advisory-lock contention that happens when several services boot at once. Schema-owning services are auth, pets, rescue, applications, chat, notifications, moderation, matching, cms, audit; the gateway owns no tables.
+
+   To run migrations or seeds by hand for a single service:
 
    ```bash
-   # From the repo root — wrappers shell into the service-backend container
-   pnpm db:migrate                                       # runs `ts-node src/migrations/runner.ts up`
-   docker compose exec service-backend pnpm db:seed:reference  # idempotent reference data
-   docker compose exec service-backend pnpm db:seed:demo       # Faker-generated demo data (dev/staging only)
-   docker compose exec service-backend pnpm db:seed:fixtures   # deterministic e2e fixtures
+   docker compose exec service-auth pnpm db:migrate          # or any schema-owning service
+   docker compose exec service-auth pnpm db:seed             # auth / pets / rescue / applications / chat have seeds
+   pnpm db:seed                                              # host-side orchestrator: seeds every service in dep order
    ```
 
-5. **Backend is reachable at**
+5. **Services are reachable via the API gateway at**
 
    ```
-   http://localhost:5000       # direct
-   http://api.localhost        # via the nginx reverse proxy
+   http://localhost:4000        # gateway direct (REST + WebSocket)
+   http://api.localhost         # via the nginx reverse proxy
    ```
 
 ### Native (no-Docker) Development
@@ -76,14 +76,17 @@ DB_HOST=localhost
 DB_PORT=5432
 DB_USERNAME=postgres
 DB_PASSWORD=postgres
-DB_NAME=adopt_dont_shop_dev
+# `.env.example` uses POSTGRES_DB + DEV_DB_NAME / TEST_DB_NAME / PROD_DB_NAME
+# (validate-env.ts selects per NODE_ENV); see `.env.example` for the full list.
+POSTGRES_DB=adopt_dont_shop_dev
+DEV_DB_NAME=adopt_dont_shop_dev
 
 # JWT
 JWT_SECRET=your-development-jwt-secret
 JWT_EXPIRES_IN=15m
 JWT_REFRESH_EXPIRES_IN=7d
 
-# Email (Development - Free)
+# Email — one of: console | ethereal | resend (see Email Service Setup)
 EMAIL_PROVIDER=ethereal
 
 # Storage (Development - Free)
@@ -111,9 +114,9 @@ RATE_LIMIT_MAX_REQUESTS=100
 NODE_ENV=production
 
 # Email (Production)
-EMAIL_PROVIDER=sendgrid
-SENDGRID_API_KEY=your_sendgrid_api_key
-SENDGRID_FROM_EMAIL=noreply@adoptdontshop.com
+EMAIL_PROVIDER=resend
+RESEND_API_KEY=your_resend_api_key
+DEFAULT_FROM_EMAIL=noreply@adoptdontshop.com
 
 # Storage (Production)
 STORAGE_PROVIDER=s3
@@ -126,31 +129,33 @@ CLOUDFRONT_DOMAIN=cdn.adoptdontshop.com
 
 ## Email Service Setup
 
-### Ethereal Mail (Development)
+The notifications service picks its provider from `EMAIL_PROVIDER` — one of `console` | `ethereal` | `resend`. `console` is dev-only (refused in production); `ethereal` is the default for local work; `resend` is the production transport.
 
-Ethereal creates test accounts automatically - no configuration needed!
+### Console (default, dev)
 
-```typescript
-// Automatically configured in development
-EMAIL_PROVIDER = ethereal;
+```bash
+EMAIL_PROVIDER=console
 ```
 
-Access preview emails at the URL logged in console:
+Every send is logged to stdout — useful for tests where you don't need to inspect rendered HTML.
 
+### Ethereal Mail (dev with preview)
+
+```bash
+EMAIL_PROVIDER=ethereal
 ```
-📧 Preview Email: https://ethereal.email/messages/xxxxx
+
+The provider creates a throwaway Ethereal account on boot and logs the preview URL of each send. Open the URL printed in `docker compose logs -f service-notifications` to see the rendered message.
+
+### Resend (production)
+
+```bash
+EMAIL_PROVIDER=resend
+RESEND_API_KEY=your_api_key
+DEFAULT_FROM_EMAIL=noreply@adoptdontshop.com
 ```
 
-### SendGrid (Production)
-
-1. Create SendGrid account
-2. Generate API key
-3. Configure environment:
-   ```bash
-   EMAIL_PROVIDER=sendgrid
-   SENDGRID_API_KEY=your_api_key
-   SENDGRID_FROM_EMAIL=noreply@adoptdontshop.com
-   ```
+`RESEND_API_KEY` and `DEFAULT_FROM_EMAIL` are both mandatory when `EMAIL_PROVIDER=resend`; the service refuses to boot otherwise.
 
 ## File Storage Setup
 
@@ -188,36 +193,35 @@ uploads/
 
 ## Database Management
 
-Each service runs its own migrations and seeders — `sequelize-cli` is **not** installed. Migrations live in `services/<name>/src/migrations/`; seeders (where a service has them) in `services/<name>/src/seeders/`.
+Each schema-owning service ships its own migrations and (where it makes sense) seeds — `sequelize-cli` is **not** installed. Migrations live in `services/<name>/src/migrations/`; seed entry points live next to them in `services/<name>/src/db/`. The runner is `node-pg-migrate` via `@adopt-dont-shop/db`, with applied migrations tracked in a `pgmigrations` table inside each service's owning schema.
 
 ### Migrations
 
 ```bash
-# Run pending migrations (from repo root)
-pnpm db:migrate
-
-# Status / rollback — exec inside the backend container
-docker compose exec service-backend pnpm db:migrate:status
-docker compose exec service-backend pnpm db:migrate:undo
+# Run pending migrations for a single service (e.g. service-auth)
+docker compose exec service-auth pnpm db:migrate
 
 # Authoring a new migration: copy an existing file in the owning service's
 # services/<name>/src/migrations/ and follow the numbered naming pattern
-# (e.g. 01-add-something.ts). The runner picks them up automatically.
+# (e.g. 01-add-something.ts). The runner picks them up automatically on the
+# next service boot (its CMD runs `pnpm run --if-present db:migrate`).
 ```
 
-### Seeders
+Schema-owning services: `service-auth`, `service-pets`, `service-rescue`, `service-applications`, `service-chat`, `service-notifications`, `service-moderation`, `service-matching`, `service-cms`, `service-audit`. The gateway owns no tables, so `docker compose exec service-gateway pnpm db:migrate` will fail with "missing script" — that's expected, skip it.
 
-Seeds are deliberately not fungible — each type has a different safety profile:
+### Seeds
+
+Only services that need dev/e2e data ship a `db:seed` script today: `service-auth`, `service-rescue`, `service-pets`, `service-applications`, `service-chat`. Seeds use `ON CONFLICT DO UPDATE` everywhere, so they're idempotent and safe to re-run.
 
 ```bash
-docker compose exec service-backend pnpm db:seed:reference   # idempotent, safe anywhere
-docker compose exec service-backend pnpm db:seed:demo        # Faker (dev/staging) — ALLOW_DEMO_SEED required
-docker compose exec service-backend pnpm db:seed:fixtures    # deterministic e2e fixtures
-docker compose exec service-backend pnpm db:seed:reset       # truncate demo+fixture tables
-docker compose exec service-backend pnpm db:bootstrap        # first-run admin in production
+# Seed every service in dependency order (host-side orchestrator).
+pnpm db:seed
+
+# Or seed a single service.
+docker compose exec service-auth pnpm db:seed
 ```
 
-See the owning service's `src/seeders/` directory for the full split.
+`pnpm db:seed` is a thin wrapper around `scripts/seed.mjs` that shells into each service container in order (auth → rescue → pets → applications → chat) — see the script header for the full ordering and why it must not import workspace packages from the host.
 
 ## Testing
 
@@ -248,49 +252,29 @@ Load-testing and performance-profiling scripts are not yet set up.
 
 ### Health Check Endpoints
 
+The gateway exposes a single liveness probe; backing services are reachable over gRPC only, not HTTP, so there is no aggregated HTTP `/health` route to call against the gateway.
+
 ```bash
-# Full health check
-GET http://localhost:5000/health
-
-# Simple check (for load balancers)
-GET http://localhost:5000/health/simple
-
-# Readiness check (for Kubernetes)
-GET http://localhost:5000/health/ready
+# Simple liveness check (cheap, for load balancers / compose healthchecks)
+GET http://localhost:4000/health/simple
 ```
 
-### Development Dashboard
-
-View real-time service health at:
-
-```
-http://localhost:5000/monitoring/dashboard
-```
-
-Shows:
-
-- Service status (database, email, storage)
-- Response times
-- Memory usage
-- Active connections
-- Auto-refreshes every 5 seconds
+Each backing service publishes its own structured health over gRPC + Prometheus metrics — see [`docs/observability/tracing.md`](../observability/tracing.md) for the full observability surface.
 
 ## Docker Deployment
 
 ### Development
 
 ```bash
-# Start all services
-docker compose up
+# Start the full dev stack via the preflight wrapper (recommended)
+pnpm docker:dev
 
-# Build and start
-docker compose up --build
+# Start one service in the foreground (useful for debugging a single service)
+docker compose -f docker-compose.yml -f docker-compose.dev.yml up service-auth
 
-# Start specific service
-docker compose up service-backend
-
-# View logs
-docker compose logs -f service-backend
+# View logs for a specific service
+pnpm docker:logs                    # follow all services
+docker compose logs -f service-auth # one service
 ```
 
 ### Production
@@ -312,32 +296,34 @@ The root `docker-compose.prod.yml` overlay exercises this path end-to-end — se
 
 ## Common Tasks
 
-### Add New API Endpoint
+### Add a new API endpoint
 
-1. **Create route file** `src/routes/myresource.routes.ts`
-2. **Create controller** `src/controllers/myresource.controller.ts`
-3. **Create service** `src/services/myresource.service.ts`
-4. **Add model** (if needed) `src/models/MyResource.ts`
-5. **Register route** in `src/index.ts`
-6. **Add tests** under `src/__tests__/services/myresource.service.test.ts`
+The gateway is the only HTTP edge. Domain logic lives in a gRPC microservice; the gateway route translates REST → gRPC.
 
-### Add Database Model
+1. **Define / extend the proto** in `packages/proto/proto/<domain>.v1.proto`, regenerate (`pnpm exec turbo build --filter=@adopt-dont-shop/proto`), and implement the new RPC in `services/<domain>/src/grpc/handlers.ts` with a co-located `*.test.ts`.
+2. **Add the gateway route** in `services/gateway/src/routes/<domain>.ts` — register a Fastify route that validates input with the shared zod schemas in `lib.validation`, calls the gRPC client, and maps the response with the generated proto JSON helpers.
+3. **Wire the route** in `services/gateway/src/server.ts` (or its existing per-domain registration helper).
+4. **Permission-gate** the route via the `requirePermission(...)` Fastify hook from `@adopt-dont-shop/authz`.
 
-1. **Create migration** by copying the latest file in the owning service's `services/<name>/src/migrations/` and renaming it (the runner picks files up automatically — no generator). Follow the existing numbered naming pattern (`NN-create-my-table.ts`).
-2. **Define schema** in the migration file under `src/migrations/`
-3. **Create model** `src/models/MyModel.ts`
-4. **Run migration** `pnpm db:migrate` (from the repo root)
-5. **Add associations** in the model file
-6. **Create seeder** (optional) under `src/seeders/{reference,demo,fixtures}/` depending on whether it's idempotent reference data, Faker-generated demo data, or a deterministic e2e fixture.
+### Add a database table
 
-### Update Email Template
+1. **Create the migration** by copying the latest file in the owning service's `services/<name>/src/migrations/` and renaming it (`NN-create-my-table.ts` — the `node-pg-migrate` runner picks files up by alphabetical order, no generator). Author both `up()` and `down()`.
+2. **Restart the service** — its boot CMD runs `pnpm run --if-present db:migrate` and applies the new migration, or run it explicitly with `docker compose exec service-<name> pnpm db:migrate`.
+3. **Update the gRPC handlers** in `services/<name>/src/grpc/` to read/write the new table via the connection from `@adopt-dont-shop/db`. Direct parameterised SQL — there is no ORM.
+4. **Add seed rows** (optional) by extending `services/<name>/src/db/seed-data.ts` + `seed.ts`. Keep inserts idempotent with `ON CONFLICT DO UPDATE`.
 
-1. **Create template** `src/templates/emails/my-template.html`
-2. **Register in service** `src/services/email.service.ts`
-3. **Test template**
-   ```bash
-   POST /api/v1/email/templates/:templateId/test
-   ```
+### Update an email template
+
+Templates are stored as `notifications.email_templates` rows (not files) and edited through the admin UI / the gateway's `/api/v1/email/templates/*` admin routes. To preview a template against sample data:
+
+```bash
+curl -X POST http://localhost:4000/api/v1/email/templates/<templateId>/preview \
+  -H "Authorization: Bearer <admin token>" \
+  -H "Content-Type: application/json" \
+  -d '{ "variables": { "firstName": "Ada" } }'
+```
+
+To add a brand-new template, `POST /api/v1/email/templates` with the template body + subject + variables, or insert a seed row in `services/notifications/src/db/seed.ts` for it to land on every fresh stack.
 
 ## Troubleshooting
 
@@ -349,42 +335,39 @@ docker compose ps database
 
 # Nuclear reset (wipes the volume, then re-initializes)
 pnpm docker:reset
-pnpm docker:dev:detach
-pnpm db:migrate
-docker compose exec service-backend pnpm db:seed:reference
-docker compose exec service-backend pnpm db:seed:fixtures
+pnpm docker:dev:detach   # each service runs its own db:migrate + db:seed on boot
+pnpm db:seed             # re-run if you need to top up seed rows after boot
 ```
 
 ### Email Not Sending
 
 ```bash
-# Check Ethereal credentials in logs
-# Look for: "Ethereal Email Provider initialized"
+# Follow the notifications service logs and look for the Ethereal init line
+docker compose logs -f service-notifications
 
-# Test email manually
-curl -X POST http://localhost:5000/api/v1/email/templates/welcome/test \
-  -H "Authorization: Bearer YOUR_TOKEN"
+# Render a template against sample data without sending — POST to the
+# notifications admin route on the gateway (admin auth required).
+curl -X POST http://localhost:4000/api/v1/email/templates/<templateId>/preview \
+  -H "Authorization: Bearer YOUR_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{ "variables": {} }'
 ```
 
 ### File Upload Failures
 
-```bash
-# Check upload directory permissions
-ls -la uploads/
+The local storage provider writes under `services/<owning-service>/uploads/` (e.g. pet media under `service-pets`). Check the directory exists and is writable by the container's non-root user.
 
-# Recreate upload directories
-rm -rf uploads
-pnpm dev  # Will recreate automatically
+```bash
+docker compose exec service-pets ls -la uploads/
 ```
+
+If you have to wipe local upload state, run `pnpm docker:reset` to drop the named volumes and re-start the stack.
 
 ### Performance Issues
 
 ```bash
-# Toggle Sequelize query logging by setting DB_LOGGING=true in .env and restarting the service
-# (each service's `src/sequelize.ts` reads DB_LOGGING).
-
-# Monitor in development dashboard
-open http://localhost:5000/monitoring/dashboard
+# Trace requests end-to-end via the observability stack (see docs/observability/tracing.md).
+# Prometheus + Tempo + Loki are wired in `docker-compose.yml` under the `observability` profile.
 ```
 
 Load-testing and performance-profiling scripts are not yet set up.

--- a/docs/backend/service-backend-prd.md
+++ b/docs/backend/service-backend-prd.md
@@ -1,10 +1,21 @@
 # Product Requirements Document: Backend Service
 
+> **Status — architecture section is historical.** The product
+> requirements (auth, user, pet, application, chat, moderation,
+> matching surfaces) below still describe what the system does. The
+> "Architecture Overview" describes the deleted monolith and is kept
+> for context. The current architecture is a Fastify gateway fronting
+> a fleet of Node.js gRPC microservices (`services/gateway/` plus
+> `services/{auth,pets,rescue,applications,chat,notifications,
+> moderation,matching,cms,audit}/`). For current implementation
+> details see [`docs/backend/implementation-guide.md`](./implementation-guide.md)
+> and [`docs/infrastructure/MICROSERVICES-STANDARDS.md`](../infrastructure/MICROSERVICES-STANDARDS.md).
+
 ## Overview
 
 The Backend Service is the core API and data management layer that powers all applications in the Adopt Don't Shop ecosystem. It provides secure, scalable, and reliable backend services for user management, pet data, adoption workflows, communication, and reporting.
 
-## Architecture Overview
+## Architecture Overview (historical — see banner above)
 
 - **Service Type**: RESTful API with WebSocket support
 - **Technology**: Node.js + Express + TypeScript

--- a/docs/backend/testing.md
+++ b/docs/backend/testing.md
@@ -2,15 +2,31 @@
 
 ## Overview
 
-Comprehensive testing strategy for the backend service using **Vitest**. We follow a behaviour-driven pyramid: most tests exercise service-layer behaviour through public APIs, with a smaller ring of integration tests that hit the database and routes end-to-end.
+Comprehensive testing strategy for the backend services using
+**Vitest**. We follow a behaviour-driven pyramid: most tests exercise
+behaviour through public APIs (gateway routes, gRPC handlers), with
+direct unit tests for pure helpers and a smaller ring of integration
+tests that hit the database.
 
 ```
 Testing Pyramid
-├── Integration Tests — Database + HTTP routes (src/__tests__/integration/, src/__tests__/controllers/)
-└── Service / behaviour tests — Services, utilities, middleware, models (src/__tests__/services/, etc.)
+├── Gateway route tests — Fastify + injected handler (services/gateway/src/routes/*.test.ts)
+├── gRPC handler tests — handler + mocked clients (services/<name>/src/grpc/*.test.ts)
+└── Pure unit tests — adapters, mappers, domain logic (services/<name>/src/**/*.test.ts)
 ```
 
-Tests live alongside the code in each service under `services/<name>/src/`, organised by layer (services, controllers/handlers, integration, middleware, models, security, utils, validation).
+Tests are **colocated** with the source file they cover —
+`handlers.ts` next to `handlers.test.ts`, no `__tests__/` directory
+or per-layer split. The Vitest config in each service picks up
+`**/*.test.ts` automatically.
+
+> The legacy Express + Sequelize + supertest examples further down
+> in this file describe the deleted monolith. They are kept as a
+> rough shape for the testing **pyramid** and BDD style — for
+> current patterns (Fastify route injection, gRPC handler stubbing,
+> direct SQL via `@adopt-dont-shop/db`), use any of the existing
+> `*.test.ts` files in `services/<name>/src/grpc/` or
+> `services/gateway/src/routes/` as a worked example.
 
 ## Quick Start
 
@@ -343,9 +359,9 @@ Vitest uses the database configured via `DB_*` / `TEST_DB_NAME` env vars (see `.
 
 ```bash
 docker compose ps database      # must be "healthy"
-pnpm docker:reset            # last resort — wipes the volume
-pnpm docker:dev:detach
-pnpm db:reset
+pnpm docker:reset               # last resort — wipes the volume
+pnpm docker:dev:detach          # each service runs its own db:migrate on boot
+pnpm db:seed                    # re-seed dev personas / data
 ```
 
 **Timeout Errors**
@@ -407,4 +423,4 @@ pnpm test:coverage -- --coverageThreshold='{"global":{"lines":80}}'
 - **API Documentation**: [api-endpoints.md](./api-endpoints.md)
 - **Implementation Guide**: [implementation-guide.md](./implementation-guide.md)
 - **Database Schema**: [database-schema.md](./database-schema.md)
-- **Service PRD**: [service-backend-prd.md](./service-backend-prd.md)
+- **Service PRD**: [service-backend-prd.md](./service-backend-prd.md) (architecture section is historical)

--- a/docs/infrastructure/DEPLOYMENT-PLAN.md
+++ b/docs/infrastructure/DEPLOYMENT-PLAN.md
@@ -252,8 +252,7 @@ echo "0 2 * * * deploy /opt/ads/backup.sh" >> /etc/crontab
 - [ ] Create `.env` files on server for both environments
 - [ ] Start gateway: `cd /opt/ads/gateway && docker compose up -d`
 - [ ] Start prod stack: `cd /opt/ads/production && docker compose up -d` (uses `:latest` tag initially)
-- [ ] Seed SequelizeMeta with baseline migration
-- [ ] Run remaining migrations: `docker compose exec -T service-backend pnpm migrate`
+- [ ] Wait for each schema-owning service to apply its own migrations on first boot (visible in `docker compose logs service-<name>`); the `pgmigrations` table per schema is created automatically
 - [ ] First deploy via workflow: `make staging`
 - [ ] Verify staging works end-to-end
 - [ ] `make prod`

--- a/docs/infrastructure/INFRASTRUCTURE.md
+++ b/docs/infrastructure/INFRASTRUCTURE.md
@@ -142,17 +142,17 @@ See [Libraries Documentation](../libraries/README.md) for details.
 ### Development
 
 ```bash
-# Start all services
-docker compose up
+# Start the full dev stack via the preflight wrapper
+pnpm docker:dev
 
-# Start specific service
-docker compose up service-backend
+# Start a single service in the foreground (e.g. service-pets)
+docker compose -f docker-compose.yml -f docker-compose.dev.yml up service-pets
 
 # View logs
-docker compose logs -f
+pnpm docker:logs
 
-# Rebuild
-docker compose up --build
+# Force-rebuild the shared dev image (pnpm-lock.yaml or Dockerfile.dev changes)
+pnpm docker:dev:build
 ```
 
 ### Production

--- a/docs/operations/deploy.md
+++ b/docs/operations/deploy.md
@@ -155,10 +155,20 @@ only takes effect once required reviewers are saved.
 
 ## Release deploy
 
-The `service-backend-migrate` init container runs `pnpm db:migrate`
-(custom Umzug runner) once before `service-backend` starts. Compose's
-`service_completed_successfully` dependency gates the backend on a clean
-migration. [ADS-393]
+Every schema-owning service migrates **its own** schema on every
+boot — the entrypoint in `Dockerfile.service` runs
+`pnpm run --if-present db:migrate` before the long-running process
+starts. There is no dedicated `service-backend-migrate` init
+container; migrations land alongside the new binary in the same
+container, and Docker keeps the container restarting until the
+migration step succeeds. [ADS-393]
+
+The runner is `node-pg-migrate` wrapped by `@adopt-dont-shop/db`
+(`packages/db/src/migrate.ts`), with applied migrations recorded in
+a `pgmigrations` table inside each owning schema. The runner takes
+a database-wide advisory lock around `pgmigrations` and retries with
+linear backoff (12× × 250ms × attempt) so simultaneous service boots
+don't trample each other.
 
 ```bash
 # Pull immutable image tags (sha-prefixed or vX.Y.Z) — never :latest in
@@ -171,72 +181,83 @@ Verify:
 
 ```bash
 docker compose -f docker-compose.prod.yml ps           # all healthy
-docker compose -f docker-compose.prod.yml logs service-backend-migrate
-curl -sf https://${PROD_HOSTNAME}/health
+# Each schema-owning service logs its own migration output on boot:
+docker compose -f docker-compose.prod.yml logs service-auth | grep migration
+curl -sf https://${PROD_HOSTNAME}/health/simple
 ```
 
-## When the migration init container fails
+## When a service's migrations fail
 
-If `service-backend-migrate` exits non-zero, the `service-backend` service
-will not start (compose's `service_completed_successfully` dependency
-blocks it). The deploy job's health-check loop in
-`.github/workflows/deploy.yml` will then time out and exit non-zero,
-leaving the previous backend container still running on `:latest` /
-the old SHA. No traffic is shifted to the failed image.
+If a service's `db:migrate` exits non-zero, its container exits
+non-zero from CMD and Docker keeps restarting it. The deploy job's
+per-service health-check loop in `.github/workflows/deploy.yml`
+will then time out and exit non-zero. The gateway and the unaffected
+services keep serving on their previous tags, so only the failing
+domain is down.
 
 Triage:
 
 ```bash
-# Read the migration runner's logs — the failing migration is named at the top.
-docker compose -f docker-compose.prod.yml logs --no-color service-backend-migrate
+# Find the failing service and its migration error.
+docker compose -f docker-compose.prod.yml ps
+docker compose -f docker-compose.prod.yml logs --no-color --tail=200 service-<name>
 
-# Inspect what's already applied vs. pending.
+# Inspect what's already applied vs. pending in that service's schema.
 docker compose -f docker-compose.prod.yml exec -T database \
   psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" \
-  -c 'SELECT name FROM "SequelizeMeta" ORDER BY name;'
+  -c 'SELECT name, run_on FROM <schema>.pgmigrations ORDER BY id DESC LIMIT 10;'
 ```
 
-Recovery paths:
+Full recovery procedure: [`docs/runbooks/migration-failure.md`](../runbooks/migration-failure.md).
+Summary of the four canonical paths:
 
-1. **Migration code bug** — fix forward. Push the corrective migration on
-   a follow-up PR; the next deploy re-runs all pending migrations
-   including the new fix.
+1. **Migration code bug** — fix forward. Push the corrective
+   migration on a follow-up PR; the next deploy boots a new image
+   that re-runs the migration set.
 2. **Migration partially applied (multi-statement, no transaction)** —
-   the affected migration's row is NOT in `SequelizeMeta` because
-   the Umzug runner only writes it after `up()` returns successfully.
-   Re-running `db:migrate` will retry the whole `up()`. If the migration
-   is not idempotent, hand-revert what landed via psql before re-running.
-3. **Migration succeeded but health check failed** — the migration is
-   in `SequelizeMeta`. Roll the application image back per the next
-   section; the schema is now ahead of the binary, which is the failure
-   mode the schema-audit runbook covers.
-4. **Lock contention** (`could not obtain lock`) — usually a long-running
-   query holding the table. The migration will exit on
-   `DB_LOCK_TIMEOUT_MS` (default 10s). Identify the offending session and
-   either let it finish or terminate it, then re-deploy.
-
-The migration runner is single-instance; if multi-replica deploys are
-introduced later, wrap the `up()` body in a Postgres advisory lock —
-tracked in ADS-393's follow-up.
+   the affected migration's row is NOT in `pgmigrations` (the runner
+   only writes it after `up()` returns). Re-running `db:migrate`
+   will retry the whole `up()`. If the migration is not idempotent,
+   hand-revert what landed via psql before restarting the service.
+3. **Migration succeeded but the binary won't boot for another
+   reason** — the migration is in `pgmigrations`. Roll the affected
+   service back per the next section; the schema is now ahead of
+   the old binary.
+4. **Advisory-lock contention** — the runner already retries 12×
+   on the database-wide lock around `pgmigrations`, so this rarely
+   surfaces. If it does, a stuck migration elsewhere is holding the
+   lock; identify and clear it, then restart the failing service.
 
 ## Rollback
 
-Because release.yml emits immutable `:sha-<long>` and `:vX.Y.Z` tags, rollback
-is deterministic: pick the previous known-good tag and re-deploy. [ADS-396]
+Because release.yml emits immutable `:sha-<long>` and `:vX.Y.Z` tags
+**per service**, rollback is deterministic: pick the previous
+known-good tag(s) and re-deploy. Each service has its own
+`SERVICE_<NAME>_TAG` env var that overrides `DEPLOY_SHA` for that
+one service, so single-service rollback is supported without
+reverting the whole stack. [ADS-396]
 
 ```bash
-export IMAGE_TAG=v1.2.3   # previous good release
+# Single-service rollback (preferred):
+export SERVICE_PETS_TAG=sha-abc1234
+docker compose -f docker-compose.prod.yml pull service-pets
+docker compose -f docker-compose.prod.yml up -d service-pets
+
+# Whole-stack rollback:
+export DEPLOY_SHA=sha-abc1234
 docker compose -f docker-compose.prod.yml pull
 docker compose -f docker-compose.prod.yml up -d
 ```
 
-If a migration introduced incompatible schema, run the corresponding `down`
-migration before rolling back the application image:
-
-```bash
-docker compose -f docker-compose.prod.yml run --rm service-backend-migrate \
-  pnpm db:migrate:undo
-```
+There is **no `pnpm db:migrate:undo` script** — the runner is
+`up`-only. If a migration introduced incompatible schema, you must
+write a corrective migration that performs the reverse DDL, ship a
+new image, and let the next boot apply it. Running a migration's
+`down()` directly via `node-pg-migrate` from inside the container
+is possible but bypasses the deploy pipeline; only do it with a DBA
+on the line and a backup taken first. See
+[`docs/runbooks/migration-failure.md`](../runbooks/migration-failure.md)
+path E.
 
 ## Database TLS (ADS-540)
 
@@ -250,16 +271,21 @@ supported:
 | `verify-ca`   | TLS, verify CA chain |
 | `verify-full` | TLS, verify CA chain + hostname (recommended for managed providers) |
 
-The backend refuses to boot in production with `DB_SSL_MODE=disable` unless
-`ALLOW_INSECURE_DB=true` is also set — only safe on a fully trusted bridge
-such as the in-cluster docker network on the same host.
+Every schema-owning service refuses to boot in production with
+`DB_SSL_MODE=disable` unless `ALLOW_INSECURE_DB=true` is also set —
+only safe on a fully trusted bridge such as the in-cluster docker
+network on the same host.
 
 ### Managed Postgres (RDS / Neon / Supabase)
 
 1. Download the provider's CA bundle (e.g. `rds-combined-ca-bundle.pem`).
-2. Mount it into the backend container: add a `volumes:` entry to the
-   `service-backend` / `service-backend-migrate` services pointing to a
-   read-only path inside the container.
+2. Mount it into every schema-owning service container: add a
+   `volumes:` entry to each `service-*` service in
+   `docker-compose.prod.yml` that runs migrations or holds a pg pool
+   (`service-auth`, `service-pets`, `service-rescue`,
+   `service-applications`, `service-chat`, `service-notifications`,
+   `service-moderation`, `service-matching`, `service-cms`,
+   `service-audit`) pointing to a read-only path inside the container.
 3. Set the env vars in `.env`:
    ```
    DB_SSL_MODE=verify-full
@@ -284,12 +310,12 @@ See [`snapshot-policy.md`](./snapshot-policy.md). [ADS-500]
 
 ## WebSocket sticky sessions (ADS-678)
 
-The Socket.IO per-user connection cap is enforced per backend instance,
-not globally. Multi-replica deploys MUST configure load-balancer
-stickiness on the `/socket.io` route so a given user's sockets land on
-one backend. With nginx in front, add `ip_hash;` to the backend
-upstream block; with AWS ALB, enable `lb_cookie` stickiness on the
-target group.
+The Socket.IO per-user connection cap is enforced per gateway
+instance, not globally. Multi-replica gateway deploys MUST configure
+load-balancer stickiness on the `/socket.io` route so a given user's
+sockets land on one gateway. With nginx in front, add `ip_hash;` to
+the gateway upstream block; with AWS ALB, enable `lb_cookie`
+stickiness on the target group.
 
 See [`../architecture/adr-socket-sticky-sessions.md`](../architecture/adr-socket-sticky-sessions.md)
 for the full rationale, alternatives considered, and the explicit LB
@@ -300,6 +326,7 @@ settings the ops team must apply.
 - nginx hostname substitution is manual (placeholder string). A future
   iteration could ship a `docker-entrypoint` that runs `envsubst` over a
   template, but that would change the compose volume mount.
-- `service-backend-migrate` runs single-instance. Multi-replica deploys must
-  wrap migrations in a Postgres advisory lock — tracked in ADS-393's
-  follow-up.
+- Each service runs its own migrations on boot. Multi-replica deploys
+  rely on the database-wide advisory lock around `pgmigrations` (built
+  into `@adopt-dont-shop/db`) to serialise concurrent boots — see
+  `packages/db/src/migrate.ts` for the retry policy.

--- a/docs/operations/snapshot-policy.md
+++ b/docs/operations/snapshot-policy.md
@@ -9,7 +9,7 @@ has its own RPO / RTO and backup mechanism.
 | Volume / Store        | Source                                 | Recovery class | Retention |
 |-----------------------|----------------------------------------|----------------|-----------|
 | `postgres_data`       | `database` service (Postgres 16+PostGIS) | Tier-1 (full)  | 30 days   |
-| `uploads`             | `service-backend` user uploads         | Tier-1 (full)  | 90 days   |
+| `uploads`             | Shared user-uploads volume (gateway writes, per-stack nginx serves read-only) | Tier-1 (full)  | 90 days   |
 | `letsencrypt`         | nginx TLS state                        | Regenerable — no backup |  N/A     |
 | Application images    | GitHub Container Registry (GHCR)       | Immutable tags | indefinite (per-tag) |
 

--- a/docs/runbooks/5xx-spike.md
+++ b/docs/runbooks/5xx-spike.md
@@ -17,10 +17,14 @@ curl -s -H "Authorization: Bearer $METRICS_AUTH_TOKEN" \
   https://${PROD_HOSTNAME}/metrics \
   | grep -E '^http_requests_total{.*status_code="5'
 
-# 2. Which routes are bleeding? (last 30m of logs, group by status)
-docker compose -f docker-compose.prod.yml logs --since 30m service-backend \
+# 2. Which routes are bleeding? (last 30m of gateway access logs)
+docker compose -f docker-compose.prod.yml logs --since 30m service-gateway \
   | grep -E '"statusCode":5[0-9]{2}' \
   | head -50
+
+# If the gateway is fine but a specific backing service is erroring, follow
+# its logs too — e.g.:
+#   docker compose -f docker-compose.prod.yml logs --since 30m service-pets
 ```
 
 In Grafana, open the **Error rate by route** panel:
@@ -38,19 +42,24 @@ Match the symptom to a cause:
 | Signal                                                       | Likely cause                                | Jump to                                  |
 | ------------------------------------------------------------ | ------------------------------------------- | ---------------------------------------- |
 | Started immediately after a deploy                           | Bad release                                 | [`deploy-rollback.md`](./deploy-rollback.md) |
-| `redis` failing in `/api/v1/health`; auth routes 503         | Redis outage                                | [`redis-outage.md`](./redis-outage.md)   |
-| `acquire timeout` / `pool` errors in logs                    | DB pool exhaustion                          | [`db-pool-exhaustion.md`](./db-pool-exhaustion.md) |
-| `service-backend-migrate` exited non-zero recently           | Migration failure                           | [`migration-failure.md`](./migration-failure.md) |
+| Auth / rate-limit routes erroring; `redis` container unhealthy | Redis outage                              | [`redis-outage.md`](./redis-outage.md)   |
+| `acquire timeout` / `pool is draining` in service logs       | DB pool exhaustion                          | [`db-pool-exhaustion.md`](./db-pool-exhaustion.md) |
+| One service stuck in `restarting`; recent deploy ran a migration | Migration failure for that service       | [`migration-failure.md`](./migration-failure.md) |
 | Errors confined to one route, no other signal                | Application bug on a code path              | continue below                           |
 
-Check `/api/v1/health` for an authoritative per-dependency status:
+The gateway only exposes `/health/simple` (liveness — `200 ok`). There
+is no aggregated `/api/v1/health` route; check per-dependency state by
+inspecting the containers directly:
 
 ```bash
-curl -sf https://${PROD_HOSTNAME}/api/v1/health | jq '.services'
+# Backing services + infrastructure
+docker compose -f docker-compose.prod.yml ps
+# A specific service's logs
+docker compose -f docker-compose.prod.yml logs --tail=200 service-auth
 ```
 
-Any `"status": "unhealthy"` in `database`, `redis`, or `queue` points
-directly at the dependency to investigate.
+A service stuck in `restarting`, `unhealthy`, or `exited` is the
+dependency to investigate first.
 
 ## Mitigation
 
@@ -59,12 +68,14 @@ Pick the fastest reversible action:
 1. **Recent deploy** — roll back per
    [`deploy-rollback.md`](./deploy-rollback.md). This is the most
    common cause; do it before deeper debugging.
-2. **One bad pod** — restart it:
+2. **One bad replica** — restart the affected service. Identify it
+   from the diagnosis table above (gateway vs. a specific domain
+   service), then:
    ```bash
-   docker compose -f docker-compose.prod.yml restart service-backend
+   docker compose -f docker-compose.prod.yml restart service-<name>
    ```
    Watch the 5xx rate fall in Grafana. If it doesn't, the cause isn't
-   pod-local.
+   restart-local.
 3. **Specific route hot** — if the failing route is non-critical (e.g.
    `/api/v1/reports/*`), consider flipping a feature flag to disable
    the code path. See [`maintenance-mode.md`](./maintenance-mode.md)
@@ -78,18 +89,20 @@ Pick the fastest reversible action:
 - Grafana error rate drops below 1% and stays there for 5 min.
 - `HighFiveHundredRate` alert resolves (Alertmanager `resolved` event
   in `#oncall-page`).
-- `curl -sf https://${PROD_HOSTNAME}/api/v1/health` returns
-  `"status": "healthy"`.
+- `curl -sf https://${PROD_HOSTNAME}/health/simple` returns 200 and
+  `docker compose -f docker-compose.prod.yml ps` shows every service
+  healthy.
 
 ## Capture before you leave
 
 ```bash
-# Logs, scoped to the spike window
+# Logs, scoped to the spike window — pull the gateway PLUS any service
+# you identified in diagnosis.
 docker compose -f docker-compose.prod.yml logs --since 1h --no-color \
-  service-backend > /tmp/incident-$(date +%s).log
+  service-gateway service-<name> > /tmp/incident-$(date +%s).log
 
-# Image SHA actually running
-docker compose -f docker-compose.prod.yml images service-backend
+# Image SHAs actually running across the stack
+docker compose -f docker-compose.prod.yml images
 ```
 
 Attach both to the Linear follow-up ticket along with the Grafana

--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -10,11 +10,13 @@ decide in 10 seconds whether to escalate.
 | Runbook                                          | When to open it                                          |
 | ------------------------------------------------ | -------------------------------------------------------- |
 | [`5xx-spike.md`](./5xx-spike.md)                 | `HighFiveHundredRate` page; 5xx ratio >1% over 5m        |
-| [`redis-outage.md`](./redis-outage.md)           | Readiness flap on `redis`; auth `429`s spike or vanish   |
+| [`redis-outage.md`](./redis-outage.md)           | `redis` container unhealthy; rate-limiters misbehaving   |
 | [`db-pool-exhaustion.md`](./db-pool-exhaustion.md) | `acquire timeout` errors; p95 latency climbs in lockstep |
 | [`deploy-rollback.md`](./deploy-rollback.md)     | Bad deploy: image is live but error rate is up           |
-| [`migration-failure.md`](./migration-failure.md) | `service-backend-migrate` exited non-zero; backend won't start |
+| [`migration-failure.md`](./migration-failure.md) | A schema-owning service stuck in `restarting` after a deploy ran a migration |
 | [`maintenance-mode.md`](./maintenance-mode.md)   | Planned outage, controlled brownout, or kill-switch needed |
+| [`jetstream-backlog.md`](./jetstream-backlog.md) | NATS JetStream consumer lag / backlog                   |
+| [`gdpr-erasure-incident.md`](./gdpr-erasure-incident.md) | GDPR erasure run failed mid-way                  |
 | [`applications-cutover.md`](./applications-cutover.md) | _Obsolete_ — per-domain cutover flags removed; gateway always registers routes |
 
 ## On-call principles
@@ -26,7 +28,8 @@ that the rules are simple enough to follow when you're half-awake.
 
 - A `critical` alert fired and stayed firing past its `for:` window
   (see [`docs/observability-alerting.md`](../observability-alerting.md)).
-- `/api/v1/ready` returns `503` and the load balancer is dropping pods.
+- A schema-owning service is stuck in `restarting` (visible via
+  `docker compose ps`), blocking its domain routes.
 - A deploy is in flight and the health-check loop in
   `.github/workflows/deploy.yml` has timed out.
 - Customer-visible 5xx rate is above 1% for >5 min.
@@ -40,9 +43,10 @@ from the alert annotation, post a 1-line status in `#oncall-page`,
 - A `warning` fired but has not been firing for 30+ minutes.
 - p95 latency is high but error rate is flat — start investigating
   in `#alerts`, don't escalate.
-- A single readiness probe failed and recovered within 2 min — the
-  `ReadinessProbeFailing` rule requires `for: 2m`, so a single blip
-  won't page. Investigate, don't escalate.
+- A single container healthcheck failed and recovered within
+  ~30 s — Docker's healthcheck cadence will eventually mark it
+  unhealthy on a sustained failure; a single blip isn't actionable.
+  Investigate, don't escalate.
 - Heap usage warning during a known batch job (reports, exports).
 
 ### Mitigate before you debug

--- a/docs/runbooks/db-pool-exhaustion.md
+++ b/docs/runbooks/db-pool-exhaustion.md
@@ -5,14 +5,14 @@ otherwise `warning` (`P95LatencyHigh`).
 
 ## Symptoms
 
-- p95 latency climbs across many unrelated routes simultaneously.
-- Errors in backend logs include
-  `SequelizeConnectionAcquireTimeoutError`, `pool is draining`, or
-  `acquire timeout`.
+- p95 latency climbs across routes owned by the affected service
+  (each service has its own pg pool, so exhaustion is per-service).
+- Errors in the affected service's logs include `pool is draining`
+  or `Error: timeout exceeded when trying to connect` (pg-pool).
 - `process_cpu_*` looks fine; the bottleneck isn't CPU.
 - Postgres `pg_stat_activity` shows many `idle in transaction` or
   long-running queries.
-- 5xx may rise once the `DB_POOL_ACQUIRE_MS` timeout (default 30s) is
+- 5xx may rise once the pool's connection-timeout (default 30s) is
   hit — see the service's database connection config.
 
 ## Pool config (current defaults)
@@ -36,8 +36,9 @@ Effective settings are logged at boot:
 
 ```bash
 # 1. Confirm pool-acquire errors are firing (not generic DB errors).
-docker compose -f docker-compose.prod.yml logs --since 15m service-backend \
-  | grep -iE 'acquire timeout|pool is draining|connectionacquire'
+#    Identify the noisy service via `docker compose ps`, then:
+docker compose -f docker-compose.prod.yml logs --since 15m service-<name> \
+  | grep -iE 'acquire timeout|pool is draining|timeout exceeded when trying to connect'
 
 # 2. How many sessions are open on the DB right now?
 docker compose -f docker-compose.prod.yml exec -T database \
@@ -76,15 +77,17 @@ is up and tracking the saturation, capacity is the cause.
    ```
    Watch the `state` distribution drop back to mostly `idle`.
 
-2. **Bump the pool** (temporary; requires backend restart):
+2. **Bump the pool** (temporary; requires the affected service to
+   restart and pick up the new env):
    ```bash
    # Edit .env on the prod host
    DB_POOL_MAX=40
-   docker compose -f docker-compose.prod.yml up -d service-backend
+   docker compose -f docker-compose.prod.yml up -d service-<name>
    ```
    Do **not** exceed the Postgres `max_connections` ceiling
-   (typically 100 on a small managed instance) — leaving headroom for
-   `service-backend-migrate`, `psql`, and the operator is mandatory.
+   (typically 100 on a small managed instance). Every schema-owning
+   service holds up to `DB_POOL_MAX` connections; budget across all
+   of them and leave headroom for `psql` + the operator.
 
 3. **Disable a hot endpoint** — if a known feature is driving the
    load (e.g. a search endpoint hitting a missing index), flip its
@@ -111,8 +114,8 @@ docker compose -f docker-compose.prod.yml exec -T database \
   -c "SELECT * FROM pg_stat_activity WHERE datname=current_database() AND state <> 'idle';" \
   > /tmp/pgstat-$(date +%s).txt
 
-# Pool config + boot env that was in effect
-docker compose -f docker-compose.prod.yml logs service-backend \
+# Pool config + boot env that was in effect on the affected service
+docker compose -f docker-compose.prod.yml logs service-<name> \
   | grep '\[db\] pool' | tail -1
 ```
 

--- a/docs/runbooks/deploy-rollback.md
+++ b/docs/runbooks/deploy-rollback.md
@@ -26,88 +26,106 @@ rolling the image back.
 ## Image-tag refresher
 
 From [`docs/operations/deploy.md`](../operations/deploy.md): production
-runs immutable `:sha-<long>` or `:vX.Y.Z` tags, never `:latest`. The
-previous good tag is in the deploy log / release notes.
+runs immutable `:sha-<long>` or `:vX.Y.Z` tags per service, never
+`:latest`. Each service has its own image and its own per-service tag
+override in `docker-compose.prod.yml`
+(`SERVICE_GATEWAY_TAG`, `SERVICE_AUTH_TAG`, …). The default is
+`DEPLOY_SHA`, but a single service can be pinned to a different
+SHA when rolling forward / back independently.
 
 ```bash
-# What's running right now?
-docker compose -f docker-compose.prod.yml images service-backend
+# What's running across the whole stack right now?
+docker compose -f docker-compose.prod.yml images
 ```
 
 ## Rollback procedure
 
+You can roll back **a single service** (preferred when only one
+service regressed) or **the entire stack** (when the regression spans
+multiple services or you can't pinpoint it).
+
+### Single service rollback (preferred)
+
 ```bash
-# 1. Identify the previous good tag.
-export IMAGE_TAG=v1.2.3        # or sha-<long> from release notes
+# 1. Identify the previous good tag for the affected service.
+export SERVICE_PETS_TAG=sha-abc1234     # or vX.Y.Z
 
-# 2. Pull + restart with the old tag.
-DEPLOY_SHA=${IMAGE_TAG} \
-  docker compose -f docker-compose.prod.yml pull service-backend
-DEPLOY_SHA=${IMAGE_TAG} \
-  docker compose -f docker-compose.prod.yml up -d service-backend
+# 2. Pull + restart just that service. The other services keep their
+#    current tags.
+docker compose -f docker-compose.prod.yml pull service-pets
+docker compose -f docker-compose.prod.yml up -d service-pets
 
-# 3. Confirm the new (old) image is live.
-docker compose -f docker-compose.prod.yml images service-backend
+# 3. Confirm the new (old) image is live for that service.
+docker compose -f docker-compose.prod.yml images service-pets
 
 # 4. Health check.
-curl -sf https://${PROD_HOSTNAME}/health
-curl -sf https://${PROD_HOSTNAME}/api/v1/ready | jq
+curl -sf https://${PROD_HOSTNAME}/health/simple
+docker compose -f docker-compose.prod.yml ps
 ```
 
-The `service-backend-migrate` init container also pins to
-`${DEPLOY_SHA}`, so re-running it would replay the migration set the
-*old* tag knows about. **Do not** restart `service-backend-migrate`
-during an image rollback unless you're also reverting a migration —
-see below.
+### Whole-stack rollback
+
+```bash
+# 1. Identify the previous good DEPLOY_SHA.
+export DEPLOY_SHA=sha-abc1234
+
+# 2. Pull + restart everything.
+docker compose -f docker-compose.prod.yml pull
+docker compose -f docker-compose.prod.yml up -d
+
+# 3. Confirm tags across the stack.
+docker compose -f docker-compose.prod.yml images
+```
 
 ## Schema-compatibility caveat
 
 The deploy contract is **forward-only schemas**: a deploy may add
 columns but the previous binary must still run against the new schema.
 That assumption is documented in
-[`docs/operations/deploy.md`](../operations/deploy.md#rollback).
+[`docs/operations/deploy.md`](../operations/deploy.md).
 
 If the failed deploy ran a migration that the previous binary cannot
 tolerate (e.g. removed a column it still reads, added a `NOT NULL`
-constraint it doesn't populate):
+constraint it doesn't populate), an image rollback alone won't help —
+the old binary will fail against the new schema.
 
-```bash
-# 1. Roll the migration back FIRST.
-docker compose -f docker-compose.prod.yml run --rm service-backend-migrate \
-  pnpm db:migrate:undo
+There is **no `pnpm db:migrate:undo` script**. The runner is
+`node-pg-migrate` driven `up`-only by `@adopt-dont-shop/db`
+(`packages/db/src/migrate.ts`). To reverse a schema change you must
+write a corrective migration that performs the reverse DDL, ship it
+in a new image, and let the service's boot `db:migrate` apply it.
 
-# 2. Then roll the image back per the procedure above.
-```
-
-Confirm the migration that ran during this deploy actually has a
-working `down()` — many do not (see
-`db-backup-runbook.md` for the broader "forward-only" warning). If
-`down()` is missing, you cannot roll back cleanly; jump to
-[`migration-failure.md`](./migration-failure.md) and call the on-call
-DBA.
+If the affected migration has a working `down()`, you can run it
+directly via `node-pg-migrate` from inside the service container, but
+this is bypassing the deploy pipeline — only do it with a DBA on the
+line and a backup taken first. See
+[`migration-failure.md`](./migration-failure.md) path E for the
+"schema is ahead of binary" recovery sequence.
 
 ## Verify
 
 - Error rate drops to pre-deploy baseline within 5 min.
-- `/api/v1/ready` returns 200.
+- `/health/simple` returns 200 and `docker compose ps` shows every
+  service healthy.
 - `HighFiveHundredRate` (and any latency alerts) resolve.
-- `docker compose ... images service-backend` shows the old tag.
+- `docker compose ... images` shows the old tag on the affected
+  services.
 
 ## Capture
 
 ```bash
-# Record the bad image SHA before it scrolls out of logs.
+# Record the bad image SHA before it scrolls out of logs. Pull the
+# gateway + the affected service(s) you rolled back.
 docker compose -f docker-compose.prod.yml logs --since 2h --no-color \
-  service-backend > /tmp/rollback-incident-$(date +%s).log
+  service-gateway service-<name> > /tmp/rollback-incident-$(date +%s).log
 
 # Note in the Linear follow-up:
 #  - bad tag, previous good tag, time window of the spike, link to
-#    the failing CI build.
+#    the failing CI build, which services were rolled back.
 ```
 
 Open a Linear ticket on the offending release and link the original
-PR. If the migration also needed reverting, attach the `db:migrate:undo`
-output too.
+PR. If a corrective migration was needed too, link that PR alongside.
 
 ## When NOT to roll back
 

--- a/docs/runbooks/maintenance-mode.md
+++ b/docs/runbooks/maintenance-mode.md
@@ -26,9 +26,9 @@ traffic without taking the whole app down.
 
 **When set to `true`**, the frontends consume the flag via the
 `useDynamicConfig(KNOWN_CONFIGS.APPLICATION_SETTINGS)` hook and
-render the maintenance banner / block protected actions. The backend
-continues to serve `/health`, `/api/v1/ready`, and read endpoints
-unless you also stop the container.
+render the maintenance banner / block protected actions. The gateway
+continues to serve `/health/simple` and read endpoints unless you
+also stop the container.
 
 ## When to use it
 
@@ -42,8 +42,8 @@ unless you also stop the container.
 
 Maintenance mode does **not** prevent direct API hits — it's a UX
 contract enforced by the frontend. Determined clients can still call
-the API. If you need a hard block, scale `service-backend` to zero
-or stop nginx.
+the API. If you need a hard block, stop nginx (preferred) or stop
+`service-gateway` directly.
 
 ## Flipping the flag
 
@@ -125,7 +125,7 @@ docker compose -f docker-compose.prod.yml start nginx
 
 This is louder than maintenance mode (no friendly banner, just a
 connection failure) but it's the cleanest way to guarantee zero
-traffic reaches the backend.
+traffic reaches the gateway / backing services.
 
 ## Capture
 

--- a/docs/runbooks/migration-failure.md
+++ b/docs/runbooks/migration-failure.md
@@ -1,93 +1,131 @@
 # Migration Failure
 
-**Page severity:** `critical` — `service-backend` will not start until
-`service-backend-migrate` exits 0. Site is effectively down.
+**Page severity:** `critical` for the affected service — the failing
+service won't start until its migrations apply. The rest of the stack
+keeps serving on the old binary (gateway + healthy services), so the
+site is degraded, not down.
+
+## Background — how migrations run
+
+There is **no** dedicated `service-backend-migrate` init container.
+Every schema-owning service migrates **its own** schema on every boot:
+the entrypoint (`Dockerfile.service`) runs
+`pnpm run --if-present db:migrate` before the long-running process
+starts. Schema-owning services are `service-auth`, `service-pets`,
+`service-rescue`, `service-applications`, `service-chat`,
+`service-notifications`, `service-moderation`, `service-matching`,
+`service-cms`, `service-audit`. The gateway owns no tables and
+exits the migrate step as a no-op.
+
+The runner is `node-pg-migrate` wrapped by `@adopt-dont-shop/db`
+(`packages/db/src/migrate.ts`). Applied migrations are recorded in a
+`pgmigrations` table inside each owning schema (not `SequelizeMeta`).
+The runner takes a database-wide advisory lock around `pgmigrations`
+and retries with linear backoff on contention, so multiple services
+booting at once is expected and self-resolving — true failures are
+either bad SQL or schema drift.
 
 ## Symptoms
 
-- Deploy job's health-check loop in `.github/workflows/deploy.yml`
-  times out and exits non-zero.
-- `docker compose ps` shows `service-backend-migrate` as `exited (1)`
-  and `service-backend` as not started (blocked by compose's
-  `service_completed_successfully` dependency — see
-  [`docs/operations/deploy.md`](../operations/deploy.md)).
-- Old backend container is still running on the previous tag — **no
-  traffic is shifted to the failed image**. Site stays up on the old
-  release.
+- Deploy job's per-service health-check loop in
+  `.github/workflows/deploy.yml` times out and exits non-zero.
+- `docker compose ps` shows the affected service stuck in
+  `restarting` (Docker keeps restarting a container that exits
+  non-zero from its CMD).
+- Service logs (`docker compose logs --no-color service-<name>`) show
+  the node-pg-migrate runner output and an error line, after which
+  the container exits.
+- The gateway and unaffected services keep serving. The affected
+  service's gRPC routes return upstream errors via the gateway —
+  expect 5xx on the affected domain, not site-wide.
 
-The good news: the deploy gate worked. The old binary is still
-serving. You have time to triage; you do not need to mitigate user
-impact first.
+The good news: only the failing service is down. You have time to
+triage without taking the rest of the site with it.
 
 ## Triage in 60 seconds
 
 ```bash
-# 1. Read the failing migration name + error.
-docker compose -f docker-compose.prod.yml logs --no-color \
-  service-backend-migrate
+# 1. Which service is failing, and on which migration?
+docker compose -f docker-compose.prod.yml ps
+docker compose -f docker-compose.prod.yml logs --no-color --tail=200 \
+  service-<name>   # e.g. service-pets
 
-# 2. What's actually been applied?
+# 2. What's actually been applied in that service's schema?
 docker compose -f docker-compose.prod.yml exec -T database \
   psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" \
-  -c 'SELECT name FROM "SequelizeMeta" ORDER BY name DESC LIMIT 10;'
+  -c 'SELECT name, run_on FROM <schema>.pgmigrations ORDER BY id DESC LIMIT 10;'
+# <schema> matches the owning service: auth, pets, rescue, applications,
+# chat, notifications, moderation, matching, cms, audit.
 ```
 
-The failing migration is logged at the top of `service-backend-migrate`'s
-output. Note its filename — you'll need it to decide recovery path.
+The runner logs each migration name as it tries it. Note the filename
+of the one that failed — you'll need it to decide recovery path.
 
 ## Diagnosis — choose ONE recovery path
-
-These mirror the four documented modes in
-[`docs/operations/deploy.md`](../operations/deploy.md#when-the-migration-init-container-fails).
 
 ### A. Migration code bug → fix forward
 
 The failing migration has a logic error.
 
-- The migration's row will **not** be in `SequelizeMeta` (the Umzug
-  runner only writes it after `up()` returns).
-- Re-running `db:migrate` will replay the whole `up()`.
+- The migration's row will **not** be in `pgmigrations` (the runner
+  only writes it after `up()` returns).
+- Re-running `db:migrate` on the next deploy will replay the whole
+  `up()`.
 
 ```bash
 # 1. Author the corrective migration on a branch, get it merged.
-# 2. Wait for CI to build a new image tag.
-# 3. Re-deploy with the new tag.
+# 2. Wait for CI to build a new image tag for the affected service.
+# 3. Re-deploy. Each service boots and runs its own migrations again.
 ```
 
-The site continues to serve on the old binary while you do this. No
-emergency action needed beyond a fast PR review.
+The rest of the site continues to serve. No emergency action needed
+beyond a fast PR review.
 
 ### B. Migration partially applied (multi-statement, no tx)
 
-Some DDL landed, the rest failed. `SequelizeMeta` is still missing
-the migration's row, so a re-run will try to land the already-applied
-DDL again.
+Some DDL landed, the rest failed. The migration's row is **not** in
+`pgmigrations`, so a re-run will try to land the already-applied DDL
+again and fail on "relation already exists" or similar.
 
 ```bash
 # 1. Identify what landed.
 docker compose -f docker-compose.prod.yml exec -T database \
   psql -U "$POSTGRES_USER" -d "$POSTGRES_DB"
-# ... inspect schema by hand: \d <table>
+# ... inspect schema by hand: \d <schema>.<table>
 
 # 2. Hand-revert the partial changes via psql so the migration's
 #    up() can run cleanly from scratch.
 
-# 3. Re-run the migration init container.
-docker compose -f docker-compose.prod.yml run --rm service-backend-migrate
+# 3. Restart the service so its CMD re-runs db:migrate.
+docker compose -f docker-compose.prod.yml restart service-<name>
 ```
 
-This is the most dangerous path — make a backup first (see
-[`docs/db-backup-runbook.md`](../db-backup-runbook.md#pre-migration-backup-checklist))
-and have the DBA on the line.
+This is the most dangerous path — make a backup first and have the
+DBA on the line.
 
-### C. Lock contention (`could not obtain lock`)
+### C. Schema/data drift the migration didn't expect
 
-A long-running query is holding the table. The migration exits on
-`DB_LOCK_TIMEOUT_MS` (default 10s — see the service's database
-connection config).
+A migration that assumed (for example) a column was nullable but
+production has rows that violate the new constraint.
+
+- The runner logs the violating row's constraint name.
+- Decide: fix the data in production, or rewrite the migration with
+  a backfill step that handles the existing rows.
+
+Same recovery loop as path A — author the corrective migration, ship
+a new image, the next boot re-runs the migration set.
+
+### D. Lock contention (advisory or table-level)
+
+If several services boot at the same time they race for the
+database-wide advisory lock around `pgmigrations`. The runner retries
+12× with linear backoff (250ms × attempt — see
+`packages/db/src/migrate.ts`). True contention is rare in prod; if
+you see the contention message, it usually means a stuck migration
+elsewhere is holding the lock.
 
 ```bash
-# Find the blocker.
+# Find sessions holding migration-related locks.
 docker compose -f docker-compose.prod.yml exec -T database \
   psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" -c \
   "SELECT pid, state, now()-query_start AS age, left(query, 100) AS q
@@ -95,75 +133,78 @@ docker compose -f docker-compose.prod.yml exec -T database \
    WHERE datname=current_database() AND state <> 'idle'
    ORDER BY age DESC LIMIT 10;"
 
-# Wait it out, or terminate it.
+# Terminate the blocker if it's stuck.
 docker compose -f docker-compose.prod.yml exec -T database \
   psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" \
   -c "SELECT pg_terminate_backend(<pid>);"
 
-# Re-run the migration.
-docker compose -f docker-compose.prod.yml run --rm service-backend-migrate
+# Restart the failing service so it retries.
+docker compose -f docker-compose.prod.yml restart service-<name>
 ```
 
-### D. Migration succeeded but health-check failed
+### E. Schema is ahead of binary
 
-`SequelizeMeta` **does** contain the migration. The schema is ahead
-of the old binary that's still serving traffic. This is the "schema
-is ahead of binary" failure mode.
+The migration applied successfully (it's in `pgmigrations`) but the
+new binary won't start for an unrelated reason. The schema is now
+ahead of the old binary that's still serving traffic via the gateway.
 
-```bash
-# 1. Decide: forward-fix (deploy a new image that handles the new
-#    schema) or back out (run the migration's down()).
-docker compose -f docker-compose.prod.yml run --rm service-backend-migrate \
-  pnpm db:migrate:undo
-```
+- The deploy contract is **forward-only** — you can't roll the
+  migration back without a corrective migration.
+- If `down()` is implemented and the change is recoverable, write a
+  corrective migration; ship a new image; let `up()` apply it on the
+  next boot.
+- If `down()` would be destructive (drops columns / tables), **stop
+  and call the DBA**. Restore from the pre-migration backup is
+  sometimes the only safe option.
 
-If `down()` is a no-op or destructive, **stop and call the DBA**.
-Backing out a forward-only schema change is a one-way door — restore
-from the pre-migration backup is sometimes the only safe option.
+There is no `pnpm db:migrate:undo` script — the runner only runs
+`up`. Rolling back a forward-only migration means writing a new
+migration that performs the reverse change.
 
 ## Mitigation
 
-The old binary is still serving. Don't break that:
+The rest of the site is still serving. Don't break that:
 
-- **Do not** restart `service-backend` until the migration succeeds —
-  compose will block startup on the failed init container, leaving
-  you with zero replicas.
-- **Do not** delete `service-backend-migrate`'s container before
-  reading its logs — you lose the failure diagnostic.
+- **Do not** force-restart the affected service in a loop expecting
+  the migration to "just work" — each restart re-runs the failing
+  migration and re-logs the error. Fix the cause first.
+- **Do not** wipe the `pgmigrations` row for a partially-applied
+  migration unless you've reverted the DDL it landed first —
+  otherwise the next `up()` will trip over the existing schema.
 
-If business pressure forces serving while the migration is being
-authored, enable maintenance mode per
-[`maintenance-mode.md`](./maintenance-mode.md) for write paths and
-let reads continue on the old binary.
+If the affected service is in a hot user path (e.g. `service-auth`)
+and the cause will take >15 min to fix, enable maintenance mode
+per [`maintenance-mode.md`](./maintenance-mode.md).
 
 ## Verify
 
 ```bash
 # 1. Migration applied cleanly.
-docker compose -f docker-compose.prod.yml logs service-backend-migrate \
-  | tail -20
+docker compose -f docker-compose.prod.yml logs service-<name> \
+  | tail -50
 
-# 2. SequelizeMeta now contains the migration row.
+# 2. pgmigrations now contains the migration row.
 docker compose -f docker-compose.prod.yml exec -T database \
   psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" \
-  -c 'SELECT name FROM "SequelizeMeta" ORDER BY name DESC LIMIT 5;'
+  -c 'SELECT name FROM <schema>.pgmigrations ORDER BY id DESC LIMIT 5;'
 
-# 3. Backend starts and is healthy.
-docker compose -f docker-compose.prod.yml up -d service-backend
-curl -sf https://${PROD_HOSTNAME}/api/v1/ready | jq
+# 3. Service is healthy.
+docker compose -f docker-compose.prod.yml ps service-<name>
+curl -sf https://${PROD_HOSTNAME}/health/simple
+# Spot-check a route the affected domain owns to confirm gRPC fan-out works.
 ```
 
 ## Capture
 
 ```bash
-# The init container's logs are your post-mortem.
+# The failing service's logs are your post-mortem.
 docker compose -f docker-compose.prod.yml logs --no-color \
-  service-backend-migrate > /tmp/migration-incident-$(date +%s).log
+  service-<name> > /tmp/migration-incident-$(date +%s).log
 
 # Note the backup filename you took before the deploy.
 ls -lh /var/backups/adopt-dont-shop/ | tail
 ```
 
 File a Linear follow-up linking the PR that introduced the bad
-migration. If recovery used path B or D, schedule a restore drill
+migration. If recovery used path B or E, schedule a restore drill
 sooner than the next quarterly cycle.

--- a/docs/runbooks/redis-outage.md
+++ b/docs/runbooks/redis-outage.md
@@ -1,35 +1,31 @@
 # Redis Outage
 
-**Page severity:** `critical` (`ReadinessProbeFailing` when `redis`
-probe fails for 2m)
+**Page severity:** `critical` when auth or rate-limit-dependent
+flows start failing.
 
 ## Symptoms
 
-- `/api/v1/ready` returns `503` with
-  `failures: [{ service: 'redis', ... }]`.
-- Kubernetes / LB drops pods from rotation; effective capacity falls.
-- BullMQ reports queue stops processing (the `queue` probe fails
-  alongside Redis — see the gateway's health-check service).
+- `docker compose ps` shows the `redis` container `unhealthy` or
+  `exited`.
 - Auth `/login`, `/register` either rate-limit oddly or fail to
-  enforce limits across replicas (the Redis-backed rate-limit
-  middleware's `RedisStore` falls back to in-memory **per-replica**
-  when Redis is unconfigured, but **errors out** mid-request if Redis
-  was up and then dies).
-- Cache-fronted endpoints stay up but slow down — the read-through
-  cache helper falls through to the loader on any Redis failure.
+  enforce limits across replicas (the gateway's `@fastify/rate-limit`
+  plugin uses Redis as its store; on Redis failure `skipOnError:true`
+  falls through in-memory **per-replica**, so coordinated limits are
+  lost across replicas).
+- Cache-fronted endpoints stay up but slow down — read-through caches
+  fall through to the loader on any Redis failure.
 
 ## What still works vs. what doesn't
 
-| Subsystem            | Behaviour without Redis                                  |
-| -------------------- | -------------------------------------------------------- |
-| `cached()` helper    | Falls through to loader. Slower but correct.             |
-| Auth rate-limiters   | **Degraded** — per-replica only, shared state lost.      |
-| BullMQ reports queue | Down. New jobs cannot be enqueued; existing jobs stall.  |
-| Readiness probe      | Returns 503. LB drops pods until Redis recovers.         |
+| Subsystem               | Behaviour without Redis                                   |
+| ----------------------- | --------------------------------------------------------- |
+| Cache helpers           | Fall through to the loader. Slower but correct.           |
+| Gateway rate-limiters   | **Degraded** — per-replica in-memory, shared state lost.  |
+| Async / scheduled jobs  | Down. Enqueues fail; in-flight jobs stall.                |
 
-The cache fallthrough is safe; the rate-limiter and queue are not.
-Plan to enable maintenance mode for write-heavy flows if the outage
-runs long.
+The cache fallthrough is safe; the rate-limiter and any Redis-backed
+job system are not. Plan to enable maintenance mode for write-heavy
+flows if the outage runs long.
 
 ## Triage in 60 seconds
 
@@ -43,9 +39,9 @@ docker compose -f docker-compose.prod.yml exec -T redis \
 docker compose -f docker-compose.prod.yml ps redis
 docker compose -f docker-compose.prod.yml logs --tail=100 --no-color redis
 
-# 3. From the backend's perspective (proves DNS + creds work).
-docker compose -f docker-compose.prod.yml exec -T service-backend \
-  sh -c 'curl -sf http://localhost:5000/api/v1/health | jq .services.redis'
+# 3. From the gateway's perspective (proves DNS + creds work).
+docker compose -f docker-compose.prod.yml exec -T service-gateway \
+  sh -c 'getent hosts redis && redis-cli -h redis -a "$REDIS_PASSWORD" ping'
 ```
 
 ## Diagnosis
@@ -56,9 +52,9 @@ Match the symptom:
   OOMed. Check `docker compose logs redis` for `OOM`, `MISCONF`,
   `Background save terminated`.
 - `redis-cli ping` works from inside the redis container but the
-  backend probe fails → network / `REDIS_URL` / `REDIS_PASSWORD`
-  mismatch. Re-check the backend's `REDIS_HOST` and `REDIS_PASSWORD`
-  env in `docker-compose.prod.yml`.
+  gateway can't reach it → network / `REDIS_URL` / `REDIS_PASSWORD`
+  mismatch. Re-check the gateway's Redis env in
+  `docker-compose.prod.yml`.
 - Disk full inside the redis container (`MISCONF`) → AOF write
   failed. Free space on the host or grow the `redis_data` volume.
 
@@ -70,8 +66,8 @@ Match the symptom:
    # Wait for healthcheck to pass (~10s)
    docker compose -f docker-compose.prod.yml ps redis
    ```
-   The backend's `ensureRedisReady()` lazy-reconnects on the next
-   request, so no backend restart is needed.
+   The gateway's Redis client is configured with lazy reconnect, so
+   no gateway restart is needed.
 
 2. **If restart fails** — check the AOF / RDB on the `redis_data`
    volume. If corrupt, accept data loss:
@@ -90,23 +86,21 @@ Match the symptom:
    traffic that depends on auth rate-limiting. See
    [`maintenance-mode.md`](./maintenance-mode.md).
 
-4. **Confirm BullMQ recovers** — once Redis is back, the queue probe
-   should clear within one health-check interval:
-   ```bash
-   curl -sf https://${PROD_HOSTNAME}/api/v1/ready | jq
-   ```
+4. **Confirm dependents recover** — once Redis is back, hit a
+   rate-limited route (e.g. `POST /api/v1/auth/login` with bad creds)
+   and verify the limiter responds without 5xx.
 
 ## Verify
 
-- `/api/v1/ready` returns 200.
-- `ReadinessProbeFailing` alert resolves.
-- Pods rejoin LB rotation; request volume returns to baseline.
+- `redis-cli ping` returns `PONG` and the container is healthy.
+- A test login round-trip succeeds (auth → rate-limiter writes work).
+- Error rate in Grafana returns to baseline.
 
 ## Capture
 
 ```bash
 docker compose -f docker-compose.prod.yml logs --since 1h --no-color \
-  redis service-backend > /tmp/redis-incident-$(date +%s).log
+  redis service-gateway > /tmp/redis-incident-$(date +%s).log
 ```
 
 File the Linear follow-up. If this is the second Redis outage in a


### PR DESCRIPTION
## Summary

Documentation accuracy review. A large set of docs, runbooks, and Claude skill files still described the deleted `service.backend` monolith — commands referenced containers that don't exist (`service-backend`, `service-backend-migrate`), scripts that don't exist (`pnpm db:migrate:undo`, `pnpm db:seed:reference|demo|fixtures`, `pnpm db:bootstrap`), file layouts that don't exist (`src/controllers/`, `src/models/`, `src/__tests__/`, `src/seeders/`), and architectural patterns from the deleted monolith (Express + Sequelize + supertest). A developer or on-call engineer following them would either run commands that fail or quietly do the wrong thing.

Fixed in four batched commits on this branch:

1. **`docs/backend/implementation-guide.md`** — per-service `db:migrate` via node-pg-migrate, `pgmigrations` tracking table, real `EMAIL_PROVIDER` values (`console | ethereal | resend`), gateway on port 4000 with `/health/simple`, and rewritten "Common Tasks" pointing at proto + gRPC handlers + gateway routes.
2. **`docs/runbooks/*` + `docs/operations/deploy.md` + `docs/SECRETS-MANAGEMENT.md` + `docs/operations/snapshot-policy.md`** — full rewrite of `migration-failure.md` for the "this service is stuck restarting because its db:migrate failed" failure mode + five canonical recovery paths; `deploy.md` migration section rewritten for the per-service boot model; `deploy-rollback.md` rewritten with single-service vs whole-stack rollback and the explicit "no db:migrate:undo" note; surgical fixes to `5xx-spike.md`, `db-pool-exhaustion.md`, `redis-outage.md`, `maintenance-mode.md`, `runbooks/README.md`, `snapshot-policy.md`, and `SECRETS-MANAGEMENT.md` for the same set of stale container/endpoint references.
3. **`docs/backend/service-backend-prd.md` + scattered references** — banner on the monolith PRD clarifying the Architecture section is historical; surgical fixes to `backend/testing.md` (colocated `*.test.ts`, drop `pnpm db:reset`), `infrastructure/INFRASTRUCTURE.md` and `infrastructure/DEPLOYMENT-PLAN.md` (replace `docker compose up service-backend` and the SequelizeMeta seeding step), `architecture/adr-socket-sticky-sessions.md` (nginx upstream block targets `service-gateway`, the current Socket.IO server).
4. **`.claude/skills/{db-migration,backend-endpoint,backend-test}/SKILL.md`** — full rewrite of the three backend skills Claude actively loads when scoped to a backend task. Each was 100% aligned with the deleted monolith; rewritten against the actual current patterns (node-pg-migrate + MigrationBuilder, proto → gRPC handler → gateway route, colocated tests with Fastify `app.inject` + stubbed pool/clients).

The same three skills (`db-migration`, `backend-endpoint`, `backend-test`) have been the leading cause of "Claude wrote me a file in `src/controllers/`" mistakes — that should stop now.

## Fact-checked against (sample)

- `package.json`, `services/*/package.json` (no root `db:migrate`, no `db:seed:*` variants, per-service `db:migrate` + `db:seed`)
- `Dockerfile.service` CMD (`pnpm run --if-present db:migrate && pnpm run --if-present db:seed && pnpm run dev`)
- `docker-compose.{yml,prod.yml,dev.yml}` (no `service-backend`; `service-gateway` owns Socket.IO + `uploads` volume; per-service `SERVICE_<NAME>_TAG` overrides)
- `packages/db/src/migrate.ts` (node-pg-migrate runner, `pgmigrations` table, advisory-lock retry)
- `services/notifications/src/config.ts` (`EMAIL_PROVIDER` = `console | ethereal | resend`)
- `services/gateway/src/server.ts` (only `/health/simple`)
- `services/gateway/src/routes/email.ts` (preview body uses `variables`, not `context`)
- `services/pets/src/migrations/*.ts` (actual node-pg-migrate filename pattern + MigrationBuilder API)
- `services/pets/src/grpc/favorite-handlers.ts` (current handler shape with HandlerDeps + HandlerError + direct SQL)
- `scripts/seed.mjs` (host orchestrator ordering: auth → rescue → pets → applications → chat)

## Out of scope (deliberately)

- `docs/backend/service-backend-prd.md` itself — the product requirements (auth, pets, applications, chat, etc.) still describe what the system does, so I left the body intact and just prepended a banner explaining the Architecture section is historical. Full PRD rewrite is a bigger product / scope conversation.
- `docs/upgrades/express-5-migration.md` — explicitly marked `Status: ✅ Shipped — historical plan retained for context only`. References to `service.backend` there are intentional context.
- Other `.claude/skills/*` files (`docker-build`, `field-permissions`, `audit-logging`, `new-app`, `api-fetch`) — they have remaining `service.backend` references too. Saving for a follow-up if you want; lower blast radius than the three I rewrote.
- The `docs/backend/testing.md` example code blocks (Sequelize / supertest) — flagged at the top of the file as legacy patterns rather than rewriting every example.

## Commits in this PR

1. `docs(backend): align implementation guide with microservices architecture`
2. `docs(runbooks): rewrite migration + ops runbooks for per-service migrations`
3. `docs: mark monolith PRD as historical + fix scattered service-backend refs`
4. `docs(skills): rewrite backend skills for Fastify gateway + gRPC services`

## Test plan

- [ ] Skim each updated runbook and confirm every command is one you'd actually run during an incident
- [ ] Confirm `docs/backend/implementation-guide.md` reads as a working setup guide from a fresh checkout
- [ ] Spot-check the rewritten skill files against a recent backend PR (e.g. anything that adds a gRPC handler or migration) to confirm the patterns match

🤖 Generated with [Claude Code](https://claude.com/claude-code)
