### PR TITLE
feat: add AdminCreateUser RPC + admin Create User route

### DIFF
--- a/packages/proto/proto/adopt_dont_shop/auth/v1/auth.proto
+++ b/packages/proto/proto/adopt_dont_shop/auth/v1/auth.proto
@@ -154,6 +154,14 @@ service AuthService {
   // Fetch a single user by id (admin view — full row). admin.users.read.
   rpc AdminGetUser(AdminGetUserRequest) returns (AdminGetUserResponse);
 
+  // Create a new user from the admin console as a pending, credential-less
+  // account and issue a single-use invitation token (emailed via the
+  // auth.userInvited event) the invitee redeems to set their password.
+  // Gates on admin.users.create; creating an elevated role (admin,
+  // moderator, super_admin) additionally requires the caller to be a
+  // super_admin. ALREADY_EXISTS when the email is already in use.
+  rpc AdminCreateUser(AdminCreateUserRequest) returns (AdminCreateUserResponse);
+
   // Partially update a user's admin-controllable fields (status,
   // user_type, verification flags). admin.users.update. Only set fields
   // are written.
@@ -740,6 +748,25 @@ message AdminUpdateUserRequest {
 }
 
 message AdminUpdateUserResponse {
+  User user = 1;
+}
+
+message AdminCreateUserRequest {
+  string email = 1;
+  string first_name = 2;
+  string last_name = 3;
+  // The new account's role. Maps directly onto user_type (the RBAC
+  // primary role grant). Required.
+  UserRole user_type = 4;
+  // When true, the auth.userInvited event carries the invitation token so
+  // the notifications service emails a set-password link. The account is
+  // always created pending until the invitation is redeemed regardless.
+  bool send_invitation = 5;
+}
+
+message AdminCreateUserResponse {
+  // The newly created (pending) user. Carries no usable credentials until
+  // the invitation is redeemed.
   User user = 1;
 }
 

--- a/packages/proto/src/generated/proto/adopt_dont_shop/auth/v1/auth.ts
+++ b/packages/proto/src/generated/proto/adopt_dont_shop/auth/v1/auth.ts
@@ -814,6 +814,31 @@ export interface AdminUpdateUserResponse {
   user?: User | undefined;
 }
 
+export interface AdminCreateUserRequest {
+  email: string;
+  firstName: string;
+  lastName: string;
+  /**
+   * The new account's role. Maps directly onto user_type (the RBAC
+   * primary role grant). Required.
+   */
+  userType: UserRole;
+  /**
+   * When true, the auth.userInvited event carries the invitation token so
+   * the notifications service emails a set-password link. The account is
+   * always created pending until the invitation is redeemed regardless.
+   */
+  sendInvitation: boolean;
+}
+
+export interface AdminCreateUserResponse {
+  /**
+   * The newly created (pending) user. Carries no usable credentials until
+   * the invitation is redeemed.
+   */
+  user?: User | undefined;
+}
+
 export interface DeactivateUserRequest {
   userId: string;
   reason?: string | undefined;
@@ -6580,6 +6605,216 @@ export const AdminUpdateUserResponse: MessageFns<AdminUpdateUserResponse> = {
   },
 };
 
+function createBaseAdminCreateUserRequest(): AdminCreateUserRequest {
+  return { email: '', firstName: '', lastName: '', userType: 0, sendInvitation: false };
+}
+
+export const AdminCreateUserRequest: MessageFns<AdminCreateUserRequest> = {
+  encode(message: AdminCreateUserRequest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+    if (message.email !== '') {
+      writer.uint32(10).string(message.email);
+    }
+    if (message.firstName !== '') {
+      writer.uint32(18).string(message.firstName);
+    }
+    if (message.lastName !== '') {
+      writer.uint32(26).string(message.lastName);
+    }
+    if (message.userType !== 0) {
+      writer.uint32(32).int32(message.userType);
+    }
+    if (message.sendInvitation !== false) {
+      writer.uint32(40).bool(message.sendInvitation);
+    }
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): AdminCreateUserRequest {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseAdminCreateUserRequest();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1: {
+          if (tag !== 10) {
+            break;
+          }
+
+          message.email = reader.string();
+          continue;
+        }
+        case 2: {
+          if (tag !== 18) {
+            break;
+          }
+
+          message.firstName = reader.string();
+          continue;
+        }
+        case 3: {
+          if (tag !== 26) {
+            break;
+          }
+
+          message.lastName = reader.string();
+          continue;
+        }
+        case 4: {
+          if (tag !== 32) {
+            break;
+          }
+
+          message.userType = reader.int32() as any;
+          continue;
+        }
+        case 5: {
+          if (tag !== 40) {
+            break;
+          }
+
+          message.sendInvitation = reader.bool();
+          continue;
+        }
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): AdminCreateUserRequest {
+    return {
+      email: isSet(object.email) ? globalThis.String(object.email) : '',
+      firstName: isSet(object.firstName)
+        ? globalThis.String(object.firstName)
+        : isSet(object.first_name)
+          ? globalThis.String(object.first_name)
+          : '',
+      lastName: isSet(object.lastName)
+        ? globalThis.String(object.lastName)
+        : isSet(object.last_name)
+          ? globalThis.String(object.last_name)
+          : '',
+      userType: isSet(object.userType)
+        ? userRoleFromJSON(object.userType)
+        : isSet(object.user_type)
+          ? userRoleFromJSON(object.user_type)
+          : 0,
+      sendInvitation: isSet(object.sendInvitation)
+        ? globalThis.Boolean(object.sendInvitation)
+        : isSet(object.send_invitation)
+          ? globalThis.Boolean(object.send_invitation)
+          : false,
+    };
+  },
+
+  toJSON(message: AdminCreateUserRequest): unknown {
+    const obj: any = {};
+    if (message.email !== '') {
+      obj.email = message.email;
+    }
+    if (message.firstName !== '') {
+      obj.firstName = message.firstName;
+    }
+    if (message.lastName !== '') {
+      obj.lastName = message.lastName;
+    }
+    if (message.userType !== 0) {
+      obj.userType = userRoleToJSON(message.userType);
+    }
+    if (message.sendInvitation !== false) {
+      obj.sendInvitation = message.sendInvitation;
+    }
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<AdminCreateUserRequest>, I>>(
+    base?: I
+  ): AdminCreateUserRequest {
+    return AdminCreateUserRequest.fromPartial(base ?? ({} as any));
+  },
+  fromPartial<I extends Exact<DeepPartial<AdminCreateUserRequest>, I>>(
+    object: I
+  ): AdminCreateUserRequest {
+    const message = createBaseAdminCreateUserRequest();
+    message.email = object.email ?? '';
+    message.firstName = object.firstName ?? '';
+    message.lastName = object.lastName ?? '';
+    message.userType = object.userType ?? 0;
+    message.sendInvitation = object.sendInvitation ?? false;
+    return message;
+  },
+};
+
+function createBaseAdminCreateUserResponse(): AdminCreateUserResponse {
+  return { user: undefined };
+}
+
+export const AdminCreateUserResponse: MessageFns<AdminCreateUserResponse> = {
+  encode(
+    message: AdminCreateUserResponse,
+    writer: BinaryWriter = new BinaryWriter()
+  ): BinaryWriter {
+    if (message.user !== undefined) {
+      User.encode(message.user, writer.uint32(10).fork()).join();
+    }
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): AdminCreateUserResponse {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseAdminCreateUserResponse();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1: {
+          if (tag !== 10) {
+            break;
+          }
+
+          message.user = User.decode(reader, reader.uint32());
+          continue;
+        }
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): AdminCreateUserResponse {
+    return { user: isSet(object.user) ? User.fromJSON(object.user) : undefined };
+  },
+
+  toJSON(message: AdminCreateUserResponse): unknown {
+    const obj: any = {};
+    if (message.user !== undefined) {
+      obj.user = User.toJSON(message.user);
+    }
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<AdminCreateUserResponse>, I>>(
+    base?: I
+  ): AdminCreateUserResponse {
+    return AdminCreateUserResponse.fromPartial(base ?? ({} as any));
+  },
+  fromPartial<I extends Exact<DeepPartial<AdminCreateUserResponse>, I>>(
+    object: I
+  ): AdminCreateUserResponse {
+    const message = createBaseAdminCreateUserResponse();
+    message.user =
+      object.user !== undefined && object.user !== null ? User.fromPartial(object.user) : undefined;
+    return message;
+  },
+};
+
 function createBaseDeactivateUserRequest(): DeactivateUserRequest {
   return { userId: '', reason: undefined };
 }
@@ -11514,6 +11749,27 @@ export const AuthServiceService = {
       AdminGetUserResponse.decode(value),
   },
   /**
+   * Create a new user from the admin console as a pending, credential-less
+   * account and issue a single-use invitation token (emailed via the
+   * auth.userInvited event) the invitee redeems to set their password.
+   * Gates on admin.users.create; creating an elevated role (admin,
+   * moderator, super_admin) additionally requires the caller to be a
+   * super_admin. ALREADY_EXISTS when the email is already in use.
+   */
+  adminCreateUser: {
+    path: '/adopt_dont_shop.auth.v1.AuthService/AdminCreateUser' as const,
+    requestStream: false as const,
+    responseStream: false as const,
+    requestSerialize: (value: AdminCreateUserRequest): Buffer =>
+      Buffer.from(AdminCreateUserRequest.encode(value).finish()),
+    requestDeserialize: (value: Buffer): AdminCreateUserRequest =>
+      AdminCreateUserRequest.decode(value),
+    responseSerialize: (value: AdminCreateUserResponse): Buffer =>
+      Buffer.from(AdminCreateUserResponse.encode(value).finish()),
+    responseDeserialize: (value: Buffer): AdminCreateUserResponse =>
+      AdminCreateUserResponse.decode(value),
+  },
+  /**
    * Partially update a user's admin-controllable fields (status,
    * user_type, verification flags). admin.users.update. Only set fields
    * are written.
@@ -12020,6 +12276,15 @@ export interface AuthServiceServer extends UntypedServiceImplementation {
   searchUsers: handleUnaryCall<SearchUsersRequest, SearchUsersResponse>;
   /** Fetch a single user by id (admin view — full row). admin.users.read. */
   adminGetUser: handleUnaryCall<AdminGetUserRequest, AdminGetUserResponse>;
+  /**
+   * Create a new user from the admin console as a pending, credential-less
+   * account and issue a single-use invitation token (emailed via the
+   * auth.userInvited event) the invitee redeems to set their password.
+   * Gates on admin.users.create; creating an elevated role (admin,
+   * moderator, super_admin) additionally requires the caller to be a
+   * super_admin. ALREADY_EXISTS when the email is already in use.
+   */
+  adminCreateUser: handleUnaryCall<AdminCreateUserRequest, AdminCreateUserResponse>;
   /**
    * Partially update a user's admin-controllable fields (status,
    * user_type, verification flags). admin.users.update. Only set fields
@@ -12605,6 +12870,29 @@ export interface AuthServiceClient extends Client {
     metadata: Metadata,
     options: Partial<CallOptions>,
     callback: (error: ServiceError | null, response: AdminGetUserResponse) => void
+  ): ClientUnaryCall;
+  /**
+   * Create a new user from the admin console as a pending, credential-less
+   * account and issue a single-use invitation token (emailed via the
+   * auth.userInvited event) the invitee redeems to set their password.
+   * Gates on admin.users.create; creating an elevated role (admin,
+   * moderator, super_admin) additionally requires the caller to be a
+   * super_admin. ALREADY_EXISTS when the email is already in use.
+   */
+  adminCreateUser(
+    request: AdminCreateUserRequest,
+    callback: (error: ServiceError | null, response: AdminCreateUserResponse) => void
+  ): ClientUnaryCall;
+  adminCreateUser(
+    request: AdminCreateUserRequest,
+    metadata: Metadata,
+    callback: (error: ServiceError | null, response: AdminCreateUserResponse) => void
+  ): ClientUnaryCall;
+  adminCreateUser(
+    request: AdminCreateUserRequest,
+    metadata: Metadata,
+    options: Partial<CallOptions>,
+    callback: (error: ServiceError | null, response: AdminCreateUserResponse) => void
   ): ClientUnaryCall;
   /**
    * Partially update a user's admin-controllable fields (status,

--- a/packages/proto/src/index.ts
+++ b/packages/proto/src/index.ts
@@ -146,6 +146,8 @@ export type {
   AdminGetUserResponse,
   AdminUpdateUserRequest,
   AdminUpdateUserResponse,
+  AdminCreateUserRequest,
+  AdminCreateUserResponse,
   DeactivateUserRequest,
   DeactivateUserResponse,
   ReactivateUserRequest,

--- a/services/auth/src/grpc/admin-handlers.test.ts
+++ b/services/auth/src/grpc/admin-handlers.test.ts
@@ -7,6 +7,7 @@ import type { Permission, UserId } from '@adopt-dont-shop/lib.types';
 import { AuthV1 } from '@adopt-dont-shop/proto';
 
 import {
+  adminCreateUser,
   adminGetUser,
   adminLockAccount,
   adminResetPassword,
@@ -43,6 +44,18 @@ const ADMIN: Principal = {
 const NO_PERMS: Principal = {
   userId: 'usr-nobody' as UserId,
   roles: ['adopter'],
+  permissions: [],
+};
+
+const ADMIN_CREATOR: Principal = {
+  userId: 'svc-admin-creator' as UserId,
+  roles: ['admin'],
+  permissions: ['admin.users.create' as Permission],
+};
+
+const SUPER_ADMIN: Principal = {
+  userId: 'svc-super-admin' as UserId,
+  roles: ['super_admin'],
   permissions: [],
 };
 
@@ -904,5 +917,121 @@ describe('listUserIdsByCohort', () => {
     expect(res.total).toBe(237);
     expect(res.page).toBe(3);
     expect(res.totalPages).toBe(5);
+  });
+});
+
+// --- adminCreateUser -------------------------------------------------
+
+describe('adminCreateUser', () => {
+  let mocks: ReturnType<typeof makeMocks>;
+  beforeEach(() => {
+    mocks = makeMocks();
+  });
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  const baseReq = {
+    email: 'new@example.com',
+    firstName: 'New',
+    lastName: 'User',
+    userType: AuthV1.UserRole.USER_ROLE_ADOPTER,
+    sendInvitation: true,
+  };
+
+  it('rejects principals without admin.users.create', async () => {
+    await expect(adminCreateUser(mocks.deps, NO_PERMS, baseReq)).rejects.toMatchObject({
+      code: 'PERMISSION_DENIED',
+    });
+  });
+
+  it('rejects an invalid email', async () => {
+    await expect(
+      adminCreateUser(mocks.deps, ADMIN_CREATOR, { ...baseReq, email: 'nope' })
+    ).rejects.toMatchObject({ code: 'INVALID_ARGUMENT' });
+  });
+
+  it('rejects a missing first/last name', async () => {
+    await expect(
+      adminCreateUser(mocks.deps, ADMIN_CREATOR, { ...baseReq, firstName: '' })
+    ).rejects.toMatchObject({ code: 'INVALID_ARGUMENT' });
+  });
+
+  it('rejects an unspecified user_type', async () => {
+    await expect(
+      adminCreateUser(mocks.deps, ADMIN_CREATOR, {
+        ...baseReq,
+        userType: AuthV1.UserRole.USER_ROLE_UNSPECIFIED,
+      })
+    ).rejects.toMatchObject({ code: 'INVALID_ARGUMENT' });
+  });
+
+  it('forbids a non-super_admin from minting an elevated role', async () => {
+    await expect(
+      adminCreateUser(mocks.deps, ADMIN_CREATOR, {
+        ...baseReq,
+        userType: AuthV1.UserRole.USER_ROLE_ADMIN,
+      })
+    ).rejects.toMatchObject({ code: 'PERMISSION_DENIED' });
+    // No writes when the privilege guard blocks the create.
+    expect(mocks.clientMock.query).not.toHaveBeenCalled();
+  });
+
+  it('rejects a duplicate email with ALREADY_EXISTS', async () => {
+    mocks.poolMock.query.mockResolvedValueOnce({ rows: [{ exists: 1 }] });
+    await expect(adminCreateUser(mocks.deps, ADMIN_CREATOR, baseReq)).rejects.toMatchObject({
+      code: 'ALREADY_EXISTS',
+    });
+    expect(mocks.clientMock.query).not.toHaveBeenCalled();
+  });
+
+  it('creates a pending user + invitation and emits auth.userInvited with the token', async () => {
+    mocks.poolMock.query.mockResolvedValueOnce({ rows: [] }); // no existing email
+    mocks.clientScript.push({
+      rows: [
+        userRow({ user_id: 'usr-new', email: 'new@example.com', status: 'pending_verification' }),
+      ],
+    }); // INSERT auth.users
+    mocks.clientScript.push({ rows: [] }); // INSERT auth.user_invitations
+
+    const res = await adminCreateUser(mocks.deps, ADMIN_CREATOR, baseReq);
+
+    expect(res.user?.userId).toBe('usr-new');
+    const sqls = (mocks.clientMock.query.mock.calls as Array<[string]>).map(([s]) => s);
+    expect(sqls.some(s => s.includes('INSERT INTO auth.users'))).toBe(true);
+    expect(sqls.some(s => s.includes('INSERT INTO auth.user_invitations'))).toBe(true);
+
+    expect(mocks.natsMock.publish.mock.calls[0][0]).toBe('auth.userInvited');
+    const envelope = JSON.parse(
+      new TextDecoder().decode(mocks.natsMock.publish.mock.calls[0][1] as Uint8Array)
+    );
+    expect(envelope.payload).toMatchObject({ userId: 'usr-new', role: 'adopter' });
+    expect(typeof envelope.payload.token).toBe('string');
+    expect(envelope.payload.token.length).toBeGreaterThan(0);
+  });
+
+  it('omits the token when send_invitation is false', async () => {
+    mocks.poolMock.query.mockResolvedValueOnce({ rows: [] });
+    mocks.clientScript.push({ rows: [userRow({ user_id: 'usr-new' })] });
+    mocks.clientScript.push({ rows: [] });
+
+    await adminCreateUser(mocks.deps, ADMIN_CREATOR, { ...baseReq, sendInvitation: false });
+
+    const envelope = JSON.parse(
+      new TextDecoder().decode(mocks.natsMock.publish.mock.calls[0][1] as Uint8Array)
+    );
+    expect(envelope.payload.token).toBeUndefined();
+  });
+
+  it('allows a super_admin to mint an elevated role', async () => {
+    mocks.poolMock.query.mockResolvedValueOnce({ rows: [] });
+    mocks.clientScript.push({ rows: [userRow({ user_id: 'usr-mod', user_type: 'moderator' })] });
+    mocks.clientScript.push({ rows: [] });
+
+    const res = await adminCreateUser(mocks.deps, SUPER_ADMIN, {
+      ...baseReq,
+      userType: AuthV1.UserRole.USER_ROLE_MODERATOR,
+    });
+    expect(res.user?.userId).toBe('usr-mod');
   });
 });

--- a/services/auth/src/grpc/admin-handlers.ts
+++ b/services/auth/src/grpc/admin-handlers.ts
@@ -7,7 +7,7 @@
 // Reuses rowToProtoUser + UserRow + the enum maps from handlers.ts so
 // the admin view returns the same User shape GetMe does.
 
-import { randomBytes, randomUUID } from 'node:crypto';
+import { createHash, randomBytes, randomUUID } from 'node:crypto';
 
 import { hasPermission, type Principal } from '@adopt-dont-shop/authz';
 import { withTransaction } from '@adopt-dont-shop/events';
@@ -15,6 +15,8 @@ import type { Permission } from '@adopt-dont-shop/lib.types';
 
 import {
   AuthV1,
+  type AdminCreateUserRequest,
+  type AdminCreateUserResponse,
   type AdminGetUserRequest,
   type AdminGetUserResponse,
   type AdminLockAccountRequest,
@@ -62,6 +64,7 @@ import {
 const ADMIN_USERS_SEARCH: Permission = 'admin.users.search' as Permission;
 const ADMIN_USERS_READ: Permission = 'admin.users.read' as Permission;
 const ADMIN_USERS_UPDATE: Permission = 'admin.users.update' as Permission;
+const ADMIN_USERS_CREATE: Permission = 'admin.users.create' as Permission;
 const ADMIN_USERS_DEACTIVATE: Permission = 'admin.users.deactivate' as Permission;
 const ADMIN_USERS_REACTIVATE: Permission = 'admin.users.reactivate' as Permission;
 const ADMIN_USERS_BULK_UPDATE: Permission = 'admin.users.bulk_update' as Permission;
@@ -202,6 +205,116 @@ export async function adminGetUser(
     throw new HandlerError('NOT_FOUND', `user ${req.userId} not found`);
   }
   return { user: rowToProtoUser(res.rows[0]) };
+}
+
+// --- AdminCreateUser -------------------------------------------------
+
+// user_type values an ordinary admin may NOT mint — only a super_admin
+// can create another elevated account (privilege-escalation guard).
+const ELEVATED_ROLES: ReadonlySet<string> = new Set(['admin', 'moderator', 'super_admin']);
+
+// Invitation tokens are short-lived; the invitee must redeem within a week.
+const INVITATION_TTL_MS = 7 * 24 * 60 * 60 * 1000;
+
+export async function adminCreateUser(
+  deps: HandlerDeps,
+  principal: Principal,
+  req: AdminCreateUserRequest
+): Promise<AdminCreateUserResponse> {
+  if (!req.email || !req.email.includes('@') || req.email.length > 255) {
+    throw new HandlerError('INVALID_ARGUMENT', 'email is invalid');
+  }
+  if (!req.firstName || !req.lastName) {
+    throw new HandlerError('INVALID_ARGUMENT', 'first_name and last_name are required');
+  }
+  if (req.userType === AuthV1.UserRole.USER_ROLE_UNSPECIFIED) {
+    throw new HandlerError('INVALID_ARGUMENT', 'user_type is required');
+  }
+  if (!hasPermission(principal, ADMIN_USERS_CREATE)) {
+    throw new HandlerError('PERMISSION_DENIED', `'${ADMIN_USERS_CREATE}' required`);
+  }
+
+  const userType = roleToDb(req.userType);
+  // hasPermission already short-circuits true for super_admin, so this
+  // guard only ever bites a lower-privileged admin trying to mint an
+  // elevated account.
+  if (ELEVATED_ROLES.has(userType) && !principal.roles.includes('super_admin')) {
+    throw new HandlerError(
+      'PERMISSION_DENIED',
+      'only a super_admin may create admin, moderator, or super_admin accounts'
+    );
+  }
+
+  // Reject a duplicate up front for a clean error; the unique constraint on
+  // email is still the source of truth against a race.
+  const existing = await deps.pool.query(
+    `SELECT 1 FROM auth.users WHERE email = $1 AND deleted_at IS NULL LIMIT 1`,
+    [req.email]
+  );
+  if (existing.rows.length > 0) {
+    throw new HandlerError('ALREADY_EXISTS', `a user with email ${req.email} already exists`);
+  }
+
+  // Pending users carry no usable credential until they redeem the invite;
+  // seed the NOT NULL password column with a random, unguessable hash.
+  const placeholderPassword = await deps.passwordHasher.hash(randomBytes(32).toString('base64url'));
+  const token = randomBytes(32).toString('base64url');
+  const tokenHash = createHash('sha256').update(token).digest('hex');
+  const expiresAt = new Date(Date.now() + INVITATION_TTL_MS);
+
+  let createdUser: UserRow | undefined;
+  await withTransaction(deps, async ({ client, publish }) => {
+    const userRes = await client.query<UserRow>(
+      `
+      INSERT INTO auth.users (
+        user_id, email, password, first_name, last_name,
+        status, user_type, email_verified, phone_verified,
+        two_factor_enabled, login_attempts, created_at, updated_at
+      )
+      VALUES (
+        gen_random_uuid(), $1, $2, $3, $4,
+        'pending_verification', $5, false, false,
+        false, 0, now(), now()
+      )
+      RETURNING ${USER_SELECT}
+      `,
+      [req.email, placeholderPassword, req.firstName, req.lastName, userType]
+    );
+    createdUser = userRes.rows[0];
+
+    await client.query(
+      `
+      INSERT INTO auth.user_invitations (
+        invitation_id, user_id, token_hash, status, invited_by,
+        expires_at, created_at, updated_at
+      )
+      VALUES (gen_random_uuid(), $1, $2, 'pending', $3, $4, now(), now())
+      `,
+      [createdUser.user_id, tokenHash, principal.userId, expiresAt]
+    );
+
+    publish({
+      type: 'auth.userInvited',
+      id: `auth.userInvited.${createdUser.user_id}`,
+      payload: {
+        userId: createdUser.user_id,
+        email: createdUser.email,
+        firstName: createdUser.first_name,
+        role: userType,
+        invitedBy: principal.userId,
+        // The raw token travels ONLY on this internal event so the
+        // notifications service can build the set-password link. Omitted
+        // when the admin opted out of the invitation email.
+        token: req.sendInvitation ? token : undefined,
+        sendInvitation: req.sendInvitation,
+      },
+    });
+  });
+
+  if (!createdUser) {
+    throw new HandlerError('INTERNAL', 'insert returned no rows');
+  }
+  return { user: rowToProtoUser(createdUser) };
 }
 
 // --- AdminUpdateUser -------------------------------------------------

--- a/services/auth/src/grpc/server.ts
+++ b/services/auth/src/grpc/server.ts
@@ -38,6 +38,7 @@ import {
   type HandlerDeps,
 } from './handlers.js';
 import {
+  adminCreateUser,
   adminGetUser,
   adminLockAccount,
   adminResetPassword,
@@ -127,6 +128,7 @@ export const createGrpcServer = (opts: CreateGrpcServerOptions): Server => {
     // Admin user management — /api/v1/users/* admin surface.
     searchUsers: adapt(searchUsers, { deps, logger }),
     adminGetUser: adapt(adminGetUser, { deps, logger }),
+    adminCreateUser: adapt(adminCreateUser, { deps, logger }),
     adminUpdateUser: adapt(adminUpdateUser, { deps, logger }),
     deactivateUser: adapt(deactivateUser, { deps, logger }),
     reactivateUser: adapt(reactivateUser, { deps, logger }),
@@ -180,6 +182,7 @@ export const createGrpcServer = (opts: CreateGrpcServerOptions): Server => {
       'resetPrivacyPreferences',
       'searchUsers',
       'adminGetUser',
+      'adminCreateUser',
       'adminUpdateUser',
       'deactivateUser',
       'reactivateUser',

--- a/services/auth/src/migrations/020_create_user_invitations.ts
+++ b/services/auth/src/migrations/020_create_user_invitations.ts
@@ -1,0 +1,39 @@
+import type { MigrationBuilder } from 'node-pg-migrate';
+
+// Invitation tokens for admin-created users. AdminCreateUser inserts a
+// pending, credential-less auth.users row and one row here carrying a
+// single-use token (stored as a SHA-256 hex digest, never the raw value).
+// The invitee redeems the token to set their password and activate the
+// account. `expires_at` bounds the token's lifetime; a redeemed or revoked
+// invitation is marked via `status` rather than deleted, so the audit
+// trail of who was invited (and by whom) survives.
+
+export const up = async (pgm: MigrationBuilder): Promise<void> => {
+  pgm.createType('user_invitation_status', ['pending', 'accepted', 'revoked']);
+
+  pgm.createTable('user_invitations', {
+    invitation_id: { type: 'uuid', primaryKey: true, default: pgm.func('gen_random_uuid()') },
+    user_id: {
+      type: 'uuid',
+      notNull: true,
+      references: 'users(user_id)',
+      onDelete: 'CASCADE',
+    },
+    // SHA-256 hex digest of the single-use token (64 chars). The raw token
+    // only ever lives in the auth.userInvited event payload + the email.
+    token_hash: { type: 'varchar(64)', notNull: true, unique: true },
+    status: { type: 'user_invitation_status', notNull: true, default: 'pending' },
+    invited_by: { type: 'uuid' },
+    expires_at: { type: 'timestamptz', notNull: true },
+    accepted_at: { type: 'timestamptz' },
+    created_at: { type: 'timestamptz', notNull: true, default: pgm.func('now()') },
+    updated_at: { type: 'timestamptz', notNull: true, default: pgm.func('now()') },
+  });
+
+  pgm.createIndex('user_invitations', 'user_id', { name: 'user_invitations_user_id_idx' });
+};
+
+export const down = async (pgm: MigrationBuilder): Promise<void> => {
+  pgm.dropTable('user_invitations');
+  pgm.dropType('user_invitation_status');
+};

--- a/services/gateway/src/grpc-clients/auth-client.ts
+++ b/services/gateway/src/grpc-clients/auth-client.ts
@@ -75,6 +75,8 @@ import {
   type ResetPrivacyPreferencesResponse,
   type SearchUsersRequest,
   type SearchUsersResponse,
+  type AdminCreateUserRequest,
+  type AdminCreateUserResponse,
   type AdminGetUserRequest,
   type AdminGetUserResponse,
   type AdminUpdateUserRequest,
@@ -180,6 +182,10 @@ export type AuthClient = {
   ): Promise<ResetPrivacyPreferencesResponse>;
   searchUsers(req: SearchUsersRequest, metadata: Metadata): Promise<SearchUsersResponse>;
   adminGetUser(req: AdminGetUserRequest, metadata: Metadata): Promise<AdminGetUserResponse>;
+  adminCreateUser(
+    req: AdminCreateUserRequest,
+    metadata: Metadata
+  ): Promise<AdminCreateUserResponse>;
   adminUpdateUser(
     req: AdminUpdateUserRequest,
     metadata: Metadata
@@ -322,6 +328,7 @@ export const createAuthClient = (opts: CreateAuthClientOptions): AuthClient => {
       callUnary(stub.resetPrivacyPreferences, req, metadata, false),
     assignRole: (req, metadata) => callUnary(stub.assignRole, req, metadata, false),
     adminUpdateUser: (req, metadata) => callUnary(stub.adminUpdateUser, req, metadata, false),
+    adminCreateUser: (req, metadata) => callUnary(stub.adminCreateUser, req, metadata, false),
     deactivateUser: (req, metadata) => callUnary(stub.deactivateUser, req, metadata, false),
     reactivateUser: (req, metadata) => callUnary(stub.reactivateUser, req, metadata, false),
     bulkUpdateUsers: (req, metadata) => callUnary(stub.bulkUpdateUsers, req, metadata, false),

--- a/services/gateway/src/routes/users.test.ts
+++ b/services/gateway/src/routes/users.test.ts
@@ -69,6 +69,7 @@ function makeAuthClient(): AuthClient & {
   resetPrivacyPreferencesMock: ReturnType<typeof vi.fn>;
   searchUsersMock: ReturnType<typeof vi.fn>;
   adminGetUserMock: ReturnType<typeof vi.fn>;
+  adminCreateUserMock: ReturnType<typeof vi.fn>;
   adminUpdateUserMock: ReturnType<typeof vi.fn>;
   deactivateUserMock: ReturnType<typeof vi.fn>;
   reactivateUserMock: ReturnType<typeof vi.fn>;
@@ -84,6 +85,7 @@ function makeAuthClient(): AuthClient & {
   const resetPrivacyPreferencesMock = vi.fn();
   const searchUsersMock = vi.fn();
   const adminGetUserMock = vi.fn();
+  const adminCreateUserMock = vi.fn();
   const adminUpdateUserMock = vi.fn();
   const deactivateUserMock = vi.fn();
   const reactivateUserMock = vi.fn();
@@ -99,6 +101,7 @@ function makeAuthClient(): AuthClient & {
     resetPrivacyPreferences: resetPrivacyPreferencesMock,
     searchUsers: searchUsersMock,
     adminGetUser: adminGetUserMock,
+    adminCreateUser: adminCreateUserMock,
     adminUpdateUser: adminUpdateUserMock,
     deactivateUser: deactivateUserMock,
     reactivateUser: reactivateUserMock,
@@ -127,6 +130,7 @@ function makeAuthClient(): AuthClient & {
     resetPrivacyPreferencesMock,
     searchUsersMock,
     adminGetUserMock,
+    adminCreateUserMock,
     adminUpdateUserMock,
     deactivateUserMock,
     reactivateUserMock,
@@ -628,6 +632,129 @@ describe('/api/v1/admin/users surface', () => {
     expect(res.statusCode).toBe(400);
     expect(auth.adminUpdateUserMock).not.toHaveBeenCalled();
     expect(auth.reactivateUserMock).not.toHaveBeenCalled();
+  });
+
+  it('POST creates a user, mapping role → userType and 201ing the new user', async () => {
+    auth.adminCreateUserMock.mockResolvedValueOnce({ user: ADMIN_USER_FIXTURE });
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/v1/admin/users',
+      headers: {
+        'x-user-id': 'svc-admin',
+        'x-user-roles': 'admin',
+        'content-type': 'application/json',
+      },
+      payload: JSON.stringify({
+        email: 'new@example.com',
+        first_name: 'New',
+        last_name: 'User',
+        role: 'adopter',
+        send_invitation: true,
+      }),
+    });
+    expect(res.statusCode).toBe(201);
+    const [grpcReq] = auth.adminCreateUserMock.mock.calls[0] as [
+      {
+        email: string;
+        firstName: string;
+        lastName: string;
+        userType: AuthV1.UserRole;
+        sendInvitation: boolean;
+      },
+      Metadata,
+    ];
+    expect(grpcReq).toMatchObject({
+      email: 'new@example.com',
+      firstName: 'New',
+      lastName: 'User',
+      userType: AuthV1.UserRole.USER_ROLE_ADOPTER,
+      sendInvitation: true,
+    });
+    const body = res.json() as { success: boolean; data: { userId: string } };
+    expect(body.success).toBe(true);
+    expect(body.data.userId).toBe('usr-9');
+  });
+
+  it('POST defaults send_invitation to true when omitted', async () => {
+    auth.adminCreateUserMock.mockResolvedValueOnce({ user: ADMIN_USER_FIXTURE });
+    await app.inject({
+      method: 'POST',
+      url: '/api/v1/admin/users',
+      headers: {
+        'x-user-id': 'svc-admin',
+        'x-user-roles': 'admin',
+        'content-type': 'application/json',
+      },
+      payload: JSON.stringify({
+        email: 'new@example.com',
+        first_name: 'New',
+        last_name: 'User',
+        role: 'moderator',
+      }),
+    });
+    const [grpcReq] = auth.adminCreateUserMock.mock.calls[0] as [
+      { sendInvitation: boolean },
+      Metadata,
+    ];
+    expect(grpcReq.sendInvitation).toBe(true);
+  });
+
+  it('POST with a missing email → 400 without calling the RPC', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/v1/admin/users',
+      headers: {
+        'x-user-id': 'svc-admin',
+        'x-user-roles': 'admin',
+        'content-type': 'application/json',
+      },
+      payload: JSON.stringify({ first_name: 'New', last_name: 'User', role: 'adopter' }),
+    });
+    expect(res.statusCode).toBe(400);
+    expect(auth.adminCreateUserMock).not.toHaveBeenCalled();
+  });
+
+  it('POST with an invalid role → 400 without calling the RPC', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/v1/admin/users',
+      headers: {
+        'x-user-id': 'svc-admin',
+        'x-user-roles': 'admin',
+        'content-type': 'application/json',
+      },
+      payload: JSON.stringify({
+        email: 'new@example.com',
+        first_name: 'New',
+        last_name: 'User',
+        role: 'wizard',
+      }),
+    });
+    expect(res.statusCode).toBe(400);
+    expect(auth.adminCreateUserMock).not.toHaveBeenCalled();
+  });
+
+  it('POST surfaces a gRPC PERMISSION_DENIED as 403', async () => {
+    auth.adminCreateUserMock.mockRejectedValueOnce({
+      code: status.PERMISSION_DENIED,
+      details: 'no',
+    });
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/v1/admin/users',
+      headers: {
+        'x-user-id': 'svc-admin',
+        'x-user-roles': 'admin',
+        'content-type': 'application/json',
+      },
+      payload: JSON.stringify({
+        email: 'boss@example.com',
+        first_name: 'Boss',
+        last_name: 'Person',
+        role: 'super_admin',
+      }),
+    });
+    expect(res.statusCode).toBe(403);
   });
 });
 

--- a/services/gateway/src/routes/users.ts
+++ b/services/gateway/src/routes/users.ts
@@ -509,6 +509,60 @@ export const registerUsersRoutes = async (
     }
   );
 
+  // POST /api/v1/admin/users — create a user from the admin console. The
+  // account is created pending + credential-less; service.auth issues a
+  // single-use invitation token (emailed when send_invitation is set) the
+  // invitee redeems to set their password. Elevated roles require a
+  // super_admin caller (enforced in service.auth).
+  app.post(
+    '/api/v1/admin/users',
+    {
+      schema: {
+        tags: ['users'],
+        summary: 'Create a user (admin)',
+      },
+    },
+    async (req, reply) => {
+      const body = (req.body ?? {}) as {
+        email?: string;
+        first_name?: string;
+        firstName?: string;
+        last_name?: string;
+        lastName?: string;
+        role?: string;
+        user_type?: string;
+        userType?: string;
+        send_invitation?: boolean;
+        sendInvitation?: boolean;
+      };
+      const email = typeof body.email === 'string' ? body.email : '';
+      const firstName = body.firstName ?? body.first_name ?? '';
+      const lastName = body.lastName ?? body.last_name ?? '';
+      const userType = userTypeFilterFromString(body.role ?? body.userType ?? body.user_type);
+      if (!email) {
+        return reply.code(400).send({ success: false, error: 'email is required' });
+      }
+      if (!firstName || !lastName) {
+        return reply
+          .code(400)
+          .send({ success: false, error: 'first_name and last_name are required' });
+      }
+      if (userType === AuthV1.UserRole.USER_ROLE_UNSPECIFIED) {
+        return reply.code(400).send({ success: false, error: 'a valid role is required' });
+      }
+      const sendInvitation = body.sendInvitation ?? body.send_invitation ?? true;
+      try {
+        const res = await authClient.adminCreateUser(
+          { email, firstName, lastName, userType, sendInvitation },
+          buildMetadata(req)
+        );
+        return reply.code(201).send({ success: true, data: userToApiJson(res.user!) });
+      } catch (err) {
+        return handleGrpcError(err, reply);
+      }
+    }
+  );
+
   // GET /api/v1/admin/users/:userId — single user detail.
   app.get<{ Params: { userId: string } }>(
     '/api/v1/admin/users/:userId',


### PR DESCRIPTION
## Summary

Closes a real end-to-end gap: the admin **Users** page's "Add User" modal (`AddUserModal` → `useCreateUser` → `userManagementService.createUser`) posts to `POST /api/v1/admin/users`, but **neither the gateway nor `service.auth` implemented it** — every create silently 404'd. `service.auth` already had the entire admin user surface (search/get/update/deactivate/reactivate/reset-password/lock/statistics/bulk) — *except* create.

This is the **first of two slices** for the full invitation-token flow (chosen over a temp-password shortcut). It covers **creation + invitation issuance**; redemption (set-password-via-token) + the notifications email template are the follow-up.

## What it does

- **New `AdminCreateUser` RPC** (`service.auth`):
  - Creates a **pending, credential-less** `auth.users` row with the chosen role mapped onto `user_type` (the RBAC primary grant — the 6 `user_type` values exactly match the modal's roles, so no `user_roles` insert is needed).
  - Issues a **single-use, SHA-256-hashed invitation token** in a new `auth.user_invitations` table (raw token never persisted).
  - Emits a new `auth.userInvited` event carrying the raw token so the notifications service can email a set-password link (omitted when `send_invitation` is false).
  - **Role safety:** minting an elevated role (`admin`/`moderator`/`super_admin`) requires a `super_admin` caller; everything else gates on `admin.users.create`.
  - Rejects duplicate emails with `ALREADY_EXISTS`.
- **New migration** `020_create_user_invitations.ts` (table + status enum + FK to `auth.users`).
- **Gateway** `POST /api/v1/admin/users` — maps the modal's `{email, first_name, last_name, role, send_invitation}` onto the RPC, validates email/names/role, returns `201 { success, data: <pending user> }`.

## Notes / scope

- The created user is `pending_verification` and cannot log in until the invitation is redeemed — that **redemption RPC + gateway route + the notifications email template/consumer for `auth.userInvited` are the follow-up slice**. This PR lands the durable backend state + event.
- The modal's `is_active` toggle is intentionally not wired — an invited account has no credential to be "active" with until it's redeemed.
- Gated on `admin.users.create` to stay consistent with the sibling `admin.users.*` handlers in the same file (the broader `admin.users.*`-vs-`users.*` permission-naming question is pre-existing and uniform across that surface — out of scope here).

## Verification

- `packages/proto` type-checks ✅
- `service.auth` — 295/295 tests (9 new for `adminCreateUser`), type-check ✅
- `service.gateway` — 842/842 tests (5 new for the route), type-check ✅
- Generated `auth.ts` is a clean `+288` vs `main` (no codegen churn).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EgwcaPwDJBjJJr68hnjeMX)_