### PR TITLE
feat: back the sanction banner with active-list + acknowledge

### DIFF
--- a/packages/proto/proto/adopt_dont_shop/moderation/v1/moderation.proto
+++ b/packages/proto/proto/adopt_dont_shop/moderation/v1/moderation.proto
@@ -82,6 +82,13 @@ service ModerationService {
   // moderation.sanctionAppealed.
   rpc AppealSanction(AppealSanctionRequest) returns (AppealSanctionResponse);
 
+  // Mark a sanction acknowledged (the sanctioned user dismisses the
+  // in-app banner). Ownership-gated like AppealSanction — a user can
+  // only acknowledge their own sanction. Idempotent: acknowledging an
+  // already-acknowledged sanction is a no-op success.
+  rpc AcknowledgeSanction(AcknowledgeSanctionRequest)
+      returns (AcknowledgeSanctionResponse);
+
   // ---------- Support tickets ----------
 
   // Open a new support ticket. user_id is optional — unauthenticated
@@ -334,6 +341,10 @@ message UserSanction {
   optional string appeal_status = 15;
   string created_at = 16;
   string updated_at = 17;
+  // Set when the sanctioned user dismisses the in-app banner. Unset
+  // while the banner is still showing (the active-banner query filters
+  // on this being null).
+  optional string acknowledged_at = 18;
 }
 
 message SupportTicket {
@@ -531,6 +542,9 @@ message ListUserSanctionsRequest {
   // When true, returns ALL sanctions (active + expired + revoked).
   // Default false returns only active ones (the banner query).
   bool include_inactive = 2;
+  // When true, excludes sanctions the user has already acknowledged —
+  // the in-app banner passes this so dismissed sanctions stay gone.
+  bool unacknowledged_only = 3;
 }
 
 message ListUserSanctionsResponse {
@@ -545,6 +559,16 @@ message AppealSanctionRequest {
 }
 
 message AppealSanctionResponse {
+  UserSanction sanction = 1;
+}
+
+// --- AcknowledgeSanction ---------------------------------------------
+
+message AcknowledgeSanctionRequest {
+  string sanction_id = 1;
+}
+
+message AcknowledgeSanctionResponse {
   UserSanction sanction = 1;
 }
 

--- a/packages/proto/src/generated/proto/adopt_dont_shop/moderation/v1/moderation.ts
+++ b/packages/proto/src/generated/proto/adopt_dont_shop/moderation/v1/moderation.ts
@@ -933,6 +933,12 @@ export interface UserSanction {
   appealStatus?: string | undefined;
   createdAt: string;
   updatedAt: string;
+  /**
+   * Set when the sanctioned user dismisses the in-app banner. Unset
+   * while the banner is still showing (the active-banner query filters
+   * on this being null).
+   */
+  acknowledgedAt?: string | undefined;
 }
 
 export interface SupportTicket {
@@ -1128,6 +1134,11 @@ export interface ListUserSanctionsRequest {
    * Default false returns only active ones (the banner query).
    */
   includeInactive: boolean;
+  /**
+   * When true, excludes sanctions the user has already acknowledged —
+   * the in-app banner passes this so dismissed sanctions stay gone.
+   */
+  unacknowledgedOnly: boolean;
 }
 
 export interface ListUserSanctionsResponse {
@@ -1140,6 +1151,14 @@ export interface AppealSanctionRequest {
 }
 
 export interface AppealSanctionResponse {
+  sanction?: UserSanction | undefined;
+}
+
+export interface AcknowledgeSanctionRequest {
+  sanctionId: string;
+}
+
+export interface AcknowledgeSanctionResponse {
   sanction?: UserSanction | undefined;
 }
 
@@ -2477,6 +2496,7 @@ function createBaseUserSanction(): UserSanction {
     appealStatus: undefined,
     createdAt: '',
     updatedAt: '',
+    acknowledgedAt: undefined,
   };
 }
 
@@ -2532,6 +2552,9 @@ export const UserSanction: MessageFns<UserSanction> = {
     }
     if (message.updatedAt !== '') {
       writer.uint32(138).string(message.updatedAt);
+    }
+    if (message.acknowledgedAt !== undefined) {
+      writer.uint32(146).string(message.acknowledgedAt);
     }
     return writer;
   },
@@ -2679,6 +2702,14 @@ export const UserSanction: MessageFns<UserSanction> = {
           message.updatedAt = reader.string();
           continue;
         }
+        case 18: {
+          if (tag !== 146) {
+            break;
+          }
+
+          message.acknowledgedAt = reader.string();
+          continue;
+        }
       }
       if ((tag & 7) === 4 || tag === 0) {
         break;
@@ -2763,6 +2794,11 @@ export const UserSanction: MessageFns<UserSanction> = {
         : isSet(object.updated_at)
           ? globalThis.String(object.updated_at)
           : '',
+      acknowledgedAt: isSet(object.acknowledgedAt)
+        ? globalThis.String(object.acknowledgedAt)
+        : isSet(object.acknowledged_at)
+          ? globalThis.String(object.acknowledged_at)
+          : undefined,
     };
   },
 
@@ -2819,6 +2855,9 @@ export const UserSanction: MessageFns<UserSanction> = {
     if (message.updatedAt !== '') {
       obj.updatedAt = message.updatedAt;
     }
+    if (message.acknowledgedAt !== undefined) {
+      obj.acknowledgedAt = message.acknowledgedAt;
+    }
     return obj;
   },
 
@@ -2844,6 +2883,7 @@ export const UserSanction: MessageFns<UserSanction> = {
     message.appealStatus = object.appealStatus ?? undefined;
     message.createdAt = object.createdAt ?? '';
     message.updatedAt = object.updatedAt ?? '';
+    message.acknowledgedAt = object.acknowledgedAt ?? undefined;
     return message;
   },
 };
@@ -5422,7 +5462,7 @@ export const IssueSanctionResponse: MessageFns<IssueSanctionResponse> = {
 };
 
 function createBaseListUserSanctionsRequest(): ListUserSanctionsRequest {
-  return { userId: '', includeInactive: false };
+  return { userId: '', includeInactive: false, unacknowledgedOnly: false };
 }
 
 export const ListUserSanctionsRequest: MessageFns<ListUserSanctionsRequest> = {
@@ -5435,6 +5475,9 @@ export const ListUserSanctionsRequest: MessageFns<ListUserSanctionsRequest> = {
     }
     if (message.includeInactive !== false) {
       writer.uint32(16).bool(message.includeInactive);
+    }
+    if (message.unacknowledgedOnly !== false) {
+      writer.uint32(24).bool(message.unacknowledgedOnly);
     }
     return writer;
   },
@@ -5462,6 +5505,14 @@ export const ListUserSanctionsRequest: MessageFns<ListUserSanctionsRequest> = {
           message.includeInactive = reader.bool();
           continue;
         }
+        case 3: {
+          if (tag !== 24) {
+            break;
+          }
+
+          message.unacknowledgedOnly = reader.bool();
+          continue;
+        }
       }
       if ((tag & 7) === 4 || tag === 0) {
         break;
@@ -5483,6 +5534,11 @@ export const ListUserSanctionsRequest: MessageFns<ListUserSanctionsRequest> = {
         : isSet(object.include_inactive)
           ? globalThis.Boolean(object.include_inactive)
           : false,
+      unacknowledgedOnly: isSet(object.unacknowledgedOnly)
+        ? globalThis.Boolean(object.unacknowledgedOnly)
+        : isSet(object.unacknowledged_only)
+          ? globalThis.Boolean(object.unacknowledged_only)
+          : false,
     };
   },
 
@@ -5493,6 +5549,9 @@ export const ListUserSanctionsRequest: MessageFns<ListUserSanctionsRequest> = {
     }
     if (message.includeInactive !== false) {
       obj.includeInactive = message.includeInactive;
+    }
+    if (message.unacknowledgedOnly !== false) {
+      obj.unacknowledgedOnly = message.unacknowledgedOnly;
     }
     return obj;
   },
@@ -5508,6 +5567,7 @@ export const ListUserSanctionsRequest: MessageFns<ListUserSanctionsRequest> = {
     const message = createBaseListUserSanctionsRequest();
     message.userId = object.userId ?? '';
     message.includeInactive = object.includeInactive ?? false;
+    message.unacknowledgedOnly = object.unacknowledgedOnly ?? false;
     return message;
   },
 };
@@ -5726,6 +5786,147 @@ export const AppealSanctionResponse: MessageFns<AppealSanctionResponse> = {
     object: I
   ): AppealSanctionResponse {
     const message = createBaseAppealSanctionResponse();
+    message.sanction =
+      object.sanction !== undefined && object.sanction !== null
+        ? UserSanction.fromPartial(object.sanction)
+        : undefined;
+    return message;
+  },
+};
+
+function createBaseAcknowledgeSanctionRequest(): AcknowledgeSanctionRequest {
+  return { sanctionId: '' };
+}
+
+export const AcknowledgeSanctionRequest: MessageFns<AcknowledgeSanctionRequest> = {
+  encode(
+    message: AcknowledgeSanctionRequest,
+    writer: BinaryWriter = new BinaryWriter()
+  ): BinaryWriter {
+    if (message.sanctionId !== '') {
+      writer.uint32(10).string(message.sanctionId);
+    }
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): AcknowledgeSanctionRequest {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseAcknowledgeSanctionRequest();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1: {
+          if (tag !== 10) {
+            break;
+          }
+
+          message.sanctionId = reader.string();
+          continue;
+        }
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): AcknowledgeSanctionRequest {
+    return {
+      sanctionId: isSet(object.sanctionId)
+        ? globalThis.String(object.sanctionId)
+        : isSet(object.sanction_id)
+          ? globalThis.String(object.sanction_id)
+          : '',
+    };
+  },
+
+  toJSON(message: AcknowledgeSanctionRequest): unknown {
+    const obj: any = {};
+    if (message.sanctionId !== '') {
+      obj.sanctionId = message.sanctionId;
+    }
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<AcknowledgeSanctionRequest>, I>>(
+    base?: I
+  ): AcknowledgeSanctionRequest {
+    return AcknowledgeSanctionRequest.fromPartial(base ?? ({} as any));
+  },
+  fromPartial<I extends Exact<DeepPartial<AcknowledgeSanctionRequest>, I>>(
+    object: I
+  ): AcknowledgeSanctionRequest {
+    const message = createBaseAcknowledgeSanctionRequest();
+    message.sanctionId = object.sanctionId ?? '';
+    return message;
+  },
+};
+
+function createBaseAcknowledgeSanctionResponse(): AcknowledgeSanctionResponse {
+  return { sanction: undefined };
+}
+
+export const AcknowledgeSanctionResponse: MessageFns<AcknowledgeSanctionResponse> = {
+  encode(
+    message: AcknowledgeSanctionResponse,
+    writer: BinaryWriter = new BinaryWriter()
+  ): BinaryWriter {
+    if (message.sanction !== undefined) {
+      UserSanction.encode(message.sanction, writer.uint32(10).fork()).join();
+    }
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): AcknowledgeSanctionResponse {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseAcknowledgeSanctionResponse();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1: {
+          if (tag !== 10) {
+            break;
+          }
+
+          message.sanction = UserSanction.decode(reader, reader.uint32());
+          continue;
+        }
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): AcknowledgeSanctionResponse {
+    return {
+      sanction: isSet(object.sanction) ? UserSanction.fromJSON(object.sanction) : undefined,
+    };
+  },
+
+  toJSON(message: AcknowledgeSanctionResponse): unknown {
+    const obj: any = {};
+    if (message.sanction !== undefined) {
+      obj.sanction = UserSanction.toJSON(message.sanction);
+    }
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<AcknowledgeSanctionResponse>, I>>(
+    base?: I
+  ): AcknowledgeSanctionResponse {
+    return AcknowledgeSanctionResponse.fromPartial(base ?? ({} as any));
+  },
+  fromPartial<I extends Exact<DeepPartial<AcknowledgeSanctionResponse>, I>>(
+    object: I
+  ): AcknowledgeSanctionResponse {
+    const message = createBaseAcknowledgeSanctionResponse();
     message.sanction =
       object.sanction !== undefined && object.sanction !== null
         ? UserSanction.fromPartial(object.sanction)
@@ -6994,6 +7195,25 @@ export const ModerationServiceService = {
       AppealSanctionResponse.decode(value),
   },
   /**
+   * Mark a sanction acknowledged (the sanctioned user dismisses the
+   * in-app banner). Ownership-gated like AppealSanction — a user can
+   * only acknowledge their own sanction. Idempotent: acknowledging an
+   * already-acknowledged sanction is a no-op success.
+   */
+  acknowledgeSanction: {
+    path: '/adopt_dont_shop.moderation.v1.ModerationService/AcknowledgeSanction' as const,
+    requestStream: false as const,
+    responseStream: false as const,
+    requestSerialize: (value: AcknowledgeSanctionRequest): Buffer =>
+      Buffer.from(AcknowledgeSanctionRequest.encode(value).finish()),
+    requestDeserialize: (value: Buffer): AcknowledgeSanctionRequest =>
+      AcknowledgeSanctionRequest.decode(value),
+    responseSerialize: (value: AcknowledgeSanctionResponse): Buffer =>
+      Buffer.from(AcknowledgeSanctionResponse.encode(value).finish()),
+    responseDeserialize: (value: Buffer): AcknowledgeSanctionResponse =>
+      AcknowledgeSanctionResponse.decode(value),
+  },
+  /**
    * Open a new support ticket. user_id is optional — unauthenticated
    * users can open tickets too (email + name only). Publishes
    * moderation.ticketOpened.
@@ -7147,6 +7367,13 @@ export interface ModerationServiceServer extends UntypedServiceImplementation {
    * moderation.sanctionAppealed.
    */
   appealSanction: handleUnaryCall<AppealSanctionRequest, AppealSanctionResponse>;
+  /**
+   * Mark a sanction acknowledged (the sanctioned user dismisses the
+   * in-app banner). Ownership-gated like AppealSanction — a user can
+   * only acknowledge their own sanction. Idempotent: acknowledging an
+   * already-acknowledged sanction is a no-op success.
+   */
+  acknowledgeSanction: handleUnaryCall<AcknowledgeSanctionRequest, AcknowledgeSanctionResponse>;
   /**
    * Open a new support ticket. user_id is optional — unauthenticated
    * users can open tickets too (email + name only). Publishes
@@ -7394,6 +7621,27 @@ export interface ModerationServiceClient extends Client {
     metadata: Metadata,
     options: Partial<CallOptions>,
     callback: (error: ServiceError | null, response: AppealSanctionResponse) => void
+  ): ClientUnaryCall;
+  /**
+   * Mark a sanction acknowledged (the sanctioned user dismisses the
+   * in-app banner). Ownership-gated like AppealSanction — a user can
+   * only acknowledge their own sanction. Idempotent: acknowledging an
+   * already-acknowledged sanction is a no-op success.
+   */
+  acknowledgeSanction(
+    request: AcknowledgeSanctionRequest,
+    callback: (error: ServiceError | null, response: AcknowledgeSanctionResponse) => void
+  ): ClientUnaryCall;
+  acknowledgeSanction(
+    request: AcknowledgeSanctionRequest,
+    metadata: Metadata,
+    callback: (error: ServiceError | null, response: AcknowledgeSanctionResponse) => void
+  ): ClientUnaryCall;
+  acknowledgeSanction(
+    request: AcknowledgeSanctionRequest,
+    metadata: Metadata,
+    options: Partial<CallOptions>,
+    callback: (error: ServiceError | null, response: AcknowledgeSanctionResponse) => void
   ): ClientUnaryCall;
   /**
    * Open a new support ticket. user_id is optional — unauthenticated

--- a/packages/proto/src/index.ts
+++ b/packages/proto/src/index.ts
@@ -451,6 +451,8 @@ export type {
   ListUserSanctionsResponse,
   AppealSanctionRequest,
   AppealSanctionResponse,
+  AcknowledgeSanctionRequest,
+  AcknowledgeSanctionResponse,
   OpenSupportTicketRequest,
   OpenSupportTicketResponse,
   GetSupportTicketRequest,

--- a/services/gateway/src/grpc-clients/moderation-client.contract.test.ts
+++ b/services/gateway/src/grpc-clients/moderation-client.contract.test.ts
@@ -57,6 +57,7 @@ const makeHandlers = (
   issueSanction: unimplemented,
   listUserSanctions: unimplemented,
   appealSanction: unimplemented,
+  acknowledgeSanction: unimplemented,
   openSupportTicket: unimplemented,
   getSupportTicket: unimplemented,
   listSupportTickets: unimplemented,

--- a/services/gateway/src/grpc-clients/moderation-client.ts
+++ b/services/gateway/src/grpc-clients/moderation-client.ts
@@ -11,6 +11,8 @@ import { credentials, Metadata, type CallOptions } from '@grpc/grpc-js';
 
 import {
   ModerationV1,
+  type AcknowledgeSanctionRequest,
+  type AcknowledgeSanctionResponse,
   type AddEvidenceRequest,
   type AddEvidenceResponse,
   type AppealSanctionRequest,
@@ -70,6 +72,10 @@ export type ModerationClient = {
     metadata: Metadata
   ): Promise<ListUserSanctionsResponse>;
   appealSanction(req: AppealSanctionRequest, metadata: Metadata): Promise<AppealSanctionResponse>;
+  acknowledgeSanction(
+    req: AcknowledgeSanctionRequest,
+    metadata: Metadata
+  ): Promise<AcknowledgeSanctionResponse>;
   openSupportTicket(
     req: OpenSupportTicketRequest,
     metadata: Metadata
@@ -160,6 +166,8 @@ export const createModerationClient = (opts: CreateModerationClientOptions): Mod
     addEvidence: (req, metadata) => callUnary(stub.addEvidence, req, metadata, false),
     issueSanction: (req, metadata) => callUnary(stub.issueSanction, req, metadata, false),
     appealSanction: (req, metadata) => callUnary(stub.appealSanction, req, metadata, false),
+    acknowledgeSanction: (req, metadata) =>
+      callUnary(stub.acknowledgeSanction, req, metadata, false),
     openSupportTicket: (req, metadata) => callUnary(stub.openSupportTicket, req, metadata, false),
     respondToTicket: (req, metadata) => callUnary(stub.respondToTicket, req, metadata, false),
     assignSupportTicket: (req, metadata) =>

--- a/services/gateway/src/routes/moderation.test.ts
+++ b/services/gateway/src/routes/moderation.test.ts
@@ -25,6 +25,7 @@ function makeClient(): {
     'issueSanction',
     'listUserSanctions',
     'appealSanction',
+    'acknowledgeSanction',
     'openSupportTicket',
     'getSupportTicket',
     'listSupportTickets',
@@ -197,6 +198,65 @@ describe('moderation sanction + ticket routes', () => {
       sanctionId: 'sanc-1',
       appealReason: 'provoked',
     });
+  });
+
+  it('GET /api/v1/auth/sanctions/active scopes to the caller + maps the banner shape', async () => {
+    mocks.listUserSanctions.mockResolvedValue({
+      sanctions: [
+        {
+          sanctionId: 'sanc-1',
+          userId: 'mod-1',
+          sanctionType: ModerationV1.SanctionType.SANCTION_TYPE_TEMPORARY_BAN,
+          reason: ModerationV1.SanctionReason.SANCTION_REASON_HARASSMENT,
+          description: 'Abusive behaviour',
+          isActive: true,
+          startDate: '2026-06-01T00:00:00.000Z',
+          endDate: '2026-06-08T00:00:00.000Z',
+          issuedBy: 'admin-1',
+          createdAt: '2026-06-01T00:00:00.000Z',
+          updatedAt: '2026-06-01T00:00:00.000Z',
+        },
+      ],
+    });
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/v1/auth/sanctions/active',
+      headers: HEADERS,
+    });
+    expect(res.statusCode).toBe(200);
+    // Scoped to the caller, active-only, unacknowledged-only (the banner query).
+    expect(mocks.listUserSanctions.mock.calls[0][0]).toEqual({
+      userId: 'mod-1',
+      includeInactive: false,
+      unacknowledgedOnly: true,
+    });
+    expect((res.json() as { sanctions: unknown[] }).sanctions).toEqual([
+      {
+        id: 'sanc-1',
+        type: 'user_suspended',
+        reason: 'Abusive behaviour',
+        severity: 'high',
+        expiresAt: '2026-06-08T00:00:00.000Z',
+        acknowledgedAt: null,
+      },
+    ]);
+  });
+
+  it('GET /api/v1/auth/sanctions/active → 401 without an authenticated caller', async () => {
+    const res = await app.inject({ method: 'GET', url: '/api/v1/auth/sanctions/active' });
+    expect(res.statusCode).toBe(401);
+    expect(mocks.listUserSanctions).not.toHaveBeenCalled();
+  });
+
+  it('POST /api/v1/auth/sanctions/:id/acknowledge → AcknowledgeSanction, 204', async () => {
+    mocks.acknowledgeSanction.mockResolvedValue({ sanction: { sanctionId: 'sanc-1' } });
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/v1/auth/sanctions/sanc-1/acknowledge',
+      headers: HEADERS,
+    });
+    expect(res.statusCode).toBe(204);
+    expect(mocks.acknowledgeSanction.mock.calls[0][0]).toEqual({ sanctionId: 'sanc-1' });
   });
 
   it('POST /api/v1/moderation/tickets → OpenSupportTicket, 201', async () => {

--- a/services/gateway/src/routes/moderation.ts
+++ b/services/gateway/src/routes/moderation.ts
@@ -33,7 +33,7 @@
 // x-user-* metadata via the Phase 2.5 authenticate middleware.
 
 import rateLimit from '@fastify/rate-limit';
-import type { FastifyInstance } from 'fastify';
+import type { FastifyInstance, FastifyRequest } from 'fastify';
 
 import {
   ModerationV1,
@@ -49,6 +49,7 @@ import {
   type OpenSupportTicketRequest,
   type ResolveReportRequest,
   type RespondToTicketRequest,
+  type UserSanction,
 } from '@adopt-dont-shop/proto';
 
 import type { ModerationClient } from '../grpc-clients/moderation-client.js';
@@ -341,7 +342,11 @@ export const registerModerationRoutes = async (
       const q = req.query as Record<string, string | undefined>;
       try {
         const res = await client.listUserSanctions(
-          { userId: req.params.userId, includeInactive: q.includeInactive === 'true' },
+          {
+            userId: req.params.userId,
+            includeInactive: q.includeInactive === 'true',
+            unacknowledgedOnly: false,
+          },
           buildMetadata(req)
         );
         return reply.send(ModerationV1.ListUserSanctionsResponse.toJSON(res));
@@ -369,6 +374,60 @@ export const registerModerationRoutes = async (
       try {
         const res = await client.appealSanction(grpcReq, buildMetadata(req));
         return reply.send(ModerationV1.AppealSanctionResponse.toJSON(res));
+      } catch (err) {
+        return handleGrpcError(err, reply);
+      }
+    }
+  );
+
+  // ---------- Self-service sanctions (in-app banner) ----------
+  //
+  // These carry the SPA's /api/v1/auth/sanctions/* paths (app.client's
+  // SanctionBannerHost) but are backed by the moderation service — the
+  // gateway is just a router, and the moderation client lives here. Both
+  // are scoped to the CALLING user: the list passes the caller's own id
+  // (the service allows self-reads) and acknowledge gates on ownership.
+
+  app.get(
+    '/api/v1/auth/sanctions/active',
+    {
+      config: { rateLimit: RL_READ },
+      schema: {
+        tags: ['moderation'],
+        summary: "List the caller's active, unacknowledged sanctions",
+      },
+    },
+    async (req, reply) => {
+      const userId = headerUserId(req);
+      if (userId === undefined) {
+        return reply.code(401).send({ error: 'unauthenticated' });
+      }
+      try {
+        const res = await client.listUserSanctions(
+          { userId, includeInactive: false, unacknowledgedOnly: true },
+          buildMetadata(req)
+        );
+        return reply.send({ sanctions: res.sanctions.map(sanctionToActiveSanction) });
+      } catch (err) {
+        return handleGrpcError(err, reply);
+      }
+    }
+  );
+
+  app.post<{ Params: { id: string } }>(
+    '/api/v1/auth/sanctions/:id/acknowledge',
+    {
+      config: { rateLimit: RL_WRITE },
+      schema: {
+        tags: ['moderation'],
+        summary: "Acknowledge (dismiss the banner for) one of the caller's sanctions",
+        params: { type: 'object', properties: { id: { type: 'string' } }, required: ['id'] },
+      },
+    },
+    async (req, reply) => {
+      try {
+        await client.acknowledgeSanction({ sanctionId: req.params.id }, buildMetadata(req));
+        return reply.code(204).send();
       } catch (err) {
         return handleGrpcError(err, reply);
       }
@@ -641,4 +700,69 @@ function parseTicketCategory(raw: string | undefined): ModerationV1.SupportTicke
     ModerationV1.SupportTicketCategory.UNRECOGNIZED,
     raw
   );
+}
+
+// Read the authenticated caller's id from the gateway-stamped header
+// (the same header buildMetadata forwards as the gRPC principal).
+function headerUserId(req: FastifyRequest): string | undefined {
+  const raw = (req.headers as Record<string, string | string[] | undefined>)['x-user-id'];
+  return typeof raw === 'string' && raw.length > 0 ? raw : undefined;
+}
+
+// UserSanction → the SPA's ActiveSanction banner shape. The banner keys
+// its title/variant off ModeratorActionType-style strings, so the 7
+// SanctionType values collapse onto the 4 it recognises. `reason` carries
+// the moderator's free-text description; severity is a display hint only.
+type ActiveSanctionView = {
+  id: string;
+  type: string;
+  reason: string;
+  severity: string;
+  expiresAt: string | null;
+  acknowledgedAt: string | null;
+};
+
+const SANCTION_TYPE_VIEW: Record<ModerationV1.SanctionType, { type: string; severity: string }> = {
+  [ModerationV1.SanctionType.SANCTION_TYPE_WARNING]: { type: 'warning_issued', severity: 'low' },
+  [ModerationV1.SanctionType.SANCTION_TYPE_RESTRICTION]: {
+    type: 'account_restricted',
+    severity: 'medium',
+  },
+  [ModerationV1.SanctionType.SANCTION_TYPE_MESSAGING_RESTRICTION]: {
+    type: 'account_restricted',
+    severity: 'medium',
+  },
+  [ModerationV1.SanctionType.SANCTION_TYPE_POSTING_RESTRICTION]: {
+    type: 'account_restricted',
+    severity: 'medium',
+  },
+  [ModerationV1.SanctionType.SANCTION_TYPE_APPLICATION_RESTRICTION]: {
+    type: 'account_restricted',
+    severity: 'medium',
+  },
+  [ModerationV1.SanctionType.SANCTION_TYPE_TEMPORARY_BAN]: {
+    type: 'user_suspended',
+    severity: 'high',
+  },
+  [ModerationV1.SanctionType.SANCTION_TYPE_PERMANENT_BAN]: {
+    type: 'user_banned',
+    severity: 'critical',
+  },
+  [ModerationV1.SanctionType.SANCTION_TYPE_UNSPECIFIED]: {
+    type: 'account_restricted',
+    severity: 'medium',
+  },
+  [ModerationV1.SanctionType.UNRECOGNIZED]: { type: 'account_restricted', severity: 'medium' },
+};
+
+function sanctionToActiveSanction(s: UserSanction): ActiveSanctionView {
+  const view = SANCTION_TYPE_VIEW[s.sanctionType];
+  return {
+    id: s.sanctionId,
+    type: view.type,
+    reason: s.description,
+    severity: view.severity,
+    expiresAt: s.endDate ?? null,
+    acknowledgedAt: s.acknowledgedAt ?? null,
+  };
 }

--- a/services/moderation/src/grpc/sanction-handlers.test.ts
+++ b/services/moderation/src/grpc/sanction-handlers.test.ts
@@ -2,13 +2,19 @@ import { describe, expect, it, vi } from 'vitest';
 
 import {
   ModerationV1,
+  type AcknowledgeSanctionRequest,
   type AppealSanctionRequest,
   type IssueSanctionRequest,
   type ListUserSanctionsRequest,
 } from '@adopt-dont-shop/proto';
 
 import { HandlerError, type HandlerDeps } from './adapter.js';
-import { appealSanction, issueSanction, listUserSanctions } from './sanction-handlers.js';
+import {
+  acknowledgeSanction,
+  appealSanction,
+  issueSanction,
+  listUserSanctions,
+} from './sanction-handlers.js';
 
 function makePrincipal(
   overrides: Partial<{ userId: string; permissions: string[]; roles: string[] }> = {}
@@ -72,6 +78,7 @@ function sanctionRow(overrides: Record<string, unknown> = {}) {
     appealed_at: null,
     appeal_reason: null,
     appeal_status: null,
+    acknowledged_at: null,
     created_at: new Date('2026-06-01T12:00:00.000Z'),
     updated_at: new Date('2026-06-01T12:00:00.000Z'),
     ...overrides,
@@ -177,6 +184,75 @@ describe('listUserSanctions', () => {
     const all = makeDeps([{ rows: [] }]);
     await listUserSanctions(all.deps, makePrincipal(), { userId: 'usr-2', includeInactive: true });
     expect(all.query.mock.calls[0][0]).not.toContain('is_active = true');
+  });
+
+  it('excludes acknowledged sanctions when unacknowledged_only is set (the banner query)', async () => {
+    const banner = makeDeps([{ rows: [] }]);
+    await listUserSanctions(banner.deps, makePrincipal({ userId: 'usr-2', permissions: [] }), {
+      userId: 'usr-2',
+      unacknowledgedOnly: true,
+    });
+    expect(banner.query.mock.calls[0][0]).toContain('acknowledged_at IS NULL');
+
+    const all = makeDeps([{ rows: [] }]);
+    await listUserSanctions(all.deps, makePrincipal(), { userId: 'usr-2' });
+    expect(all.query.mock.calls[0][0]).not.toContain('acknowledged_at IS NULL');
+  });
+});
+
+describe('acknowledgeSanction', () => {
+  it('throws INVALID_ARGUMENT on missing sanction_id', async () => {
+    const { deps } = makeDeps([]);
+    await expect(
+      acknowledgeSanction(deps, makePrincipal(), { sanctionId: '' } as AcknowledgeSanctionRequest)
+    ).rejects.toMatchObject({ code: 'INVALID_ARGUMENT' });
+  });
+
+  it('throws NOT_FOUND on a missing sanction', async () => {
+    const { deps } = makeDeps([{ rows: [] }]);
+    await expect(
+      acknowledgeSanction(deps, makePrincipal({ userId: 'usr-2' }), { sanctionId: 'gone' })
+    ).rejects.toMatchObject({ code: 'NOT_FOUND' });
+  });
+
+  it("throws PERMISSION_DENIED acknowledging another user's sanction", async () => {
+    const { deps } = makeDeps([{ rows: [sanctionRow({ user_id: 'usr-2' })] }]);
+    await expect(
+      acknowledgeSanction(deps, makePrincipal({ userId: 'usr-99', permissions: [] }), {
+        sanctionId: 'sanc-1',
+      })
+    ).rejects.toMatchObject({ code: 'PERMISSION_DENIED' });
+  });
+
+  it('stamps acknowledged_at for the owner and returns the updated sanction', async () => {
+    const acknowledgedRow = sanctionRow({
+      user_id: 'usr-2',
+      acknowledged_at: new Date('2026-06-02T09:00:00.000Z'),
+    });
+    const { deps, query } = makeDeps([
+      { rows: [sanctionRow({ user_id: 'usr-2' })] }, // SELECT FOR UPDATE
+      { rows: [acknowledgedRow] }, // UPDATE RETURNING
+    ]);
+    const res = await acknowledgeSanction(
+      deps,
+      makePrincipal({ userId: 'usr-2', permissions: [] }),
+      {
+        sanctionId: 'sanc-1',
+      }
+    );
+    expect(res.sanction.acknowledgedAt).toBe('2026-06-02T09:00:00.000Z');
+    expect(query.mock.calls[1][0]).toContain('acknowledged_at = NOW()');
+  });
+
+  it('is idempotent — an already-acknowledged sanction is returned without a second write', async () => {
+    const { deps, query } = makeDeps([
+      { rows: [sanctionRow({ user_id: 'usr-2', acknowledged_at: new Date() })] },
+    ]);
+    await acknowledgeSanction(deps, makePrincipal({ userId: 'usr-2', permissions: [] }), {
+      sanctionId: 'sanc-1',
+    });
+    // Only the SELECT ran — no UPDATE.
+    expect(query).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/services/moderation/src/grpc/sanction-handlers.ts
+++ b/services/moderation/src/grpc/sanction-handlers.ts
@@ -15,6 +15,8 @@ import { requirePermission, type Principal } from '@adopt-dont-shop/authz';
 import { withTransaction } from '@adopt-dont-shop/events';
 import { MODERATION_SANCTIONS_MANAGE } from '@adopt-dont-shop/lib.types';
 import type {
+  AcknowledgeSanctionRequest,
+  AcknowledgeSanctionResponse,
   AppealSanctionRequest,
   AppealSanctionResponse,
   IssueSanctionRequest,
@@ -31,7 +33,7 @@ const SANCTION_SELECT = `
   sanction_id, user_id, sanction_type, reason, description, is_active,
   start_date, end_date, duration, issued_by, report_id,
   moderator_action_id, appealed_at, appeal_reason, appeal_status,
-  created_at, updated_at
+  acknowledged_at, created_at, updated_at
 `;
 
 function ensureModerationPermission(principal: Principal): void {
@@ -152,18 +154,74 @@ export async function listUserSanctions(
   }
 
   // Default: active sanctions only (the banner). include_inactive
-  // returns the full history.
+  // returns the full history. unacknowledged_only additionally drops
+  // sanctions the user has already dismissed (the in-app banner query).
   const activeFilter = req.includeInactive ? '' : 'AND is_active = true';
+  const ackFilter = req.unacknowledgedOnly ? 'AND acknowledged_at IS NULL' : '';
 
   const { rows } = await deps.pool.query<UserSanctionRow>(
     `SELECT ${SANCTION_SELECT}
      FROM user_sanctions
-     WHERE user_id = $1 ${activeFilter}
+     WHERE user_id = $1 ${activeFilter} ${ackFilter}
      ORDER BY start_date DESC`,
     [req.userId]
   );
 
   return { sanctions: rows.map(sanctionRowToProto) };
+}
+
+// --- AcknowledgeSanction ---------------------------------------------
+
+export async function acknowledgeSanction(
+  deps: HandlerDeps,
+  principal: Principal,
+  req: AcknowledgeSanctionRequest
+): Promise<AcknowledgeSanctionResponse> {
+  // The sanctioned user dismisses their own banner — gate on ownership
+  // (super_admin may act on a user's behalf, mirroring AppealSanction).
+  if (req.sanctionId === undefined || req.sanctionId === '') {
+    throw new HandlerError('INVALID_ARGUMENT', 'sanction_id is required');
+  }
+
+  return withTransaction(deps, async ({ client }) => {
+    const existing = await client.query<UserSanctionRow>(
+      `SELECT ${SANCTION_SELECT}
+       FROM user_sanctions
+       WHERE sanction_id = $1
+       FOR UPDATE`,
+      [req.sanctionId]
+    );
+
+    if (existing.rows.length === 0) {
+      throw new HandlerError('NOT_FOUND', `sanction ${req.sanctionId} not found`);
+    }
+
+    const row = existing.rows[0];
+
+    if (row.user_id !== principal.userId && !principal.roles.includes('super_admin')) {
+      throw new HandlerError('PERMISSION_DENIED', 'can only acknowledge your own sanction');
+    }
+
+    // Idempotent: acknowledging again is a no-op success — the banner
+    // calls this best-effort and shouldn't error on a double-dismiss.
+    if (row.acknowledged_at !== null) {
+      return { sanction: sanctionRowToProto(row) };
+    }
+
+    const updated = await client.query<UserSanctionRow>(
+      `UPDATE user_sanctions
+       SET acknowledged_at = NOW(), updated_at = NOW()
+       WHERE sanction_id = $1
+       RETURNING ${SANCTION_SELECT}`,
+      [req.sanctionId]
+    );
+
+    if (updated.rows.length !== 1) {
+      throw new HandlerError('INTERNAL', 'update returned no rows');
+    }
+
+    return { sanction: sanctionRowToProto(updated.rows[0]) };
+  });
 }
 
 // --- AppealSanction --------------------------------------------------

--- a/services/moderation/src/grpc/sanction-ticket-mapper.test.ts
+++ b/services/moderation/src/grpc/sanction-ticket-mapper.test.ts
@@ -28,6 +28,7 @@ function baseSanctionRow(overrides: Partial<UserSanctionRow> = {}): UserSanction
     appealed_at: null,
     appeal_reason: null,
     appeal_status: null,
+    acknowledged_at: null,
     created_at: new Date('2026-06-01T12:00:00.000Z'),
     updated_at: new Date('2026-06-01T12:00:00.000Z'),
     ...overrides,
@@ -80,6 +81,14 @@ describe('sanctionRowToProto', () => {
     expect(proto.appealReason).toBe('I was provoked.');
     // appeal_status is forwarded raw — string, not enum.
     expect(proto.appealStatus).toBe('pending');
+  });
+
+  it('maps acknowledged_at when the user has dismissed the banner; omits it otherwise', () => {
+    expect(sanctionRowToProto(baseSanctionRow()).acknowledgedAt).toBeUndefined();
+    const acked = sanctionRowToProto(
+      baseSanctionRow({ acknowledged_at: new Date('2026-06-03T08:00:00.000Z') })
+    );
+    expect(acked.acknowledgedAt).toBe('2026-06-03T08:00:00.000Z');
   });
 
   it('omits report_id + moderator_action_id when sanction is direct (no originator)', () => {

--- a/services/moderation/src/grpc/sanction-ticket-mapper.ts
+++ b/services/moderation/src/grpc/sanction-ticket-mapper.ts
@@ -40,6 +40,7 @@ export type UserSanctionRow = {
   // but the proto carries it as an `optional string` so the gateway
   // forwards the raw value unchanged. No enum-map dispatch here.
   appeal_status: string | null;
+  acknowledged_at: Date | null;
   created_at: Date;
   updated_at: Date;
 };
@@ -78,6 +79,9 @@ export function sanctionRowToProto(row: UserSanctionRow): UserSanction {
   }
   if (row.appeal_status !== null) {
     sanction.appealStatus = row.appeal_status;
+  }
+  if (row.acknowledged_at !== null) {
+    sanction.acknowledgedAt = row.acknowledged_at.toISOString();
   }
 
   return sanction;

--- a/services/moderation/src/grpc/server.ts
+++ b/services/moderation/src/grpc/server.ts
@@ -19,7 +19,12 @@ import type { ModerationConfig } from '../config.js';
 import { addEvidence, listModeratorActions, logModeratorAction } from './action-handlers.js';
 import { adapt } from './adapter.js';
 import { assignReport, fileReport, getReport, listReports, resolveReport } from './handlers.js';
-import { appealSanction, issueSanction, listUserSanctions } from './sanction-handlers.js';
+import {
+  acknowledgeSanction,
+  appealSanction,
+  issueSanction,
+  listUserSanctions,
+} from './sanction-handlers.js';
 import {
   assignSupportTicket,
   getSupportTicket,
@@ -57,6 +62,7 @@ export const createGrpcServer = (opts: CreateGrpcServerOptions): Server => {
     issueSanction: adapt(issueSanction, { deps, logger }),
     listUserSanctions: adapt(listUserSanctions, { deps, logger }),
     appealSanction: adapt(appealSanction, { deps, logger }),
+    acknowledgeSanction: adapt(acknowledgeSanction, { deps, logger }),
     // Support tickets (ticket-handlers.ts)
     openSupportTicket: adapt(openSupportTicket, { deps, logger }),
     getSupportTicket: adapt(getSupportTicket, { deps, logger }),
@@ -66,7 +72,7 @@ export const createGrpcServer = (opts: CreateGrpcServerOptions): Server => {
   });
 
   logger.info('gRPC ModerationService registered', {
-    methodCount: 16,
+    methodCount: 17,
     grpcPort: config.grpcPort,
   });
 

--- a/services/moderation/src/migrations/011_add_sanction_acknowledged_at.ts
+++ b/services/moderation/src/migrations/011_add_sanction_acknowledged_at.ts
@@ -1,0 +1,24 @@
+import type { MigrationBuilder } from 'node-pg-migrate';
+
+// Add user_sanctions.acknowledged_at — set when the sanctioned user
+// dismisses the in-app banner (GET /api/v1/auth/sanctions/active filters
+// on it being null so dismissed sanctions stay gone). Nullable: existing
+// rows are treated as unacknowledged. The partial index backs the
+// active-and-unacknowledged banner query.
+
+export const up = async (pgm: MigrationBuilder): Promise<void> => {
+  pgm.addColumn('user_sanctions', {
+    acknowledged_at: { type: 'timestamptz' },
+  });
+  pgm.createIndex('user_sanctions', ['user_id'], {
+    name: 'user_sanctions_user_unacknowledged_idx',
+    where: 'is_active = true AND acknowledged_at IS NULL',
+  });
+};
+
+export const down = async (pgm: MigrationBuilder): Promise<void> => {
+  pgm.dropIndex('user_sanctions', ['user_id'], {
+    name: 'user_sanctions_user_unacknowledged_idx',
+  });
+  pgm.dropColumn('user_sanctions', 'acknowledged_at');
+};

--- a/services/moderation/src/migrations/migrations.test.ts
+++ b/services/moderation/src/migrations/migrations.test.ts
@@ -49,6 +49,7 @@ describe('moderation migrations', () => {
     '008_create_support_ticket_responses.ts',
     '009_add_system_autoreport_unique_index.ts',
     '010_make_reporter_id_nullable.ts',
+    '011_add_sanction_acknowledged_at.ts',
   ])('%s exports `up` and `down` functions', async filename => {
     const mod = (await import(`./${filename}`)) as {
       up: unknown;


### PR DESCRIPTION
## Why

The last remaining **live, always-mounted** gap from the `app.client` route audit. `SanctionBannerHost` (mounted in `AppShell`, shown on every page) calls:
- `GET /api/v1/auth/sanctions/active` — the caller's active, unacknowledged sanctions
- `POST /api/v1/auth/sanctions/:id/acknowledge` — dismiss a sanction's banner

Neither route existed at the gateway, and the moderation service had no way to acknowledge a sanction (the `UserSanction` row had no `acknowledged_at`).

## What

### moderation service
- **Migration** `011_add_sanction_acknowledged_at`: adds `user_sanctions.acknowledged_at` + a partial index for the active-and-unacknowledged banner query.
- **`ListUserSanctions`**: new `unacknowledged_only` filter (the banner passes it so dismissed sanctions stay gone).
- **`AcknowledgeSanction`** RPC + handler: ownership-gated like `AppealSanction` (a user acks only their own sanction; super_admin may act on their behalf), idempotent (re-acking is a no-op success). Mapper + `acknowledged_at` round-trip.

### gateway
- `GET /api/v1/auth/sanctions/active` — scoped to the caller (`x-user-id`), active + unacknowledged, mapping `UserSanction` → the SPA's `ActiveSanction` shape (the 7 `SanctionType` values collapse onto the 4 banner title keys; `reason` ← moderator description; severity is a display hint). Returns `{ sanctions: [...] }`.
- `POST /api/v1/auth/sanctions/:id/acknowledge` → 204.
- Backed by the moderation client (the gateway is just a router; these self-service paths live alongside the other sanctions routes). **Frontend unchanged** — it already targeted these exact paths/contract.

## Testing
TDD throughout. Green: `service.moderation` (316), `service.gateway` (877). Type-check + lint clean.

## Audit status
This closes the last live gap. The only remaining flagged item is dead code: `notificationService.registerDeviceToken`/`unregisterDeviceToken` hit `/api/v1/device-tokens` vs the gateway's `/api/v1/devices`, but neither has a live caller.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KXLTwu5Lue8SekkbNYZaY1

---
_Generated by [Claude Code](https://claude.ai/code/session_01KXLTwu5Lue8SekkbNYZaY1)_