### PR TITLE
fix(gateway): hash/validate user-supplied values used in Redis keys (ADS-880)

### DIFF
--- a/services/gateway/src/routes/email-rate-limiter.test.ts
+++ b/services/gateway/src/routes/email-rate-limiter.test.ts
@@ -124,4 +124,45 @@ describe('createEmailRateLimiter (redis-backed)', () => {
     expect(await limiter.consume('a@example.com')).toBe(true);
     expect(await limiter.consume('a@example.com')).toBe(true);
   });
+
+  it('never stores the raw email in the Redis key, so a crafted email cannot fragment it', async () => {
+    const seenKeys: string[] = [];
+    const counts = new Map<string, number>();
+    const redis = {
+      incr: (key: string): Promise<number> => {
+        seenKeys.push(key);
+        const next = (counts.get(key) ?? 0) + 1;
+        counts.set(key, next);
+        return Promise.resolve(next);
+      },
+      expire: (): Promise<number> => Promise.resolve(1),
+    };
+    const limiter = createEmailRateLimiter({ max: 1, windowMs: 60_000, redis });
+
+    await limiter.consume('attacker:0\r\nINJECTED@example.com');
+
+    expect(seenKeys).toHaveLength(1);
+    // Exactly two colons: prefix:bucket:hash — the email's own colon/CRLF
+    // never reach the key, so they can't smuggle in a third segment.
+    expect(seenKeys[0].split(':')).toHaveLength(3);
+    expect(seenKeys[0]).not.toContain('INJECTED');
+  });
+
+  it('hits the same Redis bucket for the same email across calls', async () => {
+    const counts = new Map<string, number>();
+    const redis = {
+      incr: (key: string): Promise<number> => {
+        const next = (counts.get(key) ?? 0) + 1;
+        counts.set(key, next);
+        return Promise.resolve(next);
+      },
+      expire: (): Promise<number> => Promise.resolve(1),
+    };
+    const limiter = createEmailRateLimiter({ max: 2, windowMs: 60_000, redis });
+
+    expect(await limiter.consume('a@example.com')).toBe(true);
+    expect(await limiter.consume('a@example.com')).toBe(true);
+    // Same email hashes to the same key, so the 3rd attempt is throttled.
+    expect(await limiter.consume('a@example.com')).toBe(false);
+  });
 });

--- a/services/gateway/src/routes/email-rate-limiter.ts
+++ b/services/gateway/src/routes/email-rate-limiter.ts
@@ -11,6 +11,8 @@
 // is N-replica-safe), otherwise a per-replica in-memory counter. Like the IP
 // limiter it fails OPEN on a Redis error — availability over a hard fail.
 
+import { hashKeyPart, redisKey } from '../utils/redis-key.js';
+
 // The slim Redis surface this limiter uses. ioredis' Redis satisfies it.
 export type EmailRateLimiterRedis = {
   incr: (key: string) => Promise<number>;
@@ -76,8 +78,10 @@ const redisLimiter = (
   return {
     consume: async (email: string): Promise<boolean> => {
       // Fixed-window bucket: same email in the same window shares a key.
+      // The email is hashed (not stored raw) so a crafted value containing
+      // `:` or newlines can't fragment or collide with a neighbouring key.
       const bucket = Math.floor(now() / windowMs);
-      const key = `${KEY_PREFIX}:${bucket}:${email}`;
+      const key = redisKey(KEY_PREFIX, String(bucket), hashKeyPart(email));
       try {
         const count = await redis.incr(key);
         if (count === 1) {

--- a/services/gateway/src/routes/gdpr.test.ts
+++ b/services/gateway/src/routes/gdpr.test.ts
@@ -168,7 +168,7 @@ describe('POST /api/v1/users/me/erasure-request — idempotency', () => {
     const first = await app.inject({
       method: 'POST',
       url: '/api/v1/users/me/erasure-request',
-      headers: { 'x-user-id': 'usr-idem' },
+      headers: { 'x-user-id': '11111111-1111-1111-1111-111111111111' },
       payload: {},
     });
     expect(first.statusCode).toBe(202);
@@ -180,7 +180,7 @@ describe('POST /api/v1/users/me/erasure-request — idempotency', () => {
     const second = await app.inject({
       method: 'POST',
       url: '/api/v1/users/me/erasure-request',
-      headers: { 'x-user-id': 'usr-idem' },
+      headers: { 'x-user-id': '11111111-1111-1111-1111-111111111111' },
       payload: {},
     });
     expect(second.statusCode).toBe(202);
@@ -192,17 +192,27 @@ describe('POST /api/v1/users/me/erasure-request — idempotency', () => {
     expect(published).toHaveLength(1);
   });
 
+  it('rejects a non-UUID x-user-id rather than building an unvalidated Redis key', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/v1/users/me/erasure-request',
+      headers: { 'x-user-id': 'usr-1' },
+      payload: {},
+    });
+    expect(res.statusCode).toBe(500);
+  });
+
   it('does not deduplicate across different users', async () => {
     await app.inject({
       method: 'POST',
       url: '/api/v1/users/me/erasure-request',
-      headers: { 'x-user-id': 'usr-a' },
+      headers: { 'x-user-id': '22222222-2222-2222-2222-222222222222' },
       payload: {},
     });
     const res = await app.inject({
       method: 'POST',
       url: '/api/v1/users/me/erasure-request',
-      headers: { 'x-user-id': 'usr-b' },
+      headers: { 'x-user-id': '33333333-3333-3333-3333-333333333333' },
       payload: {},
     });
     expect(res.statusCode).toBe(202);
@@ -236,7 +246,7 @@ describe('POST /api/v1/users/me/erasure-request — rate-limit', () => {
       const res = await app.inject({
         method: 'POST',
         url: '/api/v1/users/me/erasure-request',
-        headers: { 'x-user-id': 'usr-rl' },
+        headers: { 'x-user-id': '44444444-4444-4444-4444-444444444444' },
         payload: {},
       });
       expect(res.statusCode).toBe(202);
@@ -244,7 +254,7 @@ describe('POST /api/v1/users/me/erasure-request — rate-limit', () => {
     const limited = await app.inject({
       method: 'POST',
       url: '/api/v1/users/me/erasure-request',
-      headers: { 'x-user-id': 'usr-rl' },
+      headers: { 'x-user-id': '44444444-4444-4444-4444-444444444444' },
       payload: {},
     });
     expect(limited.statusCode).toBe(429);
@@ -255,14 +265,14 @@ describe('POST /api/v1/users/me/erasure-request — rate-limit', () => {
       await app.inject({
         method: 'POST',
         url: '/api/v1/users/me/erasure-request',
-        headers: { 'x-user-id': 'usr-exhausted' },
+        headers: { 'x-user-id': '55555555-5555-5555-5555-555555555555' },
         payload: {},
       });
     }
     const other = await app.inject({
       method: 'POST',
       url: '/api/v1/users/me/erasure-request',
-      headers: { 'x-user-id': 'usr-fresh' },
+      headers: { 'x-user-id': '66666666-6666-6666-6666-666666666666' },
       payload: {},
     });
     expect(other.statusCode).toBe(202);

--- a/services/gateway/src/routes/gdpr.ts
+++ b/services/gateway/src/routes/gdpr.ts
@@ -21,6 +21,7 @@ import type { AuditClient } from '../grpc-clients/audit-client.js';
 import type { AuthClient } from '../grpc-clients/auth-client.js';
 import { buildMetadata } from '../middleware/metadata.js';
 import { handleGrpcError } from '../middleware/grpc-error.js';
+import { assertUuid, redisKey } from '../utils/redis-key.js';
 
 // Minimal Redis interface — only the operations the route needs.
 // Satisfied by ioredis.Redis and the test doubles alike.
@@ -43,7 +44,11 @@ export type GdprRoutesOptions = {
   redis?: ErasureStore;
 };
 
-const ERASURE_IDEMPOTENCY_KEY = (userId: string) => `gdpr:erasure:${userId}`;
+// userId is sourced from the authenticated x-user-id header today, so this
+// is safe — but validating the UUID shape here means a future change that
+// takes userId from a less-trusted source fails loudly instead of silently
+// widening this key's input space (ADS-880).
+const ERASURE_IDEMPOTENCY_KEY = (userId: string) => redisKey('gdpr', 'erasure', assertUuid(userId));
 const ERASURE_IDEMPOTENCY_TTL_SECONDS = 24 * 60 * 60;
 
 // Per-route rate-limit: 5 requests per hour per authenticated user.

--- a/services/gateway/src/utils/redis-key.test.ts
+++ b/services/gateway/src/utils/redis-key.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+
+import { assertUuid, hashKeyPart, redisKey } from './redis-key.js';
+
+describe('redisKey', () => {
+  it('joins safe segments with a colon', () => {
+    expect(redisKey('auth-email-rl', '123', 'abc')).toBe('auth-email-rl:123:abc');
+  });
+
+  it('rejects a segment containing a colon', () => {
+    expect(() => redisKey('prefix', 'a:b')).toThrow(/Unsafe Redis key segment/);
+  });
+
+  it('rejects a segment containing a newline or carriage return', () => {
+    expect(() => redisKey('prefix', 'a\nb')).toThrow(/Unsafe Redis key segment/);
+    expect(() => redisKey('prefix', 'a\rb')).toThrow(/Unsafe Redis key segment/);
+  });
+});
+
+describe('hashKeyPart', () => {
+  it('returns a stable SHA-256 hex digest', () => {
+    const hash = hashKeyPart('alex@example.com');
+    expect(hash).toMatch(/^[0-9a-f]{64}$/);
+    expect(hashKeyPart('alex@example.com')).toBe(hash);
+  });
+
+  it('produces different digests for different inputs', () => {
+    expect(hashKeyPart('a@example.com')).not.toBe(hashKeyPart('b@example.com'));
+  });
+
+  it('never contains characters that could fragment a Redis key', () => {
+    const hash = hashKeyPart('attacker:1\r\nINJECTED');
+    expect(redisKey('prefix', hash)).toBe(`prefix:${hash}`);
+  });
+});
+
+describe('assertUuid', () => {
+  it('returns the value when it is a valid UUID', () => {
+    const id = '123e4567-e89b-12d3-a456-426614174000';
+    expect(assertUuid(id)).toBe(id);
+  });
+
+  it('throws for a non-UUID value', () => {
+    expect(() => assertUuid('not-a-uuid')).toThrow(/Expected a UUID/);
+  });
+
+  it('throws for a value smuggling Redis key delimiters', () => {
+    expect(() => assertUuid('abc:1\r\nINJECTED')).toThrow(/Expected a UUID/);
+  });
+});

--- a/services/gateway/src/utils/redis-key.ts
+++ b/services/gateway/src/utils/redis-key.ts
@@ -1,0 +1,41 @@
+// Shared sanitization contract for building Redis keys from
+// user-controlled or otherwise untrusted segments (ADS-880).
+//
+// Redis keys are colon-delimited by convention in this codebase
+// (`prefix:bucket:value`). A segment containing a raw `:`, `\r`, or `\n`
+// can fragment the key and let a crafted value collide with or escape its
+// intended namespace. Pre-trusted segments (literal prefixes, numeric
+// buckets) are validated as-is; values derived from request input must be
+// hashed first via `hashKeyPart`.
+
+import { createHash } from 'node:crypto';
+
+const UNSAFE_KEY_CHARS = /[:\r\n]/;
+
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+// Joins pre-sanitized segments into a single Redis key, rejecting any
+// segment that could fragment or collide with a neighbouring key.
+export const redisKey = (...parts: string[]): string => parts.map(assertSafeKeyPart).join(':');
+
+const assertSafeKeyPart = (part: string): string => {
+  if (UNSAFE_KEY_CHARS.test(part)) {
+    throw new Error(`Unsafe Redis key segment: ${JSON.stringify(part)}`);
+  }
+  return part;
+};
+
+// Hashes an untrusted value (e.g. a user-supplied email) into a fixed-shape,
+// always-safe key segment. Also avoids storing the raw value in Redis.
+export const hashKeyPart = (value: string): string =>
+  createHash('sha256').update(value).digest('hex');
+
+// Validates that a value used to key a Redis entry is a UUID, so a future
+// change that takes the value from an untrusted source fails loudly rather
+// than silently widening the key's input space.
+export const assertUuid = (value: string): string => {
+  if (!UUID_PATTERN.test(value)) {
+    throw new Error(`Expected a UUID, got: ${JSON.stringify(value)}`);
+  }
+  return value;
+};


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

Closes [ADS-880](https://linear.app/ideasquared/issue/ADS-880): hash or encode user-supplied values used in Redis keys.

- Adds `services/gateway/src/utils/redis-key.ts`: a `redisKey()` / `hashKeyPart()` / `assertUuid()` sanitization contract for building Redis keys from untrusted segments (rejects `:`, `\r`, `\n`; hashes arbitrary input to a safe fixed shape).
- `services/gateway/src/routes/email-rate-limiter.ts`: the Redis-backed limiter key is now built from a SHA-256 hash of the (already-normalized) email instead of the raw value, closing the key-fragmentation/namespace-escape vector.
- `services/gateway/src/routes/gdpr.ts`: the erasure idempotency key now validates `userId` is a UUID before building the key, so a future change sourcing `userId` from a less-trusted input fails loudly instead of silently widening the key's input space.
- Tests cover: a crafted email containing `:`/CRLF cannot smuggle a third key segment, the same (normalized) email still hits the same bucket, and a non-UUID `userId` is rejected rather than reaching Redis unvalidated.

**Deviation from the ticket's suggested location:** the ticket proposes putting the shared helper in `lib.utils`, but that package is one of the frontend-shared libs and the gateway service has no existing dependency on it. Introducing that cross-boundary dependency for two backend-only call sites didn't seem justified, so the helper is colocated under `services/gateway/src/utils/` instead.

## Test plan

- [x] `vitest run` in `services/gateway` — 889/889 passing
- [x] `eslint src` in `services/gateway` — clean
- [x] `tsc --noEmit` in `services/gateway` — clean
- [x] New tests for crafted-email key-fragmentation, hash consistency, and non-UUID `userId` rejection

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TLqEj5K8RY38VrmW666vdE
EOF
)