### PR TITLE
feat(gateway): add Zod validation to remaining auth routes (ADS-879)

### DIFF
--- a/services/gateway/src/routes/auth.schemas.ts
+++ b/services/gateway/src/routes/auth.schemas.ts
@@ -40,6 +40,113 @@ export const normalizeRegisterBody = (body: Record<string, unknown>): Record<str
   privacyPolicyAccepted: pickRaw(body, ['privacyPolicyAccepted', 'privacy_policy_accepted']),
 });
 
+const tokenField = z.string().trim().min(1).max(512);
+const emailField = z
+  .string()
+  .trim()
+  .min(1, 'email is required')
+  .max(254)
+  .email('email must be valid');
+const newPasswordField = z.string().min(8, 'password must be at least 8 characters').max(128);
+
+export const VerifyEmailBodySchema = z.object({
+  verificationToken: tokenField,
+});
+
+export type VerifyEmailBody = z.infer<typeof VerifyEmailBodySchema>;
+
+export const normalizeVerifyEmailBody = (
+  body: Record<string, unknown>
+): Record<string, unknown> => ({
+  verificationToken: pickRaw(body, ['verificationToken', 'verification_token']),
+});
+
+export const ForgotPasswordBodySchema = z.object({
+  email: emailField,
+});
+
+export type ForgotPasswordBody = z.infer<typeof ForgotPasswordBodySchema>;
+
+export const ResendVerificationBodySchema = z.object({
+  email: emailField,
+});
+
+export type ResendVerificationBody = z.infer<typeof ResendVerificationBodySchema>;
+
+export const ResetPasswordBodySchema = z.object({
+  resetToken: tokenField,
+  newPassword: newPasswordField,
+});
+
+export type ResetPasswordBody = z.infer<typeof ResetPasswordBodySchema>;
+
+export const normalizeResetPasswordBody = (
+  body: Record<string, unknown>
+): Record<string, unknown> => ({
+  resetToken: pickRaw(body, ['resetToken', 'reset_token']),
+  newPassword: pickRaw(body, ['newPassword', 'new_password']),
+});
+
+export const RedeemInvitationBodySchema = z.object({
+  invitationToken: tokenField,
+  newPassword: newPasswordField,
+});
+
+export type RedeemInvitationBody = z.infer<typeof RedeemInvitationBodySchema>;
+
+export const normalizeRedeemInvitationBody = (
+  body: Record<string, unknown>
+): Record<string, unknown> => ({
+  invitationToken: pickRaw(body, ['invitationToken', 'invitation_token']),
+  newPassword: pickRaw(body, ['newPassword', 'new_password']),
+});
+
+export const ChangePasswordBodySchema = z.object({
+  currentPassword: z.string().min(1, 'currentPassword is required').max(128),
+  newPassword: newPasswordField,
+});
+
+export type ChangePasswordBody = z.infer<typeof ChangePasswordBodySchema>;
+
+export const normalizeChangePasswordBody = (
+  body: Record<string, unknown>
+): Record<string, unknown> => ({
+  currentPassword: pickRaw(body, ['currentPassword', 'current_password']),
+  newPassword: pickRaw(body, ['newPassword', 'new_password']),
+});
+
+export const UpdateAccountBodySchema = z.object({
+  firstName: z.string().trim().max(100).optional(),
+  lastName: z.string().trim().max(100).optional(),
+  phoneNumber: z.string().trim().max(32).optional(),
+  bio: z.string().trim().max(1000).optional(),
+  timezone: z.string().trim().max(64).optional(),
+  language: z.string().trim().max(10).optional(),
+  country: z.string().trim().max(64).optional(),
+  city: z.string().trim().max(64).optional(),
+  addressLine1: z.string().trim().max(200).optional(),
+  addressLine2: z.string().trim().max(200).optional(),
+  postalCode: z.string().trim().max(16).optional(),
+});
+
+export type UpdateAccountBody = z.infer<typeof UpdateAccountBodySchema>;
+
+export const normalizeUpdateAccountBody = (
+  body: Record<string, unknown>
+): Record<string, unknown> => ({
+  firstName: pickRaw(body, ['firstName', 'first_name']),
+  lastName: pickRaw(body, ['lastName', 'last_name']),
+  phoneNumber: pickRaw(body, ['phoneNumber', 'phone_number']),
+  bio: body.bio,
+  timezone: body.timezone,
+  language: body.language,
+  country: body.country,
+  city: body.city,
+  addressLine1: pickRaw(body, ['addressLine1', 'address_line_1']),
+  addressLine2: pickRaw(body, ['addressLine2', 'address_line_2']),
+  postalCode: pickRaw(body, ['postalCode', 'postal_code']),
+});
+
 export type ValidationFailure = {
   error: string;
   details: { path: string; message: string }[];

--- a/services/gateway/src/routes/auth.test.ts
+++ b/services/gateway/src/routes/auth.test.ts
@@ -843,6 +843,345 @@ describe('auth account-lifecycle input validation (ADS-853)', () => {
   });
 });
 
+describe('auth account-lifecycle input validation (ADS-879)', () => {
+  it('POST /auth/verify-email rejects a missing token with 400', async () => {
+    const m = makeClient();
+    const app = await makeApp(m.client);
+    try {
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/v1/auth/verify-email',
+        payload: {},
+      });
+      expect(res.statusCode).toBe(400);
+      expect(res.json()).toMatchObject({ error: 'Invalid request body' });
+      expect(m.verifyEmailMock).not.toHaveBeenCalled();
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('POST /auth/verify-email rejects an overlength token with 400', async () => {
+    const m = makeClient();
+    const app = await makeApp(m.client);
+    try {
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/v1/auth/verify-email',
+        payload: { verificationToken: 'x'.repeat(513) },
+      });
+      expect(res.statusCode).toBe(400);
+      expect(m.verifyEmailMock).not.toHaveBeenCalled();
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('POST /auth/verify-email accepts the snake_case alias', async () => {
+    const m = makeClient();
+    const app = await makeApp(m.client);
+    try {
+      m.verifyEmailMock.mockResolvedValueOnce({});
+      await app.inject({
+        method: 'POST',
+        url: '/api/v1/auth/verify-email',
+        payload: { verification_token: 'valid-token' },
+      });
+      expect(m.verifyEmailMock.mock.calls[0][0].verificationToken).toBe('valid-token');
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('POST /auth/forgot-password rejects a missing email with 400', async () => {
+    const m = makeClient();
+    const app = await makeApp(m.client);
+    try {
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/v1/auth/forgot-password',
+        payload: {},
+      });
+      expect(res.statusCode).toBe(400);
+      expect(res.json()).toMatchObject({ error: 'Invalid request body' });
+      expect(m.forgotPasswordMock).not.toHaveBeenCalled();
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('POST /auth/forgot-password rejects an invalid email format with 400', async () => {
+    const m = makeClient();
+    const app = await makeApp(m.client);
+    try {
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/v1/auth/forgot-password',
+        payload: { email: 'not-an-email' },
+      });
+      expect(res.statusCode).toBe(400);
+      expect(m.forgotPasswordMock).not.toHaveBeenCalled();
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('POST /auth/resend-verification rejects a missing email with 400', async () => {
+    const m = makeClient();
+    const app = await makeApp(m.client);
+    try {
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/v1/auth/resend-verification',
+        payload: {},
+      });
+      expect(res.statusCode).toBe(400);
+      expect(res.json()).toMatchObject({ error: 'Invalid request body' });
+      expect(m.resendVerificationMock).not.toHaveBeenCalled();
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('POST /auth/resend-verification rejects an invalid email format with 400', async () => {
+    const m = makeClient();
+    const app = await makeApp(m.client);
+    try {
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/v1/auth/resend-verification',
+        payload: { email: 'not-an-email' },
+      });
+      expect(res.statusCode).toBe(400);
+      expect(m.resendVerificationMock).not.toHaveBeenCalled();
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('POST /auth/resend-verification passes a valid email through to the gRPC stub', async () => {
+    const m = makeClient();
+    const app = await makeApp(m.client);
+    try {
+      m.resendVerificationMock.mockResolvedValueOnce({});
+      await app.inject({
+        method: 'POST',
+        url: '/api/v1/auth/resend-verification',
+        payload: { email: 'user@example.com' },
+      });
+      expect(m.resendVerificationMock.mock.calls[0][0].email).toBe('user@example.com');
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('POST /auth/reset-password rejects a missing resetToken with 400', async () => {
+    const m = makeClient();
+    const app = await makeApp(m.client);
+    try {
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/v1/auth/reset-password',
+        payload: { newPassword: 'longenoughpw' },
+      });
+      expect(res.statusCode).toBe(400);
+      expect(m.resetPasswordMock).not.toHaveBeenCalled();
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('POST /auth/reset-password rejects a too-short newPassword with 400', async () => {
+    const m = makeClient();
+    const app = await makeApp(m.client);
+    try {
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/v1/auth/reset-password',
+        payload: { resetToken: 'tok', newPassword: 'short' },
+      });
+      expect(res.statusCode).toBe(400);
+      expect(m.resetPasswordMock).not.toHaveBeenCalled();
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('POST /auth/reset-password accepts snake_case aliases', async () => {
+    const m = makeClient();
+    const app = await makeApp(m.client);
+    try {
+      m.resetPasswordMock.mockResolvedValueOnce({});
+      await app.inject({
+        method: 'POST',
+        url: '/api/v1/auth/reset-password',
+        payload: { reset_token: 'tok', new_password: 'longenoughpw' },
+      });
+      expect(m.resetPasswordMock.mock.calls[0][0]).toMatchObject({
+        resetToken: 'tok',
+        newPassword: 'longenoughpw',
+      });
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('POST /auth/redeem-invitation rejects a missing invitationToken with 400', async () => {
+    const m = makeClient();
+    const app = await makeApp(m.client);
+    try {
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/v1/auth/redeem-invitation',
+        payload: { newPassword: 'longenoughpw' },
+      });
+      expect(res.statusCode).toBe(400);
+      expect(res.json()).toMatchObject({ error: 'Invalid request body' });
+      expect(m.redeemInvitationMock).not.toHaveBeenCalled();
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('POST /auth/redeem-invitation rejects a too-short newPassword with 400', async () => {
+    const m = makeClient();
+    const app = await makeApp(m.client);
+    try {
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/v1/auth/redeem-invitation',
+        payload: { invitationToken: 'tok', newPassword: 'short' },
+      });
+      expect(res.statusCode).toBe(400);
+      expect(m.redeemInvitationMock).not.toHaveBeenCalled();
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('POST /auth/redeem-invitation accepts snake_case aliases', async () => {
+    const m = makeClient();
+    const app = await makeApp(m.client);
+    try {
+      m.redeemInvitationMock.mockResolvedValueOnce({ user: { userId: 'u1' } });
+      await app.inject({
+        method: 'POST',
+        url: '/api/v1/auth/redeem-invitation',
+        payload: { invitation_token: 'tok', new_password: 'longenoughpw' },
+      });
+      expect(m.redeemInvitationMock.mock.calls[0][0]).toMatchObject({
+        invitationToken: 'tok',
+        newPassword: 'longenoughpw',
+      });
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('POST /auth/change-password rejects a missing currentPassword with 400', async () => {
+    const m = makeClient();
+    const app = await makeApp(m.client);
+    try {
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/v1/auth/change-password',
+        payload: { newPassword: 'longenoughpw' },
+      });
+      expect(res.statusCode).toBe(400);
+      expect(m.changePasswordMock).not.toHaveBeenCalled();
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('POST /auth/change-password rejects a too-short newPassword with 400', async () => {
+    const m = makeClient();
+    const app = await makeApp(m.client);
+    try {
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/v1/auth/change-password',
+        payload: { currentPassword: 'old', newPassword: 'short' },
+      });
+      expect(res.statusCode).toBe(400);
+      expect(m.changePasswordMock).not.toHaveBeenCalled();
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('POST /auth/change-password accepts snake_case aliases', async () => {
+    const m = makeClient();
+    const app = await makeApp(m.client);
+    try {
+      m.changePasswordMock.mockResolvedValueOnce({});
+      await app.inject({
+        method: 'POST',
+        url: '/api/v1/auth/change-password',
+        payload: { current_password: 'old', new_password: 'longenoughpw' },
+      });
+      expect(m.changePasswordMock.mock.calls[0][0]).toMatchObject({
+        currentPassword: 'old',
+        newPassword: 'longenoughpw',
+      });
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('PATCH /users/account rejects an overlength firstName with 400', async () => {
+    const m = makeClient();
+    const app = await makeApp(m.client);
+    try {
+      const res = await app.inject({
+        method: 'PATCH',
+        url: '/api/v1/users/account',
+        payload: { firstName: 'x'.repeat(101) },
+      });
+      expect(res.statusCode).toBe(400);
+      expect(m.updateAccountMock).not.toHaveBeenCalled();
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('PATCH /users/account rejects an overlength bio with 400', async () => {
+    const m = makeClient();
+    const app = await makeApp(m.client);
+    try {
+      const res = await app.inject({
+        method: 'PATCH',
+        url: '/api/v1/users/account',
+        payload: { bio: 'x'.repeat(1001) },
+      });
+      expect(res.statusCode).toBe(400);
+      expect(m.updateAccountMock).not.toHaveBeenCalled();
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('PATCH /users/account accepts snake_case aliases and passes validated fields through', async () => {
+    const m = makeClient();
+    const app = await makeApp(m.client);
+    try {
+      m.updateAccountMock.mockResolvedValueOnce({});
+      await app.inject({
+        method: 'PATCH',
+        url: '/api/v1/users/account',
+        payload: { first_name: 'Alice', last_name: 'Smith', timezone: 'Europe/London' },
+      });
+      expect(m.updateAccountMock.mock.calls[0][0]).toMatchObject({
+        firstName: 'Alice',
+        lastName: 'Smith',
+        timezone: 'Europe/London',
+      });
+    } finally {
+      await app.close();
+    }
+  });
+});
+
 describe('auth rate limiting (ADS-844)', () => {
   it('throttles a per-EMAIL flood spread across many IPs', async () => {
     const m = makeClient();

--- a/services/gateway/src/routes/auth.ts
+++ b/services/gateway/src/routes/auth.ts
@@ -36,7 +36,23 @@ import { handleGrpcError } from '../middleware/grpc-error.js';
 
 import { normalizeEmail, type EmailRateLimiter } from './email-rate-limiter.js';
 import { rolesToApi, withApiUser } from './auth-user-json.js';
-import { normalizeRegisterBody, RegisterBodySchema, toValidationFailure } from './auth.schemas.js';
+import {
+  normalizeRegisterBody,
+  RegisterBodySchema,
+  toValidationFailure,
+  normalizeVerifyEmailBody,
+  VerifyEmailBodySchema,
+  ForgotPasswordBodySchema,
+  ResendVerificationBodySchema,
+  normalizeResetPasswordBody,
+  ResetPasswordBodySchema,
+  normalizeRedeemInvitationBody,
+  RedeemInvitationBodySchema,
+  normalizeChangePasswordBody,
+  ChangePasswordBodySchema,
+  normalizeUpdateAccountBody,
+  UpdateAccountBodySchema,
+} from './auth.schemas.js';
 
 export type AuthRoutesOptions = {
   client: AuthClient;
@@ -328,19 +344,18 @@ export const registerAuthRoutes = async (
     },
     async (req, reply) => {
       const b = (req.body ?? {}) as Record<string, unknown>;
+      const parsed = VerifyEmailBodySchema.safeParse(normalizeVerifyEmailBody(b));
+      if (!parsed.success) {
+        return reply.code(400).send(toValidationFailure(parsed.error));
+      }
       try {
         const res = await client.verifyEmail(
-          {
-            verificationToken: pickString(b, ['verificationToken', 'verification_token'], ''),
-          },
+          { verificationToken: parsed.data.verificationToken },
           buildMetadata(req)
         );
         const json = AuthV1.VerifyEmailResponse.toJSON(res) as Record<string, unknown>;
         return reply.send(withApiUser(json, res.user));
       } catch (err) {
-        if (err instanceof BadRequestError) {
-          return reply.code(400).send({ error: err.message });
-        }
         return handleGrpcError(err, reply);
       }
     }
@@ -359,16 +374,17 @@ export const registerAuthRoutes = async (
     },
     async (req, reply) => {
       const b = (req.body ?? {}) as Record<string, unknown>;
+      const parsed = ResendVerificationBodySchema.safeParse(b);
+      if (!parsed.success) {
+        return reply.code(400).send(toValidationFailure(parsed.error));
+      }
       try {
         const res = await client.resendVerification(
-          { email: pickString(b, ['email'], '') },
+          { email: parsed.data.email },
           buildMetadata(req)
         );
         return reply.send(AuthV1.ResendVerificationResponse.toJSON(res));
       } catch (err) {
-        if (err instanceof BadRequestError) {
-          return reply.code(400).send({ error: err.message });
-        }
         return handleGrpcError(err, reply);
       }
     }
@@ -387,16 +403,14 @@ export const registerAuthRoutes = async (
     },
     async (req, reply) => {
       const b = (req.body ?? {}) as Record<string, unknown>;
+      const parsed = ForgotPasswordBodySchema.safeParse(b);
+      if (!parsed.success) {
+        return reply.code(400).send(toValidationFailure(parsed.error));
+      }
       try {
-        const res = await client.forgotPassword(
-          { email: pickString(b, ['email'], '') },
-          buildMetadata(req)
-        );
+        const res = await client.forgotPassword({ email: parsed.data.email }, buildMetadata(req));
         return reply.send(AuthV1.ForgotPasswordResponse.toJSON(res));
       } catch (err) {
-        if (err instanceof BadRequestError) {
-          return reply.code(400).send({ error: err.message });
-        }
         return handleGrpcError(err, reply);
       }
     }
@@ -417,19 +431,20 @@ export const registerAuthRoutes = async (
     },
     async (req, reply) => {
       const b = (req.body ?? {}) as Record<string, unknown>;
+      const parsed = ResetPasswordBodySchema.safeParse(normalizeResetPasswordBody(b));
+      if (!parsed.success) {
+        return reply.code(400).send(toValidationFailure(parsed.error));
+      }
       try {
         const res = await client.resetPassword(
           {
-            resetToken: pickString(b, ['resetToken', 'reset_token'], ''),
-            newPassword: pickString(b, ['newPassword', 'new_password'], ''),
+            resetToken: parsed.data.resetToken,
+            newPassword: parsed.data.newPassword,
           },
           buildMetadata(req)
         );
         return reply.send(AuthV1.ResetPasswordResponse.toJSON(res));
       } catch (err) {
-        if (err instanceof BadRequestError) {
-          return reply.code(400).send({ error: err.message });
-        }
         return handleGrpcError(err, reply);
       }
     }
@@ -450,20 +465,21 @@ export const registerAuthRoutes = async (
     },
     async (req, reply) => {
       const b = (req.body ?? {}) as Record<string, unknown>;
+      const parsed = RedeemInvitationBodySchema.safeParse(normalizeRedeemInvitationBody(b));
+      if (!parsed.success) {
+        return reply.code(400).send(toValidationFailure(parsed.error));
+      }
       try {
         const res = await client.redeemInvitation(
           {
-            invitationToken: pickString(b, ['invitationToken', 'invitation_token'], ''),
-            newPassword: pickString(b, ['newPassword', 'new_password'], ''),
+            invitationToken: parsed.data.invitationToken,
+            newPassword: parsed.data.newPassword,
           },
           buildMetadata(req)
         );
         const json = AuthV1.RedeemInvitationResponse.toJSON(res) as Record<string, unknown>;
         return reply.send(withApiUser(json, res.user));
       } catch (err) {
-        if (err instanceof BadRequestError) {
-          return reply.code(400).send({ error: err.message });
-        }
         return handleGrpcError(err, reply);
       }
     }
@@ -480,19 +496,20 @@ export const registerAuthRoutes = async (
     },
     async (req, reply) => {
       const b = (req.body ?? {}) as Record<string, unknown>;
+      const parsed = ChangePasswordBodySchema.safeParse(normalizeChangePasswordBody(b));
+      if (!parsed.success) {
+        return reply.code(400).send(toValidationFailure(parsed.error));
+      }
       try {
         const res = await client.changePassword(
           {
-            currentPassword: pickString(b, ['currentPassword', 'current_password'], ''),
-            newPassword: pickString(b, ['newPassword', 'new_password'], ''),
+            currentPassword: parsed.data.currentPassword,
+            newPassword: parsed.data.newPassword,
           },
           buildMetadata(req)
         );
         return reply.send(AuthV1.ChangePasswordResponse.toJSON(res));
       } catch (err) {
-        if (err instanceof BadRequestError) {
-          return reply.code(400).send({ error: err.message });
-        }
         return handleGrpcError(err, reply);
       }
     }
@@ -575,29 +592,15 @@ export const registerAuthRoutes = async (
     },
     async (req, reply) => {
       const b = (req.body ?? {}) as Record<string, unknown>;
+      const parsed = UpdateAccountBodySchema.safeParse(normalizeUpdateAccountBody(b));
+      if (!parsed.success) {
+        return reply.code(400).send(toValidationFailure(parsed.error));
+      }
       try {
-        const res = await client.updateAccount(
-          {
-            firstName: pickString(b, ['firstName', 'first_name']),
-            lastName: pickString(b, ['lastName', 'last_name']),
-            phoneNumber: pickString(b, ['phoneNumber', 'phone_number']),
-            bio: pickString(b, ['bio']),
-            timezone: pickString(b, ['timezone']),
-            language: pickString(b, ['language']),
-            country: pickString(b, ['country']),
-            city: pickString(b, ['city']),
-            addressLine1: pickString(b, ['addressLine1', 'address_line_1']),
-            addressLine2: pickString(b, ['addressLine2', 'address_line_2']),
-            postalCode: pickString(b, ['postalCode', 'postal_code']),
-          },
-          buildMetadata(req)
-        );
+        const res = await client.updateAccount(parsed.data, buildMetadata(req));
         const json = AuthV1.UpdateAccountResponse.toJSON(res) as Record<string, unknown>;
         return reply.send(withApiUser(json, res.user));
       } catch (err) {
-        if (err instanceof BadRequestError) {
-          return reply.code(400).send({ error: err.message });
-        }
         return handleGrpcError(err, reply);
       }
     }
@@ -627,39 +630,11 @@ export const registerAuthRoutes = async (
 
 // --- Helpers ---------------------------------------------------------
 
-// Thrown by the body parsers below when a present field carries the wrong
-// type. Caught per-handler and mapped to a 400 — a non-string smuggled into a
-// string proto field is a client error, not a downstream INTERNAL.
+// Thrown when a present field carries the wrong type. Caught in the /register
+// handler and mapped to a 400 — a non-string smuggled into a string proto field
+// is a client error, not a downstream INTERNAL. (The other routes now use Zod
+// schemas instead of pickString, so they no longer throw this.)
 class BadRequestError extends Error {}
-
-const isPresent = (v: unknown): boolean => v !== undefined && v !== null;
-
-// Resolve a string from the first present key (camelCase preferred, then any
-// aliases), preserving the `firstName ?? first_name ?? fallback` semantics. A
-// present-but-non-string value is rejected rather than silently forwarded.
-function pickString(
-  body: Record<string, unknown>,
-  keys: readonly string[],
-  fallback: string
-): string;
-function pickString(body: Record<string, unknown>, keys: readonly string[]): string | undefined;
-function pickString(
-  body: Record<string, unknown>,
-  keys: readonly string[],
-  fallback?: string
-): string | undefined {
-  for (const key of keys) {
-    const value = body[key];
-    if (!isPresent(value)) {
-      continue;
-    }
-    if (typeof value !== 'string') {
-      throw new BadRequestError(`${key} must be a string`);
-    }
-    return value;
-  }
-  return fallback;
-}
 
 // Accept the canonical DB role string (`adopter`, `rescue_staff`, …)
 // OR the SCREAMING proto form (`USER_ROLE_ADOPTER`). The handler's


### PR DESCRIPTION
## Summary

Closes ADS-879.

PR #1167 added Zod validation for `POST /auth/register`. This PR extends that pattern to all remaining auth routes that were still using raw `pickString` extraction with no format/length checks:

- `POST /auth/verify-email` — validates `verificationToken` (min 1, max 512, camelCase + snake_case alias)
- `POST /auth/forgot-password` — validates `email` (required, valid format, max 254)
- `POST /auth/resend-verification` — validates `email` (same rules)
- `POST /auth/reset-password` — validates `resetToken` + `newPassword` (min 8, max 128), snake_case aliases
- `POST /auth/redeem-invitation` — validates `invitationToken` + `newPassword`, snake_case aliases
- `POST /auth/change-password` — validates `currentPassword` (min 1, max 128) + `newPassword` (min 8, max 128)
- `PATCH /users/account` — validates all profile fields with per-field length limits (firstName/lastName max 100, bio max 1000, timezone/country/city max 64, language max 10, phoneNumber max 32)

Invalid types, missing required fields, overlength values, and bad email formats all return `400` with structured `{ error, details }` before the request reaches the gRPC layer. The `pickString` helper and its `isPresent` dependency are removed (my changes made them unused); `BadRequestError` is retained as the `/auth/register` handler still references it.

## Test plan

- New `describe('auth account-lifecycle input validation (ADS-879)')` block with 18 tests covering missing required fields → 400, overlength values → 400, invalid email format → 400, snake_case alias acceptance, and valid bodies passing through to gRPC stubs
- All 919 gateway tests pass (`pnpm test` in `services/gateway`)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TmWePwb8A5PSgCZVxMM1DX)_