### PR TITLE
feat: back application drafts autosave + fix defaults envelope

### DIFF
--- a/apps/client/src/services/applicationProfileService.test.ts
+++ b/apps/client/src/services/applicationProfileService.test.ts
@@ -30,9 +30,9 @@ beforeEach(() => {
 });
 
 describe('getApplicationDefaults', () => {
-  it('returns the defaults from the backend', async () => {
+  it('unwraps the { data } envelope the gateway returns', async () => {
     const defaults = { personalInfo: { firstName: 'Ada' } };
-    apiGet.mockResolvedValue(defaults);
+    apiGet.mockResolvedValue({ data: defaults });
 
     const result = await applicationProfileService.getApplicationDefaults();
 
@@ -48,9 +48,9 @@ describe('getApplicationDefaults', () => {
 });
 
 describe('updateApplicationDefaults', () => {
-  it('PUTs the wrapped defaults payload and returns the response', async () => {
+  it('PUTs the wrapped defaults payload and unwraps the { data } response', async () => {
     const updated = { personalInfo: { firstName: 'Grace' } };
-    apiPut.mockResolvedValue(updated);
+    apiPut.mockResolvedValue({ data: updated });
 
     const result = await applicationProfileService.updateApplicationDefaults({
       personalInfo: { firstName: 'Grace' },

--- a/apps/client/src/services/applicationProfileService.ts
+++ b/apps/client/src/services/applicationProfileService.ts
@@ -19,10 +19,10 @@ export class ApplicationProfileService {
    */
   async getApplicationDefaults(): Promise<ApplicationDefaults | null> {
     try {
-      const response = (await api.get(
-        `${this.baseUrl}/application-defaults`
-      )) as ApplicationDefaults;
-      return response || null;
+      const response = (await api.get(`${this.baseUrl}/application-defaults`)) as {
+        data: ApplicationDefaults;
+      };
+      return response.data || null;
     } catch (error) {
       console.error('Failed to get application defaults:', error);
       return null;
@@ -37,8 +37,8 @@ export class ApplicationProfileService {
   ): Promise<ApplicationDefaults> {
     const response = (await api.put(`${this.baseUrl}/application-defaults`, {
       applicationDefaults,
-    })) as ApplicationDefaults;
-    return response;
+    })) as { data: ApplicationDefaults };
+    return response.data;
   }
 
   /**

--- a/packages/proto/proto/adopt_dont_shop/applications/v1/application.proto
+++ b/packages/proto/proto/adopt_dont_shop/applications/v1/application.proto
@@ -119,6 +119,24 @@ service ApplicationService {
   // the patch are left untouched.
   rpc UpdateApplicationDefaults(UpdateApplicationDefaultsRequest)
       returns (UpdateApplicationDefaultsResponse);
+
+  // Backend-synced application DRAFT for a (caller, pet) pair — the
+  // autosave scratchpad the SPA writes while the adopter fills out the
+  // form, distinct from the event-sourced draft Application above. Always
+  // scoped to the calling principal's own user_id. `found` is false when
+  // the adopter has no draft for that pet (the SPA starts fresh).
+  rpc GetApplicationDraft(GetApplicationDraftRequest)
+      returns (GetApplicationDraftResponse);
+
+  // Upsert the (caller, pet) draft — last-write-wins, stamping a fresh
+  // 30-day TTL on every write.
+  rpc SaveApplicationDraft(SaveApplicationDraftRequest)
+      returns (SaveApplicationDraftResponse);
+
+  // Delete the (caller, pet) draft. Idempotent — deleting a draft that
+  // isn't there succeeds (the SPA calls this best-effort on submit).
+  rpc DeleteApplicationDraft(DeleteApplicationDraftRequest)
+      returns (DeleteApplicationDraftResponse);
 }
 
 // --- ENUMs — value lists mirror the Postgres types verbatim ----------
@@ -433,3 +451,39 @@ message UpdateApplicationDefaultsResponse {
   // JSON-stringified ApplicationDefaults after the merge.
   string defaults_json = 1;
 }
+
+// --- Application drafts (autosave scratchpad) ------------------------
+
+message GetApplicationDraftRequest {
+  string pet_id = 1;
+}
+
+message GetApplicationDraftResponse {
+  // False when the caller has no draft for this pet. The other fields
+  // are unset / empty in that case.
+  bool found = 1;
+  // JSON-stringified answers map. Empty string == `{}`.
+  string answers_json = 2;
+  string updated_at = 3;
+  // TTL — when the daily purge will reap the row. Unset when the row
+  // carries no expiry.
+  optional string expires_at = 4;
+}
+
+message SaveApplicationDraftRequest {
+  string pet_id = 1;
+  // JSON-stringified answers map. Stored verbatim (last-write-wins).
+  string answers_json = 2;
+}
+
+message SaveApplicationDraftResponse {
+  string answers_json = 1;
+  string updated_at = 2;
+  optional string expires_at = 3;
+}
+
+message DeleteApplicationDraftRequest {
+  string pet_id = 1;
+}
+
+message DeleteApplicationDraftResponse {}

--- a/packages/proto/src/generated/proto/adopt_dont_shop/applications/v1/application.ts
+++ b/packages/proto/src/generated/proto/adopt_dont_shop/applications/v1/application.ts
@@ -438,6 +438,44 @@ export interface UpdateApplicationDefaultsResponse {
   defaultsJson: string;
 }
 
+export interface GetApplicationDraftRequest {
+  petId: string;
+}
+
+export interface GetApplicationDraftResponse {
+  /**
+   * False when the caller has no draft for this pet. The other fields
+   * are unset / empty in that case.
+   */
+  found: boolean;
+  /** JSON-stringified answers map. Empty string == `{}`. */
+  answersJson: string;
+  updatedAt: string;
+  /**
+   * TTL — when the daily purge will reap the row. Unset when the row
+   * carries no expiry.
+   */
+  expiresAt?: string | undefined;
+}
+
+export interface SaveApplicationDraftRequest {
+  petId: string;
+  /** JSON-stringified answers map. Stored verbatim (last-write-wins). */
+  answersJson: string;
+}
+
+export interface SaveApplicationDraftResponse {
+  answersJson: string;
+  updatedAt: string;
+  expiresAt?: string | undefined;
+}
+
+export interface DeleteApplicationDraftRequest {
+  petId: string;
+}
+
+export interface DeleteApplicationDraftResponse {}
+
 function createBaseApplication(): Application {
   return {
     applicationId: '',
@@ -4315,6 +4353,527 @@ export const UpdateApplicationDefaultsResponse: MessageFns<UpdateApplicationDefa
   },
 };
 
+function createBaseGetApplicationDraftRequest(): GetApplicationDraftRequest {
+  return { petId: '' };
+}
+
+export const GetApplicationDraftRequest: MessageFns<GetApplicationDraftRequest> = {
+  encode(
+    message: GetApplicationDraftRequest,
+    writer: BinaryWriter = new BinaryWriter()
+  ): BinaryWriter {
+    if (message.petId !== '') {
+      writer.uint32(10).string(message.petId);
+    }
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): GetApplicationDraftRequest {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseGetApplicationDraftRequest();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1: {
+          if (tag !== 10) {
+            break;
+          }
+
+          message.petId = reader.string();
+          continue;
+        }
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): GetApplicationDraftRequest {
+    return {
+      petId: isSet(object.petId)
+        ? globalThis.String(object.petId)
+        : isSet(object.pet_id)
+          ? globalThis.String(object.pet_id)
+          : '',
+    };
+  },
+
+  toJSON(message: GetApplicationDraftRequest): unknown {
+    const obj: any = {};
+    if (message.petId !== '') {
+      obj.petId = message.petId;
+    }
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<GetApplicationDraftRequest>, I>>(
+    base?: I
+  ): GetApplicationDraftRequest {
+    return GetApplicationDraftRequest.fromPartial(base ?? ({} as any));
+  },
+  fromPartial<I extends Exact<DeepPartial<GetApplicationDraftRequest>, I>>(
+    object: I
+  ): GetApplicationDraftRequest {
+    const message = createBaseGetApplicationDraftRequest();
+    message.petId = object.petId ?? '';
+    return message;
+  },
+};
+
+function createBaseGetApplicationDraftResponse(): GetApplicationDraftResponse {
+  return { found: false, answersJson: '', updatedAt: '', expiresAt: undefined };
+}
+
+export const GetApplicationDraftResponse: MessageFns<GetApplicationDraftResponse> = {
+  encode(
+    message: GetApplicationDraftResponse,
+    writer: BinaryWriter = new BinaryWriter()
+  ): BinaryWriter {
+    if (message.found !== false) {
+      writer.uint32(8).bool(message.found);
+    }
+    if (message.answersJson !== '') {
+      writer.uint32(18).string(message.answersJson);
+    }
+    if (message.updatedAt !== '') {
+      writer.uint32(26).string(message.updatedAt);
+    }
+    if (message.expiresAt !== undefined) {
+      writer.uint32(34).string(message.expiresAt);
+    }
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): GetApplicationDraftResponse {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseGetApplicationDraftResponse();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1: {
+          if (tag !== 8) {
+            break;
+          }
+
+          message.found = reader.bool();
+          continue;
+        }
+        case 2: {
+          if (tag !== 18) {
+            break;
+          }
+
+          message.answersJson = reader.string();
+          continue;
+        }
+        case 3: {
+          if (tag !== 26) {
+            break;
+          }
+
+          message.updatedAt = reader.string();
+          continue;
+        }
+        case 4: {
+          if (tag !== 34) {
+            break;
+          }
+
+          message.expiresAt = reader.string();
+          continue;
+        }
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): GetApplicationDraftResponse {
+    return {
+      found: isSet(object.found) ? globalThis.Boolean(object.found) : false,
+      answersJson: isSet(object.answersJson)
+        ? globalThis.String(object.answersJson)
+        : isSet(object.answers_json)
+          ? globalThis.String(object.answers_json)
+          : '',
+      updatedAt: isSet(object.updatedAt)
+        ? globalThis.String(object.updatedAt)
+        : isSet(object.updated_at)
+          ? globalThis.String(object.updated_at)
+          : '',
+      expiresAt: isSet(object.expiresAt)
+        ? globalThis.String(object.expiresAt)
+        : isSet(object.expires_at)
+          ? globalThis.String(object.expires_at)
+          : undefined,
+    };
+  },
+
+  toJSON(message: GetApplicationDraftResponse): unknown {
+    const obj: any = {};
+    if (message.found !== false) {
+      obj.found = message.found;
+    }
+    if (message.answersJson !== '') {
+      obj.answersJson = message.answersJson;
+    }
+    if (message.updatedAt !== '') {
+      obj.updatedAt = message.updatedAt;
+    }
+    if (message.expiresAt !== undefined) {
+      obj.expiresAt = message.expiresAt;
+    }
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<GetApplicationDraftResponse>, I>>(
+    base?: I
+  ): GetApplicationDraftResponse {
+    return GetApplicationDraftResponse.fromPartial(base ?? ({} as any));
+  },
+  fromPartial<I extends Exact<DeepPartial<GetApplicationDraftResponse>, I>>(
+    object: I
+  ): GetApplicationDraftResponse {
+    const message = createBaseGetApplicationDraftResponse();
+    message.found = object.found ?? false;
+    message.answersJson = object.answersJson ?? '';
+    message.updatedAt = object.updatedAt ?? '';
+    message.expiresAt = object.expiresAt ?? undefined;
+    return message;
+  },
+};
+
+function createBaseSaveApplicationDraftRequest(): SaveApplicationDraftRequest {
+  return { petId: '', answersJson: '' };
+}
+
+export const SaveApplicationDraftRequest: MessageFns<SaveApplicationDraftRequest> = {
+  encode(
+    message: SaveApplicationDraftRequest,
+    writer: BinaryWriter = new BinaryWriter()
+  ): BinaryWriter {
+    if (message.petId !== '') {
+      writer.uint32(10).string(message.petId);
+    }
+    if (message.answersJson !== '') {
+      writer.uint32(18).string(message.answersJson);
+    }
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): SaveApplicationDraftRequest {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseSaveApplicationDraftRequest();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1: {
+          if (tag !== 10) {
+            break;
+          }
+
+          message.petId = reader.string();
+          continue;
+        }
+        case 2: {
+          if (tag !== 18) {
+            break;
+          }
+
+          message.answersJson = reader.string();
+          continue;
+        }
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): SaveApplicationDraftRequest {
+    return {
+      petId: isSet(object.petId)
+        ? globalThis.String(object.petId)
+        : isSet(object.pet_id)
+          ? globalThis.String(object.pet_id)
+          : '',
+      answersJson: isSet(object.answersJson)
+        ? globalThis.String(object.answersJson)
+        : isSet(object.answers_json)
+          ? globalThis.String(object.answers_json)
+          : '',
+    };
+  },
+
+  toJSON(message: SaveApplicationDraftRequest): unknown {
+    const obj: any = {};
+    if (message.petId !== '') {
+      obj.petId = message.petId;
+    }
+    if (message.answersJson !== '') {
+      obj.answersJson = message.answersJson;
+    }
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<SaveApplicationDraftRequest>, I>>(
+    base?: I
+  ): SaveApplicationDraftRequest {
+    return SaveApplicationDraftRequest.fromPartial(base ?? ({} as any));
+  },
+  fromPartial<I extends Exact<DeepPartial<SaveApplicationDraftRequest>, I>>(
+    object: I
+  ): SaveApplicationDraftRequest {
+    const message = createBaseSaveApplicationDraftRequest();
+    message.petId = object.petId ?? '';
+    message.answersJson = object.answersJson ?? '';
+    return message;
+  },
+};
+
+function createBaseSaveApplicationDraftResponse(): SaveApplicationDraftResponse {
+  return { answersJson: '', updatedAt: '', expiresAt: undefined };
+}
+
+export const SaveApplicationDraftResponse: MessageFns<SaveApplicationDraftResponse> = {
+  encode(
+    message: SaveApplicationDraftResponse,
+    writer: BinaryWriter = new BinaryWriter()
+  ): BinaryWriter {
+    if (message.answersJson !== '') {
+      writer.uint32(10).string(message.answersJson);
+    }
+    if (message.updatedAt !== '') {
+      writer.uint32(18).string(message.updatedAt);
+    }
+    if (message.expiresAt !== undefined) {
+      writer.uint32(26).string(message.expiresAt);
+    }
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): SaveApplicationDraftResponse {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseSaveApplicationDraftResponse();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1: {
+          if (tag !== 10) {
+            break;
+          }
+
+          message.answersJson = reader.string();
+          continue;
+        }
+        case 2: {
+          if (tag !== 18) {
+            break;
+          }
+
+          message.updatedAt = reader.string();
+          continue;
+        }
+        case 3: {
+          if (tag !== 26) {
+            break;
+          }
+
+          message.expiresAt = reader.string();
+          continue;
+        }
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): SaveApplicationDraftResponse {
+    return {
+      answersJson: isSet(object.answersJson)
+        ? globalThis.String(object.answersJson)
+        : isSet(object.answers_json)
+          ? globalThis.String(object.answers_json)
+          : '',
+      updatedAt: isSet(object.updatedAt)
+        ? globalThis.String(object.updatedAt)
+        : isSet(object.updated_at)
+          ? globalThis.String(object.updated_at)
+          : '',
+      expiresAt: isSet(object.expiresAt)
+        ? globalThis.String(object.expiresAt)
+        : isSet(object.expires_at)
+          ? globalThis.String(object.expires_at)
+          : undefined,
+    };
+  },
+
+  toJSON(message: SaveApplicationDraftResponse): unknown {
+    const obj: any = {};
+    if (message.answersJson !== '') {
+      obj.answersJson = message.answersJson;
+    }
+    if (message.updatedAt !== '') {
+      obj.updatedAt = message.updatedAt;
+    }
+    if (message.expiresAt !== undefined) {
+      obj.expiresAt = message.expiresAt;
+    }
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<SaveApplicationDraftResponse>, I>>(
+    base?: I
+  ): SaveApplicationDraftResponse {
+    return SaveApplicationDraftResponse.fromPartial(base ?? ({} as any));
+  },
+  fromPartial<I extends Exact<DeepPartial<SaveApplicationDraftResponse>, I>>(
+    object: I
+  ): SaveApplicationDraftResponse {
+    const message = createBaseSaveApplicationDraftResponse();
+    message.answersJson = object.answersJson ?? '';
+    message.updatedAt = object.updatedAt ?? '';
+    message.expiresAt = object.expiresAt ?? undefined;
+    return message;
+  },
+};
+
+function createBaseDeleteApplicationDraftRequest(): DeleteApplicationDraftRequest {
+  return { petId: '' };
+}
+
+export const DeleteApplicationDraftRequest: MessageFns<DeleteApplicationDraftRequest> = {
+  encode(
+    message: DeleteApplicationDraftRequest,
+    writer: BinaryWriter = new BinaryWriter()
+  ): BinaryWriter {
+    if (message.petId !== '') {
+      writer.uint32(10).string(message.petId);
+    }
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): DeleteApplicationDraftRequest {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseDeleteApplicationDraftRequest();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1: {
+          if (tag !== 10) {
+            break;
+          }
+
+          message.petId = reader.string();
+          continue;
+        }
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): DeleteApplicationDraftRequest {
+    return {
+      petId: isSet(object.petId)
+        ? globalThis.String(object.petId)
+        : isSet(object.pet_id)
+          ? globalThis.String(object.pet_id)
+          : '',
+    };
+  },
+
+  toJSON(message: DeleteApplicationDraftRequest): unknown {
+    const obj: any = {};
+    if (message.petId !== '') {
+      obj.petId = message.petId;
+    }
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<DeleteApplicationDraftRequest>, I>>(
+    base?: I
+  ): DeleteApplicationDraftRequest {
+    return DeleteApplicationDraftRequest.fromPartial(base ?? ({} as any));
+  },
+  fromPartial<I extends Exact<DeepPartial<DeleteApplicationDraftRequest>, I>>(
+    object: I
+  ): DeleteApplicationDraftRequest {
+    const message = createBaseDeleteApplicationDraftRequest();
+    message.petId = object.petId ?? '';
+    return message;
+  },
+};
+
+function createBaseDeleteApplicationDraftResponse(): DeleteApplicationDraftResponse {
+  return {};
+}
+
+export const DeleteApplicationDraftResponse: MessageFns<DeleteApplicationDraftResponse> = {
+  encode(
+    _: DeleteApplicationDraftResponse,
+    writer: BinaryWriter = new BinaryWriter()
+  ): BinaryWriter {
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): DeleteApplicationDraftResponse {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseDeleteApplicationDraftResponse();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(_: any): DeleteApplicationDraftResponse {
+    return {};
+  },
+
+  toJSON(_: DeleteApplicationDraftResponse): unknown {
+    const obj: any = {};
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<DeleteApplicationDraftResponse>, I>>(
+    base?: I
+  ): DeleteApplicationDraftResponse {
+    return DeleteApplicationDraftResponse.fromPartial(base ?? ({} as any));
+  },
+  fromPartial<I extends Exact<DeepPartial<DeleteApplicationDraftResponse>, I>>(
+    _: I
+  ): DeleteApplicationDraftResponse {
+    const message = createBaseDeleteApplicationDraftResponse();
+    return message;
+  },
+};
+
 /**
  * ApplicationService is the gRPC contract for the applications
  * vertical — the EVENT-SOURCED extraction. Owns the `applications.*`
@@ -4649,6 +5208,60 @@ export const ApplicationServiceService = {
     responseDeserialize: (value: Buffer): UpdateApplicationDefaultsResponse =>
       UpdateApplicationDefaultsResponse.decode(value),
   },
+  /**
+   * Backend-synced application DRAFT for a (caller, pet) pair — the
+   * autosave scratchpad the SPA writes while the adopter fills out the
+   * form, distinct from the event-sourced draft Application above. Always
+   * scoped to the calling principal's own user_id. `found` is false when
+   * the adopter has no draft for that pet (the SPA starts fresh).
+   */
+  getApplicationDraft: {
+    path: '/adopt_dont_shop.applications.v1.ApplicationService/GetApplicationDraft' as const,
+    requestStream: false as const,
+    responseStream: false as const,
+    requestSerialize: (value: GetApplicationDraftRequest): Buffer =>
+      Buffer.from(GetApplicationDraftRequest.encode(value).finish()),
+    requestDeserialize: (value: Buffer): GetApplicationDraftRequest =>
+      GetApplicationDraftRequest.decode(value),
+    responseSerialize: (value: GetApplicationDraftResponse): Buffer =>
+      Buffer.from(GetApplicationDraftResponse.encode(value).finish()),
+    responseDeserialize: (value: Buffer): GetApplicationDraftResponse =>
+      GetApplicationDraftResponse.decode(value),
+  },
+  /**
+   * Upsert the (caller, pet) draft — last-write-wins, stamping a fresh
+   * 30-day TTL on every write.
+   */
+  saveApplicationDraft: {
+    path: '/adopt_dont_shop.applications.v1.ApplicationService/SaveApplicationDraft' as const,
+    requestStream: false as const,
+    responseStream: false as const,
+    requestSerialize: (value: SaveApplicationDraftRequest): Buffer =>
+      Buffer.from(SaveApplicationDraftRequest.encode(value).finish()),
+    requestDeserialize: (value: Buffer): SaveApplicationDraftRequest =>
+      SaveApplicationDraftRequest.decode(value),
+    responseSerialize: (value: SaveApplicationDraftResponse): Buffer =>
+      Buffer.from(SaveApplicationDraftResponse.encode(value).finish()),
+    responseDeserialize: (value: Buffer): SaveApplicationDraftResponse =>
+      SaveApplicationDraftResponse.decode(value),
+  },
+  /**
+   * Delete the (caller, pet) draft. Idempotent — deleting a draft that
+   * isn't there succeeds (the SPA calls this best-effort on submit).
+   */
+  deleteApplicationDraft: {
+    path: '/adopt_dont_shop.applications.v1.ApplicationService/DeleteApplicationDraft' as const,
+    requestStream: false as const,
+    responseStream: false as const,
+    requestSerialize: (value: DeleteApplicationDraftRequest): Buffer =>
+      Buffer.from(DeleteApplicationDraftRequest.encode(value).finish()),
+    requestDeserialize: (value: Buffer): DeleteApplicationDraftRequest =>
+      DeleteApplicationDraftRequest.decode(value),
+    responseSerialize: (value: DeleteApplicationDraftResponse): Buffer =>
+      Buffer.from(DeleteApplicationDraftResponse.encode(value).finish()),
+    responseDeserialize: (value: Buffer): DeleteApplicationDraftResponse =>
+      DeleteApplicationDraftResponse.decode(value),
+  },
 } as const;
 
 export interface ApplicationServiceServer extends UntypedServiceImplementation {
@@ -4770,6 +5383,27 @@ export interface ApplicationServiceServer extends UntypedServiceImplementation {
   updateApplicationDefaults: handleUnaryCall<
     UpdateApplicationDefaultsRequest,
     UpdateApplicationDefaultsResponse
+  >;
+  /**
+   * Backend-synced application DRAFT for a (caller, pet) pair — the
+   * autosave scratchpad the SPA writes while the adopter fills out the
+   * form, distinct from the event-sourced draft Application above. Always
+   * scoped to the calling principal's own user_id. `found` is false when
+   * the adopter has no draft for that pet (the SPA starts fresh).
+   */
+  getApplicationDraft: handleUnaryCall<GetApplicationDraftRequest, GetApplicationDraftResponse>;
+  /**
+   * Upsert the (caller, pet) draft — last-write-wins, stamping a fresh
+   * 30-day TTL on every write.
+   */
+  saveApplicationDraft: handleUnaryCall<SaveApplicationDraftRequest, SaveApplicationDraftResponse>;
+  /**
+   * Delete the (caller, pet) draft. Idempotent — deleting a draft that
+   * isn't there succeeds (the SPA calls this best-effort on submit).
+   */
+  deleteApplicationDraft: handleUnaryCall<
+    DeleteApplicationDraftRequest,
+    DeleteApplicationDraftResponse
   >;
 }
 
@@ -5138,6 +5772,66 @@ export interface ApplicationServiceClient extends Client {
     metadata: Metadata,
     options: Partial<CallOptions>,
     callback: (error: ServiceError | null, response: UpdateApplicationDefaultsResponse) => void
+  ): ClientUnaryCall;
+  /**
+   * Backend-synced application DRAFT for a (caller, pet) pair — the
+   * autosave scratchpad the SPA writes while the adopter fills out the
+   * form, distinct from the event-sourced draft Application above. Always
+   * scoped to the calling principal's own user_id. `found` is false when
+   * the adopter has no draft for that pet (the SPA starts fresh).
+   */
+  getApplicationDraft(
+    request: GetApplicationDraftRequest,
+    callback: (error: ServiceError | null, response: GetApplicationDraftResponse) => void
+  ): ClientUnaryCall;
+  getApplicationDraft(
+    request: GetApplicationDraftRequest,
+    metadata: Metadata,
+    callback: (error: ServiceError | null, response: GetApplicationDraftResponse) => void
+  ): ClientUnaryCall;
+  getApplicationDraft(
+    request: GetApplicationDraftRequest,
+    metadata: Metadata,
+    options: Partial<CallOptions>,
+    callback: (error: ServiceError | null, response: GetApplicationDraftResponse) => void
+  ): ClientUnaryCall;
+  /**
+   * Upsert the (caller, pet) draft — last-write-wins, stamping a fresh
+   * 30-day TTL on every write.
+   */
+  saveApplicationDraft(
+    request: SaveApplicationDraftRequest,
+    callback: (error: ServiceError | null, response: SaveApplicationDraftResponse) => void
+  ): ClientUnaryCall;
+  saveApplicationDraft(
+    request: SaveApplicationDraftRequest,
+    metadata: Metadata,
+    callback: (error: ServiceError | null, response: SaveApplicationDraftResponse) => void
+  ): ClientUnaryCall;
+  saveApplicationDraft(
+    request: SaveApplicationDraftRequest,
+    metadata: Metadata,
+    options: Partial<CallOptions>,
+    callback: (error: ServiceError | null, response: SaveApplicationDraftResponse) => void
+  ): ClientUnaryCall;
+  /**
+   * Delete the (caller, pet) draft. Idempotent — deleting a draft that
+   * isn't there succeeds (the SPA calls this best-effort on submit).
+   */
+  deleteApplicationDraft(
+    request: DeleteApplicationDraftRequest,
+    callback: (error: ServiceError | null, response: DeleteApplicationDraftResponse) => void
+  ): ClientUnaryCall;
+  deleteApplicationDraft(
+    request: DeleteApplicationDraftRequest,
+    metadata: Metadata,
+    callback: (error: ServiceError | null, response: DeleteApplicationDraftResponse) => void
+  ): ClientUnaryCall;
+  deleteApplicationDraft(
+    request: DeleteApplicationDraftRequest,
+    metadata: Metadata,
+    options: Partial<CallOptions>,
+    callback: (error: ServiceError | null, response: DeleteApplicationDraftResponse) => void
   ): ClientUnaryCall;
 }
 

--- a/packages/proto/src/index.ts
+++ b/packages/proto/src/index.ts
@@ -343,6 +343,12 @@ export type {
   GetApplicationDefaultsResponse,
   UpdateApplicationDefaultsRequest,
   UpdateApplicationDefaultsResponse,
+  GetApplicationDraftRequest,
+  GetApplicationDraftResponse,
+  SaveApplicationDraftRequest,
+  SaveApplicationDraftResponse,
+  DeleteApplicationDraftRequest,
+  DeleteApplicationDraftResponse,
   ApplicationServiceServer,
   ApplicationServiceClient,
 } from './generated/proto/adopt_dont_shop/applications/v1/application.js';

--- a/services/applications/src/grpc/application-draft-handlers.test.ts
+++ b/services/applications/src/grpc/application-draft-handlers.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { HandlerError, type HandlerDeps } from './adapter.js';
+import {
+  deleteApplicationDraft,
+  getApplicationDraft,
+  saveApplicationDraft,
+} from './application-draft-handlers.js';
+
+function makePrincipal(
+  overrides: Partial<{ userId: string; roles: string[]; permissions: string[] }> = {}
+) {
+  return {
+    userId: overrides.userId ?? 'usr-1',
+    roles: overrides.roles ?? ['adopter'],
+    permissions: overrides.permissions ?? ['applications.read', 'applications.update'],
+  } as unknown as Parameters<typeof getApplicationDraft>[1];
+}
+
+function makeDeps(): { deps: HandlerDeps; query: ReturnType<typeof vi.fn> } {
+  const query = vi.fn();
+  const pool = { query } as unknown as HandlerDeps['pool'];
+  return { deps: { pool, nats: {} } as unknown as HandlerDeps, query };
+}
+
+describe('getApplicationDraft', () => {
+  it('throws PERMISSION_DENIED without applications.read', async () => {
+    const { deps } = makeDeps();
+    await expect(
+      getApplicationDraft(deps, makePrincipal({ permissions: [] }), { petId: 'pet-1' })
+    ).rejects.toBeInstanceOf(HandlerError);
+  });
+
+  it('throws INVALID_ARGUMENT when pet_id is empty', async () => {
+    const { deps, query } = makeDeps();
+    await expect(getApplicationDraft(deps, makePrincipal(), { petId: '' })).rejects.toBeInstanceOf(
+      HandlerError
+    );
+    expect(query).not.toHaveBeenCalled();
+  });
+
+  it('returns found=false when the adopter has no draft for the pet', async () => {
+    const { deps, query } = makeDeps();
+    query.mockResolvedValueOnce({ rows: [] });
+
+    const res = await getApplicationDraft(deps, makePrincipal(), { petId: 'pet-1' });
+
+    expect(res.found).toBe(false);
+    expect(res.answersJson).toBe('');
+  });
+
+  it('returns the stored draft with answers + timestamps when found', async () => {
+    const { deps, query } = makeDeps();
+    const updatedAt = new Date('2026-06-20T10:00:00.000Z');
+    const expiresAt = new Date('2026-07-20T10:00:00.000Z');
+    query.mockResolvedValueOnce({
+      rows: [{ answers: { q1: 'a' }, updated_at: updatedAt, expires_at: expiresAt }],
+    });
+
+    const res = await getApplicationDraft(deps, makePrincipal(), { petId: 'pet-1' });
+
+    expect(res.found).toBe(true);
+    expect(JSON.parse(res.answersJson)).toEqual({ q1: 'a' });
+    expect(res.updatedAt).toBe('2026-06-20T10:00:00.000Z');
+    expect(res.expiresAt).toBe('2026-07-20T10:00:00.000Z');
+  });
+
+  it('scopes the read to the calling principal and the requested pet', async () => {
+    const { deps, query } = makeDeps();
+    query.mockResolvedValueOnce({ rows: [] });
+
+    await getApplicationDraft(deps, makePrincipal({ userId: 'usr-9' }), { petId: 'pet-7' });
+
+    expect(query.mock.calls[0][1]).toEqual(['usr-9', 'pet-7']);
+  });
+});
+
+describe('saveApplicationDraft', () => {
+  it('throws PERMISSION_DENIED without applications.update', async () => {
+    const { deps } = makeDeps();
+    await expect(
+      saveApplicationDraft(deps, makePrincipal({ permissions: ['applications.read'] }), {
+        petId: 'pet-1',
+        answersJson: '{}',
+      })
+    ).rejects.toBeInstanceOf(HandlerError);
+  });
+
+  it('throws INVALID_ARGUMENT when pet_id is empty', async () => {
+    const { deps, query } = makeDeps();
+    await expect(
+      saveApplicationDraft(deps, makePrincipal(), { petId: '', answersJson: '{}' })
+    ).rejects.toBeInstanceOf(HandlerError);
+    expect(query).not.toHaveBeenCalled();
+  });
+
+  it('throws INVALID_ARGUMENT when answers_json is not a JSON object', async () => {
+    const { deps, query } = makeDeps();
+    await expect(
+      saveApplicationDraft(deps, makePrincipal(), { petId: 'pet-1', answersJson: '[1,2]' })
+    ).rejects.toBeInstanceOf(HandlerError);
+    expect(query).not.toHaveBeenCalled();
+  });
+
+  it('upserts the draft scoped to the principal + pet and returns the saved row', async () => {
+    const { deps, query } = makeDeps();
+    const updatedAt = new Date('2026-06-20T10:00:00.000Z');
+    const expiresAt = new Date('2026-07-20T10:00:00.000Z');
+    query.mockResolvedValueOnce({
+      rows: [{ answers: { q1: 'a' }, updated_at: updatedAt, expires_at: expiresAt }],
+    });
+
+    const res = await saveApplicationDraft(deps, makePrincipal({ userId: 'usr-9' }), {
+      petId: 'pet-7',
+      answersJson: JSON.stringify({ q1: 'a' }),
+    });
+
+    const [sql, params] = query.mock.calls[0];
+    expect(sql).toContain('INSERT INTO application_drafts');
+    expect(sql).toContain('ON CONFLICT');
+    expect(params[1]).toBe('usr-9');
+    expect(params[2]).toBe('pet-7');
+    expect(JSON.parse(params[3])).toEqual({ q1: 'a' });
+    expect(JSON.parse(res.answersJson)).toEqual({ q1: 'a' });
+    expect(res.updatedAt).toBe('2026-06-20T10:00:00.000Z');
+    expect(res.expiresAt).toBe('2026-07-20T10:00:00.000Z');
+  });
+
+  it('treats an empty answers_json as an empty object', async () => {
+    const { deps, query } = makeDeps();
+    query.mockResolvedValueOnce({
+      rows: [{ answers: {}, updated_at: new Date('2026-06-20T10:00:00.000Z'), expires_at: null }],
+    });
+
+    await saveApplicationDraft(deps, makePrincipal(), { petId: 'pet-1', answersJson: '' });
+
+    expect(JSON.parse(query.mock.calls[0][1][3])).toEqual({});
+  });
+});
+
+describe('deleteApplicationDraft', () => {
+  it('throws PERMISSION_DENIED without applications.update', async () => {
+    const { deps } = makeDeps();
+    await expect(
+      deleteApplicationDraft(deps, makePrincipal({ permissions: [] }), { petId: 'pet-1' })
+    ).rejects.toBeInstanceOf(HandlerError);
+  });
+
+  it('deletes the draft scoped to the principal + pet (idempotent — no NOT_FOUND)', async () => {
+    const { deps, query } = makeDeps();
+    query.mockResolvedValueOnce({ rowCount: 0 });
+
+    const res = await deleteApplicationDraft(deps, makePrincipal({ userId: 'usr-9' }), {
+      petId: 'pet-7',
+    });
+
+    expect(res).toEqual({});
+    const [sql, params] = query.mock.calls[0];
+    expect(sql).toContain('DELETE FROM application_drafts');
+    expect(params).toEqual(['usr-9', 'pet-7']);
+  });
+});

--- a/services/applications/src/grpc/application-draft-handlers.ts
+++ b/services/applications/src/grpc/application-draft-handlers.ts
@@ -1,0 +1,132 @@
+// gRPC handlers — backend-synced application drafts (autosave scratchpad).
+//
+// The (user_id, pet_id) draft the SPA writes while an adopter fills out a
+// form — distinct from the event-sourced draft Application (handlers.ts).
+// Last-write-wins; every upsert stamps a fresh 30-day TTL (a daily purge
+// reaps expired rows). Always scoped to the calling principal's own
+// user_id — there's no cross-adopter read or write, so like
+// application-defaults-handlers.ts there's no owner row to load first.
+// All three run OUTSIDE a transaction (straight off deps.pool).
+
+import { randomUUID } from 'node:crypto';
+
+import { requirePermission, type Principal } from '@adopt-dont-shop/authz';
+import { APPLICATIONS_UPDATE, APPLICATIONS_VIEW } from '@adopt-dont-shop/lib.types';
+import type {
+  DeleteApplicationDraftRequest,
+  DeleteApplicationDraftResponse,
+  GetApplicationDraftRequest,
+  GetApplicationDraftResponse,
+  SaveApplicationDraftRequest,
+  SaveApplicationDraftResponse,
+} from '@adopt-dont-shop/proto';
+
+import { HandlerError, type HandlerDeps } from './adapter.js';
+import { type JsonObject } from './json-merge.js';
+
+type DraftRow = {
+  answers: JsonObject;
+  updated_at: Date;
+  expires_at: Date | null;
+};
+
+export async function getApplicationDraft(
+  deps: HandlerDeps,
+  principal: Principal,
+  req: GetApplicationDraftRequest
+): Promise<GetApplicationDraftResponse> {
+  if (!requirePermission(principal, APPLICATIONS_VIEW)) {
+    throw new HandlerError('PERMISSION_DENIED', `'${APPLICATIONS_VIEW}' required`);
+  }
+  if (req.petId === '') {
+    throw new HandlerError('INVALID_ARGUMENT', 'pet_id is required');
+  }
+
+  const { rows } = await deps.pool.query<DraftRow>(
+    `SELECT answers, updated_at, expires_at
+       FROM application_drafts
+      WHERE user_id = $1 AND pet_id = $2`,
+    [principal.userId, req.petId]
+  );
+
+  const row = rows[0];
+  if (row === undefined) {
+    return { found: false, answersJson: '', updatedAt: '' };
+  }
+  return rowToResponse(row, { found: true });
+}
+
+export async function saveApplicationDraft(
+  deps: HandlerDeps,
+  principal: Principal,
+  req: SaveApplicationDraftRequest
+): Promise<SaveApplicationDraftResponse> {
+  if (!requirePermission(principal, APPLICATIONS_UPDATE)) {
+    throw new HandlerError('PERMISSION_DENIED', `'${APPLICATIONS_UPDATE}' required`);
+  }
+  if (req.petId === '') {
+    throw new HandlerError('INVALID_ARGUMENT', 'pet_id is required');
+  }
+  const answers = parseAnswers(req.answersJson);
+
+  const { rows } = await deps.pool.query<DraftRow>(
+    `INSERT INTO application_drafts (draft_id, user_id, pet_id, answers, expires_at, updated_at)
+     VALUES ($1, $2, $3, $4, now() + interval '30 days', now())
+     ON CONFLICT (user_id, pet_id) DO UPDATE
+       SET answers = $4, expires_at = now() + interval '30 days', updated_at = now()
+     RETURNING answers, updated_at, expires_at`,
+    [randomUUID(), principal.userId, req.petId, JSON.stringify(answers)]
+  );
+
+  return rowToResponse(rows[0], {});
+}
+
+export async function deleteApplicationDraft(
+  deps: HandlerDeps,
+  principal: Principal,
+  req: DeleteApplicationDraftRequest
+): Promise<DeleteApplicationDraftResponse> {
+  if (!requirePermission(principal, APPLICATIONS_UPDATE)) {
+    throw new HandlerError('PERMISSION_DENIED', `'${APPLICATIONS_UPDATE}' required`);
+  }
+  if (req.petId === '') {
+    throw new HandlerError('INVALID_ARGUMENT', 'pet_id is required');
+  }
+
+  // Idempotent: deleting a draft that isn't there is success — the SPA
+  // calls this best-effort on submit and shouldn't see a 404.
+  await deps.pool.query(`DELETE FROM application_drafts WHERE user_id = $1 AND pet_id = $2`, [
+    principal.userId,
+    req.petId,
+  ]);
+
+  return {};
+}
+
+function rowToResponse<T extends { found?: boolean }>(
+  row: DraftRow,
+  extra: T
+): T & { answersJson: string; updatedAt: string; expiresAt?: string } {
+  return {
+    ...extra,
+    answersJson: JSON.stringify(row.answers),
+    updatedAt: row.updated_at.toISOString(),
+    ...(row.expires_at !== null ? { expiresAt: row.expires_at.toISOString() } : {}),
+  };
+}
+
+function parseAnswers(raw: string): JsonObject {
+  if (raw === '') {
+    return {};
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    throw new HandlerError('INVALID_ARGUMENT', 'answers_json must be valid JSON');
+  }
+  if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+    throw new HandlerError('INVALID_ARGUMENT', 'answers_json must be a JSON object');
+  }
+  return parsed as JsonObject;
+}

--- a/services/applications/src/grpc/server.ts
+++ b/services/applications/src/grpc/server.ts
@@ -21,6 +21,11 @@ import {
   getApplicationDefaults,
   updateApplicationDefaults,
 } from './application-defaults-handlers.js';
+import {
+  deleteApplicationDraft,
+  getApplicationDraft,
+  saveApplicationDraft,
+} from './application-draft-handlers.js';
 import { makeStartDraft, saveDraftAnswers, submitDraft } from './handlers.js';
 import { createPetsClient, type PetsClient } from './pets-client.js';
 import { addDocument, listDocuments, removeDocument } from './document-handlers.js';
@@ -81,6 +86,10 @@ export const createGrpcServer = (opts: CreateGrpcServerOptions): Server => {
     // Application defaults (application-defaults-handlers.ts)
     getApplicationDefaults: adapt(getApplicationDefaults, { deps, logger }),
     updateApplicationDefaults: adapt(updateApplicationDefaults, { deps, logger }),
+    // Application drafts — autosave scratchpad (application-draft-handlers.ts)
+    getApplicationDraft: adapt(getApplicationDraft, { deps, logger }),
+    saveApplicationDraft: adapt(saveApplicationDraft, { deps, logger }),
+    deleteApplicationDraft: adapt(deleteApplicationDraft, { deps, logger }),
   });
 
   logger.info('gRPC ApplicationService registered', {
@@ -103,6 +112,9 @@ export const createGrpcServer = (opts: CreateGrpcServerOptions): Server => {
       'removeDocument',
       'getApplicationDefaults',
       'updateApplicationDefaults',
+      'getApplicationDraft',
+      'saveApplicationDraft',
+      'deleteApplicationDraft',
     ],
     grpcPort: config.grpcPort,
   });

--- a/services/gateway/src/grpc-clients/applications-client.contract.test.ts
+++ b/services/gateway/src/grpc-clients/applications-client.contract.test.ts
@@ -64,6 +64,9 @@ const makeHandlers = (
   removeDocument: unimplemented,
   getApplicationDefaults: unimplemented,
   updateApplicationDefaults: unimplemented,
+  getApplicationDraft: unimplemented,
+  saveApplicationDraft: unimplemented,
+  deleteApplicationDraft: unimplemented,
   ...overrides,
 });
 

--- a/services/gateway/src/grpc-clients/applications-client.ts
+++ b/services/gateway/src/grpc-clients/applications-client.ts
@@ -17,8 +17,12 @@ import {
   type ApproveResponse,
   type CompleteHomeVisitRequest,
   type CompleteHomeVisitResponse,
+  type DeleteApplicationDraftRequest,
+  type DeleteApplicationDraftResponse,
   type GetApplicationDefaultsRequest,
   type GetApplicationDefaultsResponse,
+  type GetApplicationDraftRequest,
+  type GetApplicationDraftResponse,
   type GetApplicationRequest,
   type GetApplicationResponse,
   type GetStatsRequest,
@@ -33,6 +37,8 @@ import {
   type RejectResponse,
   type RemoveDocumentRequest,
   type RemoveDocumentResponse,
+  type SaveApplicationDraftRequest,
+  type SaveApplicationDraftResponse,
   type SaveDraftAnswersRequest,
   type SaveDraftAnswersResponse,
   type ScheduleHomeVisitRequest,
@@ -87,6 +93,18 @@ export type ApplicationsClient = {
     req: UpdateApplicationDefaultsRequest,
     metadata: Metadata
   ): Promise<UpdateApplicationDefaultsResponse>;
+  getApplicationDraft(
+    req: GetApplicationDraftRequest,
+    metadata: Metadata
+  ): Promise<GetApplicationDraftResponse>;
+  saveApplicationDraft(
+    req: SaveApplicationDraftRequest,
+    metadata: Metadata
+  ): Promise<SaveApplicationDraftResponse>;
+  deleteApplicationDraft(
+    req: DeleteApplicationDraftRequest,
+    metadata: Metadata
+  ): Promise<DeleteApplicationDraftResponse>;
   close(): void;
 };
 
@@ -169,13 +187,21 @@ export const createApplicationsClient = (
     removeDocument: (req, metadata) => callUnary(stub.removeDocument, req, metadata, false),
     updateApplicationDefaults: (req, metadata) =>
       callUnary(stub.updateApplicationDefaults, req, metadata, false),
-    // ── Idempotent (reads) ───────────────────────────────────────────
+    saveApplicationDraft: (req, metadata) =>
+      callUnary(stub.saveApplicationDraft, req, metadata, false),
+    // ── Idempotent (reads + idempotent deletes) ──────────────────────
     get: (req, metadata) => callUnary(stub.get, req, metadata, true),
     list: (req, metadata) => callUnary(stub.list, req, metadata, true),
     getStats: (req, metadata) => callUnary(stub.getStats, req, metadata, true),
     listDocuments: (req, metadata) => callUnary(stub.listDocuments, req, metadata, true),
     getApplicationDefaults: (req, metadata) =>
       callUnary(stub.getApplicationDefaults, req, metadata, true),
+    getApplicationDraft: (req, metadata) =>
+      callUnary(stub.getApplicationDraft, req, metadata, true),
+    // DeleteApplicationDraft is idempotent (deleting a missing draft is a
+    // no-op success), so it's safe to retry.
+    deleteApplicationDraft: (req, metadata) =>
+      callUnary(stub.deleteApplicationDraft, req, metadata, true),
     close: () => stub.close(),
   };
 };

--- a/services/gateway/src/routes/applications.test.ts
+++ b/services/gateway/src/routes/applications.test.ts
@@ -44,6 +44,9 @@ function makeClient(): {
     'getStats',
     'getApplicationDefaults',
     'updateApplicationDefaults',
+    'getApplicationDraft',
+    'saveApplicationDraft',
+    'deleteApplicationDraft',
   ]) {
     mocks[m] = vi.fn();
   }
@@ -461,6 +464,86 @@ describe('applications routes', () => {
     expect((res.json() as { data: unknown }).data).toEqual({
       personalInfo: { firstName: 'Grace', lastName: 'Hopper' },
     });
+  });
+
+  it('GET /api/v1/applications/drafts/:petId returns the draft payload in { data }', async () => {
+    mocks.getApplicationDraft.mockResolvedValue({
+      found: true,
+      answersJson: JSON.stringify({ q1: 'a' }),
+      updatedAt: '2026-06-20T10:00:00.000Z',
+      expiresAt: '2026-07-20T10:00:00.000Z',
+    });
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/v1/applications/drafts/pet-1',
+      headers: ADOPTER,
+    });
+    expect(res.statusCode).toBe(200);
+    expect((res.json() as { data: unknown }).data).toEqual({
+      petId: 'pet-1',
+      answers: { q1: 'a' },
+      updatedAt: '2026-06-20T10:00:00.000Z',
+      expiresAt: '2026-07-20T10:00:00.000Z',
+    });
+    expect(mocks.getApplicationDraft.mock.calls[0][0]).toEqual({ petId: 'pet-1' });
+  });
+
+  it('GET /api/v1/applications/drafts/:petId 404s when the caller has no draft', async () => {
+    mocks.getApplicationDraft.mockResolvedValue({ found: false, answersJson: '', updatedAt: '' });
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/v1/applications/drafts/pet-1',
+      headers: ADOPTER,
+    });
+    expect(res.statusCode).toBe(404);
+  });
+
+  it('PUT /api/v1/applications/drafts/:petId sends answers and returns the saved payload', async () => {
+    mocks.saveApplicationDraft.mockResolvedValue({
+      answersJson: JSON.stringify({ q1: 'a' }),
+      updatedAt: '2026-06-20T10:00:00.000Z',
+      expiresAt: undefined,
+    });
+    const res = await app.inject({
+      method: 'PUT',
+      url: '/api/v1/applications/drafts/pet-1',
+      headers: ADOPTER,
+      payload: { answers: { q1: 'a' } },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(mocks.saveApplicationDraft.mock.calls[0][0]).toEqual({
+      petId: 'pet-1',
+      answersJson: JSON.stringify({ q1: 'a' }),
+    });
+    expect((res.json() as { data: { expiresAt: string | null } }).data).toEqual({
+      petId: 'pet-1',
+      answers: { q1: 'a' },
+      updatedAt: '2026-06-20T10:00:00.000Z',
+      expiresAt: null,
+    });
+  });
+
+  it('DELETE /api/v1/applications/drafts/:petId returns 204', async () => {
+    mocks.deleteApplicationDraft.mockResolvedValue({});
+    const res = await app.inject({
+      method: 'DELETE',
+      url: '/api/v1/applications/drafts/pet-1',
+      headers: ADOPTER,
+    });
+    expect(res.statusCode).toBe(204);
+    expect(mocks.deleteApplicationDraft.mock.calls[0][0]).toEqual({ petId: 'pet-1' });
+  });
+
+  it('does not let the drafts route shadow GET /api/v1/applications/:id', async () => {
+    mocks.get.mockResolvedValue({ application: SUBMITTED, timeline: [] });
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/v1/applications/app-1',
+      headers: ADOPTER,
+    });
+    expect(res.statusCode).toBe(200);
+    expect(mocks.get).toHaveBeenCalled();
+    expect(mocks.getApplicationDraft).not.toHaveBeenCalled();
   });
 
   it('maps PERMISSION_DENIED on GET /api/v1/profile/application-defaults → 403', async () => {

--- a/services/gateway/src/routes/applications.ts
+++ b/services/gateway/src/routes/applications.ts
@@ -577,6 +577,85 @@ export const registerApplicationsRoutes = async (
     }
   );
 
+  // ---------- Application drafts (autosave scratchpad) ----------
+  //
+  // Backend-synced draft for a (caller, pet) pair — the autosave the SPA
+  // writes while the adopter fills out the form (useApplicationDraft.ts).
+  // Scoped to the caller via x-user-id metadata; distinct from the
+  // event-sourced draft Application above. `drafts/:petId` is two static-
+  // then-param segments, so it never collides with the one-segment
+  // `/api/v1/applications/:id` route.
+
+  app.get<{ Params: { petId: string } }>(
+    '/api/v1/applications/drafts/:petId',
+    {
+      config: { rateLimit: RL_READ },
+      schema: {
+        tags: ['applications'],
+        summary: "Get the caller's saved draft for a pet",
+      },
+    },
+    async (req, reply) => {
+      try {
+        const res = await client.getApplicationDraft(
+          { petId: req.params.petId },
+          buildMetadata(req)
+        );
+        // No draft yet is the common case — 404 is the SPA's "start fresh"
+        // signal (useApplicationDraft treats it as non-error).
+        if (!res.found) {
+          return reply.code(404).send({ error: 'draft not found' });
+        }
+        return reply.send({ data: draftToView(req.params.petId, res) });
+      } catch (err) {
+        return handleGrpcError(err, reply);
+      }
+    }
+  );
+
+  app.put<{ Params: { petId: string } }>(
+    '/api/v1/applications/drafts/:petId',
+    {
+      config: { rateLimit: RL_WRITE },
+      schema: {
+        tags: ['applications'],
+        summary: "Upsert the caller's draft for a pet (last-write-wins)",
+      },
+    },
+    async (req, reply) => {
+      const b = (req.body ?? {}) as Record<string, unknown>;
+      const answers = b.answers ?? {};
+      try {
+        const res = await client.saveApplicationDraft(
+          { petId: req.params.petId, answersJson: JSON.stringify(answers) },
+          buildMetadata(req)
+        );
+        return reply.send({ data: draftToView(req.params.petId, res) });
+      } catch (err) {
+        return handleGrpcError(err, reply);
+      }
+    }
+  );
+
+  app.delete<{ Params: { petId: string } }>(
+    '/api/v1/applications/drafts/:petId',
+    {
+      config: { rateLimit: RL_WRITE },
+      schema: {
+        tags: ['applications'],
+        summary: "Delete the caller's draft for a pet",
+      },
+    },
+    async (req, reply) => {
+      try {
+        await client.deleteApplicationDraft({ petId: req.params.petId }, buildMetadata(req));
+        return reply.code(204).send();
+      } catch (err) {
+        return handleGrpcError(err, reply);
+      }
+    }
+  );
+
   // ---------- Adopter application defaults ----------
   //
   // Reusable personal-info / living-situation / pet-experience / references
@@ -628,6 +707,21 @@ export const registerApplicationsRoutes = async (
 };
 
 // --- Helpers ---------------------------------------------------------
+
+// Shape a draft gRPC response into the SPA's ApplicationDraftPayload.
+// Both Get and Save responses carry these fields; expires_at is optional
+// on the wire and surfaces as null when unset.
+function draftToView(
+  petId: string,
+  res: { answersJson: string; updatedAt: string; expiresAt?: string }
+): { petId: string; answers: unknown; updatedAt: string; expiresAt: string | null } {
+  return {
+    petId,
+    answers: res.answersJson === '' ? {} : JSON.parse(res.answersJson),
+    updatedAt: res.updatedAt,
+    expiresAt: res.expiresAt ?? null,
+  };
+}
 
 function headerUserId(req: FastifyRequest): string | undefined {
   const raw = (req.headers as Record<string, string | string[] | undefined>)['x-user-id'];


### PR DESCRIPTION
## Why

Continuing the `app.client` route audit (after #1130 top-picks and #1131 application-defaults). Two more findings on the adoption-application path:

1. **Application drafts have no backend.** `ApplicationPage` uses `useApplicationDraft` to GET/PUT/DELETE `/api/v1/applications/drafts/:petId` — backend-synced form autosave so adopters resume from any device. The `application_drafts` table was already migrated (`007_create_application_drafts`), but no proto RPC, gRPC handler, or gateway route ever backed it. Every autosave 404s today.
2. **The defaults pre-population silently no-ops in production.** `applicationProfileService.getApplicationDefaults()` cast `api.get(...)` straight to `ApplicationDefaults` without reading the gateway's `{ data }` envelope, so `ApplicationPage` got `{ data: {...} }` and read `undefined` fields. The unit test masked it by mocking the already-unwrapped value.

## What

### Backend — application drafts
- **proto**: `GetApplicationDraft` / `SaveApplicationDraft` / `DeleteApplicationDraft` RPCs on `ApplicationService` (JSON-stringified `answers_json`, mirroring the existing draft fields).
- **service.applications**: direct-pool CRUD handlers (`application-draft-handlers.ts`) — same pattern as `application-defaults-handlers.ts` (no event sourcing; this is a scratchpad, not the Application aggregate). Always scoped to `principal.userId`; last-write-wins upsert stamping a fresh 30-day TTL; `DeleteApplicationDraft` is idempotent (missing draft → success, so the SPA's best-effort clear-on-submit never 404s).
- **gateway**: `GET`/`PUT`/`DELETE /api/v1/applications/drafts/:petId` (404 on no-draft = the SPA's "start fresh" signal; `{ data }` envelope matching `useApplicationDraft`'s `response.data` read). The two-segment `drafts/:petId` path never shadows the one-segment `/:id` route — covered by a test.

### Frontend — defaults envelope fix
- `applicationProfileService.getApplicationDefaults` / `updateApplicationDefaults` now read `.data`, and their tests mock the realistic `{ data: ... }` gateway response.

## Testing
TDD throughout. Green: `service.applications` (266), `service.gateway` (874), `app.client` (547). Type-check + lint clean.

## Out of scope (flagged, not built)
- **Sanctions banner** (`SanctionBannerHost` → `/api/v1/auth/sanctions/active` + `/acknowledge`): moderation has `ListUserSanctions` (active-only = the banner query) but **no `AcknowledgeSanction` RPC**, and only under `/api/v1/moderation/*`. Needs a new RPC + an auth-vs-moderation URL/ownership decision — left for a follow-up.
- **`notificationService.registerDeviceToken`/`unregisterDeviceToken`** hit `/api/v1/device-tokens` while the gateway serves `/api/v1/devices`, but neither method has a live caller (only their own test), so it's dead code rather than a wiring gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KXLTwu5Lue8SekkbNYZaY1

---
_Generated by [Claude Code](https://claude.ai/code/session_01KXLTwu5Lue8SekkbNYZaY1)_