### PR TITLE
Add CountRescues RPC for exact admin dashboard rescue counts

### DIFF
--- a/packages/proto/proto/adopt_dont_shop/rescue/v1/rescue.proto
+++ b/packages/proto/proto/adopt_dont_shop/rescue/v1/rescue.proto
@@ -140,6 +140,12 @@ service RescueService {
   rpc GetRescueStatistics(GetRescueStatisticsRequest)
       returns (GetRescueStatisticsResponse);
 
+  // Exact rescue counts per lifecycle status for the admin dashboard.
+  // A single `SELECT status, COUNT(*) ... GROUP BY status` — cheap and
+  // uncapped, unlike counting List() page lengths (capped at 100). Caller
+  // MUST have `rescues.read`.
+  rpc CountRescues(CountRescuesRequest) returns (CountRescuesResponse);
+
   // Validate + enqueue an admin email to a rescue's contact address.
   // Admin-only — caller MUST have `admin.security.manage`. Confirms the
   // rescue exists, then publishes `rescue.adminEmailRequested` for the
@@ -587,6 +593,23 @@ message RescueStatistics {
 
 message GetRescueStatisticsResponse {
   RescueStatistics statistics = 1;
+}
+
+// --- CountRescues -----------------------------------------------------
+
+message CountRescuesRequest {}
+
+// Exact platform-wide rescue counts, one field per lifecycle status plus
+// the grand total. Flat scalar fields (mirrors RescueStatistics) rather
+// than a map so consumers read named counts without a key lookup.
+message CountRescuesResponse {
+  uint32 pending = 1;
+  uint32 verified = 2;
+  uint32 suspended = 3;
+  uint32 inactive = 4;
+  uint32 rejected = 5;
+  // Sum across every status (includes any not broken out above).
+  uint32 total = 6;
 }
 
 message SendRescueEmailRequest {

--- a/packages/proto/src/generated/proto/adopt_dont_shop/rescue/v1/rescue.ts
+++ b/packages/proto/src/generated/proto/adopt_dont_shop/rescue/v1/rescue.ts
@@ -663,6 +663,23 @@ export interface GetRescueStatisticsResponse {
   statistics?: RescueStatistics | undefined;
 }
 
+export interface CountRescuesRequest {}
+
+/**
+ * Exact platform-wide rescue counts, one field per lifecycle status plus
+ * the grand total. Flat scalar fields (mirrors RescueStatistics) rather
+ * than a map so consumers read named counts without a key lookup.
+ */
+export interface CountRescuesResponse {
+  pending: number;
+  verified: number;
+  suspended: number;
+  inactive: number;
+  rejected: number;
+  /** Sum across every status (includes any not broken out above). */
+  total: number;
+}
+
 export interface SendRescueEmailRequest {
   rescueId: string;
   /** Either a predefined template id, OR a custom subject + body. */
@@ -6398,6 +6415,191 @@ export const GetRescueStatisticsResponse: MessageFns<GetRescueStatisticsResponse
   },
 };
 
+function createBaseCountRescuesRequest(): CountRescuesRequest {
+  return {};
+}
+
+export const CountRescuesRequest: MessageFns<CountRescuesRequest> = {
+  encode(_: CountRescuesRequest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): CountRescuesRequest {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseCountRescuesRequest();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(_: any): CountRescuesRequest {
+    return {};
+  },
+
+  toJSON(_: CountRescuesRequest): unknown {
+    const obj: any = {};
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<CountRescuesRequest>, I>>(base?: I): CountRescuesRequest {
+    return CountRescuesRequest.fromPartial(base ?? ({} as any));
+  },
+  fromPartial<I extends Exact<DeepPartial<CountRescuesRequest>, I>>(_: I): CountRescuesRequest {
+    const message = createBaseCountRescuesRequest();
+    return message;
+  },
+};
+
+function createBaseCountRescuesResponse(): CountRescuesResponse {
+  return { pending: 0, verified: 0, suspended: 0, inactive: 0, rejected: 0, total: 0 };
+}
+
+export const CountRescuesResponse: MessageFns<CountRescuesResponse> = {
+  encode(message: CountRescuesResponse, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+    if (message.pending !== 0) {
+      writer.uint32(8).uint32(message.pending);
+    }
+    if (message.verified !== 0) {
+      writer.uint32(16).uint32(message.verified);
+    }
+    if (message.suspended !== 0) {
+      writer.uint32(24).uint32(message.suspended);
+    }
+    if (message.inactive !== 0) {
+      writer.uint32(32).uint32(message.inactive);
+    }
+    if (message.rejected !== 0) {
+      writer.uint32(40).uint32(message.rejected);
+    }
+    if (message.total !== 0) {
+      writer.uint32(48).uint32(message.total);
+    }
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): CountRescuesResponse {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseCountRescuesResponse();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1: {
+          if (tag !== 8) {
+            break;
+          }
+
+          message.pending = reader.uint32();
+          continue;
+        }
+        case 2: {
+          if (tag !== 16) {
+            break;
+          }
+
+          message.verified = reader.uint32();
+          continue;
+        }
+        case 3: {
+          if (tag !== 24) {
+            break;
+          }
+
+          message.suspended = reader.uint32();
+          continue;
+        }
+        case 4: {
+          if (tag !== 32) {
+            break;
+          }
+
+          message.inactive = reader.uint32();
+          continue;
+        }
+        case 5: {
+          if (tag !== 40) {
+            break;
+          }
+
+          message.rejected = reader.uint32();
+          continue;
+        }
+        case 6: {
+          if (tag !== 48) {
+            break;
+          }
+
+          message.total = reader.uint32();
+          continue;
+        }
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): CountRescuesResponse {
+    return {
+      pending: isSet(object.pending) ? globalThis.Number(object.pending) : 0,
+      verified: isSet(object.verified) ? globalThis.Number(object.verified) : 0,
+      suspended: isSet(object.suspended) ? globalThis.Number(object.suspended) : 0,
+      inactive: isSet(object.inactive) ? globalThis.Number(object.inactive) : 0,
+      rejected: isSet(object.rejected) ? globalThis.Number(object.rejected) : 0,
+      total: isSet(object.total) ? globalThis.Number(object.total) : 0,
+    };
+  },
+
+  toJSON(message: CountRescuesResponse): unknown {
+    const obj: any = {};
+    if (message.pending !== 0) {
+      obj.pending = Math.round(message.pending);
+    }
+    if (message.verified !== 0) {
+      obj.verified = Math.round(message.verified);
+    }
+    if (message.suspended !== 0) {
+      obj.suspended = Math.round(message.suspended);
+    }
+    if (message.inactive !== 0) {
+      obj.inactive = Math.round(message.inactive);
+    }
+    if (message.rejected !== 0) {
+      obj.rejected = Math.round(message.rejected);
+    }
+    if (message.total !== 0) {
+      obj.total = Math.round(message.total);
+    }
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<CountRescuesResponse>, I>>(base?: I): CountRescuesResponse {
+    return CountRescuesResponse.fromPartial(base ?? ({} as any));
+  },
+  fromPartial<I extends Exact<DeepPartial<CountRescuesResponse>, I>>(
+    object: I
+  ): CountRescuesResponse {
+    const message = createBaseCountRescuesResponse();
+    message.pending = object.pending ?? 0;
+    message.verified = object.verified ?? 0;
+    message.suspended = object.suspended ?? 0;
+    message.inactive = object.inactive ?? 0;
+    message.rejected = object.rejected ?? 0;
+    message.total = object.total ?? 0;
+    return message;
+  },
+};
+
 function createBaseSendRescueEmailRequest(): SendRescueEmailRequest {
   return { rescueId: '', templateId: undefined, subject: undefined, body: undefined };
 }
@@ -6940,6 +7142,24 @@ export const RescueServiceService = {
       GetRescueStatisticsResponse.decode(value),
   },
   /**
+   * Exact rescue counts per lifecycle status for the admin dashboard.
+   * A single `SELECT status, COUNT(*) ... GROUP BY status` — cheap and
+   * uncapped, unlike counting List() page lengths (capped at 100). Caller
+   * MUST have `rescues.read`.
+   */
+  countRescues: {
+    path: '/adopt_dont_shop.rescue.v1.RescueService/CountRescues' as const,
+    requestStream: false as const,
+    responseStream: false as const,
+    requestSerialize: (value: CountRescuesRequest): Buffer =>
+      Buffer.from(CountRescuesRequest.encode(value).finish()),
+    requestDeserialize: (value: Buffer): CountRescuesRequest => CountRescuesRequest.decode(value),
+    responseSerialize: (value: CountRescuesResponse): Buffer =>
+      Buffer.from(CountRescuesResponse.encode(value).finish()),
+    responseDeserialize: (value: Buffer): CountRescuesResponse =>
+      CountRescuesResponse.decode(value),
+  },
+  /**
    * Validate + enqueue an admin email to a rescue's contact address.
    * Admin-only — caller MUST have `admin.security.manage`. Confirms the
    * rescue exists, then publishes `rescue.adminEmailRequested` for the
@@ -7093,6 +7313,13 @@ export interface RescueServiceServer extends UntypedServiceImplementation {
    * cross-service aggregation. Caller MUST have `rescues.read`.
    */
   getRescueStatistics: handleUnaryCall<GetRescueStatisticsRequest, GetRescueStatisticsResponse>;
+  /**
+   * Exact rescue counts per lifecycle status for the admin dashboard.
+   * A single `SELECT status, COUNT(*) ... GROUP BY status` — cheap and
+   * uncapped, unlike counting List() page lengths (capped at 100). Caller
+   * MUST have `rescues.read`.
+   */
+  countRescues: handleUnaryCall<CountRescuesRequest, CountRescuesResponse>;
   /**
    * Validate + enqueue an admin email to a rescue's contact address.
    * Admin-only — caller MUST have `admin.security.manage`. Confirms the
@@ -7488,6 +7715,27 @@ export interface RescueServiceClient extends Client {
     metadata: Metadata,
     options: Partial<CallOptions>,
     callback: (error: ServiceError | null, response: GetRescueStatisticsResponse) => void
+  ): ClientUnaryCall;
+  /**
+   * Exact rescue counts per lifecycle status for the admin dashboard.
+   * A single `SELECT status, COUNT(*) ... GROUP BY status` — cheap and
+   * uncapped, unlike counting List() page lengths (capped at 100). Caller
+   * MUST have `rescues.read`.
+   */
+  countRescues(
+    request: CountRescuesRequest,
+    callback: (error: ServiceError | null, response: CountRescuesResponse) => void
+  ): ClientUnaryCall;
+  countRescues(
+    request: CountRescuesRequest,
+    metadata: Metadata,
+    callback: (error: ServiceError | null, response: CountRescuesResponse) => void
+  ): ClientUnaryCall;
+  countRescues(
+    request: CountRescuesRequest,
+    metadata: Metadata,
+    options: Partial<CallOptions>,
+    callback: (error: ServiceError | null, response: CountRescuesResponse) => void
   ): ClientUnaryCall;
   /**
    * Validate + enqueue an admin email to a rescue's contact address.

--- a/packages/proto/src/index.ts
+++ b/packages/proto/src/index.ts
@@ -276,6 +276,8 @@ export type {
   GetRescueStatisticsRequest,
   GetRescueStatisticsResponse,
   RescueStatistics,
+  CountRescuesRequest,
+  CountRescuesResponse,
   SendRescueEmailRequest,
   SendRescueEmailResponse,
   RescueServiceServer,

--- a/services/gateway/src/grpc-clients/rescue-client.ts
+++ b/services/gateway/src/grpc-clients/rescue-client.ts
@@ -15,6 +15,8 @@ import {
   RescueV1,
   type AcceptInvitationRequest,
   type AcceptInvitationResponse,
+  type CountRescuesRequest,
+  type CountRescuesResponse,
   type CreateApplicationQuestionRequest,
   type CreateApplicationQuestionResponse,
   type CreateFosterPlacementRequest,
@@ -72,6 +74,7 @@ export type RescueClient = {
     req: GetRescueStatisticsRequest,
     metadata: Metadata
   ): Promise<GetRescueStatisticsResponse>;
+  countRescues(req: CountRescuesRequest, metadata: Metadata): Promise<CountRescuesResponse>;
   sendRescueEmail(
     req: SendRescueEmailRequest,
     metadata: Metadata
@@ -204,6 +207,7 @@ export const createRescueClient = (opts: CreateRescueClientOptions): RescueClien
     list: (req, metadata) => callUnary(stub.list, req, metadata, true),
     getRescueStatistics: (req, metadata) =>
       callUnary(stub.getRescueStatistics, req, metadata, true),
+    countRescues: (req, metadata) => callUnary(stub.countRescues, req, metadata, true),
     getMyStaffMembership: (req, metadata) =>
       callUnary(stub.getMyStaffMembership, req, metadata, true),
     listStaffMembers: (req, metadata) => callUnary(stub.listStaffMembers, req, metadata, true),

--- a/services/gateway/src/routes/admin-analytics.test.ts
+++ b/services/gateway/src/routes/admin-analytics.test.ts
@@ -1,4 +1,4 @@
-import { Metadata, status } from '@grpc/grpc-js';
+import { status } from '@grpc/grpc-js';
 import Fastify, { type FastifyInstance } from 'fastify';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -55,18 +55,14 @@ const APP_STATS_FIXTURE = {
   adopted: 1,
 };
 
-const makeRescue = (rescueId: string): RescueV1.Rescue =>
-  ({
-    rescueId,
-    name: `Rescue ${rescueId}`,
-    email: 'r@example.com',
-    address: '1 St',
-    city: 'Town',
-    postcode: 'AB1 2CD',
-    country: 'UK',
-    contactPerson: 'Jo',
-    status: RescueV1.RescueStatus.RESCUE_STATUS_VERIFIED,
-  }) as unknown as RescueV1.Rescue;
+const RESCUE_COUNTS_FIXTURE: RescueV1.CountRescuesResponse = {
+  pending: 1,
+  verified: 2,
+  suspended: 0,
+  inactive: 0,
+  rejected: 0,
+  total: 3,
+};
 
 // --- Mocks ----------------------------------------------------------
 
@@ -97,9 +93,15 @@ function makeApplicationsClient(): {
   return { client: stubClient<ApplicationsClient>({ getStats: getStatsMock }), getStatsMock };
 }
 
-function makeRescueClient(): { client: RescueClient; listMock: ReturnType<typeof vi.fn> } {
-  const listMock = vi.fn();
-  return { client: stubClient<RescueClient>({ list: listMock }), listMock };
+function makeRescueClient(): {
+  client: RescueClient;
+  countRescuesMock: ReturnType<typeof vi.fn>;
+} {
+  const countRescuesMock = vi.fn();
+  return {
+    client: stubClient<RescueClient>({ countRescues: countRescuesMock }),
+    countRescuesMock,
+  };
 }
 
 type Clients = {
@@ -122,10 +124,8 @@ function primeHappyPath(c: Clients): void {
   c.auth.getUserStatisticsMock.mockResolvedValue(USER_STATS_FIXTURE);
   c.pets.getStatsMock.mockResolvedValue(PET_STATS_FIXTURE);
   c.apps.getStatsMock.mockResolvedValue(APP_STATS_FIXTURE);
-  // First list call = verified filter, second = pending filter.
-  c.rescue.listMock
-    .mockResolvedValueOnce({ rescues: [makeRescue('rsc-1'), makeRescue('rsc-2')] })
-    .mockResolvedValueOnce({ rescues: [makeRescue('rsc-3')] });
+  // Single grouped count — exact verified / pending / total.
+  c.rescue.countRescuesMock.mockResolvedValue(RESCUE_COUNTS_FIXTURE);
 }
 
 async function buildApp(c: Clients): Promise<FastifyInstance> {
@@ -188,7 +188,7 @@ describe('GET /api/v1/admin/metrics', () => {
     expect(body.data.users.newThisMonth).toBe(12);
     expect(body.data.users.byRole).toEqual({ adopter: 100, rescue_staff: 18, admin: 2 });
 
-    // Rescues — counted from the two filtered list calls (verified + pending).
+    // Rescues — exact grouped counts from CountRescues.
     expect(body.data.rescues.verified).toBe(2);
     expect(body.data.rescues.pending).toBe(1);
     expect(body.data.rescues.total).toBe(3);
@@ -207,21 +207,13 @@ describe('GET /api/v1/admin/metrics', () => {
     expect(body.data.applications.newThisMonth).toBe(0);
   });
 
-  it('queries rescues with VERIFIED then PENDING status filters', async () => {
+  it('counts rescues with a single grouped CountRescues call', async () => {
     primeHappyPath(c);
 
     await app.inject({ method: 'GET', url: '/api/v1/admin/metrics', headers: ADMIN_HEADERS });
 
-    const [verifiedReq] = c.rescue.listMock.mock.calls[0] as [
-      { statusFilter: RescueV1.RescueStatus },
-      Metadata,
-    ];
-    const [pendingReq] = c.rescue.listMock.mock.calls[1] as [
-      { statusFilter: RescueV1.RescueStatus },
-      Metadata,
-    ];
-    expect(verifiedReq.statusFilter).toBe(RescueV1.RescueStatus.RESCUE_STATUS_VERIFIED);
-    expect(pendingReq.statusFilter).toBe(RescueV1.RescueStatus.RESCUE_STATUS_PENDING);
+    // One exact, uncapped grouped count — not per-status paginated list scans.
+    expect(c.rescue.countRescuesMock).toHaveBeenCalledTimes(1);
   });
 
   it('maps an upstream PERMISSION_DENIED to a 403', async () => {
@@ -231,7 +223,7 @@ describe('GET /api/v1/admin/metrics', () => {
     });
     c.pets.getStatsMock.mockResolvedValue(PET_STATS_FIXTURE);
     c.apps.getStatsMock.mockResolvedValue(APP_STATS_FIXTURE);
-    c.rescue.listMock.mockResolvedValue({ rescues: [] });
+    c.rescue.countRescuesMock.mockResolvedValue(RESCUE_COUNTS_FIXTURE);
 
     const res = await app.inject({
       method: 'GET',
@@ -344,7 +336,7 @@ describe('GET /api/v1/admin/analytics/dashboard', () => {
     c.auth.getUserStatisticsMock.mockResolvedValue(USER_STATS_FIXTURE);
     c.pets.getStatsMock.mockRejectedValue({ code: status.UNAVAILABLE, details: 'down' });
     c.apps.getStatsMock.mockResolvedValue(APP_STATS_FIXTURE);
-    c.rescue.listMock.mockResolvedValue({ rescues: [] });
+    c.rescue.countRescuesMock.mockResolvedValue(RESCUE_COUNTS_FIXTURE);
 
     const res = await app.inject({
       method: 'GET',

--- a/services/gateway/src/routes/admin-analytics.ts
+++ b/services/gateway/src/routes/admin-analytics.ts
@@ -1,17 +1,20 @@
 // REST → gRPC aggregation for the admin SPA's Dashboard + Analytics pages.
 //
 // There is no analytics microservice. Both endpoints fan out to the
-// EXISTING stats/list RPCs on auth, pets, applications and rescue and
-// compose the SPA's documented shapes at the gateway. Fields with no
-// feasible upstream source (time-series trends, session/retention
-// metrics, per-rescue performance, "new this month" for entities whose
-// stats RPC doesn't expose it) are zero/empty-defaulted rather than
-// inventing new backend RPCs.
+// stats/count RPCs on auth, pets, applications and rescue and compose the
+// SPA's documented shapes at the gateway. Rescue counts come from
+// rescue.CountRescues — a single grouped count, so verified/pending/total
+// are exact and uncapped (the earlier rescue.List ×2 approach capped each
+// status at the 100-row page limit). Fields with no feasible upstream
+// source (time-series trends, session/retention metrics, per-rescue
+// performance, "new this month" for entities whose stats RPC doesn't
+// expose it) are zero/empty-defaulted rather than inventing new backend
+// RPCs.
 //
 // Route map:
 //   GET /api/v1/admin/metrics             → auth.GetUserStatistics +
 //                                           pets.GetStats + apps.GetStats +
-//                                           rescue.List ×2 (verified, pending)
+//                                           rescue.CountRescues
 //   GET /api/v1/admin/analytics/dashboard → same fan-out, reshaped into the
 //                                           larger DashboardAnalytics contract
 //
@@ -23,13 +26,12 @@ import type { FastifyInstance } from 'fastify';
 
 import {
   AuthV1,
-  RescueV1,
   type GetUserStatisticsResponse,
   type GetPetStatsRequest,
   type GetPetStatsResponse,
   type GetStatsRequest as ApplicationsGetStatsRequest,
   type GetStatsResponse as ApplicationsGetStatsResponse,
-  type ListRescuesRequest,
+  type CountRescuesResponse,
 } from '@adopt-dont-shop/proto';
 
 import type { AuthClient } from '../grpc-clients/auth-client.js';
@@ -53,11 +55,6 @@ const ADMIN_ANALYTICS_RATE_LIMITS = {
   metrics: { max: 120, timeWindow: '1 minute' },
   dashboard: { max: 120, timeWindow: '1 minute' },
 } as const;
-
-// rescue.List is cursor-paginated with no total; the max page is 100, so
-// counts derived from it are accurate up to 100 per status. Good enough
-// for the dashboard KPI; a future revision can add a rescue stats RPC.
-const RESCUE_COUNT_LIMIT = 100;
 
 // --- Response shapes (gateway-local; no lib.types dependency) --------
 
@@ -100,8 +97,7 @@ type SourceStats = {
   users: GetUserStatisticsResponse;
   pets: GetPetStatsResponse;
   applications: ApplicationsGetStatsResponse;
-  verifiedRescues: number;
-  pendingRescues: number;
+  rescues: CountRescuesResponse;
 };
 
 // --- Pure aggregation helpers ----------------------------------------
@@ -139,9 +135,9 @@ const toPlatformMetrics = (s: SourceStats): PlatformMetrics => ({
     byRole: usersByRole(s.users),
   },
   rescues: {
-    total: s.verifiedRescues + s.pendingRescues,
-    verified: s.verifiedRescues,
-    pending: s.pendingRescues,
+    total: s.rescues.total,
+    verified: s.rescues.verified,
+    pending: s.rescues.pending,
     newThisMonth: 0,
   },
   pets: {
@@ -199,27 +195,17 @@ export const registerAdminAnalyticsRoutes = async (
   const collectSourceStats = (metadata: ReturnType<typeof buildMetadata>): Promise<SourceStats> => {
     const petStatsReq: GetPetStatsRequest = {};
     const appStatsReq: ApplicationsGetStatsRequest = {};
-    const verifiedReq: ListRescuesRequest = {
-      limit: RESCUE_COUNT_LIMIT,
-      statusFilter: RescueV1.RescueStatus.RESCUE_STATUS_VERIFIED,
-    };
-    const pendingReq: ListRescuesRequest = {
-      limit: RESCUE_COUNT_LIMIT,
-      statusFilter: RescueV1.RescueStatus.RESCUE_STATUS_PENDING,
-    };
 
     return Promise.all([
       authClient.getUserStatistics({}, metadata),
       petsClient.getStats(petStatsReq, metadata),
       applicationsClient.getStats(appStatsReq, metadata),
-      rescueClient.list(verifiedReq, metadata),
-      rescueClient.list(pendingReq, metadata),
-    ]).then(([users, pets, applications, verified, pending]) => ({
+      rescueClient.countRescues({}, metadata),
+    ]).then(([users, pets, applications, rescues]) => ({
       users,
       pets,
       applications,
-      verifiedRescues: verified.rescues.length,
-      pendingRescues: pending.rescues.length,
+      rescues,
     }));
   };
 

--- a/services/rescue/src/grpc/handlers.test.ts
+++ b/services/rescue/src/grpc/handlers.test.ts
@@ -7,6 +7,7 @@ import type { Permission, RescueId, UserId } from '@adopt-dont-shop/lib.types';
 import { RescueV1, type CreateRescueRequest } from '@adopt-dont-shop/proto';
 
 import {
+  countRescues,
   createRescue,
   getRescue,
   getRescueStatistics,
@@ -703,6 +704,73 @@ describe('getRescueStatistics', () => {
     expect(res.statistics.totalPets).toBe(0);
     expect(res.statistics.totalApplications).toBe(0);
     expect(res.statistics.averageTimeToAdoption).toBe(0);
+  });
+});
+
+// --- countRescues ----------------------------------------------------
+
+describe('countRescues', () => {
+  let mocks: ReturnType<typeof makeMocks>;
+  beforeEach(() => {
+    mocks = makeMocks();
+  });
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('PERMISSION_DENIED without rescues.read', async () => {
+    const noRead: Principal = {
+      userId: 'usr-x' as UserId,
+      roles: ['adopter'],
+      permissions: [],
+    };
+    await expect(countRescues(mocks.deps, noRead, {})).rejects.toMatchObject({
+      code: 'PERMISSION_DENIED',
+    });
+  });
+
+  it('maps the grouped count into per-status fields and a summed total', async () => {
+    mocks.poolMock.query.mockResolvedValueOnce({
+      rows: [
+        { status: 'verified', count: '150' },
+        { status: 'pending', count: '12' },
+        { status: 'suspended', count: '3' },
+      ],
+    });
+
+    const res = await countRescues(mocks.deps, ADOPTER, {});
+
+    expect(res.verified).toBe(150);
+    expect(res.pending).toBe(12);
+    expect(res.suspended).toBe(3);
+    expect(res.inactive).toBe(0);
+    expect(res.rejected).toBe(0);
+    expect(res.total).toBe(165);
+  });
+
+  it('runs a single grouped count (no per-status fan-out, uncapped)', async () => {
+    mocks.poolMock.query.mockResolvedValueOnce({ rows: [{ status: 'verified', count: '0' }] });
+
+    await countRescues(mocks.deps, ADOPTER, {});
+
+    expect(mocks.poolMock.query).toHaveBeenCalledTimes(1);
+    const [sql] = mocks.poolMock.query.mock.calls[0] as [string];
+    expect(sql).toMatch(/GROUP BY status/);
+  });
+
+  it('returns all-zero counts when there are no rescues', async () => {
+    mocks.poolMock.query.mockResolvedValueOnce({ rows: [] });
+
+    const res = await countRescues(mocks.deps, ADOPTER, {});
+
+    expect(res).toEqual({
+      pending: 0,
+      verified: 0,
+      suspended: 0,
+      inactive: 0,
+      rejected: 0,
+      total: 0,
+    });
   });
 });
 

--- a/services/rescue/src/grpc/handlers.ts
+++ b/services/rescue/src/grpc/handlers.ts
@@ -26,6 +26,8 @@ import { withTransaction, type WithTransactionDeps } from '@adopt-dont-shop/even
 import type { Permission, RescueId } from '@adopt-dont-shop/lib.types';
 import {
   RescueV1,
+  type CountRescuesRequest,
+  type CountRescuesResponse,
   type CreateRescueRequest,
   type CreateRescueResponse,
   type GetRescueRequest,
@@ -773,6 +775,43 @@ export async function getRescueStatistics(
       averageTimeToAdoption: 0,
     },
   };
+}
+
+// --- CountRescues ----------------------------------------------------
+
+// Exact rescue counts per lifecycle status from a single grouped count.
+// Cheap and uncapped — the admin dashboard derives verified/pending/total
+// from this rather than counting List() page lengths (capped at 100).
+export async function countRescues(
+  deps: HandlerDeps,
+  principal: Principal,
+  _req: CountRescuesRequest
+): Promise<CountRescuesResponse> {
+  if (!hasPermission(principal, RESCUES_READ)) {
+    throw new HandlerError('PERMISSION_DENIED', `'${RESCUES_READ}' required`);
+  }
+
+  const result = await deps.pool.query<{ status: RescueStatusDb; count: string }>(
+    `SELECT status, COUNT(*)::text AS count FROM rescue.rescues
+     WHERE deleted_at IS NULL
+     GROUP BY status`
+  );
+
+  const counts: Record<RescueStatusDb, number> = {
+    pending: 0,
+    verified: 0,
+    suspended: 0,
+    inactive: 0,
+    rejected: 0,
+  };
+  let total = 0;
+  for (const row of result.rows) {
+    const n = Number.parseInt(row.count, 10);
+    counts[row.status] = n;
+    total += n;
+  }
+
+  return { ...counts, total };
 }
 
 // --- SendRescueEmail (admin) -----------------------------------------

--- a/services/rescue/src/grpc/server.ts
+++ b/services/rescue/src/grpc/server.ts
@@ -18,6 +18,7 @@ import type { RescueConfig } from '../config.js';
 
 import { adapt, adaptUnauth } from './adapter.js';
 import {
+  countRescues,
   createRescue,
   getRescue,
   getRescueStatistics,
@@ -83,6 +84,7 @@ export const createGrpcServer = (opts: CreateGrpcServerOptions): Server => {
     deleteApplicationQuestion: adapt(deleteApplicationQuestion, { deps, logger }),
     updateRescuePlan: adapt(updateRescuePlan, { deps, logger }),
     getRescueStatistics: adapt(getRescueStatistics, { deps, logger }),
+    countRescues: adapt(countRescues, { deps, logger }),
     sendRescueEmail: adapt(sendRescueEmail, { deps, logger }),
   });
 
@@ -107,6 +109,7 @@ export const createGrpcServer = (opts: CreateGrpcServerOptions): Server => {
       'deleteApplicationQuestion',
       'updateRescuePlan',
       'getRescueStatistics',
+      'countRescues',
       'sendRescueEmail',
     ],
     grpcPort: config.grpcPort,


### PR DESCRIPTION
## The gap

PR #1139 backed the admin dashboard metrics via a gateway fan-out. Its one explicit accuracy caveat: rescue counts were derived from `rescue.List(VERIFIED)` / `rescue.List(PENDING)` array lengths, which are **cursor-paginated and capped at 100 rows per status** — so a platform with >100 rescues in a status reported the wrong number.

## What this does

- **Proto** — adds a `CountRescues` RPC to `RescueService`, returning exact per-status counts (`{ pending, verified, suspended, inactive, rejected, total }`). Regenerated TS + new exports in `packages/proto/src/index.ts`.
- **Service** — `countRescues` handler in `services/rescue/src/grpc/handlers.ts`: a single `SELECT status, COUNT(*) ... GROUP BY status` against `rescue.rescues`, gated on `rescues.read` (mirrors `getRescueStatistics`). Registered in the rescue gRPC server.
- **Gateway** — `countRescues` added to the rescue client; `admin-analytics.ts` now makes one `countRescues` call instead of two capped `List` scans, mapping the result into `rescues.verified` / `rescues.pending` / `rescues.total`. Rescue counts are now **exact and uncapped**.

## Test plan

- `services/rescue/src/grpc/handlers.test.ts` — new `countRescues` handler test (grouped-count query, authz).
- `services/gateway/src/routes/admin-analytics.test.ts` — updated to mock `countRescues` (replacing the two `list` calls); asserts exact counts flow through and that a single grouped count is issued. The obsolete per-status-filter assertion was replaced with a "single CountRescues call" assertion.
- `pnpm exec turbo lint test type-check --filter=@adopt-dont-shop/service.rescue --filter=@adopt-dont-shop/service.gateway --filter=@adopt-dont-shop/proto` — all green (gateway 832 tests pass).

Scope: only the rescue-count accuracy fix. The other zero-defaulted analytics fields (popularPetTypes, adoptionTrends, rescuePerformance, session/retention, applications.trends) still need time-series/event infrastructure and remain deliberately out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EgwcaPwDJBjJJr68hnjeMX)_