### PR TITLE
fix: close gateway route gaps found in app.rescue audit

### DIFF
--- a/services/gateway/src/routes/rescue-view.ts
+++ b/services/gateway/src/routes/rescue-view.ts
@@ -17,7 +17,7 @@ function token(toJSON: (v: number) => string, value: number, prefix: string): st
   return toJSON(value).slice(prefix.length).toLowerCase();
 }
 
-function parseSettings(json: string | undefined): Record<string, unknown> {
+export function parseSettings(json: string | undefined): Record<string, unknown> {
   if (!json || json === '{}') {
     return {};
   }

--- a/services/gateway/src/routes/rescues-public.test.ts
+++ b/services/gateway/src/routes/rescues-public.test.ts
@@ -157,21 +157,83 @@ describe('rescues public routes', () => {
     expect(res.statusCode).toBe(201);
   });
 
-  it('PUT /api/v1/rescues/:id forwards the update payload and returns the envelope', async () => {
+  it('PUT /api/v1/rescues/:id updates the profile, unpacking nested address', async () => {
     mocks.update.mockResolvedValueOnce({ rescue: RESCUE });
     const res = await app.inject({
       method: 'PUT',
       url: '/api/v1/rescues/rsc-1',
-      payload: { name: 'Happy Tails Renamed', city: 'Leeds' },
+      payload: {
+        name: 'Happy Tails Renamed',
+        phone: '01234',
+        address: { street: '2 Lane', city: 'Leeds', postcode: 'LS1 1AA', country: 'GB' },
+      },
     });
     expect(res.statusCode).toBe(200);
-    const body = res.json() as { success: boolean; data: { rescue_id: string } };
-    expect(body.success).toBe(true);
-    expect(body.data.rescue_id).toBe('rsc-1');
     expect(mocks.update.mock.calls[0][0]).toMatchObject({
       rescueId: 'rsc-1',
       name: 'Happy Tails Renamed',
+      phone: '01234',
+      address: '2 Lane',
       city: 'Leeds',
+      postcode: 'LS1 1AA',
+      country: 'GB',
     });
+    expect((res.json() as { data: { rescue_id: string } }).data.rescue_id).toBe('rsc-1');
+  });
+
+  it('PUT /api/v1/rescues/:id 404s when the rescue does not exist', async () => {
+    mocks.update.mockResolvedValueOnce({ rescue: undefined });
+    const res = await app.inject({
+      method: 'PUT',
+      url: '/api/v1/rescues/rsc-x',
+      payload: { name: 'Ghost' },
+    });
+    expect(res.statusCode).toBe(404);
+  });
+
+  it('GET /api/v1/rescues/:id/adoption-policies reads adoptionPolicies out of settings', async () => {
+    mocks.get.mockResolvedValueOnce({
+      rescue: {
+        ...RESCUE,
+        settingsJson: JSON.stringify({ adoptionPolicies: { requireHomeVisit: true } }),
+      },
+    });
+    const res = await app.inject({ method: 'GET', url: '/api/v1/rescues/rsc-1/adoption-policies' });
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual({ success: true, data: { requireHomeVisit: true } });
+  });
+
+  it('GET /api/v1/rescues/:id/adoption-policies returns null when none are set', async () => {
+    mocks.get.mockResolvedValueOnce({ rescue: RESCUE });
+    const res = await app.inject({ method: 'GET', url: '/api/v1/rescues/rsc-1/adoption-policies' });
+    expect(res.json()).toEqual({ success: true, data: null });
+  });
+
+  it('PUT /api/v1/rescues/:id/adoption-policies merges into settings without clobbering other keys', async () => {
+    mocks.get.mockResolvedValueOnce({
+      rescue: { ...RESCUE, settingsJson: JSON.stringify({ theme: 'dark' }) },
+    });
+    mocks.update.mockResolvedValueOnce({ rescue: RESCUE });
+    const policy = { requireHomeVisit: true, minimumReferenceCount: 2 };
+    const res = await app.inject({
+      method: 'PUT',
+      url: '/api/v1/rescues/rsc-1/adoption-policies',
+      payload: policy,
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual({ success: true, data: policy });
+    const updateArg = mocks.update.mock.calls[0][0] as { rescueId: string; settingsJson: string };
+    expect(updateArg.rescueId).toBe('rsc-1');
+    expect(JSON.parse(updateArg.settingsJson)).toEqual({ theme: 'dark', adoptionPolicies: policy });
+  });
+
+  it('PUT /api/v1/rescues/:id/adoption-policies 404s when the rescue does not exist', async () => {
+    mocks.get.mockResolvedValueOnce({ rescue: undefined });
+    const res = await app.inject({
+      method: 'PUT',
+      url: '/api/v1/rescues/rsc-x/adoption-policies',
+      payload: {},
+    });
+    expect(res.statusCode).toBe(404);
   });
 });

--- a/services/gateway/src/routes/rescues-public.ts
+++ b/services/gateway/src/routes/rescues-public.ts
@@ -20,7 +20,7 @@ import {
 
 import type { RescueClient } from '../grpc-clients/rescue-client.js';
 
-import { rescueDataEnvelope, rescueListEnvelope } from './rescue-view.js';
+import { parseSettings, rescueDataEnvelope, rescueListEnvelope } from './rescue-view.js';
 import { buildMetadata } from '../middleware/metadata.js';
 import { handleGrpcError } from '../middleware/grpc-error.js';
 import { parsePagination } from '../middleware/pagination.js';
@@ -236,10 +236,10 @@ export const registerRescuesPublicRoutes = async (
     }
   );
 
-  // PUT /api/v1/rescues/:id — profile update. lib.rescue / app.rescue's
-  // Settings page write to the plural base path (matching the read routes
-  // above), unlike the singular /api/v1/rescue/:id PATCH route.
-  app.put<{ Params: { id: string }; Body: UpdateRescueBody }>(
+  // PUT /api/v1/rescues/:id — profile update. lib.rescue/app.rescue's
+  // RescueSettings page saves the profile form here (plural path, same
+  // base as every other rescue read above).
+  app.put<{ Params: { id: string } }>(
     '/api/v1/rescues/:id',
     {
       config: { rateLimit: RL_WRITE },
@@ -249,7 +249,7 @@ export const registerRescuesPublicRoutes = async (
       },
     },
     async (req, reply) => {
-      const grpcReq: UpdateRescueRequest = { rescueId: req.params.id, ...(req.body ?? {}) };
+      const grpcReq = buildUpdateRequest(req.params.id, req.body);
       try {
         const res = await client.update(grpcReq, buildMetadata(req));
         if (res.rescue === undefined) {
@@ -261,9 +261,66 @@ export const registerRescuesPublicRoutes = async (
       }
     }
   );
-};
 
-type UpdateRescueBody = Partial<Omit<UpdateRescueRequest, 'rescueId'>>;
+  // GET /api/v1/rescues/:id/adoption-policies — read the adoptionPolicies
+  // key out of the rescue's settings JSON blob.
+  app.get<{ Params: { id: string } }>(
+    '/api/v1/rescues/:id/adoption-policies',
+    {
+      config: { rateLimit: RL_READ },
+      schema: {
+        tags: ['rescues'],
+        summary: "Get a rescue's adoption policies",
+      },
+    },
+    async (req, reply) => {
+      try {
+        const res = await client.get({ rescueId: req.params.id }, buildMetadata(req));
+        if (res.rescue === undefined) {
+          return reply.code(404).send({ success: false, error: 'rescue not found' });
+        }
+        const settings = parseSettings(res.rescue.settingsJson);
+        return reply.send({ success: true, data: settings.adoptionPolicies ?? null });
+      } catch (err) {
+        return handleGrpcError(err, reply);
+      }
+    }
+  );
+
+  // PUT /api/v1/rescues/:id/adoption-policies — replace the adoptionPolicies
+  // key in settings, preserving the rest of the settings blob. UpdateRescue's
+  // settingsJson field replaces the whole blob, so we read-merge-write.
+  app.put<{ Params: { id: string } }>(
+    '/api/v1/rescues/:id/adoption-policies',
+    {
+      config: { rateLimit: RL_WRITE },
+      schema: {
+        tags: ['rescues'],
+        summary: "Update a rescue's adoption policies",
+      },
+    },
+    async (req, reply) => {
+      try {
+        const current = await client.get({ rescueId: req.params.id }, buildMetadata(req));
+        if (current.rescue === undefined) {
+          return reply.code(404).send({ success: false, error: 'rescue not found' });
+        }
+        const settings = parseSettings(current.rescue.settingsJson);
+        const merged = { ...settings, adoptionPolicies: req.body ?? {} };
+        const res = await client.update(
+          { rescueId: req.params.id, settingsJson: JSON.stringify(merged) },
+          buildMetadata(req)
+        );
+        if (res.rescue === undefined) {
+          return reply.code(404).send({ success: false, error: 'rescue not found' });
+        }
+        return reply.send({ success: true, data: merged.adoptionPolicies });
+      } catch (err) {
+        return handleGrpcError(err, reply);
+      }
+    }
+  );
+};
 
 // --- Helpers ---------------------------------------------------------
 
@@ -292,6 +349,34 @@ function parseStatusFilter(raw: string): RescueV1.RescueStatus {
   } catch {
     return RescueV1.RescueStatus.RESCUE_STATUS_UNSPECIFIED;
   }
+}
+
+// app.rescue's RescueProfileForm posts a nested `address: { street, city,
+// county, postcode, country }` shape; UpdateRescueRequest wants those as
+// flat fields (address = street). Pick whichever the caller sent.
+function buildUpdateRequest(rescueId: string, body: unknown): UpdateRescueRequest {
+  const b = (body ?? {}) as Record<string, unknown>;
+  const address = (b.address ?? {}) as Record<string, unknown>;
+  const str = (v: unknown): string | undefined =>
+    typeof v === 'string' && v !== '' ? v : undefined;
+
+  return {
+    rescueId,
+    name: str(b.name),
+    phone: str(b.phone),
+    address: str(address.street) ?? str(b.address),
+    city: str(address.city) ?? str(b.city),
+    county: str(address.county) ?? str(b.county),
+    postcode: str(address.postcode) ?? str(b.postcode),
+    country: str(address.country) ?? str(b.country),
+    website: str(b.website),
+    description: str(b.description),
+    mission: str(b.mission),
+    contactPerson: str(b.contactPerson ?? b.contact_person),
+    contactTitle: str(b.contactTitle ?? b.contact_title),
+    contactEmail: str(b.contactEmail ?? b.contact_email),
+    contactPhone: str(b.contactPhone ?? b.contact_phone),
+  };
 }
 
 async function createRescue(


### PR DESCRIPTION
Implements fixes for the gaps found in the app.rescue route audit (ADS-872–877). Work lands incrementally; this PR will accumulate commits as each ticket is closed.

## Done
- **ADS-876**: `/api/v1/rescues/:id` (PUT), `/api/v1/rescues/:id/adoption-policies` (GET/PUT) were missing from the SPA-facing plural route surface, causing profile and adoption-policy saves to 404. Added with tests, including unpacking the nested `address` object the rescue-app profile form posts.

## Already resolved on main (no longer part of this PR)
- **ADS-875**: staff member add/update/remove — already shipped to `main` via #1135 and follow-ups (`createStaffMember`/`updateStaffMember`/`removeStaffMember` in `rescue-admin.ts`). My independent implementation duplicated this with conflicting RPC names, so it was dropped from this branch after rebasing to avoid clobbering the merged version.

## Not started
- ADS-874, ADS-873, ADS-872, ADS-877

## Test plan
- [x] `rescues-public.test.ts` — 16/16 passing
- [x] Full gateway suite — 899/899 passing
- [x] `tsc --noEmit` clean in `services/gateway`
- [x] `eslint` clean on changed files

---
_Generated by [Claude Code](https://claude.ai/code/session_01K4J2TsHMkbw16HgkDd421D)_