### PR TITLE
chore(client): remove dead device-token methods from notificationService

### DIFF
--- a/apps/client/src/services/notificationService.test.ts
+++ b/apps/client/src/services/notificationService.test.ts
@@ -235,27 +235,3 @@ describe('subscriptions', () => {
     expect(listener).not.toHaveBeenCalled();
   });
 });
-
-describe('device tokens', () => {
-  it('registers a device token', async () => {
-    apiPost.mockResolvedValue(undefined);
-
-    await notificationService.registerDeviceToken('tok-1');
-
-    expect(apiPost).toHaveBeenCalledWith('/api/v1/device-tokens', { token: 'tok-1' });
-  });
-
-  it('unregisters a device token', async () => {
-    apiDelete.mockResolvedValue(undefined);
-
-    await notificationService.unregisterDeviceToken('tok-1');
-
-    expect(apiDelete).toHaveBeenCalledWith('/api/v1/device-tokens/tok-1');
-  });
-
-  it('propagates a registration failure', async () => {
-    apiPost.mockRejectedValue(new Error('rejected'));
-
-    await expect(notificationService.registerDeviceToken('tok-1')).rejects.toThrow('rejected');
-  });
-});

--- a/apps/client/src/services/notificationService.ts
+++ b/apps/client/src/services/notificationService.ts
@@ -302,30 +302,6 @@ class NotificationService {
   }
 
   /**
-   * Register device for push notifications
-   */
-  async registerDeviceToken(token: string): Promise<void> {
-    try {
-      await api.post('/api/v1/device-tokens', { token });
-    } catch (error) {
-      console.error('Failed to register device token:', error);
-      throw error;
-    }
-  }
-
-  /**
-   * Unregister device token
-   */
-  async unregisterDeviceToken(token: string): Promise<void> {
-    try {
-      await api.delete(`/api/v1/device-tokens/${token}`);
-    } catch (error) {
-      console.error('Failed to unregister device token:', error);
-      throw error;
-    }
-  }
-
-  /**
    * Start periodic polling for notifications (fallback if websockets not available)
    */
   startPolling(intervalMs: number = 30000): () => void {


### PR DESCRIPTION
## Summary
- Removes `registerDeviceToken`/`unregisterDeviceToken` from `apps/client/src/services/notificationService.ts` — neither had any caller anywhere in `apps/client`.
- `unregisterDeviceToken` also couldn't be cleanly repointed at the real gateway contract: `DELETE /api/v1/devices/:tokenId` (`services/gateway/src/routes/devices.ts`) deletes by the `device_tokens` row id, but the dead method only ever received the raw token value — there was no id to pass.
- Removes the corresponding `describe('device tokens', ...)` test block.

This is the last gap closed in the `app.client` route-vs-service audit (see prior PRs #1130, #1131, #1164, #1165).

## Test plan
- [x] `vitest run apps/client/src/services/notificationService.test.ts` — 20 passed
- [x] `eslint` clean on both changed files
- [x] `tsc --noEmit` clean on `apps/client`
- [x] Confirmed via grep: zero remaining references to either removed method in `apps/client/src`


---
_Generated by [Claude Code](https://claude.ai/code/session_01KXLTwu5Lue8SekkbNYZaY1)_