### PR TITLE
Back rescue admin detail endpoints (plan/analytics/email/bulk + verify/reject)

### DIFF
--- a/packages/proto/proto/adopt_dont_shop/rescue/v1/rescue.proto
+++ b/packages/proto/proto/adopt_dont_shop/rescue/v1/rescue.proto
@@ -124,6 +124,28 @@ service RescueService {
   // questions cannot be deleted (FAILED_PRECONDITION).
   rpc DeleteApplicationQuestion(DeleteApplicationQuestionRequest)
       returns (DeleteApplicationQuestionResponse);
+
+  // --- Admin extras ----------------------------------------------------
+
+  // Set a rescue's subscription plan tier (free / growth / professional)
+  // and optional expiry. Admin-only — caller MUST have
+  // `admin.security.manage`. Publishes `rescue.planUpdated` after commit.
+  rpc UpdateRescuePlan(UpdateRescuePlanRequest) returns (UpdateRescuePlanResponse);
+
+  // Compute a rescue's headline statistics for the admin detail panel.
+  // staff_count is sourced from this vertical's staff_members table; the
+  // pet- and application-derived counts (which live in other verticals)
+  // are returned as zero defaults so the panel renders without a heavy
+  // cross-service aggregation. Caller MUST have `rescues.read`.
+  rpc GetRescueStatistics(GetRescueStatisticsRequest)
+      returns (GetRescueStatisticsResponse);
+
+  // Validate + enqueue an admin email to a rescue's contact address.
+  // Admin-only — caller MUST have `admin.security.manage`. Confirms the
+  // rescue exists, then publishes `rescue.adminEmailRequested` for the
+  // notifications worker to deliver (subscriber wiring is out of scope
+  // for this RPC — it stops at the published event).
+  rpc SendRescueEmail(SendRescueEmailRequest) returns (SendRescueEmailResponse);
 }
 
 // --- ENUMs — value lists mirror the Postgres types verbatim ----------
@@ -182,6 +204,11 @@ message Rescue {
   string settings_json = 24;
   string created_at = 25;
   string updated_at = 26;
+  // Subscription plan tier — 'free' | 'growth' | 'professional'. Defaults
+  // to 'free'. Drives the admin Plan tab + feature gating downstream.
+  string plan = 27;
+  // Optional ISO-8601 plan expiry. Unset = no expiry.
+  optional string plan_expires_at = 28;
 }
 
 // Invitation mirrors the rescue.invitations row — the pending-staff
@@ -522,4 +549,54 @@ message DeleteApplicationQuestionRequest {
 
 message DeleteApplicationQuestionResponse {
   bool deleted = 1;
+}
+
+// --- Admin extras -----------------------------------------------------
+
+message UpdateRescuePlanRequest {
+  string rescue_id = 1;
+  // 'free' | 'growth' | 'professional'. Validated by the handler.
+  string plan = 2;
+  // Optional ISO-8601 expiry. Empty/unset clears the expiry.
+  optional string plan_expires_at = 3;
+}
+
+message UpdateRescuePlanResponse {
+  Rescue rescue = 1;
+}
+
+message GetRescueStatisticsRequest {
+  string rescue_id = 1;
+}
+
+// Mirrors the SPA's RescueStatistics shape. staff_count is real
+// (sourced from rescue.staff_members); the pet/application-derived
+// counts default to zero (those records live in other verticals — see
+// the RPC doc comment).
+message RescueStatistics {
+  uint32 total_pets = 1;
+  uint32 available_pets = 2;
+  uint32 adopted_pets = 3;
+  uint32 pending_applications = 4;
+  uint32 total_applications = 5;
+  uint32 staff_count = 6;
+  uint32 active_listings = 7;
+  uint32 monthly_adoptions = 8;
+  double average_time_to_adoption = 9;
+}
+
+message GetRescueStatisticsResponse {
+  RescueStatistics statistics = 1;
+}
+
+message SendRescueEmailRequest {
+  string rescue_id = 1;
+  // Either a predefined template id, OR a custom subject + body.
+  optional string template_id = 2;
+  optional string subject = 3;
+  optional string body = 4;
+}
+
+message SendRescueEmailResponse {
+  bool queued = 1;
 }

--- a/packages/proto/src/generated/proto/adopt_dont_shop/rescue/v1/rescue.ts
+++ b/packages/proto/src/generated/proto/adopt_dont_shop/rescue/v1/rescue.ts
@@ -301,6 +301,13 @@ export interface Rescue {
   settingsJson: string;
   createdAt: string;
   updatedAt: string;
+  /**
+   * Subscription plan tier — 'free' | 'growth' | 'professional'. Defaults
+   * to 'free'. Drives the admin Plan tab + feature gating downstream.
+   */
+  plan: string;
+  /** Optional ISO-8601 plan expiry. Unset = no expiry. */
+  planExpiresAt?: string | undefined;
 }
 
 /**
@@ -618,6 +625,56 @@ export interface DeleteApplicationQuestionResponse {
   deleted: boolean;
 }
 
+export interface UpdateRescuePlanRequest {
+  rescueId: string;
+  /** 'free' | 'growth' | 'professional'. Validated by the handler. */
+  plan: string;
+  /** Optional ISO-8601 expiry. Empty/unset clears the expiry. */
+  planExpiresAt?: string | undefined;
+}
+
+export interface UpdateRescuePlanResponse {
+  rescue?: Rescue | undefined;
+}
+
+export interface GetRescueStatisticsRequest {
+  rescueId: string;
+}
+
+/**
+ * Mirrors the SPA's RescueStatistics shape. staff_count is real
+ * (sourced from rescue.staff_members); the pet/application-derived
+ * counts default to zero (those records live in other verticals — see
+ * the RPC doc comment).
+ */
+export interface RescueStatistics {
+  totalPets: number;
+  availablePets: number;
+  adoptedPets: number;
+  pendingApplications: number;
+  totalApplications: number;
+  staffCount: number;
+  activeListings: number;
+  monthlyAdoptions: number;
+  averageTimeToAdoption: number;
+}
+
+export interface GetRescueStatisticsResponse {
+  statistics?: RescueStatistics | undefined;
+}
+
+export interface SendRescueEmailRequest {
+  rescueId: string;
+  /** Either a predefined template id, OR a custom subject + body. */
+  templateId?: string | undefined;
+  subject?: string | undefined;
+  body?: string | undefined;
+}
+
+export interface SendRescueEmailResponse {
+  queued: boolean;
+}
+
 function createBaseRescue(): Rescue {
   return {
     rescueId: '',
@@ -646,6 +703,8 @@ function createBaseRescue(): Rescue {
     settingsJson: '',
     createdAt: '',
     updatedAt: '',
+    plan: '',
+    planExpiresAt: undefined,
   };
 }
 
@@ -728,6 +787,12 @@ export const Rescue: MessageFns<Rescue> = {
     }
     if (message.updatedAt !== '') {
       writer.uint32(210).string(message.updatedAt);
+    }
+    if (message.plan !== '') {
+      writer.uint32(218).string(message.plan);
+    }
+    if (message.planExpiresAt !== undefined) {
+      writer.uint32(226).string(message.planExpiresAt);
     }
     return writer;
   },
@@ -947,6 +1012,22 @@ export const Rescue: MessageFns<Rescue> = {
           message.updatedAt = reader.string();
           continue;
         }
+        case 27: {
+          if (tag !== 218) {
+            break;
+          }
+
+          message.plan = reader.string();
+          continue;
+        }
+        case 28: {
+          if (tag !== 226) {
+            break;
+          }
+
+          message.planExpiresAt = reader.string();
+          continue;
+        }
       }
       if ((tag & 7) === 4 || tag === 0) {
         break;
@@ -1040,6 +1121,12 @@ export const Rescue: MessageFns<Rescue> = {
         : isSet(object.updated_at)
           ? globalThis.String(object.updated_at)
           : '',
+      plan: isSet(object.plan) ? globalThis.String(object.plan) : '',
+      planExpiresAt: isSet(object.planExpiresAt)
+        ? globalThis.String(object.planExpiresAt)
+        : isSet(object.plan_expires_at)
+          ? globalThis.String(object.plan_expires_at)
+          : undefined,
     };
   },
 
@@ -1123,6 +1210,12 @@ export const Rescue: MessageFns<Rescue> = {
     if (message.updatedAt !== '') {
       obj.updatedAt = message.updatedAt;
     }
+    if (message.plan !== '') {
+      obj.plan = message.plan;
+    }
+    if (message.planExpiresAt !== undefined) {
+      obj.planExpiresAt = message.planExpiresAt;
+    }
     return obj;
   },
 
@@ -1157,6 +1250,8 @@ export const Rescue: MessageFns<Rescue> = {
     message.settingsJson = object.settingsJson ?? '';
     message.createdAt = object.createdAt ?? '';
     message.updatedAt = object.updatedAt ?? '';
+    message.plan = object.plan ?? '';
+    message.planExpiresAt = object.planExpiresAt ?? undefined;
     return message;
   },
 };
@@ -5751,6 +5846,743 @@ export const DeleteApplicationQuestionResponse: MessageFns<DeleteApplicationQues
   },
 };
 
+function createBaseUpdateRescuePlanRequest(): UpdateRescuePlanRequest {
+  return { rescueId: '', plan: '', planExpiresAt: undefined };
+}
+
+export const UpdateRescuePlanRequest: MessageFns<UpdateRescuePlanRequest> = {
+  encode(
+    message: UpdateRescuePlanRequest,
+    writer: BinaryWriter = new BinaryWriter()
+  ): BinaryWriter {
+    if (message.rescueId !== '') {
+      writer.uint32(10).string(message.rescueId);
+    }
+    if (message.plan !== '') {
+      writer.uint32(18).string(message.plan);
+    }
+    if (message.planExpiresAt !== undefined) {
+      writer.uint32(26).string(message.planExpiresAt);
+    }
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): UpdateRescuePlanRequest {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseUpdateRescuePlanRequest();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1: {
+          if (tag !== 10) {
+            break;
+          }
+
+          message.rescueId = reader.string();
+          continue;
+        }
+        case 2: {
+          if (tag !== 18) {
+            break;
+          }
+
+          message.plan = reader.string();
+          continue;
+        }
+        case 3: {
+          if (tag !== 26) {
+            break;
+          }
+
+          message.planExpiresAt = reader.string();
+          continue;
+        }
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): UpdateRescuePlanRequest {
+    return {
+      rescueId: isSet(object.rescueId)
+        ? globalThis.String(object.rescueId)
+        : isSet(object.rescue_id)
+          ? globalThis.String(object.rescue_id)
+          : '',
+      plan: isSet(object.plan) ? globalThis.String(object.plan) : '',
+      planExpiresAt: isSet(object.planExpiresAt)
+        ? globalThis.String(object.planExpiresAt)
+        : isSet(object.plan_expires_at)
+          ? globalThis.String(object.plan_expires_at)
+          : undefined,
+    };
+  },
+
+  toJSON(message: UpdateRescuePlanRequest): unknown {
+    const obj: any = {};
+    if (message.rescueId !== '') {
+      obj.rescueId = message.rescueId;
+    }
+    if (message.plan !== '') {
+      obj.plan = message.plan;
+    }
+    if (message.planExpiresAt !== undefined) {
+      obj.planExpiresAt = message.planExpiresAt;
+    }
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<UpdateRescuePlanRequest>, I>>(
+    base?: I
+  ): UpdateRescuePlanRequest {
+    return UpdateRescuePlanRequest.fromPartial(base ?? ({} as any));
+  },
+  fromPartial<I extends Exact<DeepPartial<UpdateRescuePlanRequest>, I>>(
+    object: I
+  ): UpdateRescuePlanRequest {
+    const message = createBaseUpdateRescuePlanRequest();
+    message.rescueId = object.rescueId ?? '';
+    message.plan = object.plan ?? '';
+    message.planExpiresAt = object.planExpiresAt ?? undefined;
+    return message;
+  },
+};
+
+function createBaseUpdateRescuePlanResponse(): UpdateRescuePlanResponse {
+  return { rescue: undefined };
+}
+
+export const UpdateRescuePlanResponse: MessageFns<UpdateRescuePlanResponse> = {
+  encode(
+    message: UpdateRescuePlanResponse,
+    writer: BinaryWriter = new BinaryWriter()
+  ): BinaryWriter {
+    if (message.rescue !== undefined) {
+      Rescue.encode(message.rescue, writer.uint32(10).fork()).join();
+    }
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): UpdateRescuePlanResponse {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseUpdateRescuePlanResponse();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1: {
+          if (tag !== 10) {
+            break;
+          }
+
+          message.rescue = Rescue.decode(reader, reader.uint32());
+          continue;
+        }
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): UpdateRescuePlanResponse {
+    return { rescue: isSet(object.rescue) ? Rescue.fromJSON(object.rescue) : undefined };
+  },
+
+  toJSON(message: UpdateRescuePlanResponse): unknown {
+    const obj: any = {};
+    if (message.rescue !== undefined) {
+      obj.rescue = Rescue.toJSON(message.rescue);
+    }
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<UpdateRescuePlanResponse>, I>>(
+    base?: I
+  ): UpdateRescuePlanResponse {
+    return UpdateRescuePlanResponse.fromPartial(base ?? ({} as any));
+  },
+  fromPartial<I extends Exact<DeepPartial<UpdateRescuePlanResponse>, I>>(
+    object: I
+  ): UpdateRescuePlanResponse {
+    const message = createBaseUpdateRescuePlanResponse();
+    message.rescue =
+      object.rescue !== undefined && object.rescue !== null
+        ? Rescue.fromPartial(object.rescue)
+        : undefined;
+    return message;
+  },
+};
+
+function createBaseGetRescueStatisticsRequest(): GetRescueStatisticsRequest {
+  return { rescueId: '' };
+}
+
+export const GetRescueStatisticsRequest: MessageFns<GetRescueStatisticsRequest> = {
+  encode(
+    message: GetRescueStatisticsRequest,
+    writer: BinaryWriter = new BinaryWriter()
+  ): BinaryWriter {
+    if (message.rescueId !== '') {
+      writer.uint32(10).string(message.rescueId);
+    }
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): GetRescueStatisticsRequest {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseGetRescueStatisticsRequest();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1: {
+          if (tag !== 10) {
+            break;
+          }
+
+          message.rescueId = reader.string();
+          continue;
+        }
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): GetRescueStatisticsRequest {
+    return {
+      rescueId: isSet(object.rescueId)
+        ? globalThis.String(object.rescueId)
+        : isSet(object.rescue_id)
+          ? globalThis.String(object.rescue_id)
+          : '',
+    };
+  },
+
+  toJSON(message: GetRescueStatisticsRequest): unknown {
+    const obj: any = {};
+    if (message.rescueId !== '') {
+      obj.rescueId = message.rescueId;
+    }
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<GetRescueStatisticsRequest>, I>>(
+    base?: I
+  ): GetRescueStatisticsRequest {
+    return GetRescueStatisticsRequest.fromPartial(base ?? ({} as any));
+  },
+  fromPartial<I extends Exact<DeepPartial<GetRescueStatisticsRequest>, I>>(
+    object: I
+  ): GetRescueStatisticsRequest {
+    const message = createBaseGetRescueStatisticsRequest();
+    message.rescueId = object.rescueId ?? '';
+    return message;
+  },
+};
+
+function createBaseRescueStatistics(): RescueStatistics {
+  return {
+    totalPets: 0,
+    availablePets: 0,
+    adoptedPets: 0,
+    pendingApplications: 0,
+    totalApplications: 0,
+    staffCount: 0,
+    activeListings: 0,
+    monthlyAdoptions: 0,
+    averageTimeToAdoption: 0,
+  };
+}
+
+export const RescueStatistics: MessageFns<RescueStatistics> = {
+  encode(message: RescueStatistics, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+    if (message.totalPets !== 0) {
+      writer.uint32(8).uint32(message.totalPets);
+    }
+    if (message.availablePets !== 0) {
+      writer.uint32(16).uint32(message.availablePets);
+    }
+    if (message.adoptedPets !== 0) {
+      writer.uint32(24).uint32(message.adoptedPets);
+    }
+    if (message.pendingApplications !== 0) {
+      writer.uint32(32).uint32(message.pendingApplications);
+    }
+    if (message.totalApplications !== 0) {
+      writer.uint32(40).uint32(message.totalApplications);
+    }
+    if (message.staffCount !== 0) {
+      writer.uint32(48).uint32(message.staffCount);
+    }
+    if (message.activeListings !== 0) {
+      writer.uint32(56).uint32(message.activeListings);
+    }
+    if (message.monthlyAdoptions !== 0) {
+      writer.uint32(64).uint32(message.monthlyAdoptions);
+    }
+    if (message.averageTimeToAdoption !== 0) {
+      writer.uint32(73).double(message.averageTimeToAdoption);
+    }
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): RescueStatistics {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseRescueStatistics();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1: {
+          if (tag !== 8) {
+            break;
+          }
+
+          message.totalPets = reader.uint32();
+          continue;
+        }
+        case 2: {
+          if (tag !== 16) {
+            break;
+          }
+
+          message.availablePets = reader.uint32();
+          continue;
+        }
+        case 3: {
+          if (tag !== 24) {
+            break;
+          }
+
+          message.adoptedPets = reader.uint32();
+          continue;
+        }
+        case 4: {
+          if (tag !== 32) {
+            break;
+          }
+
+          message.pendingApplications = reader.uint32();
+          continue;
+        }
+        case 5: {
+          if (tag !== 40) {
+            break;
+          }
+
+          message.totalApplications = reader.uint32();
+          continue;
+        }
+        case 6: {
+          if (tag !== 48) {
+            break;
+          }
+
+          message.staffCount = reader.uint32();
+          continue;
+        }
+        case 7: {
+          if (tag !== 56) {
+            break;
+          }
+
+          message.activeListings = reader.uint32();
+          continue;
+        }
+        case 8: {
+          if (tag !== 64) {
+            break;
+          }
+
+          message.monthlyAdoptions = reader.uint32();
+          continue;
+        }
+        case 9: {
+          if (tag !== 73) {
+            break;
+          }
+
+          message.averageTimeToAdoption = reader.double();
+          continue;
+        }
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): RescueStatistics {
+    return {
+      totalPets: isSet(object.totalPets)
+        ? globalThis.Number(object.totalPets)
+        : isSet(object.total_pets)
+          ? globalThis.Number(object.total_pets)
+          : 0,
+      availablePets: isSet(object.availablePets)
+        ? globalThis.Number(object.availablePets)
+        : isSet(object.available_pets)
+          ? globalThis.Number(object.available_pets)
+          : 0,
+      adoptedPets: isSet(object.adoptedPets)
+        ? globalThis.Number(object.adoptedPets)
+        : isSet(object.adopted_pets)
+          ? globalThis.Number(object.adopted_pets)
+          : 0,
+      pendingApplications: isSet(object.pendingApplications)
+        ? globalThis.Number(object.pendingApplications)
+        : isSet(object.pending_applications)
+          ? globalThis.Number(object.pending_applications)
+          : 0,
+      totalApplications: isSet(object.totalApplications)
+        ? globalThis.Number(object.totalApplications)
+        : isSet(object.total_applications)
+          ? globalThis.Number(object.total_applications)
+          : 0,
+      staffCount: isSet(object.staffCount)
+        ? globalThis.Number(object.staffCount)
+        : isSet(object.staff_count)
+          ? globalThis.Number(object.staff_count)
+          : 0,
+      activeListings: isSet(object.activeListings)
+        ? globalThis.Number(object.activeListings)
+        : isSet(object.active_listings)
+          ? globalThis.Number(object.active_listings)
+          : 0,
+      monthlyAdoptions: isSet(object.monthlyAdoptions)
+        ? globalThis.Number(object.monthlyAdoptions)
+        : isSet(object.monthly_adoptions)
+          ? globalThis.Number(object.monthly_adoptions)
+          : 0,
+      averageTimeToAdoption: isSet(object.averageTimeToAdoption)
+        ? globalThis.Number(object.averageTimeToAdoption)
+        : isSet(object.average_time_to_adoption)
+          ? globalThis.Number(object.average_time_to_adoption)
+          : 0,
+    };
+  },
+
+  toJSON(message: RescueStatistics): unknown {
+    const obj: any = {};
+    if (message.totalPets !== 0) {
+      obj.totalPets = Math.round(message.totalPets);
+    }
+    if (message.availablePets !== 0) {
+      obj.availablePets = Math.round(message.availablePets);
+    }
+    if (message.adoptedPets !== 0) {
+      obj.adoptedPets = Math.round(message.adoptedPets);
+    }
+    if (message.pendingApplications !== 0) {
+      obj.pendingApplications = Math.round(message.pendingApplications);
+    }
+    if (message.totalApplications !== 0) {
+      obj.totalApplications = Math.round(message.totalApplications);
+    }
+    if (message.staffCount !== 0) {
+      obj.staffCount = Math.round(message.staffCount);
+    }
+    if (message.activeListings !== 0) {
+      obj.activeListings = Math.round(message.activeListings);
+    }
+    if (message.monthlyAdoptions !== 0) {
+      obj.monthlyAdoptions = Math.round(message.monthlyAdoptions);
+    }
+    if (message.averageTimeToAdoption !== 0) {
+      obj.averageTimeToAdoption = message.averageTimeToAdoption;
+    }
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<RescueStatistics>, I>>(base?: I): RescueStatistics {
+    return RescueStatistics.fromPartial(base ?? ({} as any));
+  },
+  fromPartial<I extends Exact<DeepPartial<RescueStatistics>, I>>(object: I): RescueStatistics {
+    const message = createBaseRescueStatistics();
+    message.totalPets = object.totalPets ?? 0;
+    message.availablePets = object.availablePets ?? 0;
+    message.adoptedPets = object.adoptedPets ?? 0;
+    message.pendingApplications = object.pendingApplications ?? 0;
+    message.totalApplications = object.totalApplications ?? 0;
+    message.staffCount = object.staffCount ?? 0;
+    message.activeListings = object.activeListings ?? 0;
+    message.monthlyAdoptions = object.monthlyAdoptions ?? 0;
+    message.averageTimeToAdoption = object.averageTimeToAdoption ?? 0;
+    return message;
+  },
+};
+
+function createBaseGetRescueStatisticsResponse(): GetRescueStatisticsResponse {
+  return { statistics: undefined };
+}
+
+export const GetRescueStatisticsResponse: MessageFns<GetRescueStatisticsResponse> = {
+  encode(
+    message: GetRescueStatisticsResponse,
+    writer: BinaryWriter = new BinaryWriter()
+  ): BinaryWriter {
+    if (message.statistics !== undefined) {
+      RescueStatistics.encode(message.statistics, writer.uint32(10).fork()).join();
+    }
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): GetRescueStatisticsResponse {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseGetRescueStatisticsResponse();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1: {
+          if (tag !== 10) {
+            break;
+          }
+
+          message.statistics = RescueStatistics.decode(reader, reader.uint32());
+          continue;
+        }
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): GetRescueStatisticsResponse {
+    return {
+      statistics: isSet(object.statistics)
+        ? RescueStatistics.fromJSON(object.statistics)
+        : undefined,
+    };
+  },
+
+  toJSON(message: GetRescueStatisticsResponse): unknown {
+    const obj: any = {};
+    if (message.statistics !== undefined) {
+      obj.statistics = RescueStatistics.toJSON(message.statistics);
+    }
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<GetRescueStatisticsResponse>, I>>(
+    base?: I
+  ): GetRescueStatisticsResponse {
+    return GetRescueStatisticsResponse.fromPartial(base ?? ({} as any));
+  },
+  fromPartial<I extends Exact<DeepPartial<GetRescueStatisticsResponse>, I>>(
+    object: I
+  ): GetRescueStatisticsResponse {
+    const message = createBaseGetRescueStatisticsResponse();
+    message.statistics =
+      object.statistics !== undefined && object.statistics !== null
+        ? RescueStatistics.fromPartial(object.statistics)
+        : undefined;
+    return message;
+  },
+};
+
+function createBaseSendRescueEmailRequest(): SendRescueEmailRequest {
+  return { rescueId: '', templateId: undefined, subject: undefined, body: undefined };
+}
+
+export const SendRescueEmailRequest: MessageFns<SendRescueEmailRequest> = {
+  encode(message: SendRescueEmailRequest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+    if (message.rescueId !== '') {
+      writer.uint32(10).string(message.rescueId);
+    }
+    if (message.templateId !== undefined) {
+      writer.uint32(18).string(message.templateId);
+    }
+    if (message.subject !== undefined) {
+      writer.uint32(26).string(message.subject);
+    }
+    if (message.body !== undefined) {
+      writer.uint32(34).string(message.body);
+    }
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): SendRescueEmailRequest {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseSendRescueEmailRequest();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1: {
+          if (tag !== 10) {
+            break;
+          }
+
+          message.rescueId = reader.string();
+          continue;
+        }
+        case 2: {
+          if (tag !== 18) {
+            break;
+          }
+
+          message.templateId = reader.string();
+          continue;
+        }
+        case 3: {
+          if (tag !== 26) {
+            break;
+          }
+
+          message.subject = reader.string();
+          continue;
+        }
+        case 4: {
+          if (tag !== 34) {
+            break;
+          }
+
+          message.body = reader.string();
+          continue;
+        }
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): SendRescueEmailRequest {
+    return {
+      rescueId: isSet(object.rescueId)
+        ? globalThis.String(object.rescueId)
+        : isSet(object.rescue_id)
+          ? globalThis.String(object.rescue_id)
+          : '',
+      templateId: isSet(object.templateId)
+        ? globalThis.String(object.templateId)
+        : isSet(object.template_id)
+          ? globalThis.String(object.template_id)
+          : undefined,
+      subject: isSet(object.subject) ? globalThis.String(object.subject) : undefined,
+      body: isSet(object.body) ? globalThis.String(object.body) : undefined,
+    };
+  },
+
+  toJSON(message: SendRescueEmailRequest): unknown {
+    const obj: any = {};
+    if (message.rescueId !== '') {
+      obj.rescueId = message.rescueId;
+    }
+    if (message.templateId !== undefined) {
+      obj.templateId = message.templateId;
+    }
+    if (message.subject !== undefined) {
+      obj.subject = message.subject;
+    }
+    if (message.body !== undefined) {
+      obj.body = message.body;
+    }
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<SendRescueEmailRequest>, I>>(
+    base?: I
+  ): SendRescueEmailRequest {
+    return SendRescueEmailRequest.fromPartial(base ?? ({} as any));
+  },
+  fromPartial<I extends Exact<DeepPartial<SendRescueEmailRequest>, I>>(
+    object: I
+  ): SendRescueEmailRequest {
+    const message = createBaseSendRescueEmailRequest();
+    message.rescueId = object.rescueId ?? '';
+    message.templateId = object.templateId ?? undefined;
+    message.subject = object.subject ?? undefined;
+    message.body = object.body ?? undefined;
+    return message;
+  },
+};
+
+function createBaseSendRescueEmailResponse(): SendRescueEmailResponse {
+  return { queued: false };
+}
+
+export const SendRescueEmailResponse: MessageFns<SendRescueEmailResponse> = {
+  encode(
+    message: SendRescueEmailResponse,
+    writer: BinaryWriter = new BinaryWriter()
+  ): BinaryWriter {
+    if (message.queued !== false) {
+      writer.uint32(8).bool(message.queued);
+    }
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): SendRescueEmailResponse {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseSendRescueEmailResponse();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1: {
+          if (tag !== 8) {
+            break;
+          }
+
+          message.queued = reader.bool();
+          continue;
+        }
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): SendRescueEmailResponse {
+    return { queued: isSet(object.queued) ? globalThis.Boolean(object.queued) : false };
+  },
+
+  toJSON(message: SendRescueEmailResponse): unknown {
+    const obj: any = {};
+    if (message.queued !== false) {
+      obj.queued = message.queued;
+    }
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<SendRescueEmailResponse>, I>>(
+    base?: I
+  ): SendRescueEmailResponse {
+    return SendRescueEmailResponse.fromPartial(base ?? ({} as any));
+  },
+  fromPartial<I extends Exact<DeepPartial<SendRescueEmailResponse>, I>>(
+    object: I
+  ): SendRescueEmailResponse {
+    const message = createBaseSendRescueEmailResponse();
+    message.queued = object.queued ?? false;
+    return message;
+  },
+};
+
 /**
  * RescueService is the gRPC contract for the rescue vertical. It owns
  * the `rescue.*` schema (Rescue, RescueSettings, StaffMember, Invitation,
@@ -6069,6 +6901,64 @@ export const RescueServiceService = {
     responseDeserialize: (value: Buffer): DeleteApplicationQuestionResponse =>
       DeleteApplicationQuestionResponse.decode(value),
   },
+  /**
+   * Set a rescue's subscription plan tier (free / growth / professional)
+   * and optional expiry. Admin-only — caller MUST have
+   * `admin.security.manage`. Publishes `rescue.planUpdated` after commit.
+   */
+  updateRescuePlan: {
+    path: '/adopt_dont_shop.rescue.v1.RescueService/UpdateRescuePlan' as const,
+    requestStream: false as const,
+    responseStream: false as const,
+    requestSerialize: (value: UpdateRescuePlanRequest): Buffer =>
+      Buffer.from(UpdateRescuePlanRequest.encode(value).finish()),
+    requestDeserialize: (value: Buffer): UpdateRescuePlanRequest =>
+      UpdateRescuePlanRequest.decode(value),
+    responseSerialize: (value: UpdateRescuePlanResponse): Buffer =>
+      Buffer.from(UpdateRescuePlanResponse.encode(value).finish()),
+    responseDeserialize: (value: Buffer): UpdateRescuePlanResponse =>
+      UpdateRescuePlanResponse.decode(value),
+  },
+  /**
+   * Compute a rescue's headline statistics for the admin detail panel.
+   * staff_count is sourced from this vertical's staff_members table; the
+   * pet- and application-derived counts (which live in other verticals)
+   * are returned as zero defaults so the panel renders without a heavy
+   * cross-service aggregation. Caller MUST have `rescues.read`.
+   */
+  getRescueStatistics: {
+    path: '/adopt_dont_shop.rescue.v1.RescueService/GetRescueStatistics' as const,
+    requestStream: false as const,
+    responseStream: false as const,
+    requestSerialize: (value: GetRescueStatisticsRequest): Buffer =>
+      Buffer.from(GetRescueStatisticsRequest.encode(value).finish()),
+    requestDeserialize: (value: Buffer): GetRescueStatisticsRequest =>
+      GetRescueStatisticsRequest.decode(value),
+    responseSerialize: (value: GetRescueStatisticsResponse): Buffer =>
+      Buffer.from(GetRescueStatisticsResponse.encode(value).finish()),
+    responseDeserialize: (value: Buffer): GetRescueStatisticsResponse =>
+      GetRescueStatisticsResponse.decode(value),
+  },
+  /**
+   * Validate + enqueue an admin email to a rescue's contact address.
+   * Admin-only — caller MUST have `admin.security.manage`. Confirms the
+   * rescue exists, then publishes `rescue.adminEmailRequested` for the
+   * notifications worker to deliver (subscriber wiring is out of scope
+   * for this RPC — it stops at the published event).
+   */
+  sendRescueEmail: {
+    path: '/adopt_dont_shop.rescue.v1.RescueService/SendRescueEmail' as const,
+    requestStream: false as const,
+    responseStream: false as const,
+    requestSerialize: (value: SendRescueEmailRequest): Buffer =>
+      Buffer.from(SendRescueEmailRequest.encode(value).finish()),
+    requestDeserialize: (value: Buffer): SendRescueEmailRequest =>
+      SendRescueEmailRequest.decode(value),
+    responseSerialize: (value: SendRescueEmailResponse): Buffer =>
+      Buffer.from(SendRescueEmailResponse.encode(value).finish()),
+    responseDeserialize: (value: Buffer): SendRescueEmailResponse =>
+      SendRescueEmailResponse.decode(value),
+  },
 } as const;
 
 export interface RescueServiceServer extends UntypedServiceImplementation {
@@ -6189,6 +7079,28 @@ export interface RescueServiceServer extends UntypedServiceImplementation {
     DeleteApplicationQuestionRequest,
     DeleteApplicationQuestionResponse
   >;
+  /**
+   * Set a rescue's subscription plan tier (free / growth / professional)
+   * and optional expiry. Admin-only — caller MUST have
+   * `admin.security.manage`. Publishes `rescue.planUpdated` after commit.
+   */
+  updateRescuePlan: handleUnaryCall<UpdateRescuePlanRequest, UpdateRescuePlanResponse>;
+  /**
+   * Compute a rescue's headline statistics for the admin detail panel.
+   * staff_count is sourced from this vertical's staff_members table; the
+   * pet- and application-derived counts (which live in other verticals)
+   * are returned as zero defaults so the panel renders without a heavy
+   * cross-service aggregation. Caller MUST have `rescues.read`.
+   */
+  getRescueStatistics: handleUnaryCall<GetRescueStatisticsRequest, GetRescueStatisticsResponse>;
+  /**
+   * Validate + enqueue an admin email to a rescue's contact address.
+   * Admin-only — caller MUST have `admin.security.manage`. Confirms the
+   * rescue exists, then publishes `rescue.adminEmailRequested` for the
+   * notifications worker to deliver (subscriber wiring is out of scope
+   * for this RPC — it stops at the published event).
+   */
+  sendRescueEmail: handleUnaryCall<SendRescueEmailRequest, SendRescueEmailResponse>;
 }
 
 export interface RescueServiceClient extends Client {
@@ -6534,6 +7446,70 @@ export interface RescueServiceClient extends Client {
     metadata: Metadata,
     options: Partial<CallOptions>,
     callback: (error: ServiceError | null, response: DeleteApplicationQuestionResponse) => void
+  ): ClientUnaryCall;
+  /**
+   * Set a rescue's subscription plan tier (free / growth / professional)
+   * and optional expiry. Admin-only — caller MUST have
+   * `admin.security.manage`. Publishes `rescue.planUpdated` after commit.
+   */
+  updateRescuePlan(
+    request: UpdateRescuePlanRequest,
+    callback: (error: ServiceError | null, response: UpdateRescuePlanResponse) => void
+  ): ClientUnaryCall;
+  updateRescuePlan(
+    request: UpdateRescuePlanRequest,
+    metadata: Metadata,
+    callback: (error: ServiceError | null, response: UpdateRescuePlanResponse) => void
+  ): ClientUnaryCall;
+  updateRescuePlan(
+    request: UpdateRescuePlanRequest,
+    metadata: Metadata,
+    options: Partial<CallOptions>,
+    callback: (error: ServiceError | null, response: UpdateRescuePlanResponse) => void
+  ): ClientUnaryCall;
+  /**
+   * Compute a rescue's headline statistics for the admin detail panel.
+   * staff_count is sourced from this vertical's staff_members table; the
+   * pet- and application-derived counts (which live in other verticals)
+   * are returned as zero defaults so the panel renders without a heavy
+   * cross-service aggregation. Caller MUST have `rescues.read`.
+   */
+  getRescueStatistics(
+    request: GetRescueStatisticsRequest,
+    callback: (error: ServiceError | null, response: GetRescueStatisticsResponse) => void
+  ): ClientUnaryCall;
+  getRescueStatistics(
+    request: GetRescueStatisticsRequest,
+    metadata: Metadata,
+    callback: (error: ServiceError | null, response: GetRescueStatisticsResponse) => void
+  ): ClientUnaryCall;
+  getRescueStatistics(
+    request: GetRescueStatisticsRequest,
+    metadata: Metadata,
+    options: Partial<CallOptions>,
+    callback: (error: ServiceError | null, response: GetRescueStatisticsResponse) => void
+  ): ClientUnaryCall;
+  /**
+   * Validate + enqueue an admin email to a rescue's contact address.
+   * Admin-only — caller MUST have `admin.security.manage`. Confirms the
+   * rescue exists, then publishes `rescue.adminEmailRequested` for the
+   * notifications worker to deliver (subscriber wiring is out of scope
+   * for this RPC — it stops at the published event).
+   */
+  sendRescueEmail(
+    request: SendRescueEmailRequest,
+    callback: (error: ServiceError | null, response: SendRescueEmailResponse) => void
+  ): ClientUnaryCall;
+  sendRescueEmail(
+    request: SendRescueEmailRequest,
+    metadata: Metadata,
+    callback: (error: ServiceError | null, response: SendRescueEmailResponse) => void
+  ): ClientUnaryCall;
+  sendRescueEmail(
+    request: SendRescueEmailRequest,
+    metadata: Metadata,
+    options: Partial<CallOptions>,
+    callback: (error: ServiceError | null, response: SendRescueEmailResponse) => void
   ): ClientUnaryCall;
 }
 

--- a/packages/proto/src/index.ts
+++ b/packages/proto/src/index.ts
@@ -271,6 +271,13 @@ export type {
   CreateApplicationQuestionResponse,
   DeleteApplicationQuestionRequest,
   DeleteApplicationQuestionResponse,
+  UpdateRescuePlanRequest,
+  UpdateRescuePlanResponse,
+  GetRescueStatisticsRequest,
+  GetRescueStatisticsResponse,
+  RescueStatistics,
+  SendRescueEmailRequest,
+  SendRescueEmailResponse,
   RescueServiceServer,
   RescueServiceClient,
 } from './generated/proto/adopt_dont_shop/rescue/v1/rescue.js';

--- a/services/gateway/src/grpc-clients/rescue-client.ts
+++ b/services/gateway/src/grpc-clients/rescue-client.ts
@@ -45,6 +45,12 @@ import {
   type ListStaffMembersResponse,
   type UpdateRescueRequest,
   type UpdateRescueResponse,
+  type UpdateRescuePlanRequest,
+  type UpdateRescuePlanResponse,
+  type GetRescueStatisticsRequest,
+  type GetRescueStatisticsResponse,
+  type SendRescueEmailRequest,
+  type SendRescueEmailResponse,
   type VerifyRescueRequest,
   type VerifyRescueResponse,
 } from '@adopt-dont-shop/proto';
@@ -58,6 +64,18 @@ export type RescueClient = {
   get(req: GetRescueRequest, metadata: Metadata): Promise<GetRescueResponse>;
   list(req: ListRescuesRequest, metadata: Metadata): Promise<ListRescuesResponse>;
   update(req: UpdateRescueRequest, metadata: Metadata): Promise<UpdateRescueResponse>;
+  updateRescuePlan(
+    req: UpdateRescuePlanRequest,
+    metadata: Metadata
+  ): Promise<UpdateRescuePlanResponse>;
+  getRescueStatistics(
+    req: GetRescueStatisticsRequest,
+    metadata: Metadata
+  ): Promise<GetRescueStatisticsResponse>;
+  sendRescueEmail(
+    req: SendRescueEmailRequest,
+    metadata: Metadata
+  ): Promise<SendRescueEmailResponse>;
   verify(req: VerifyRescueRequest, metadata: Metadata): Promise<VerifyRescueResponse>;
   inviteStaff(req: InviteStaffRequest, metadata: Metadata): Promise<InviteStaffResponse>;
   getMyStaffMembership(
@@ -169,6 +187,8 @@ export const createRescueClient = (opts: CreateRescueClientOptions): RescueClien
     // ── Non-idempotent (writes / mutations) ──────────────────────────
     create: (req, metadata) => callUnary(stub.create, req, metadata, false),
     update: (req, metadata) => callUnary(stub.update, req, metadata, false),
+    updateRescuePlan: (req, metadata) => callUnary(stub.updateRescuePlan, req, metadata, false),
+    sendRescueEmail: (req, metadata) => callUnary(stub.sendRescueEmail, req, metadata, false),
     verify: (req, metadata) => callUnary(stub.verify, req, metadata, false),
     inviteStaff: (req, metadata) => callUnary(stub.inviteStaff, req, metadata, false),
     createFosterPlacement: (req, metadata) =>
@@ -182,6 +202,8 @@ export const createRescueClient = (opts: CreateRescueClientOptions): RescueClien
     // ── Idempotent (reads) ───────────────────────────────────────────
     get: (req, metadata) => callUnary(stub.get, req, metadata, true),
     list: (req, metadata) => callUnary(stub.list, req, metadata, true),
+    getRescueStatistics: (req, metadata) =>
+      callUnary(stub.getRescueStatistics, req, metadata, true),
     getMyStaffMembership: (req, metadata) =>
       callUnary(stub.getMyStaffMembership, req, metadata, true),
     listStaffMembers: (req, metadata) => callUnary(stub.listStaffMembers, req, metadata, true),

--- a/services/gateway/src/routes/rescue-admin.test.ts
+++ b/services/gateway/src/routes/rescue-admin.test.ts
@@ -1,0 +1,394 @@
+import { status as grpcStatus } from '@grpc/grpc-js';
+import Fastify, { type FastifyInstance } from 'fastify';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { RescueV1, type Rescue } from '@adopt-dont-shop/proto';
+
+import type { RescueClient } from '../grpc-clients/rescue-client.js';
+
+import { registerRescueAdminRoutes } from './rescue-admin.js';
+
+type Mocks = {
+  client: RescueClient;
+  updatePlan: ReturnType<typeof vi.fn>;
+  getStats: ReturnType<typeof vi.fn>;
+  sendEmail: ReturnType<typeof vi.fn>;
+  verify: ReturnType<typeof vi.fn>;
+};
+
+function makeClient(): Mocks {
+  const updatePlan = vi.fn();
+  const getStats = vi.fn();
+  const sendEmail = vi.fn();
+  const verify = vi.fn();
+  // Only the methods these routes touch need to be real; the rest are
+  // present to satisfy the RescueClient shape.
+  const client = {
+    create: vi.fn(),
+    get: vi.fn(),
+    list: vi.fn(),
+    update: vi.fn(),
+    updateRescuePlan: updatePlan,
+    getRescueStatistics: getStats,
+    sendRescueEmail: sendEmail,
+    verify,
+    inviteStaff: vi.fn(),
+    getMyStaffMembership: vi.fn(),
+    listStaffMembers: vi.fn(),
+    createFosterPlacement: vi.fn(),
+    listFosterPlacements: vi.fn(),
+    getFosterPlacement: vi.fn(),
+    endFosterPlacement: vi.fn(),
+    getInvitationByToken: vi.fn(),
+    acceptInvitation: vi.fn(),
+    listApplicationQuestions: vi.fn(),
+    createApplicationQuestion: vi.fn(),
+    deleteApplicationQuestion: vi.fn(),
+    close: vi.fn(),
+  } satisfies RescueClient;
+  return { client, updatePlan, getStats, sendEmail, verify };
+}
+
+async function makeApp(client: RescueClient): Promise<FastifyInstance> {
+  const app = Fastify({ logger: false });
+  await registerRescueAdminRoutes(app, { client });
+  return app;
+}
+
+const ADMIN_HEADERS = {
+  'x-user-id': 'admin-1',
+  'x-user-roles': 'admin',
+  'x-user-permissions': 'admin.security.manage',
+};
+
+function makeRescue(overrides: Partial<Rescue> = {}): Rescue {
+  return {
+    rescueId: 'rsc-1',
+    name: 'Happy Tails',
+    email: 'hi@happytails.org',
+    address: '1 Paw St',
+    city: 'Leeds',
+    postcode: 'LS1 1AA',
+    country: 'GB',
+    contactPerson: 'Sam',
+    status: RescueV1.RescueStatus.RESCUE_STATUS_VERIFIED,
+    settingsJson: '{}',
+    plan: 'free',
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-02T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+const STATS = {
+  totalPets: 0,
+  availablePets: 0,
+  adoptedPets: 0,
+  pendingApplications: 0,
+  totalApplications: 0,
+  staffCount: 4,
+  activeListings: 0,
+  monthlyAdoptions: 0,
+  averageTimeToAdoption: 0,
+};
+
+describe('PATCH /api/v1/admin/rescues/:rescueId/plan', () => {
+  let app: FastifyInstance;
+  let m: Mocks;
+
+  beforeEach(async () => {
+    m = makeClient();
+    app = await makeApp(m.client);
+  });
+  afterEach(async () => {
+    await app.close();
+  });
+
+  it('forwards plan + planExpiresAt and returns the updated rescue', async () => {
+    m.updatePlan.mockResolvedValue({ rescue: makeRescue({ plan: 'growth' }) });
+
+    const res = await app.inject({
+      method: 'PATCH',
+      url: '/api/v1/admin/rescues/rsc-1/plan',
+      headers: ADMIN_HEADERS,
+      payload: { plan: 'growth', planExpiresAt: '2027-01-01T00:00:00.000Z' },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(m.updatePlan.mock.calls[0][0]).toMatchObject({
+      rescueId: 'rsc-1',
+      plan: 'growth',
+      planExpiresAt: '2027-01-01T00:00:00.000Z',
+    });
+    expect(res.json()).toMatchObject({
+      success: true,
+      message: 'Rescue plan updated',
+      data: { rescue_id: 'rsc-1', plan: 'growth' },
+    });
+  });
+
+  it('rejects a missing plan with 400', async () => {
+    const res = await app.inject({
+      method: 'PATCH',
+      url: '/api/v1/admin/rescues/rsc-1/plan',
+      headers: ADMIN_HEADERS,
+      payload: {},
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(m.updatePlan).not.toHaveBeenCalled();
+  });
+
+  it('maps PERMISSION_DENIED to 403', async () => {
+    m.updatePlan.mockRejectedValue({ code: grpcStatus.PERMISSION_DENIED, details: 'nope' });
+
+    const res = await app.inject({
+      method: 'PATCH',
+      url: '/api/v1/admin/rescues/rsc-1/plan',
+      headers: ADMIN_HEADERS,
+      payload: { plan: 'growth' },
+    });
+
+    expect(res.statusCode).toBe(403);
+  });
+});
+
+describe('GET /api/v1/rescues/:rescueId/analytics', () => {
+  let app: FastifyInstance;
+  let m: Mocks;
+
+  beforeEach(async () => {
+    m = makeClient();
+    app = await makeApp(m.client);
+  });
+  afterEach(async () => {
+    await app.close();
+  });
+
+  it('returns the statistics in a {success, data} envelope', async () => {
+    m.getStats.mockResolvedValue({ statistics: STATS });
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/v1/rescues/rsc-1/analytics',
+      headers: ADMIN_HEADERS,
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(m.getStats.mock.calls[0][0]).toMatchObject({ rescueId: 'rsc-1' });
+    expect(res.json()).toEqual({ success: true, data: STATS });
+  });
+
+  it('maps NOT_FOUND to 404', async () => {
+    m.getStats.mockRejectedValue({ code: grpcStatus.NOT_FOUND, details: 'gone' });
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/v1/rescues/rsc-1/analytics',
+      headers: ADMIN_HEADERS,
+    });
+
+    expect(res.statusCode).toBe(404);
+  });
+});
+
+describe('POST /api/v1/rescues/:rescueId/send-email', () => {
+  let app: FastifyInstance;
+  let m: Mocks;
+
+  beforeEach(async () => {
+    m = makeClient();
+    app = await makeApp(m.client);
+  });
+  afterEach(async () => {
+    await app.close();
+  });
+
+  it('forwards a custom subject + body', async () => {
+    m.sendEmail.mockResolvedValue({ queued: true });
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/v1/rescues/rsc-1/send-email',
+      headers: ADMIN_HEADERS,
+      payload: { subject: 'Hello', body: 'Welcome aboard' },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(m.sendEmail.mock.calls[0][0]).toMatchObject({
+      rescueId: 'rsc-1',
+      subject: 'Hello',
+      body: 'Welcome aboard',
+    });
+    expect(res.json()).toEqual({ success: true, message: 'Email queued' });
+  });
+
+  it('forwards a template id', async () => {
+    m.sendEmail.mockResolvedValue({ queued: true });
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/v1/rescues/rsc-1/send-email',
+      headers: ADMIN_HEADERS,
+      payload: { templateId: 'welcome' },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(m.sendEmail.mock.calls[0][0]).toMatchObject({ templateId: 'welcome' });
+  });
+
+  it('rejects when neither templateId nor subject is provided', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/v1/rescues/rsc-1/send-email',
+      headers: ADMIN_HEADERS,
+      payload: { body: 'orphan body' },
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(m.sendEmail).not.toHaveBeenCalled();
+  });
+});
+
+describe('POST /api/v1/rescues/bulk-update', () => {
+  let app: FastifyInstance;
+  let m: Mocks;
+
+  beforeEach(async () => {
+    m = makeClient();
+    app = await makeApp(m.client);
+  });
+  afterEach(async () => {
+    await app.close();
+  });
+
+  it('verifies each id and counts successes + failures', async () => {
+    m.verify
+      .mockResolvedValueOnce({ rescue: makeRescue() })
+      .mockRejectedValueOnce({ code: grpcStatus.FAILED_PRECONDITION, details: 'bad transition' })
+      .mockResolvedValueOnce({ rescue: makeRescue() });
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/v1/rescues/bulk-update',
+      headers: ADMIN_HEADERS,
+      payload: { rescueIds: ['r1', 'r2', 'r3'], action: 'approve' },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(m.verify).toHaveBeenCalledTimes(3);
+    expect(m.verify.mock.calls[0][0]).toMatchObject({
+      rescueId: 'r1',
+      toStatus: RescueV1.RescueStatus.RESCUE_STATUS_VERIFIED,
+      verificationSource: RescueV1.RescueVerificationSource.RESCUE_VERIFICATION_SOURCE_MANUAL,
+    });
+    expect(res.json()).toMatchObject({ data: { successCount: 2, failedCount: 1 } });
+  });
+
+  it('maps action=suspend to the SUSPENDED status', async () => {
+    m.verify.mockResolvedValue({ rescue: makeRescue() });
+
+    await app.inject({
+      method: 'POST',
+      url: '/api/v1/rescues/bulk-update',
+      headers: ADMIN_HEADERS,
+      payload: { rescueIds: ['r1'], action: 'suspend' },
+    });
+
+    expect(m.verify.mock.calls[0][0]).toMatchObject({
+      toStatus: RescueV1.RescueStatus.RESCUE_STATUS_SUSPENDED,
+    });
+  });
+
+  it('rejects an empty rescueIds list with 400', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/v1/rescues/bulk-update',
+      headers: ADMIN_HEADERS,
+      payload: { rescueIds: [], action: 'approve' },
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(m.verify).not.toHaveBeenCalled();
+  });
+
+  it('rejects an unknown action with 400', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/v1/rescues/bulk-update',
+      headers: ADMIN_HEADERS,
+      payload: { rescueIds: ['r1'], action: 'frobnicate' },
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(m.verify).not.toHaveBeenCalled();
+  });
+});
+
+describe('POST /api/v1/rescues/:rescueId/{verify,reject}', () => {
+  let app: FastifyInstance;
+  let m: Mocks;
+
+  beforeEach(async () => {
+    m = makeClient();
+    app = await makeApp(m.client);
+  });
+  afterEach(async () => {
+    await app.close();
+  });
+
+  it('verify forwards VERIFIED + MANUAL and returns the rescue', async () => {
+    m.verify.mockResolvedValue({ rescue: makeRescue() });
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/v1/rescues/rsc-1/verify',
+      headers: ADMIN_HEADERS,
+      payload: { notes: 'looks good' },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(m.verify.mock.calls[0][0]).toMatchObject({
+      rescueId: 'rsc-1',
+      toStatus: RescueV1.RescueStatus.RESCUE_STATUS_VERIFIED,
+      verificationSource: RescueV1.RescueVerificationSource.RESCUE_VERIFICATION_SOURCE_MANUAL,
+    });
+    expect(res.json()).toMatchObject({
+      success: true,
+      message: 'Rescue verified',
+      data: { rescue_id: 'rsc-1' },
+    });
+  });
+
+  it('reject forwards REJECTED + the failure reason', async () => {
+    m.verify.mockResolvedValue({
+      rescue: makeRescue({ status: RescueV1.RescueStatus.RESCUE_STATUS_REJECTED }),
+    });
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/v1/rescues/rsc-1/reject',
+      headers: ADMIN_HEADERS,
+      payload: { reason: 'incomplete documents' },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(m.verify.mock.calls[0][0]).toMatchObject({
+      rescueId: 'rsc-1',
+      toStatus: RescueV1.RescueStatus.RESCUE_STATUS_REJECTED,
+      failureReason: 'incomplete documents',
+    });
+  });
+
+  it('reject without a reason returns 400', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/v1/rescues/rsc-1/reject',
+      headers: ADMIN_HEADERS,
+      payload: {},
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(m.verify).not.toHaveBeenCalled();
+  });
+});

--- a/services/gateway/src/routes/rescue-admin.ts
+++ b/services/gateway/src/routes/rescue-admin.ts
@@ -1,0 +1,255 @@
+// REST → gRPC translation for the admin rescue detail surface.
+//
+// app.admin's rescueService calls these per-rescue admin endpoints, none
+// of which the gateway served (they 404'd):
+//
+//   PATCH /api/v1/admin/rescues/:rescueId/plan   → RescueService.UpdateRescuePlan
+//   GET   /api/v1/rescues/:rescueId/analytics    → RescueService.GetRescueStatistics
+//   POST  /api/v1/rescues/:rescueId/send-email   → RescueService.SendRescueEmail
+//   POST  /api/v1/rescues/bulk-update            → RescueService.Verify (per id)
+//   POST  /api/v1/rescues/:rescueId/verify       → RescueService.Verify (VERIFIED)
+//   POST  /api/v1/rescues/:rescueId/reject       → RescueService.Verify (REJECTED)
+//
+// The plural /api/v1/rescues/:id/{verify,reject} paths are what the admin
+// SPA calls (the existing singular /api/v1/rescue/:id/verify in rescue.ts
+// serves a different caller). Both reuse the one Verify RPC, which drives
+// the whole VERIFIED / REJECTED / SUSPENDED lifecycle off `toStatus`.
+//
+// Authz is enforced at the handlers (admin.security.manage for the
+// mutations, rescues.read for analytics); the gateway re-rate-limits and
+// threads x-user-* metadata.
+
+import rateLimit from '@fastify/rate-limit';
+import type { FastifyInstance } from 'fastify';
+
+import {
+  RescueV1,
+  type GetRescueStatisticsRequest,
+  type SendRescueEmailRequest,
+  type UpdateRescuePlanRequest,
+  type VerifyRescueRequest,
+} from '@adopt-dont-shop/proto';
+
+import type { RescueClient } from '../grpc-clients/rescue-client.js';
+import { buildMetadata } from '../middleware/metadata.js';
+import { handleGrpcError } from '../middleware/grpc-error.js';
+import { rescueToView } from './rescue-view.js';
+
+export type RescueAdminRoutesOptions = {
+  client: RescueClient;
+};
+
+const RL_READ = { max: 120, timeWindow: '1 minute' } as const;
+const RL_WRITE = { max: 30, timeWindow: '1 minute' } as const;
+
+// Bulk action → target lifecycle status. 'approve' and 'verify' are the
+// same transition; 'suspend' parks the rescue.
+const BULK_ACTION_STATUS: Record<string, RescueV1.RescueStatus> = {
+  approve: RescueV1.RescueStatus.RESCUE_STATUS_VERIFIED,
+  verify: RescueV1.RescueStatus.RESCUE_STATUS_VERIFIED,
+  suspend: RescueV1.RescueStatus.RESCUE_STATUS_SUSPENDED,
+};
+
+export const registerRescueAdminRoutes = async (
+  app: FastifyInstance,
+  opts: RescueAdminRoutesOptions
+): Promise<void> => {
+  const { client } = opts;
+
+  await app.register(rateLimit, { global: false });
+
+  // PATCH /api/v1/admin/rescues/:rescueId/plan
+  app.patch<{
+    Params: { rescueId: string };
+    Body: { plan?: string; planExpiresAt?: string | null };
+  }>(
+    '/api/v1/admin/rescues/:rescueId/plan',
+    {
+      config: { rateLimit: RL_WRITE },
+      schema: { tags: ['rescues'], summary: "Update a rescue's subscription plan" },
+    },
+    async (req, reply) => {
+      const body = req.body ?? {};
+      if (body.plan === undefined || body.plan === '') {
+        return reply.code(400).send({ success: false, error: 'plan is required' });
+      }
+      const grpcReq: UpdateRescuePlanRequest = {
+        rescueId: req.params.rescueId,
+        plan: body.plan,
+        planExpiresAt: body.planExpiresAt ?? undefined,
+      };
+      try {
+        const res = await client.updateRescuePlan(grpcReq, buildMetadata(req));
+        if (res.rescue === undefined) {
+          return reply.code(500).send({ success: false, error: 'plan update returned no rescue' });
+        }
+        return reply.send({
+          success: true,
+          message: 'Rescue plan updated',
+          data: rescueToView(res.rescue),
+        });
+      } catch (err) {
+        return handleGrpcError(err, reply);
+      }
+    }
+  );
+
+  // GET /api/v1/rescues/:rescueId/analytics
+  app.get<{ Params: { rescueId: string } }>(
+    '/api/v1/rescues/:rescueId/analytics',
+    {
+      config: { rateLimit: RL_READ },
+      schema: { tags: ['rescues'], summary: 'Get a rescue headline statistics' },
+    },
+    async (req, reply) => {
+      const grpcReq: GetRescueStatisticsRequest = { rescueId: req.params.rescueId };
+      try {
+        const res = await client.getRescueStatistics(grpcReq, buildMetadata(req));
+        if (res.statistics === undefined) {
+          return reply
+            .code(500)
+            .send({ success: false, error: 'analytics returned no statistics' });
+        }
+        return reply.send({ success: true, data: res.statistics });
+      } catch (err) {
+        return handleGrpcError(err, reply);
+      }
+    }
+  );
+
+  // POST /api/v1/rescues/:rescueId/send-email
+  app.post<{
+    Params: { rescueId: string };
+    Body: { templateId?: string; subject?: string; body?: string };
+  }>(
+    '/api/v1/rescues/:rescueId/send-email',
+    {
+      config: { rateLimit: RL_WRITE },
+      schema: { tags: ['rescues'], summary: 'Send an admin email to a rescue' },
+    },
+    async (req, reply) => {
+      const body = req.body ?? {};
+      const hasTemplate = body.templateId !== undefined && body.templateId !== '';
+      const hasCustom = body.subject !== undefined && body.subject !== '';
+      if (!hasTemplate && !hasCustom) {
+        return reply.code(400).send({ success: false, error: 'templateId or subject is required' });
+      }
+      const grpcReq: SendRescueEmailRequest = {
+        rescueId: req.params.rescueId,
+        templateId: body.templateId,
+        subject: body.subject,
+        body: body.body,
+      };
+      try {
+        await client.sendRescueEmail(grpcReq, buildMetadata(req));
+        return reply.send({ success: true, message: 'Email queued' });
+      } catch (err) {
+        return handleGrpcError(err, reply);
+      }
+    }
+  );
+
+  // POST /api/v1/rescues/bulk-update
+  app.post<{ Body: { rescueIds?: string[]; action?: string; reason?: string } }>(
+    '/api/v1/rescues/bulk-update',
+    {
+      config: { rateLimit: RL_WRITE },
+      schema: { tags: ['rescues'], summary: 'Bulk approve / suspend / verify rescues' },
+    },
+    async (req, reply) => {
+      const body = req.body ?? {};
+      const ids = body.rescueIds ?? [];
+      if (ids.length === 0) {
+        return reply.code(400).send({ success: false, error: 'rescueIds is required' });
+      }
+      const toStatus = body.action ? BULK_ACTION_STATUS[body.action] : undefined;
+      if (toStatus === undefined) {
+        return reply
+          .code(400)
+          .send({ success: false, error: 'action must be approve, suspend or verify' });
+      }
+      const metadata = buildMetadata(req);
+      const verificationSource =
+        toStatus === RescueV1.RescueStatus.RESCUE_STATUS_VERIFIED
+          ? RescueV1.RescueVerificationSource.RESCUE_VERIFICATION_SOURCE_MANUAL
+          : undefined;
+
+      const results = await Promise.all(
+        ids.map(rescueId =>
+          client
+            .verify({ rescueId, toStatus, verificationSource }, metadata)
+            .then(() => true)
+            .catch(() => false)
+        )
+      );
+      const successCount = results.filter(Boolean).length;
+      return reply.send({
+        success: true,
+        message: `Updated ${successCount} of ${ids.length} rescues`,
+        data: { successCount, failedCount: ids.length - successCount },
+      });
+    }
+  );
+
+  // POST /api/v1/rescues/:rescueId/verify
+  app.post<{ Params: { rescueId: string } }>(
+    '/api/v1/rescues/:rescueId/verify',
+    {
+      config: { rateLimit: RL_WRITE },
+      schema: { tags: ['rescues'], summary: 'Verify a rescue' },
+    },
+    async (req, reply) => {
+      const grpcReq: VerifyRescueRequest = {
+        rescueId: req.params.rescueId,
+        toStatus: RescueV1.RescueStatus.RESCUE_STATUS_VERIFIED,
+        verificationSource: RescueV1.RescueVerificationSource.RESCUE_VERIFICATION_SOURCE_MANUAL,
+      };
+      try {
+        const res = await client.verify(grpcReq, buildMetadata(req));
+        if (res.rescue === undefined) {
+          return reply.code(500).send({ success: false, error: 'verify returned no rescue' });
+        }
+        return reply.send({
+          success: true,
+          message: 'Rescue verified',
+          data: rescueToView(res.rescue),
+        });
+      } catch (err) {
+        return handleGrpcError(err, reply);
+      }
+    }
+  );
+
+  // POST /api/v1/rescues/:rescueId/reject
+  app.post<{ Params: { rescueId: string }; Body: { reason?: string } }>(
+    '/api/v1/rescues/:rescueId/reject',
+    {
+      config: { rateLimit: RL_WRITE },
+      schema: { tags: ['rescues'], summary: 'Reject a rescue' },
+    },
+    async (req, reply) => {
+      const reason = req.body?.reason;
+      if (reason === undefined || reason === '') {
+        return reply.code(400).send({ success: false, error: 'reason is required' });
+      }
+      const grpcReq: VerifyRescueRequest = {
+        rescueId: req.params.rescueId,
+        toStatus: RescueV1.RescueStatus.RESCUE_STATUS_REJECTED,
+        failureReason: reason,
+      };
+      try {
+        const res = await client.verify(grpcReq, buildMetadata(req));
+        if (res.rescue === undefined) {
+          return reply.code(500).send({ success: false, error: 'reject returned no rescue' });
+        }
+        return reply.send({
+          success: true,
+          message: 'Rescue rejected',
+          data: rescueToView(res.rescue),
+        });
+      } catch (err) {
+        return handleGrpcError(err, reply);
+      }
+    }
+  );
+};

--- a/services/gateway/src/routes/rescue-view.ts
+++ b/services/gateway/src/routes/rescue-view.ts
@@ -56,6 +56,8 @@ export type RescueView = {
   verification_source: string | null;
   verification_failure_reason: string | null;
   settings: Record<string, unknown>;
+  plan: string;
+  plan_expires_at: string | null;
   created_at: string;
   updated_at: string;
 };
@@ -92,6 +94,8 @@ export function rescueToView(r: Rescue): RescueView {
       : null,
     verification_failure_reason: r.verificationFailureReason ?? null,
     settings: parseSettings(r.settingsJson),
+    plan: r.plan === '' ? 'free' : r.plan,
+    plan_expires_at: r.planExpiresAt ?? null,
     created_at: r.createdAt,
     updated_at: r.updatedAt,
   };

--- a/services/gateway/src/server.ts
+++ b/services/gateway/src/server.ts
@@ -77,6 +77,7 @@ import { registerReportsRoutes } from './routes/reports.js';
 import { registerRescueRoutes } from './routes/rescue.js';
 import { registerInvitationAcceptRoutes } from './routes/invitation-accept.js';
 import { registerRescuesPublicRoutes } from './routes/rescues-public.js';
+import { registerRescueAdminRoutes } from './routes/rescue-admin.js';
 import { registerSecurityRoutes } from './routes/security.js';
 import { registerSessionsRoutes } from './routes/sessions.js';
 import { registerStaffFosterRoutes } from './routes/staff-foster.js';
@@ -459,6 +460,9 @@ export const createServer = async (opts: CreateServerOptions): Promise<FastifyIn
     // Staff / foster / invitation-read surface (/api/v1/staff/*,
     // /api/v1/foster/*, GET /api/v1/invitations/details/:token).
     await registerStaffFosterRoutes(server, { client: opts.rescueClient });
+    // Admin rescue detail surface — plan / analytics / send-email /
+    // bulk-update + plural verify/reject.
+    await registerRescueAdminRoutes(server, { client: opts.rescueClient });
   }
   // POST /api/v1/invitations/accept — register-on-accept. Orchestrates
   // auth (provision the invited user) + rescue (consume the invitation +

--- a/services/rescue/src/grpc/handlers.test.ts
+++ b/services/rescue/src/grpc/handlers.test.ts
@@ -9,10 +9,13 @@ import { RescueV1, type CreateRescueRequest } from '@adopt-dont-shop/proto';
 import {
   createRescue,
   getRescue,
+  getRescueStatistics,
   HandlerError,
   inviteStaff,
   listRescues,
+  sendRescueEmail,
   updateRescue,
+  updateRescuePlan,
   verifyRescue,
   type HandlerDeps,
 } from './handlers.js';
@@ -86,6 +89,8 @@ function rescueRow(overrides: Record<string, unknown> = {}) {
     verification_source: null,
     verification_failure_reason: null,
     settings: {},
+    plan: 'free',
+    plan_expires_at: null,
     version: 0,
     created_at: new Date('2026-06-01T00:00:00Z'),
     updated_at: new Date('2026-06-01T00:00:00Z'),
@@ -581,5 +586,174 @@ describe('listRescues — new filters', () => {
     } as never);
     const sql = mocks.poolMock.query.mock.calls[0][0] as string;
     expect(sql).toContain('FALSE');
+  });
+});
+
+// --- updateRescuePlan ------------------------------------------------
+
+describe('updateRescuePlan', () => {
+  let mocks: ReturnType<typeof makeMocks>;
+  beforeEach(() => {
+    mocks = makeMocks();
+  });
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('INVALID_ARGUMENT for an unknown plan tier', async () => {
+    await expect(
+      updateRescuePlan(mocks.deps, ADMIN, { rescueId: 'rsc-1', plan: 'platinum' } as never)
+    ).rejects.toMatchObject({ code: 'INVALID_ARGUMENT' });
+    // The bad-plan guard fires before any DB read.
+    expect(mocks.poolMock.query).not.toHaveBeenCalled();
+  });
+
+  it('PERMISSION_DENIED for a non-admin', async () => {
+    await expect(
+      updateRescuePlan(mocks.deps, STAFF, { rescueId: 'rsc-1', plan: 'growth' } as never)
+    ).rejects.toMatchObject({ code: 'PERMISSION_DENIED' });
+  });
+
+  it('NOT_FOUND when the rescue is gone', async () => {
+    mocks.poolMock.query.mockResolvedValueOnce({ rows: [] });
+    await expect(
+      updateRescuePlan(mocks.deps, ADMIN, { rescueId: 'ghost', plan: 'growth' } as never)
+    ).rejects.toMatchObject({ code: 'NOT_FOUND' });
+  });
+
+  it('writes the plan + expiry and publishes rescue.planUpdated after commit', async () => {
+    mocks.poolMock.query.mockResolvedValueOnce({ rows: [rescueRow({ plan: 'free' })] });
+    const order: string[] = [];
+    const publishedSubjects: string[] = [];
+    mocks.clientMock.query.mockImplementation(async (sql: string) => {
+      order.push(sql.trim().split(/\s+/)[0]);
+      return { rows: [rescueRow({ plan: 'professional' })] };
+    });
+    mocks.natsMock.publish.mockImplementation((subject: string) => {
+      order.push('NATS_PUBLISH');
+      publishedSubjects.push(subject);
+    });
+
+    const res = await updateRescuePlan(mocks.deps, ADMIN, {
+      rescueId: 'rsc-1',
+      plan: 'professional',
+      planExpiresAt: '2027-01-01T00:00:00.000Z',
+    } as never);
+
+    expect(res.rescue.plan).toBe('professional');
+    expect(order).toEqual(['BEGIN', 'UPDATE', 'COMMIT', 'NATS_PUBLISH']);
+    expect(publishedSubjects).toEqual(['rescue.planUpdated']);
+    // The UPDATE binds the parsed expiry as a Date, not the raw string.
+    const params = mocks.clientMock.query.mock.calls[1][1] as unknown[];
+    expect(params[1]).toBeInstanceOf(Date);
+  });
+
+  it('treats an empty planExpiresAt as null (clears the expiry)', async () => {
+    mocks.poolMock.query.mockResolvedValueOnce({ rows: [rescueRow()] });
+    mocks.clientMock.query.mockResolvedValue({ rows: [rescueRow({ plan: 'growth' })] });
+
+    await updateRescuePlan(mocks.deps, ADMIN, {
+      rescueId: 'rsc-1',
+      plan: 'growth',
+      planExpiresAt: '',
+    } as never);
+
+    const params = mocks.clientMock.query.mock.calls[1][1] as unknown[];
+    expect(params[1]).toBeNull();
+  });
+});
+
+// --- getRescueStatistics ---------------------------------------------
+
+describe('getRescueStatistics', () => {
+  let mocks: ReturnType<typeof makeMocks>;
+  beforeEach(() => {
+    mocks = makeMocks();
+  });
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('PERMISSION_DENIED without rescues.read', async () => {
+    const noRead: Principal = {
+      userId: 'usr-x' as UserId,
+      roles: ['adopter'],
+      permissions: [],
+    };
+    await expect(
+      getRescueStatistics(mocks.deps, noRead, { rescueId: 'rsc-1' } as never)
+    ).rejects.toMatchObject({ code: 'PERMISSION_DENIED' });
+  });
+
+  it('NOT_FOUND when the rescue is gone', async () => {
+    mocks.poolMock.query.mockResolvedValueOnce({ rows: [] });
+    await expect(
+      getRescueStatistics(mocks.deps, ADOPTER, { rescueId: 'ghost' } as never)
+    ).rejects.toMatchObject({ code: 'NOT_FOUND' });
+  });
+
+  it('returns the real staff_count with zero defaults for cross-vertical fields', async () => {
+    mocks.poolMock.query
+      .mockResolvedValueOnce({ rows: [rescueRow()] })
+      .mockResolvedValueOnce({ rows: [{ count: '4' }] });
+
+    const res = await getRescueStatistics(mocks.deps, ADOPTER, { rescueId: 'rsc-1' } as never);
+
+    expect(res.statistics.staffCount).toBe(4);
+    expect(res.statistics.totalPets).toBe(0);
+    expect(res.statistics.totalApplications).toBe(0);
+    expect(res.statistics.averageTimeToAdoption).toBe(0);
+  });
+});
+
+// --- sendRescueEmail -------------------------------------------------
+
+describe('sendRescueEmail', () => {
+  let mocks: ReturnType<typeof makeMocks>;
+  beforeEach(() => {
+    mocks = makeMocks();
+  });
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('INVALID_ARGUMENT when neither a template nor subject+body is supplied', async () => {
+    await expect(
+      sendRescueEmail(mocks.deps, ADMIN, { rescueId: 'rsc-1' } as never)
+    ).rejects.toMatchObject({ code: 'INVALID_ARGUMENT' });
+  });
+
+  it('PERMISSION_DENIED for a non-admin', async () => {
+    await expect(
+      sendRescueEmail(mocks.deps, STAFF, {
+        rescueId: 'rsc-1',
+        templateId: 'tmpl_welcome',
+      } as never)
+    ).rejects.toMatchObject({ code: 'PERMISSION_DENIED' });
+  });
+
+  it('NOT_FOUND when the rescue is gone', async () => {
+    mocks.poolMock.query.mockResolvedValueOnce({ rows: [] });
+    await expect(
+      sendRescueEmail(mocks.deps, ADMIN, {
+        rescueId: 'ghost',
+        templateId: 'tmpl_welcome',
+      } as never)
+    ).rejects.toMatchObject({ code: 'NOT_FOUND' });
+  });
+
+  it('publishes rescue.adminEmailRequested for a custom email and returns queued', async () => {
+    mocks.poolMock.query.mockResolvedValueOnce({ rows: [rescueRow()] });
+    const publishedSubjects: string[] = [];
+    mocks.natsMock.publish.mockImplementation((subject: string) => publishedSubjects.push(subject));
+
+    const res = await sendRescueEmail(mocks.deps, ADMIN, {
+      rescueId: 'rsc-1',
+      subject: 'Hello',
+      body: 'A message',
+    } as never);
+
+    expect(res.queued).toBe(true);
+    expect(publishedSubjects).toEqual(['rescue.adminEmailRequested']);
   });
 });

--- a/services/rescue/src/grpc/handlers.ts
+++ b/services/rescue/src/grpc/handlers.ts
@@ -30,12 +30,18 @@ import {
   type CreateRescueResponse,
   type GetRescueRequest,
   type GetRescueResponse,
+  type GetRescueStatisticsRequest,
+  type GetRescueStatisticsResponse,
   type InviteStaffRequest,
   type InviteStaffResponse,
   type Invitation,
   type ListRescuesRequest,
   type ListRescuesResponse,
   type Rescue,
+  type SendRescueEmailRequest,
+  type SendRescueEmailResponse,
+  type UpdateRescuePlanRequest,
+  type UpdateRescuePlanResponse,
   type UpdateRescueRequest,
   type UpdateRescueResponse,
   type VerifyRescueRequest,
@@ -98,6 +104,8 @@ type RescueRow = {
   verification_source: RescueVerificationSourceDb | null;
   verification_failure_reason: string | null;
   settings: Record<string, unknown> | null;
+  plan: string;
+  plan_expires_at: Date | null;
   version: number;
   created_at: Date;
   updated_at: Date;
@@ -145,6 +153,8 @@ function rowToProto(row: RescueRow): Rescue {
     settingsJson: JSON.stringify(row.settings ?? {}),
     createdAt: row.created_at.toISOString(),
     updatedAt: row.updated_at.toISOString(),
+    plan: row.plan,
+    planExpiresAt: row.plan_expires_at?.toISOString(),
   };
 }
 
@@ -167,7 +177,7 @@ const RESCUES_SELECT = `
   website, description, mission, companies_house_number, charity_registration_number,
   contact_person, contact_title, contact_email, contact_phone,
   status, verified_at, verified_by, verification_source, verification_failure_reason,
-  settings, version, created_at, updated_at
+  settings, plan, plan_expires_at, version, created_at, updated_at
 `;
 
 const RESCUES_CREATE: Permission = 'rescues.create' as Permission;
@@ -652,6 +662,167 @@ export async function inviteStaff(
     throw new HandlerError('INTERNAL', 'invitation insert returned no rows');
   }
   return { invitation: invitationRowToProto(inserted), token };
+}
+
+// --- UpdateRescuePlan (admin) ----------------------------------------
+
+// Canonical tier list — mirrors @adopt-dont-shop/lib.types RescuePlan and
+// the DB CHECK constraint (migration 008). Kept inline so the service has
+// no frontend-lib dependency.
+const VALID_PLANS = new Set(['free', 'growth', 'professional']);
+
+export async function updateRescuePlan(
+  deps: HandlerDeps,
+  principal: Principal,
+  req: UpdateRescuePlanRequest
+): Promise<UpdateRescuePlanResponse> {
+  if (!req.rescueId) {
+    throw new HandlerError('INVALID_ARGUMENT', 'rescue_id is required');
+  }
+  if (!VALID_PLANS.has(req.plan)) {
+    throw new HandlerError(
+      'INVALID_ARGUMENT',
+      `plan must be one of ${[...VALID_PLANS].join(', ')}`
+    );
+  }
+  if (!requirePermission(principal, ADMIN_SECURITY_MANAGE)) {
+    throw new HandlerError('PERMISSION_DENIED', `'${ADMIN_SECURITY_MANAGE}' required`);
+  }
+
+  const existing = await fetchRescue(deps, req.rescueId);
+  if (!existing) {
+    throw new HandlerError('NOT_FOUND', `rescue ${req.rescueId} not found`);
+  }
+
+  const planExpiresAt =
+    req.planExpiresAt !== undefined && req.planExpiresAt !== ''
+      ? new Date(req.planExpiresAt)
+      : null;
+
+  let updated: RescueRow | undefined;
+  await withTransaction(deps, async ({ client, publish }) => {
+    const result = await client.query<RescueRow>(
+      `UPDATE rescue.rescues
+         SET plan = $1, plan_expires_at = $2, updated_at = now(), updated_by = $3,
+             version = version + 1
+       WHERE rescue_id = $4
+       RETURNING ${RESCUES_SELECT}`,
+      [req.plan, planExpiresAt, principal.userId, req.rescueId]
+    );
+    updated = result.rows[0];
+
+    publish({
+      type: 'rescue.planUpdated',
+      id: `rescue.planUpdated.${req.rescueId}:${updated?.version}`,
+      payload: {
+        rescueId: req.rescueId,
+        fromPlan: existing.plan,
+        toPlan: req.plan,
+        updatedBy: principal.userId,
+      },
+    });
+  });
+
+  if (!updated) {
+    throw new HandlerError('INTERNAL', 'plan update returned no rows');
+  }
+  return { rescue: rowToProto(updated) };
+}
+
+// --- GetRescueStatistics ---------------------------------------------
+
+// staff_count is real (this vertical owns rescue.staff_members). The
+// pet/application-derived counts live in other verticals (service.pets,
+// service.applications); rather than fan out a heavy cross-service
+// aggregation on the admin detail panel, they return zero defaults. A
+// future revision can compose them via those services' gRPC clients.
+export async function getRescueStatistics(
+  deps: HandlerDeps,
+  principal: Principal,
+  req: GetRescueStatisticsRequest
+): Promise<GetRescueStatisticsResponse> {
+  if (!req.rescueId) {
+    throw new HandlerError('INVALID_ARGUMENT', 'rescue_id is required');
+  }
+  if (!hasPermission(principal, RESCUES_READ)) {
+    throw new HandlerError('PERMISSION_DENIED', `'${RESCUES_READ}' required`);
+  }
+
+  const existing = await fetchRescue(deps, req.rescueId);
+  if (!existing) {
+    throw new HandlerError('NOT_FOUND', `rescue ${req.rescueId} not found`);
+  }
+
+  const staffResult = await deps.pool.query<{ count: string }>(
+    `SELECT COUNT(*)::text AS count FROM rescue.staff_members
+     WHERE rescue_id = $1 AND deleted_at IS NULL`,
+    [req.rescueId]
+  );
+  const staffCount = Number.parseInt(staffResult.rows[0]?.count ?? '0', 10);
+
+  return {
+    statistics: {
+      totalPets: 0,
+      availablePets: 0,
+      adoptedPets: 0,
+      pendingApplications: 0,
+      totalApplications: 0,
+      staffCount,
+      activeListings: 0,
+      monthlyAdoptions: 0,
+      averageTimeToAdoption: 0,
+    },
+  };
+}
+
+// --- SendRescueEmail (admin) -----------------------------------------
+
+// Validate the request + confirm the rescue exists, then publish
+// `rescue.adminEmailRequested`. Actual delivery is the notifications
+// worker's job (subscriber wiring is out of scope for this RPC); the
+// boundary is the published event.
+export async function sendRescueEmail(
+  deps: HandlerDeps,
+  principal: Principal,
+  req: SendRescueEmailRequest
+): Promise<SendRescueEmailResponse> {
+  if (!req.rescueId) {
+    throw new HandlerError('INVALID_ARGUMENT', 'rescue_id is required');
+  }
+  const hasTemplate = req.templateId !== undefined && req.templateId !== '';
+  const hasCustom =
+    req.subject !== undefined && req.subject !== '' && req.body !== undefined && req.body !== '';
+  if (!hasTemplate && !hasCustom) {
+    throw new HandlerError(
+      'INVALID_ARGUMENT',
+      'either template_id or both subject and body are required'
+    );
+  }
+  if (!requirePermission(principal, ADMIN_SECURITY_MANAGE)) {
+    throw new HandlerError('PERMISSION_DENIED', `'${ADMIN_SECURITY_MANAGE}' required`);
+  }
+
+  const existing = await fetchRescue(deps, req.rescueId);
+  if (!existing) {
+    throw new HandlerError('NOT_FOUND', `rescue ${req.rescueId} not found`);
+  }
+
+  await withTransaction(deps, async ({ publish }) => {
+    publish({
+      type: 'rescue.adminEmailRequested',
+      id: `rescue.adminEmailRequested.${req.rescueId}:${Date.now()}`,
+      payload: {
+        rescueId: req.rescueId,
+        recipientEmail: existing.email,
+        templateId: hasTemplate ? req.templateId : null,
+        subject: hasCustom ? req.subject : null,
+        body: hasCustom ? req.body : null,
+        requestedBy: principal.userId,
+      },
+    });
+  });
+
+  return { queued: true };
 }
 
 // --- Helpers ---------------------------------------------------------

--- a/services/rescue/src/grpc/server.ts
+++ b/services/rescue/src/grpc/server.ts
@@ -20,9 +20,12 @@ import { adapt, adaptUnauth } from './adapter.js';
 import {
   createRescue,
   getRescue,
+  getRescueStatistics,
   inviteStaff,
   listRescues,
+  sendRescueEmail,
   updateRescue,
+  updateRescuePlan,
   verifyRescue,
 } from './handlers.js';
 import {
@@ -78,6 +81,9 @@ export const createGrpcServer = (opts: CreateGrpcServerOptions): Server => {
     listApplicationQuestions: adapt(listApplicationQuestions, { deps, logger }),
     createApplicationQuestion: adapt(createApplicationQuestion, { deps, logger }),
     deleteApplicationQuestion: adapt(deleteApplicationQuestion, { deps, logger }),
+    updateRescuePlan: adapt(updateRescuePlan, { deps, logger }),
+    getRescueStatistics: adapt(getRescueStatistics, { deps, logger }),
+    sendRescueEmail: adapt(sendRescueEmail, { deps, logger }),
   });
 
   logger.info('gRPC RescueService registered', {
@@ -99,6 +105,9 @@ export const createGrpcServer = (opts: CreateGrpcServerOptions): Server => {
       'listApplicationQuestions',
       'createApplicationQuestion',
       'deleteApplicationQuestion',
+      'updateRescuePlan',
+      'getRescueStatistics',
+      'sendRescueEmail',
     ],
     grpcPort: config.grpcPort,
   });

--- a/services/rescue/src/migrations/008_add_rescue_plan.ts
+++ b/services/rescue/src/migrations/008_add_rescue_plan.ts
@@ -1,0 +1,32 @@
+import type { MigrationBuilder } from 'node-pg-migrate';
+
+// Subscription plan columns on `rescues`.
+//
+// The admin Plan tab (app.admin RescueDetailModal/PlanTab) sets a rescue's
+// subscription tier + optional expiry. The baseline rescues table carried
+// no plan column, so this adds:
+//   - plan             — 'free' | 'growth' | 'professional' (default 'free')
+//   - plan_expires_at  — optional expiry timestamp (NULL = no expiry)
+//
+// plan is a plain varchar with a CHECK constraint rather than a Postgres
+// ENUM: the canonical tier list lives in @adopt-dont-shop/lib.types
+// (RescuePlan) and a varchar + CHECK is cheaper to evolve than an ENUM
+// (ALTER TYPE ... ADD VALUE can't run in a transaction).
+
+const PLAN_VALUES = ['free', 'growth', 'professional'];
+
+export const up = async (pgm: MigrationBuilder): Promise<void> => {
+  pgm.addColumns('rescues', {
+    plan: { type: 'varchar(32)', notNull: true, default: 'free' },
+    plan_expires_at: { type: 'timestamptz' },
+  });
+
+  pgm.addConstraint('rescues', 'rescues_plan_check', {
+    check: `plan IN (${PLAN_VALUES.map(v => `'${v}'`).join(', ')})`,
+  });
+};
+
+export const down = async (pgm: MigrationBuilder): Promise<void> => {
+  pgm.dropConstraint('rescues', 'rescues_plan_check');
+  pgm.dropColumns('rescues', ['plan', 'plan_expires_at']);
+};

--- a/services/rescue/src/migrations/migrations.test.ts
+++ b/services/rescue/src/migrations/migrations.test.ts
@@ -46,6 +46,7 @@ describe('rescue migrations', () => {
     '005_create_foster_placements.ts',
     '006_create_application_questions.ts',
     '007_invitation_pending_unique.ts',
+    '008_add_rescue_plan.ts',
   ])('%s exports `up` and `down` functions', async filename => {
     const mod = (await import(`./${filename}`)) as {
       up: unknown;


### PR DESCRIPTION
## The gap

The `app.admin` rescue detail UI (`rescueService.ts`, consumed by `RescueDetailModal/PlanTab`, `RescueDetailPanel`, `SendEmailModal`, `RescueVerificationModal`, and the Rescues bulk-action bar) called several endpoints the gateway never served, so they 404'd. This slice wires **both layers** — the rescue-service gRPC RPCs and the gateway REST routes.

| Route | Backing RPC |
|---|---|
| `PATCH /api/v1/admin/rescues/:id/plan` | `UpdateRescuePlan` (new) |
| `GET /api/v1/rescues/:id/analytics` | `GetRescueStatistics` (new) |
| `POST /api/v1/rescues/:id/send-email` | `SendRescueEmail` (new) |
| `POST /api/v1/rescues/bulk-update` | `Verify` per id (approve/verify→VERIFIED, suspend→SUSPENDED) |
| `POST /api/v1/rescues/:id/verify` | `Verify` (VERIFIED, MANUAL source) |
| `POST /api/v1/rescues/:id/reject` | `Verify` (REJECTED + failure reason) |

The plural `/api/v1/rescues/:id/{verify,reject}` paths are what the admin SPA calls; they reuse the existing `Verify` RPC (which already drives the whole VERIFIED/REJECTED/SUSPENDED lifecycle via `toStatus`). The pre-existing singular `/api/v1/rescue/:id/verify` route is left untouched.

## Backend additions (service.rescue)

- **Proto**: `UpdateRescuePlan`, `GetRescueStatistics`, `SendRescueEmail` RPCs + messages; `Rescue.plan` / `Rescue.plan_expires_at` fields.
- **Migration `008_add_rescue_plan.ts`**: adds `rescues.plan` (`varchar` + CHECK for `free|growth|professional`, default `free`) and `rescues.plan_expires_at`. Tested up + down.
- **Handlers**: `updateRescuePlan` (admin.security.manage, publishes `rescue.planUpdated`), `getRescueStatistics`, `sendRescueEmail` (validates + publishes `rescue.adminEmailRequested`).

## Scoping decisions

- **`GetRescueStatistics` `staffCount` is real** (this vertical owns `rescue.staff_members`); the pet/application-derived counts live in other verticals and are returned as **zero defaults** rather than a heavy cross-service fan-out on the detail panel. A future revision can compose them via the pets/applications gRPC clients.
- **`SendRescueEmail` stops at the published event** (`rescue.adminEmailRequested`) — the notifications worker's subscriber wiring is out of scope for this slice.
- **`send-email` / `verify` drop the SPA's `notes` field** — the `Verify` RPC persists only a `failureReason` (for rejects), and `SendRescueEmail` carries `templateId`/`subject`/`body`. No `notes` column exists; surfacing it would be a follow-up.

## Test plan

- **service.rescue**: handler + migration tests (153 tests pass; type-check clean).
- **service.gateway**: new `rescue-admin.test.ts` — 15 tests (plan forward + missing-plan 400 + PERMISSION_DENIED→403; analytics envelope + NOT_FOUND→404; send-email custom/template + missing-both 400; bulk-update success/failure counting + suspend mapping + empty-ids/bad-action 400; verify VERIFIED+MANUAL; reject REJECTED+reason + missing-reason 400).
- `pnpm exec turbo type-check test lint --filter=@adopt-dont-shop/service.gateway --filter=@adopt-dont-shop/service.rescue --filter=@adopt-dont-shop/proto` — all green (gateway 68 files / 832 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EgwcaPwDJBjJJr68hnjeMX)_