### PR TITLE
fix(auth): hash password-reset and email-verification tokens before storage (ADS-883)

### DIFF
--- a/services/auth/src/grpc/account-handlers.test.ts
+++ b/services/auth/src/grpc/account-handlers.test.ts
@@ -299,8 +299,19 @@ describe('verifyEmail', () => {
     mocks.clientScript([updated]);
     const res = await verifyEmail(mocks.deps, null, { verificationToken: 'abc' });
     expect(res.user.emailVerified).toBe(true);
-    const sql = realQueries(mocks.clientMock.query)[0][0] as string;
-    expect(sql).toContain('verification_token = $1');
+    const queries = realQueries(mocks.clientMock.query);
+    const sql = queries[0][0] as string;
+    expect(sql).toContain('verification_token_hash = $1');
+  });
+
+  it('hashes the verification token before DB lookup — raw token never reaches the query', async () => {
+    const rawToken = 'raw-verification-token';
+    mocks.clientScript([userRowFixture({ email_verified: true, status: 'active' })]);
+    await verifyEmail(mocks.deps, null, { verificationToken: rawToken });
+    const queries = realQueries(mocks.clientMock.query);
+    const params = queries[0][1] as unknown[];
+    expect(params[0]).not.toBe(rawToken);
+    expect(params[0]).toMatch(/^[0-9a-f]{64}$/);
   });
 
   it('throws INVALID_ARGUMENT for an unknown/expired token', async () => {
@@ -343,8 +354,17 @@ describe('forgotPassword', () => {
     mocks.clientScript([u]);
     const res = await forgotPassword(mocks.deps, null, { email: 'a@example.com' });
     expect(res.ok).toBe(true);
-    const sql = realQueries(mocks.clientMock.query)[0][0] as string;
-    expect(sql).toContain('SET reset_token');
+    const queries = realQueries(mocks.clientMock.query);
+    const sql = queries[0][0] as string;
+    expect(sql).toContain('SET reset_token_hash');
+  });
+
+  it('stores only the hash of the reset token — raw token never written to DB', async () => {
+    mocks.clientScript([userRowFixture()]);
+    await forgotPassword(mocks.deps, null, { email: 'a@example.com' });
+    const queries = realQueries(mocks.clientMock.query);
+    const params = queries[0][1] as unknown[];
+    expect(params[0]).toMatch(/^[0-9a-f]{64}$/);
   });
 });
 
@@ -382,6 +402,18 @@ describe('resetPassword', () => {
     expect(sql).toContain('login_attempts = 0');
     // Stamps the access-token revocation watermark.
     expect(sql).toContain('tokens_valid_from = now()');
+  });
+
+  it('hashes the reset token before DB lookup — raw token never reaches the query', async () => {
+    const rawToken = 'raw-reset-token';
+    mocks.hasherMock.hash.mockResolvedValueOnce('hash');
+    mocks.clientScript([userRowFixture()]);
+    await resetPassword(mocks.deps, null, { resetToken: rawToken, newPassword: 'longenough' });
+    const queries = realQueries(mocks.clientMock.query);
+    const params = queries[0][1] as unknown[];
+    // $2 is the token parameter in the WHERE clause
+    expect(params[1]).not.toBe(rawToken);
+    expect(params[1]).toMatch(/^[0-9a-f]{64}$/);
   });
 
   it('revokes all of the user’s refresh tokens (sessions) on reset', async () => {

--- a/services/auth/src/grpc/account-handlers.ts
+++ b/services/auth/src/grpc/account-handlers.ts
@@ -6,8 +6,8 @@
 // surface as HandlerError; the adapter maps to grpc status codes.
 //
 // All passwords are bcrypt-hashed via deps.passwordHasher. Verification
-// + reset tokens are 32-byte URL-safe random strings (raw, not hashed —
-// matches the monolith's existing column shape so backfill works).
+// + reset tokens are 32-byte URL-safe random strings; only their SHA-256
+// hash is persisted (see ADS-883 — matching the invitation-token pattern).
 //
 // Side-effects emitted via withTransaction so they fire after commit:
 //   - auth.userRegistered  → notifications service sends the verification email
@@ -49,11 +49,14 @@ const VERIFICATION_TOKEN_TTL_MS = 24 * 60 * 60 * 1000; // 24h
 const RESET_TOKEN_TTL_MS = 60 * 60 * 1000; // 1h
 const MIN_PASSWORD_LENGTH = 8;
 
-// Random URL-safe token. Same shape the monolith stores (raw base64url,
-// not hashed) so the column stays interoperable during the strangler
-// migration.
+// Random URL-safe bearer token. The raw value is sent to the user (email);
+// only its SHA-256 hash is stored — see hashToken().
 function mintToken(): string {
   return randomBytes(32).toString('base64url');
+}
+
+function hashToken(token: string): string {
+  return createHash('sha256').update(token).digest('hex');
 }
 
 function assertPassword(pw: string): void {
@@ -126,7 +129,7 @@ export async function register(
         `
         INSERT INTO auth.users (
           user_id, email, password, first_name, last_name, phone_number,
-          verification_token, verification_token_expires_at,
+          verification_token_hash, verification_token_expires_at,
           status, user_type, email_verified, phone_verified,
           two_factor_enabled, terms_accepted_at, privacy_policy_accepted_at,
           login_attempts, created_at, updated_at
@@ -146,7 +149,7 @@ export async function register(
           req.firstName,
           req.lastName,
           req.phoneNumber ?? null,
-          verificationToken,
+          hashToken(verificationToken),
           verificationExpires,
           userType,
         ]
@@ -286,15 +289,15 @@ export async function verifyEmail(
       UPDATE auth.users
       SET email_verified = true,
           status = 'active',
-          verification_token = NULL,
+          verification_token_hash = NULL,
           verification_token_expires_at = NULL,
           updated_at = now()
-      WHERE verification_token = $1
+      WHERE verification_token_hash = $1
         AND (verification_token_expires_at IS NULL OR verification_token_expires_at > now())
         AND deleted_at IS NULL
       RETURNING *
       `,
-      [req.verificationToken]
+      [hashToken(req.verificationToken)]
     );
     if (res.rows.length === 0) {
       throw new HandlerError('INVALID_ARGUMENT', 'invalid or expired verification token');
@@ -324,13 +327,13 @@ export async function resendVerification(
     const res = await client.query<UserRow>(
       `
       UPDATE auth.users
-      SET verification_token = $1,
+      SET verification_token_hash = $1,
           verification_token_expires_at = $2,
           updated_at = now()
       WHERE email = $3 AND email_verified = false AND deleted_at IS NULL
       RETURNING *
       `,
-      [verificationToken, expires, req.email]
+      [hashToken(verificationToken), expires, req.email]
     );
     // Only emit when we actually updated a row — but the RESPONSE is the
     // same either way (don't leak account existence).
@@ -366,13 +369,13 @@ export async function forgotPassword(
     const res = await client.query<UserRow>(
       `
       UPDATE auth.users
-      SET reset_token = $1,
+      SET reset_token_hash = $1,
           reset_token_expiration = $2,
           updated_at = now()
       WHERE email = $3 AND deleted_at IS NULL
       RETURNING *
       `,
-      [token, expires, req.email]
+      [hashToken(token), expires, req.email]
     );
     if (res.rows.length === 1) {
       const user = res.rows[0];
@@ -410,18 +413,18 @@ export async function resetPassword(
       `
       UPDATE auth.users
       SET password = $1,
-          reset_token = NULL,
+          reset_token_hash = NULL,
           reset_token_expiration = NULL,
           locked_until = NULL,
           login_attempts = 0,
           tokens_valid_from = now(),
           updated_at = now()
-      WHERE reset_token = $2
+      WHERE reset_token_hash = $2
         AND (reset_token_expiration IS NULL OR reset_token_expiration > now())
         AND deleted_at IS NULL
       RETURNING *
       `,
-      [password, req.resetToken]
+      [password, hashToken(req.resetToken)]
     );
     if (res.rows.length === 0) {
       throw new HandlerError('INVALID_ARGUMENT', 'invalid or expired reset token');
@@ -449,10 +452,11 @@ export async function resetPassword(
 }
 
 // --- RedeemInvitation --------------------------------------------------
-// Consumes the invitation_token minted by adminCreateUser. Unlike
-// ResetPassword (which compares the raw reset_token column), invitation
+// Consumes the invitation_token minted by adminCreateUser. Invitation
 // tokens are never persisted raw — only their SHA-256 hash lives in
 // auth.user_invitations — so the incoming token is hashed before lookup.
+// Reset and verification tokens follow the same hash-before-persist pattern
+// (ADS-883).
 
 export async function redeemInvitation(
   deps: HandlerDeps,

--- a/services/auth/src/migrations/024_hash_auth_tokens.ts
+++ b/services/auth/src/migrations/024_hash_auth_tokens.ts
@@ -1,0 +1,57 @@
+import type { MigrationBuilder } from 'node-pg-migrate';
+
+// ADS-883: store SHA-256 hashes of password-reset and email-verification
+// tokens instead of the raw bearer strings.
+//
+// Keeping raw tokens in the DB means a single DB read is a ready-made
+// account-takeover credential. Hashing mirrors the pattern already used for
+// invitation tokens in auth.user_invitations (admin-handlers.ts).
+//
+// Existing tokens in the raw columns are invalidated by the column drop —
+// any in-flight reset/verify links will fail and the user must re-request,
+// which is acceptable given the security gain.
+
+export const up = async (pgm: MigrationBuilder): Promise<void> => {
+  pgm.addColumns('users', {
+    verification_token_hash: { type: 'varchar(64)' },
+    reset_token_hash: { type: 'varchar(64)' },
+  });
+
+  // Replace the old raw-token indexes (013_index_user_lookup_tokens.ts).
+  pgm.dropIndex('users', 'verification_token', { name: 'users_verification_token_idx' });
+  pgm.dropIndex('users', 'reset_token', { name: 'users_reset_token_idx' });
+
+  pgm.createIndex('users', 'verification_token_hash', {
+    name: 'users_verification_token_hash_idx',
+    where: 'verification_token_hash IS NOT NULL',
+  });
+  pgm.createIndex('users', 'reset_token_hash', {
+    name: 'users_reset_token_hash_idx',
+    where: 'reset_token_hash IS NOT NULL',
+  });
+
+  pgm.dropColumns('users', ['verification_token', 'reset_token']);
+};
+
+export const down = async (pgm: MigrationBuilder): Promise<void> => {
+  pgm.addColumns('users', {
+    verification_token: { type: 'varchar(255)' },
+    reset_token: { type: 'varchar(255)' },
+  });
+
+  pgm.dropIndex('users', 'verification_token_hash', {
+    name: 'users_verification_token_hash_idx',
+  });
+  pgm.dropIndex('users', 'reset_token_hash', { name: 'users_reset_token_hash_idx' });
+
+  pgm.createIndex('users', 'verification_token', {
+    name: 'users_verification_token_idx',
+    where: 'verification_token IS NOT NULL',
+  });
+  pgm.createIndex('users', 'reset_token', {
+    name: 'users_reset_token_idx',
+    where: 'reset_token IS NOT NULL',
+  });
+
+  pgm.dropColumns('users', ['verification_token_hash', 'reset_token_hash']);
+};


### PR DESCRIPTION
## Summary

- Stores only SHA-256 hashes of password-reset and email-verification tokens in `auth.users`, eliminating raw bearer credentials from the database
- Mirrors the existing pattern already used for invitation tokens in `auth.user_invitations`
- Adds migration 024 that introduces `_hash` columns, repoints partial indexes, and drops the raw columns

## Changes

- `services/auth/src/migrations/024_hash_auth_tokens.ts` — adds `verification_token_hash` and `reset_token_hash` columns, drops old raw `verification_token` / `reset_token` columns and their indexes, creates new partial indexes on the hash columns
- `services/auth/src/grpc/account-handlers.ts` — `forgotPassword`, `resendVerification`, and `register` now persist only `hashToken(rawToken)`; `resetPassword` and `verifyEmail` hash the incoming token before the DB lookup
- `services/auth/src/grpc/account-handlers.test.ts` — updates existing SQL assertions to match new column names; adds 3 new tests verifying the raw token is never sent to the database

## Before requesting review

- [x] Tests for new behaviour added (TDD)
- [x] No `.env` requirements changed
- [x] No `lib.*` packages touched

## Test plan

- [x] Existing tests pass (`pnpm test` — 294 passed, 2 pre-existing infra failures unrelated to this change)
- [x] New behaviour is covered by tests
  - `verifyEmail`: asserts `verification_token_hash = $1` in SQL and `params[0]` is a 64-char hex string
  - `forgotPassword`: asserts `SET reset_token_hash` in SQL and `params[0]` is a 64-char hex string
  - `resetPassword`: asserts `params[1]` (the WHERE token) is a 64-char hex string, not the raw input
- [x] No new TypeScript errors (pre-existing `lib.types` unbuilt errors are environment-only)

## Related

Fixes ADS-883: https://linear.app/ideasquared/issue/ADS-883

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fw5RiKfyF8EB9xTMWmW5QE)_