### PR TITLE
feat(gateway): Zod validation for register + lock applications identity to auth header

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2016,6 +2016,9 @@ importers:
       winston:
         specifier: ^3.19.0
         version: 3.19.0
+      zod:
+        specifier: ^4.4.3
+        version: 4.4.3
     devDependencies:
       '@adopt-dont-shop/test-utils':
         specifier: workspace:*
@@ -7574,6 +7577,7 @@ packages:
   git-raw-commits@5.0.1:
     resolution: {integrity: sha512-Y+csSm2GD/PCSh6Isd/WiMjNAydu0VBiG9J7EdQsNA5P9uXvLayqjmTsNlK5Gs9IhblFZqOU0yid5Il5JPoLiQ==}
     engines: {node: '>=18'}
+    deprecated: Deprecated and no longer maintained. Use @conventional-changelog/git-client instead.
     hasBin: true
 
   glob-parent@6.0.2:

--- a/services/gateway/package.json
+++ b/services/gateway/package.json
@@ -56,7 +56,8 @@
     "prom-client": "^15.1.3",
     "sharp": "^0.35.2",
     "socket.io": "^4.8.3",
-    "winston": "^3.19.0"
+    "winston": "^3.19.0",
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@adopt-dont-shop/test-utils": "workspace:*",

--- a/services/gateway/src/routes/applications.test.ts
+++ b/services/gateway/src/routes/applications.test.ts
@@ -315,6 +315,23 @@ describe('applications routes', () => {
     });
   });
 
+  it('POST ignores a forged userId in the body — uses the authenticated principal (ADS-879)', async () => {
+    mocks.startDraft.mockResolvedValue({ application: { ...APP, version: 1 } });
+    mocks.saveDraftAnswers.mockResolvedValue({ application: { ...APP, version: 2 } });
+    mocks.submitDraft.mockResolvedValue({ application: SUBMITTED });
+
+    const payload = { userId: 'attacker-2', adopterId: 'attacker-2', petId: 'pet-1' };
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/v1/applications',
+      headers: ADOPTER,
+      payload,
+    });
+
+    expect(res.statusCode).toBe(201);
+    expect(mocks.startDraft.mock.calls[0][0]).toEqual({ adopterId: 'usr-1', petId: 'pet-1' });
+  });
+
   it('PATCH /:id/status approved → Approve, returns the view', async () => {
     mocks.approve.mockResolvedValue({ application: SUBMITTED });
     const res = await app.inject({

--- a/services/gateway/src/routes/applications.ts
+++ b/services/gateway/src/routes/applications.ts
@@ -90,7 +90,10 @@ export const registerApplicationsRoutes = async (
     },
     async (req, reply) => {
       const b = (req.body ?? {}) as Record<string, unknown>;
-      const adopterId = (b.userId as string) ?? (b.adopterId as string) ?? headerUserId(req) ?? '';
+      // ADS-879: identity is never trusted from the body — always the
+      // authenticated principal, so a stale/forged userId can't impersonate
+      // another adopter even if a downstream permission check regresses.
+      const adopterId = headerUserId(req) ?? '';
       const petId = (b.petId as string) ?? '';
       const meta = buildMetadata(req);
       try {

--- a/services/gateway/src/routes/auth.schemas.ts
+++ b/services/gateway/src/routes/auth.schemas.ts
@@ -1,0 +1,51 @@
+// Zod schemas for the auth account-lifecycle routes (ADS-879). The gateway
+// is the public edge — these bound format/length before a request reaches
+// the inter-service layer, instead of relying on the downstream auth
+// service to reject malformed input.
+//
+// Bodies accept both camelCase and snake_case keys (matching the existing
+// pickString/pickBool alias lists in auth.ts), so `normalizeRegisterBody`
+// resolves aliases into the canonical shape before it's validated.
+
+import { z } from 'zod';
+
+export const RegisterBodySchema = z.object({
+  email: z.string().trim().min(1, 'email is required').max(254).email('email must be valid'),
+  password: z.string().min(8, 'password must be at least 8 characters').max(128),
+  firstName: z.string().trim().max(100).default(''),
+  lastName: z.string().trim().max(100).default(''),
+  phoneNumber: z.string().trim().max(32).optional(),
+  termsAccepted: z.boolean().default(false),
+  privacyPolicyAccepted: z.boolean().default(false),
+});
+
+export type RegisterBody = z.infer<typeof RegisterBodySchema>;
+
+const pickRaw = (body: Record<string, unknown>, keys: readonly string[]): unknown => {
+  for (const key of keys) {
+    if (body[key] !== undefined && body[key] !== null) {
+      return body[key];
+    }
+  }
+  return undefined;
+};
+
+export const normalizeRegisterBody = (body: Record<string, unknown>): Record<string, unknown> => ({
+  email: body.email,
+  password: body.password,
+  firstName: pickRaw(body, ['firstName', 'first_name']),
+  lastName: pickRaw(body, ['lastName', 'last_name']),
+  phoneNumber: pickRaw(body, ['phoneNumber', 'phone_number']),
+  termsAccepted: pickRaw(body, ['termsAccepted', 'terms_accepted', 'acceptedTerms']),
+  privacyPolicyAccepted: pickRaw(body, ['privacyPolicyAccepted', 'privacy_policy_accepted']),
+});
+
+export type ValidationFailure = {
+  error: string;
+  details: { path: string; message: string }[];
+};
+
+export const toValidationFailure = (error: z.ZodError): ValidationFailure => ({
+  error: 'Invalid request body',
+  details: error.issues.map(issue => ({ path: issue.path.join('.'), message: issue.message })),
+});

--- a/services/gateway/src/routes/auth.test.ts
+++ b/services/gateway/src/routes/auth.test.ts
@@ -654,6 +654,74 @@ describe('auth account-lifecycle input validation (ADS-853)', () => {
     }
   });
 
+  it('POST /auth/register rejects a missing email with 400', async () => {
+    const m = makeClient();
+    const app = await makeApp(m.client);
+    try {
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/v1/auth/register',
+        payload: { password: 'longenoughpw' },
+      });
+      expect(res.statusCode).toBe(400);
+      expect(m.registerMock).not.toHaveBeenCalled();
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('POST /auth/register rejects a malformed email with 400', async () => {
+    const m = makeClient();
+    const app = await makeApp(m.client);
+    try {
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/v1/auth/register',
+        payload: { email: 'not-an-email', password: 'longenoughpw' },
+      });
+      expect(res.statusCode).toBe(400);
+      expect(m.registerMock).not.toHaveBeenCalled();
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('POST /auth/register rejects a too-short password with 400', async () => {
+    const m = makeClient();
+    const app = await makeApp(m.client);
+    try {
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/v1/auth/register',
+        payload: { email: 'a@example.com', password: 'short' },
+      });
+      expect(res.statusCode).toBe(400);
+      expect(m.registerMock).not.toHaveBeenCalled();
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('POST /auth/register rejects an oversized payload with 400', async () => {
+    const m = makeClient();
+    const app = await makeApp(m.client);
+    try {
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/v1/auth/register',
+        payload: {
+          email: 'a@example.com',
+          password: 'longenoughpw',
+          firstName: 'x'.repeat(500),
+        },
+      });
+      expect(res.statusCode).toBe(400);
+      expect(m.registerMock).not.toHaveBeenCalled();
+    } finally {
+      await app.close();
+    }
+  });
+
   it('POST /auth/verify-email rejects a non-string token with 400', async () => {
     const m = makeClient();
     const app = await makeApp(m.client);
@@ -760,7 +828,7 @@ describe('auth account-lifecycle input validation (ADS-853)', () => {
         url: '/api/v1/auth/register',
         payload: {
           email: 'a@example.com',
-          password: 'pw',
+          password: 'longenoughpw',
           first_name: 'SnakeFirst',
           lastName: 'CamelLast',
         },

--- a/services/gateway/src/routes/auth.ts
+++ b/services/gateway/src/routes/auth.ts
@@ -36,6 +36,7 @@ import { handleGrpcError } from '../middleware/grpc-error.js';
 
 import { normalizeEmail, type EmailRateLimiter } from './email-rate-limiter.js';
 import { rolesToApi, withApiUser } from './auth-user-json.js';
+import { normalizeRegisterBody, RegisterBodySchema, toValidationFailure } from './auth.schemas.js';
 
 export type AuthRoutesOptions = {
   client: AuthClient;
@@ -284,22 +285,23 @@ export const registerAuthRoutes = async (
     },
     async (req, reply) => {
       const b = (req.body ?? {}) as Record<string, unknown>;
+      const parsed = RegisterBodySchema.safeParse(normalizeRegisterBody(b));
+      if (!parsed.success) {
+        return reply.code(400).send(toValidationFailure(parsed.error));
+      }
+      const body = parsed.data;
       try {
         const res = await client.register(
           {
-            email: pickString(b, ['email'], ''),
-            password: pickString(b, ['password'], ''),
-            firstName: pickString(b, ['firstName', 'first_name'], ''),
-            lastName: pickString(b, ['lastName', 'last_name'], ''),
-            phoneNumber: pickString(b, ['phoneNumber', 'phone_number']),
+            email: body.email,
+            password: body.password,
+            firstName: body.firstName,
+            lastName: body.lastName,
+            phoneNumber: body.phoneNumber,
             ipAddress: req.ip,
             userAgent: req.headers['user-agent'],
-            termsAccepted: pickBool(b, ['termsAccepted', 'terms_accepted', 'acceptedTerms'], false),
-            privacyPolicyAccepted: pickBool(
-              b,
-              ['privacyPolicyAccepted', 'privacy_policy_accepted'],
-              false
-            ),
+            termsAccepted: body.termsAccepted,
+            privacyPolicyAccepted: body.privacyPolicyAccepted,
           },
           buildMetadata(req)
         );
@@ -653,25 +655,6 @@ function pickString(
     }
     if (typeof value !== 'string') {
       throw new BadRequestError(`${key} must be a string`);
-    }
-    return value;
-  }
-  return fallback;
-}
-
-// Boolean counterpart to pickString, preserving the `?? ?? false` chains.
-function pickBool(
-  body: Record<string, unknown>,
-  keys: readonly string[],
-  fallback: boolean
-): boolean {
-  for (const key of keys) {
-    const value = body[key];
-    if (!isPresent(value)) {
-      continue;
-    }
-    if (typeof value !== 'boolean') {
-      throw new BadRequestError(`${key} must be a boolean`);
     }
     return value;
   }


### PR DESCRIPTION
## Summary

- First slice of ADS-879: gateway-layer input validation hardening for auth and identity-bearing routes.
- `POST /api/v1/applications` now derives `adopterId` solely from the authenticated `x-user-id` header — body-supplied `userId`/`adopterId` is ignored, closing a defense-in-depth gap (one regressed permission check away from IDOR).
- `POST /api/v1/auth/register` gets a Zod schema (`auth.schemas.ts`) enforcing email format, password/name length bounds, and boolean field types; failures return a structured `400` instead of forwarding unvalidated input to the downstream gRPC auth service.

## Changes

- `services/gateway/src/routes/applications.ts` — identity for application creation comes only from the auth header.
- `services/gateway/src/routes/auth.schemas.ts` (new) — `RegisterBodySchema` + alias-normalization helper + structured validation-failure formatter.
- `services/gateway/src/routes/auth.ts` — register handler now validates via the new schema; removed the now-orphaned `pickBool` helper (its only caller was register).
- `services/gateway/src/routes/applications.test.ts`, `auth.test.ts` — new tests for forged body identity, missing email, malformed email, too-short password, oversized field.
- `services/gateway/package.json` / `pnpm-lock.yaml` — added `zod` as a direct dependency (was previously only transitive).

## Before requesting review

- [x] Tests for new behaviour added (TDD)
- [ ] If touching `.env` requirements, updated `.env.example`'s REQUIRED block — n/a
- [ ] If touching a `lib.*`, considered consumer impact — n/a (gateway-only)

## Test plan

- [x] Existing tests pass (`pnpm --filter @adopt-dont-shop/service.gateway test` — 882/882 passing)
- [x] New behaviour is covered by tests
- [x] Lint passes (`eslint` on changed files — clean)
- [ ] `pnpm type-check` — pre-existing unrelated failure in this sandbox (`@adopt-dont-shop/lib.types` not built before standalone `tsc --noEmit`); confirmed present on `main` before this change too.

## Related

- Linear: ADS-879 (in progress — this PR covers slice 1/2: applications identity fix + register schema). Login/forgot-password/reset-password schemas and full `pickString` removal are a follow-up slice per the ticket's own sequencing.


---
_Generated by [Claude Code](https://claude.ai/code/session_016fvK7Tq8jtTRuNTiwuafgS)_