### PR TITLE
fix(redis): move dev/staging redis password to file-mounted secret (ADS-878)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -583,7 +583,10 @@ jobs:
             # password plus the non-rotating identifiers already in the host
             # .env (POSTGRES_USER / POSTGRES_DB, and the REDIS_PASSWORD the redis
             # container itself authenticates with) so the URLs always match what
-            # the database/redis containers use.
+            # the database/redis containers use. redis_password is the same
+            # value, written separately because the redis container reads its
+            # own --requirepass from this file rather than from `environment:`
+            # (ADS-878).
             read_env() {  # read a key from the host .env, quotes stripped; fails if absent
               local v
               v="$(grep -E "^$1=" .env | head -n1 | cut -d= -f2-)" || true
@@ -598,6 +601,7 @@ jobs:
             chmod 700 secrets
             printf '%s' "postgresql://${PG_USER}:${SECRET_DB_PASSWORD}@database:5432/${PG_DB}" > secrets/database_url
             printf '%s' "redis://:${REDIS_PW}@redis:6379"      > secrets/redis_url
+            printf '%s' "$REDIS_PW"                             > secrets/redis_password
             printf '%s' "$SECRET_JWT_SECRET"                    > secrets/jwt_secret
             printf '%s' "$SECRET_JWT_REFRESH_SECRET"            > secrets/jwt_refresh_secret
             printf '%s' "$SECRET_UPLOAD_SIGNING_SECRET"         > secrets/upload_signing_secret

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -111,14 +111,16 @@ services:
     ports: []
     volumes:
       - redis_data:/data
-    command: "redis-server --appendonly yes --requirepass ${REDIS_PASSWORD:?Error: REDIS_PASSWORD required}"
-    # REDIS_PASSWORD must be in the container env (not just interpolated into
-    # `command`) so the healthcheck's `redis-cli -a "$$REDIS_PASSWORD"` can
-    # authenticate — without it the check gets NOAUTH and never goes healthy.
-    environment:
-      REDIS_PASSWORD: ${REDIS_PASSWORD}
+    secrets:
+      - redis_password
+    # ADS-878: the password is read from the file-mounted secret at container
+    # start rather than interpolated into `environment:`, which `docker
+    # inspect` can read back in plaintext. The deploy workflow materialises
+    # ./secrets/redis_password from the host .env's REDIS_PASSWORD.
+    command: >
+      sh -c 'redis-server --appendonly yes --requirepass "$$(cat /run/secrets/redis_password)"'
     healthcheck:
-      test: ['CMD-SHELL', 'redis-cli -a "$$REDIS_PASSWORD" ping | grep -q PONG']
+      test: ['CMD-SHELL', 'redis-cli -a "$$(cat /run/secrets/redis_password)" ping | grep -q PONG']
       interval: 10s
       timeout: 5s
       retries: 5
@@ -478,6 +480,8 @@ secrets:
     file: ./secrets/database_url
   redis_url:
     file: ./secrets/redis_url
+  redis_password:
+    file: ./secrets/redis_password
   jwt_secret:
     file: ./secrets/jwt_secret
   jwt_refresh_secret:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -93,15 +93,16 @@ services:
       - '127.0.0.1:6379:6379'
     volumes:
       - redis_data:/data
-    command: "redis-server --appendonly yes --requirepass ${REDIS_PASSWORD:?Error: REDIS_PASSWORD required (run `pnpm secrets:generate` or copy .env.example)}"
-    # REDIS_PASSWORD must be in the container env (not just interpolated into
-    # `command`) so the healthcheck's `redis-cli -a "$$REDIS_PASSWORD"` can
-    # authenticate — otherwise it gets NOAUTH, never reports healthy, and
-    # dependents gated on `service_healthy` fail to start.
-    environment:
-      REDIS_PASSWORD: ${REDIS_PASSWORD}
+    secrets:
+      - redis_password
+    # ADS-878: the password is read from the file-mounted secret at container
+    # start rather than interpolated into `environment:`, which `docker
+    # inspect` can read back in plaintext. `pnpm docker:dev` materialises
+    # ./secrets/redis_password from .env's REDIS_PASSWORD before `up`.
+    command: >
+      sh -c 'redis-server --appendonly yes --requirepass "$$(cat /run/secrets/redis_password)"'
     healthcheck:
-      test: ['CMD-SHELL', 'redis-cli -a "$$REDIS_PASSWORD" ping | grep -q PONG']
+      test: ['CMD-SHELL', 'redis-cli -a "$$(cat /run/secrets/redis_password)" ping | grep -q PONG']
       interval: 10s
       timeout: 5s
       retries: 5
@@ -625,3 +626,13 @@ volumes:
 networks:
   default:
     name: adopt-dont-shop-network
+
+# ============================================================================
+# DOCKER SECRETS (ADS-878)
+# ============================================================================
+# File-mounted at /run/secrets/<name>, invisible to `docker inspect`.
+# `pnpm docker:dev` materialises ./secrets/redis_password from .env's
+# REDIS_PASSWORD before bringing the stack up (see scripts/docker-dev.mjs).
+secrets:
+  redis_password:
+    file: ./secrets/redis_password

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "prepare": "husky || true",
     "dev": "turbo run dev --parallel",
     "dev:apps": "turbo run dev --filter='@adopt-dont-shop/app.*' --parallel",
-    "dev:services": "docker compose up -d database redis",
+    "dev:services": "node scripts/write-redis-secret.mjs && docker compose up -d database redis",
     "docker:dev": "node scripts/docker-dev.mjs",
     "docker:dev:detach": "node scripts/docker-dev.mjs --detach",
     "docker:dev:build": "node scripts/docker-dev.mjs --build",

--- a/scripts/docker-dev.mjs
+++ b/scripts/docker-dev.mjs
@@ -32,6 +32,7 @@ import { fileURLToPath } from 'url';
 import { createInterface } from 'readline';
 import { platform } from 'os';
 import { createHash } from 'crypto';
+import { writeRedisPasswordSecret } from './write-redis-secret.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROOT = join(__dirname, '..');
@@ -324,6 +325,9 @@ function up() {
   log('');
   checkDocker();
   checkEnv();
+  step('Writing secrets/redis_password from .env');
+  writeRedisPasswordSecret();
+  ok('secrets/redis_password written');
   checkRedisPort();
   const rebuild = needsImageRebuild();
   if (BUILD) {

--- a/scripts/write-redis-secret.mjs
+++ b/scripts/write-redis-secret.mjs
@@ -1,0 +1,40 @@
+#!/usr/bin/env node
+// Materialises ./secrets/redis_password from .env's REDIS_PASSWORD.
+//
+// The `redis` service in docker-compose.yml reads its --requirepass value
+// from this file-mounted secret instead of `environment:` (ADS-878), so it
+// must exist before `docker compose up redis` runs. Shared by
+// `pnpm docker:dev` (via docker-dev.mjs's fuller preflight) and
+// `pnpm dev:services`, which calls `docker compose up -d database redis`
+// directly and so needs this step run first.
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+
+export function writeRedisPasswordSecret() {
+  const envPath = join(ROOT, '.env');
+  if (!existsSync(envPath)) {
+    throw new Error('.env not found. Run `pnpm setup` (or copy .env.example) first.');
+  }
+  const contents = readFileSync(envPath, 'utf8');
+  const password = (contents.match(/^REDIS_PASSWORD=(.*)$/m) || [])[1]?.trim();
+  if (!password) {
+    throw new Error('.env missing a value for REDIS_PASSWORD. Run `pnpm secrets:generate`.');
+  }
+  const secretsDir = join(ROOT, 'secrets');
+  if (!existsSync(secretsDir)) mkdirSync(secretsDir);
+  writeFileSync(join(secretsDir, 'redis_password'), password);
+  return password;
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  try {
+    writeRedisPasswordSecret();
+    console.log('secrets/redis_password written');
+  } catch (err) {
+    console.error(err.message);
+    process.exit(1);
+  }
+}

--- a/secrets/README.md
+++ b/secrets/README.md
@@ -21,14 +21,21 @@ before `docker compose up -d`; the deploy workflow
 | `upload_signing_secret`       | `service-gateway`               | HMAC secret for `/uploads-signed` URLs                         |
 | `principal_signing_key`       | `service-gateway` + every domain service | HMAC key for the signed `x-principal-token` gRPC metadata (ADS-800) |
 | `db_password`                 | `database` container (staging + production) | Postgres superuser password (read via `POSTGRES_PASSWORD_FILE`) |
+| `redis_password`              | `redis` container (staging + dev) | Same value as in `redis_url`; the redis container reads it directly (`cat /run/secrets/redis_password`) for its own `--requirepass` instead of via `environment:` (ADS-878) |
 
 Each file must contain only the secret value (trailing whitespace is
 trimmed by the loader). No quoting, no `KEY=value` framing — just the value.
 
 ## Dev / escape hatch
 
-The dev compose (`docker-compose.yml`) does **not** use these files; it relies
-on plaintext env interpolation from `.env`. The loader also accepts plaintext
-env vars (`NAME=…`) when the `*_FILE` form is absent, so an operator who
-can't mount files for some reason can still boot the stack by setting the raw
-env vars.
+The dev compose (`docker-compose.yml`) does **not** use these files for the
+domain services; they still rely on plaintext env interpolation from `.env`.
+The loader also accepts plaintext env vars (`NAME=…`) when the `*_FILE` form
+is absent, so an operator who can't mount files for some reason can still
+boot the stack by setting the raw env vars.
+
+The one exception is `redis_password` (ADS-878): the `redis` container itself
+reads its `--requirepass` value from this file in dev too, so that its
+credential never shows up in `docker inspect`. `pnpm docker:dev` materialises
+`./secrets/redis_password` from `.env`'s `REDIS_PASSWORD` automatically — no
+manual step needed.


### PR DESCRIPTION
## Summary

ADS-878: the `redis` service in `docker-compose.yml` (dev) and `docker-compose.staging.yml` read `REDIS_PASSWORD` via `environment:`, so `docker inspect redis` could read the credential back in plaintext. This is the first concrete step on that ticket — fixing the `redis` server container's own credential. Migrating consumers (`REDIS_URL`/`REDIS_URL_FILE` for `service-gateway` etc.) is left as a follow-up.

- `redis` in both compose files now mounts a `redis_password` Docker secret and reads it via `cat /run/secrets/redis_password` for `--requirepass` and the healthcheck, instead of `environment:`.
- Dev still configures the value through `.env`; both entry points that bring Redis up (`pnpm docker:dev` and `pnpm dev:services`) materialise `./secrets/redis_password` from it first, via a new shared `scripts/write-redis-secret.mjs`.
- The deploy workflow (`.github/workflows/deploy.yml`) writes the same file from the host `.env` for staging.
- `secrets/README.md` updated to document the new file and the dev exception.

`docker-compose.prod.yml` is intentionally untouched — out of scope per the ticket title (dev/staging only); prod's redis still has the same plaintext issue and should be a separate follow-up.

## Test plan

- [x] `docker compose -f docker-compose.yml config --quiet` passes with a dummy `.env` + secret file present
- [x] `docker compose -f docker-compose.staging.yml config --quiet` passes (redis-specific interpolation validated; unrelated missing env vars in that file are pre-existing and out of scope)
- [x] `node scripts/write-redis-secret.mjs` functionally verified against a temp `.env` — writes `secrets/redis_password` with the trimmed value
- [x] `node --check` on both `.mjs` files
- [x] YAML validated with `yaml.safe_load` for `docker-compose.staging.yml` and `deploy.yml`
- [ ] Manual `pnpm docker:dev` / `pnpm dev:services` smoke test on a machine with Docker (not available in this sandbox)
- [ ] Staging deploy dry run to confirm `docker inspect redis` shows no plaintext password

https://claude.ai/code/session_01QBjxYoXqUzfA56az8uQ8XJ


---
_Generated by [Claude Code](https://claude.ai/code/session_01QBjxYoXqUzfA56az8uQ8XJ)_