### PR TITLE
Fix open High-priority Linear issues: DevEx docs/config drift + refresh token hashing

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -16,11 +16,11 @@
     "3000": { "label": "app.client", "onAutoForward": "notify" },
     "3001": { "label": "app.admin", "onAutoForward": "silent" },
     "3002": { "label": "app.rescue", "onAutoForward": "silent" },
-    "5000": { "label": "service.backend", "onAutoForward": "silent" },
+    "5000": { "label": "gRPC services", "onAutoForward": "silent" },
     "5432": { "label": "postgres", "onAutoForward": "ignore" },
     "6379": { "label": "redis", "onAutoForward": "ignore" }
   },
-  "postCreateCommand": "npm run setup -- --skip-playwright",
+  "postCreateCommand": "corepack enable && pnpm setup -- --skip-playwright",
   "remoteUser": "node",
   "containerEnv": {
     "NODE_OPTIONS": "--max-old-space-size=4096"

--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,14 @@
 # =============================================================================
 # Adopt Don't Shop - Root Environment Configuration
 # =============================================================================
+# 👋 Quick start:
+#   1. Copy this file to .env (or let `pnpm setup` do it for you).
+#   2. `pnpm setup` auto-generates JWT/session/CSRF/encryption secrets — you
+#      don't need to hand-write those.
+#   3. You're only responsible for POSTGRES_PASSWORD and any third-party API
+#      keys you actually use. Everything else has a working dev default.
+# Everything below is documented inline; the REQUIRED block comes first.
+# =============================================================================
 # ⚠️ IMPORTANT SECURITY NOTES:
 # - Copy this file to .env and fill in real values
 # - NEVER commit .env to version control
@@ -9,27 +17,32 @@
 # =============================================================================
 #
 # =============================================================================
-# REQUIRED — must be set before `npm run docker:dev`
+# REQUIRED — must be set before `pnpm docker:dev`
 # =============================================================================
-# `npm run setup` auto-generates the application secrets (JWT_SECRET,
+# `pnpm setup` auto-generates the application secrets (JWT_SECRET,
 # JWT_REFRESH_SECRET, SESSION_SECRET, CSRF_SECRET, ENCRYPTION_KEY). The only
-# value you MUST change by hand is POSTGRES_PASSWORD. Search the OPTIONAL
-# section below for each REQUIRED key listed here to set or review it.
+# value you MUST change by hand is POSTGRES_PASSWORD. Search this file for
+# each REQUIRED key listed here to set or review it — none of them are
+# "optional", regardless of section headers below.
 #
-#   * NODE_ENV                                                         (line ~26)
-#   * POSTGRES_USER / POSTGRES_PASSWORD / POSTGRES_DB                  (line ~38)
-#   * DB_HOST / DB_PORT / DB_USERNAME / DB_PASSWORD                    (line ~45)
-#   * DEV_DB_NAME / TEST_DB_NAME / PROD_DB_NAME (per-NODE_ENV)         (line ~49)
+#   * NODE_ENV                                                         (line ~33)
+#   * POSTGRES_USER / POSTGRES_PASSWORD / POSTGRES_DB                  (line ~45)
+#   * DB_HOST / DB_PORT / DB_USERNAME / DB_PASSWORD                    (line ~52)
+#   * DEV_DB_NAME / TEST_DB_NAME / PROD_DB_NAME (per-NODE_ENV)         (line ~56)
 #   * JWT_SECRET / JWT_REFRESH_SECRET / SESSION_SECRET / CSRF_SECRET   (auto-generated)
 #   * ENCRYPTION_KEY                                                   (auto-generated)
 #
 # A CI guard (`scripts/check-env-example.mjs`) keeps this list in sync with
 # `scripts/validate-env.ts` — add new required vars there and re-run
-# `npm run check:env-example` locally before pushing.
+# `pnpm check:env-example` locally before pushing.
 #
 # =============================================================================
 # OPTIONAL — change only if you know why
 # =============================================================================
+# Note: this section still contains the REQUIRED vars listed above (Postgres
+# credentials, JWT/session/CSRF secrets, etc.) — "optional" describes
+# everything else in the file, not those keys. They're documented inline
+# below rather than duplicated in a second block.
 
 # -----------------------------------------------------------------------------
 # Environment
@@ -45,9 +58,9 @@ PORT=4000
 # -----------------------------------------------------------------------------
 # Database Configuration (REQUIRED)
 # -----------------------------------------------------------------------------
-# ⚠️ CRITICAL: Change these values immediately!
-# Development defaults are provided for convenience only
-# Production MUST use strong, unique credentials
+# The dev default below (POSTGRES_PASSWORD) is a placeholder, not a working
+# secret — replace it locally, and for production generate a real one with
+# `pnpm secrets:generate` rather than hand-editing.
 
 # PostgreSQL Database
 POSTGRES_USER=adopt_user
@@ -109,6 +122,11 @@ DB_SSL_MODE=disable
 # -----------------------------------------------------------------------------
 REDIS_HOST=redis
 REDIS_PORT=6379
+# Host-side port the dev compose stack publishes Redis on (default 6380).
+# Only needed if 6379 is unavailable on your host — most commonly Windows,
+# where Hyper-V reserves a dynamic port range that can include 6379.
+# `pnpm docker:dev` detects the collision and tells you the free port to use:
+# REDIS_HOST_PORT=6380
 # REDIS_PASSWORD is now required by docker-compose.yml (ADS-600) — Compose
 # will refuse to start without it. Replace the placeholder before deploying
 # to anything network-exposed; for production generate with:
@@ -339,6 +357,11 @@ SEED_PASSWORD=DevPassword123!
 # native inotify doesn't surface changes (WSL2, Docker Desktop bind mounts).
 CHOKIDAR_USEPOLLING=false
 CHOKIDAR_INTERVAL=1000
+
+# Vite/webpack file watching for app-rescue specifically (docker-compose.yml
+# sets this on app-rescue only). If HMR doesn't pick up changes on macOS or
+# Windows for the rescue app, set this to true:
+# WATCHPACK_POLLING=true
 
 # ADS-512: include raw error messages in API responses. NEVER set to true in
 # production — leaks stack-trace-like information to clients. Startup

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -158,6 +158,10 @@ services:
       CHOKIDAR_INTERVAL: ${CHOKIDAR_INTERVAL:-}
       CHOKIDAR_AWAITWRITEFINISH: ${CHOKIDAR_AWAITWRITEFINISH:-}
       NODE_OPTIONS: '--max-old-space-size=3072 --max-semi-space-size=128'
+    depends_on:
+      service-gateway:
+        condition: service_healthy
+        required: false
     healthcheck:
       test: ['CMD', 'wget', '--no-verbose', '--tries=1', '--spider', 'http://localhost:3000']
       interval: 10s
@@ -193,6 +197,10 @@ services:
       CHOKIDAR_INTERVAL: ${CHOKIDAR_INTERVAL:-}
       CHOKIDAR_AWAITWRITEFINISH: ${CHOKIDAR_AWAITWRITEFINISH:-}
       NODE_OPTIONS: '--max-old-space-size=3072 --max-semi-space-size=128'
+    depends_on:
+      service-gateway:
+        condition: service_healthy
+        required: false
     healthcheck:
       test: ['CMD', 'wget', '--no-verbose', '--tries=1', '--spider', 'http://localhost:3000']
       interval: 10s
@@ -230,6 +238,10 @@ services:
       WATCHPACK_POLLING: ${WATCHPACK_POLLING:-}
       FAST_REFRESH: true
       NODE_OPTIONS: '--max-old-space-size=3072 --max-semi-space-size=128'
+    depends_on:
+      service-gateway:
+        condition: service_healthy
+        required: false
     healthcheck:
       test: ['CMD', 'wget', '--no-verbose', '--tries=1', '--spider', 'http://localhost:3000']
       interval: 10s

--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -9,7 +9,7 @@ Comprehensive guide to the Docker setup for this monorepo. Pairs with [the root 
 - [Best Practices](#best-practices)
 - [Development Workflow](#development-workflow)
 - [Production Deployment](#production-deployment)
-- [CI overlay (docker-compose.ci.yml)](#ci-overlay-docker-composeciyml)
+- [Reproducing CI E2E locally](#reproducing-ci-e2e-locally)
 - [Troubleshooting](#troubleshooting)
 
 ## Quick Start
@@ -222,7 +222,7 @@ VITE_WS_BASE_URL=wss://api.your-domain.com
 
 1. Build backend (development + production targets)
 2. Build all three frontend apps in parallel via `Dockerfile.app`
-3. Validate full-stack compose integration using `docker-compose.ci.yml`
+3. Validate full-stack compose integration using `docker-compose.yml --profile full` (see [Reproducing CI E2E locally](#reproducing-ci-e2e-locally) — there is no separate CI compose overlay)
 4. Trivy security scan on built images
 
 CI uses BuildKit cache for 40-60% faster builds:
@@ -234,41 +234,39 @@ CI uses BuildKit cache for 40-60% faster builds:
     key: ${{ runner.os }}-buildx-${{ github.sha }}
 ```
 
-## CI overlay (docker-compose.ci.yml)
+## Reproducing CI E2E locally
 
-### Why it exists
-
-The dev stack in `docker-compose.yml` is optimised for inner-loop development: it bind-mounts source code, overrides the backend `entrypoint`/`command` to wire up a runtime `lib.types` symlink, and mounts a writable `./uploads` directory from the host. None of that is appropriate for CI:
-
-- Bind-mounted source shadows the built artifacts baked into the image, so we'd be testing the host's working tree instead of the image we just built.
-- The host `./uploads` mount masks the image's `appuser`-owned uploads directory and causes `EACCES` when the backend tries to `mkdirSync` inside it.
-- The dev `entrypoint`/`command` reference paths that only resolve when bind mounts are active — in CI they don't exist.
-
-`docker-compose.ci.yml` is a minimal overlay applied on top of `docker-compose.yml` to undo exactly those dev-only behaviours.
-
-### What it changes
-
-For each microservice (e.g. `service-gateway`):
-
-- `volumes: !reset []` — the `!reset` tag *replaces* the base volume list rather than appending to it (the default Compose merge for sequences). This is what removes the dev bind mounts, including the `./uploads` mount that breaks permissions.
-- `entrypoint: ["/usr/bin/dumb-init", "--"]` — restores the Dockerfile ENTRYPOINT. The compose override entrypoint uses relative paths that only resolve under bind mounts.
-- `command: ["npm", "run", "dev"]` — restores the Dockerfile CMD. The compose command override creates a runtime symlink for bind-mounted `lib.types`, which is irrelevant when the image already contains a copy of the built library in `node_modules`.
-
-### Reproducing a CI E2E run locally
+There is no `docker-compose.ci.yml` overlay — CI runs the `test-e2e` job (`.github/workflows/ci.yml`) directly against `docker-compose.yml` using the `full` profile, with images built via `docker buildx bake` (falling back to `docker compose build` if bake can't resolve targets). To reproduce it locally:
 
 ```bash
-# Build images the same way CI does, then bring the stack up with the overlay
-docker compose -f docker-compose.yml -f docker-compose.ci.yml build
-docker compose -f docker-compose.yml -f docker-compose.ci.yml up -d
+# 1. Generate a throwaway .env — CI writes fresh secrets on every run rather than
+#    reusing the checked-in dev defaults (see "Generate secrets and write .env" in ci.yml)
+pnpm secrets:generate > .env
+echo "CORS_ORIGIN=http://localhost:3000,http://localhost:3001,http://localhost:3002" >> .env
+echo "GATEWAY_RATE_LIMIT_MAX=100000" >> .env
+echo "GATEWAY_AUTH_RATE_LIMIT_MAX=100000" >> .env
 
-# Tail logs / run the same smoke checks CI runs
-docker compose -f docker-compose.yml -f docker-compose.ci.yml logs -f service-gateway
+# 2. Start database and cache first, wait for Postgres to be ready
+docker compose -f docker-compose.yml up -d database redis
+timeout 90 bash -c 'until docker compose -f docker-compose.yml exec -T database pg_isready -U postgres; do sleep 2; done'
 
-# Tear down (always include both files so the project name matches)
-docker compose -f docker-compose.yml -f docker-compose.ci.yml down -v
+# 3. Build every image (bake if available, otherwise a plain compose build)
+docker buildx bake -f docker-compose.yml --load || \
+  docker compose -f docker-compose.yml --profile full build
+
+# 4. Bring up the full stack without rebuilding, then wait for all services healthy
+docker compose -f docker-compose.yml --profile full up -d --no-build
+docker compose -f docker-compose.yml --profile full ps
+
+# 5. Run the Playwright suite (see e2e/ for the actual specs)
+pnpm test:e2e:install
+pnpm test:e2e
+
+# 6. Tear down
+docker compose -f docker-compose.yml down -v
 ```
 
-If you skip the overlay, you'll either hit the `uploads` `EACCES` error or end up testing your local working tree rather than the built image.
+This runs the same dev-mode images and bind mounts as `pnpm docker:dev` — CI does **not** run a separate production-mode build for E2E. If you hit permission errors on `./uploads` locally that CI doesn't see, check that your local `.env` doesn't carry over a stale `POSTGRES_PASSWORD`/`REDIS_PASSWORD` from a previous run; CI always generates fresh ones.
 
 ## Troubleshooting
 

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -259,10 +259,12 @@ Aim to keep the smoke suite under ~5 minutes total. If you tag a new spec, run `
 
 ## CI
 
-The `test-e2e` job in `.github/workflows/ci.yml` runs after `test-backend` and `test-frontend` succeed. It:
+The `test-e2e` job in `.github/workflows/ci.yml` runs after `test-frontend` and `test-services` succeed. It:
 
-1. Boots the stack with `docker-compose.yml` + `docker-compose.ci.yml`.
-2. Waits for `:4000/health/simple`, `:3000`, `:3001`, `:3002`.
-3. Runs migrations and seeds inside the backend container.
+1. Generates fresh secrets into `.env`, builds every image via `docker buildx bake -f docker-compose.yml` (falling back to `docker compose build` if bake resolves no targets), and boots the stack with `docker-compose.yml --profile full`. There is no separate `docker-compose.ci.yml` overlay.
+2. Waits for `:4000/health/simple`, `:3000`, `:3001`, `:3002`, plus every service reporting healthy.
+3. Each service runs its own migrations on start via its entrypoint.
 4. Executes `pnpm test:e2e`.
 5. Uploads `e2e/playwright-report/`, `e2e/test-results/`, and `docker-compose.log` as artifacts.
+
+See [docs/DOCKER.md](../docs/DOCKER.md#reproducing-ci-e2e-locally) for the full local-reproduction steps.

--- a/services/auth/src/grpc/handlers.test.ts
+++ b/services/auth/src/grpc/handlers.test.ts
@@ -345,6 +345,32 @@ describe('login', () => {
     ]);
   });
 
+  it('persists a SHA-256 hash of the refresh token, never the raw value (ADS-884)', async () => {
+    mocks.poolMock.query.mockResolvedValueOnce({ rows: [userRowFixture()] });
+    mocks.hasherMock.compare.mockResolvedValueOnce(true);
+    mocks.issuerMock.mint.mockResolvedValueOnce(mintedFixture());
+    mocks.clientMock.query.mockResolvedValue({ rows: [] });
+    mocks.poolMock.query
+      .mockResolvedValueOnce({ rows: [{ user_type: 'adopter' }] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [{ name: 'pets.read' }] });
+
+    await login(mocks.deps, null, BASE_LOGIN_REQ);
+
+    const insertCall = mocks.clientMock.query.mock.calls.find(c =>
+      (c[0] as string).includes('INSERT INTO auth.refresh_tokens')
+    );
+    expect(insertCall).toBeDefined();
+    const [sql, params] = insertCall as [string, unknown[]];
+    expect(sql).toMatch(/token_hash/);
+    expect(sql).not.toMatch(/\btoken\b(?!_hash)/);
+    expect(params).not.toContain('refresh.jwt.token');
+    // SHA-256("refresh.jwt.token") in hex.
+    expect(params).toContain(
+      '4aae24fd4386389145fbd132ee4c5946e5ec5688261796cab855a58cc94ee74b'
+    );
+  });
+
   it('publishes a successful auth.actionTaken alongside auth.userLoggedIn', async () => {
     mocks.poolMock.query.mockResolvedValueOnce({ rows: [userRowFixture()] });
     mocks.hasherMock.compare.mockResolvedValueOnce(true);
@@ -571,6 +597,28 @@ describe('logout', () => {
     const update = sqls.find(s => s.includes('UPDATE auth.refresh_tokens'));
     expect(update).toMatch(/is_revoked = true/);
   });
+
+  it('looks up the revoked row by token_hash, never the raw refresh token (ADS-884)', async () => {
+    mocks.issuerMock.verifyRefresh.mockResolvedValueOnce({
+      sub: 'usr-1',
+      jti: 'jti-1',
+      iat: 0,
+      exp: Math.floor(Date.now() / 1000) + 1000,
+    });
+    mocks.poolMock.query.mockResolvedValueOnce({ rows: [] }); // not denylisted
+
+    const calls: Array<{ sql: string; params: unknown[] }> = [];
+    mocks.clientMock.query.mockImplementation(async (sql: string, params: unknown[] = []) => {
+      calls.push({ sql, params });
+      return { rows: [] };
+    });
+
+    await logout(mocks.deps, ADOPTER_PRINCIPAL, { refreshToken: 'my-refresh-token' });
+
+    const update = calls.find(c => c.sql.includes('UPDATE auth.refresh_tokens'));
+    expect(update?.sql).toMatch(/token_hash = \$1/);
+    expect(update?.params).not.toContain('my-refresh-token');
+  });
 });
 
 // --- refreshToken ----------------------------------------------------
@@ -733,6 +781,41 @@ describe('refreshToken', () => {
     expect(res.tokens.accessToken).toBe('access.jwt.token');
     // BEGIN → UPDATE old refresh → INSERT denylist → INSERT new refresh → COMMIT → NATS_PUBLISH
     expect(calls).toEqual(['BEGIN', 'UPDATE', 'INSERT', 'INSERT', 'COMMIT', 'NATS_PUBLISH']);
+  });
+
+  it('looks up and rotates by token_hash, never the raw refresh token (ADS-884)', async () => {
+    mocks.issuerMock.verifyRefresh.mockResolvedValueOnce({
+      sub: 'usr-1',
+      jti: 'old-jti',
+      iat: 0,
+      exp: 9_000_000_000,
+    });
+    mocks.poolMock.query
+      .mockResolvedValueOnce({ rows: [] }) // not denylisted
+      .mockResolvedValueOnce({ rows: [{ token_hash: 'stored-hash', user_id: 'usr-1', revoked_at: null }] })
+      .mockResolvedValueOnce({ rows: [{ status: 'active' }] }); // status guard
+    mocks.issuerMock.mint.mockResolvedValueOnce(mintedFixture());
+
+    const calls: Array<{ sql: string; params: unknown[] }> = [];
+    mocks.clientMock.query.mockImplementation(async (sql: string, params: unknown[] = []) => {
+      calls.push({ sql, params });
+      return { rows: [], rowCount: 1 };
+    });
+
+    await refreshToken(mocks.deps, null, { refreshToken: 'tok' });
+
+    const selectSql = mocks.poolMock.query.mock.calls[1][0] as string;
+    expect(selectSql).toMatch(/WHERE token_hash = \$1/);
+
+    const revoke = calls.find(c => c.sql.trim().startsWith('UPDATE'));
+    expect(revoke?.sql).toMatch(/WHERE token_hash = \$1/);
+    expect(revoke?.params).not.toContain('tok');
+    const insertNew = calls.find(
+      c => c.sql.trim().startsWith('INSERT') && c.sql.includes('refresh_tokens')
+    );
+    expect(insertNew?.sql).toMatch(/token_hash/);
+    expect(insertNew?.params).not.toContain('access.jwt.token');
+    expect(insertNew?.params).not.toContain('refresh.jwt.token');
   });
 
   it('rejects a concurrent reuse: when the atomic revoke flips no rows it does not mint a second family', async () => {

--- a/services/auth/src/grpc/handlers.test.ts
+++ b/services/auth/src/grpc/handlers.test.ts
@@ -366,9 +366,7 @@ describe('login', () => {
     expect(sql).not.toMatch(/\btoken\b(?!_hash)/);
     expect(params).not.toContain('refresh.jwt.token');
     // SHA-256("refresh.jwt.token") in hex.
-    expect(params).toContain(
-      '4aae24fd4386389145fbd132ee4c5946e5ec5688261796cab855a58cc94ee74b'
-    );
+    expect(params).toContain('4aae24fd4386389145fbd132ee4c5946e5ec5688261796cab855a58cc94ee74b');
   });
 
   it('publishes a successful auth.actionTaken alongside auth.userLoggedIn', async () => {
@@ -792,7 +790,9 @@ describe('refreshToken', () => {
     });
     mocks.poolMock.query
       .mockResolvedValueOnce({ rows: [] }) // not denylisted
-      .mockResolvedValueOnce({ rows: [{ token_hash: 'stored-hash', user_id: 'usr-1', revoked_at: null }] })
+      .mockResolvedValueOnce({
+        rows: [{ token_hash: 'stored-hash', user_id: 'usr-1', revoked_at: null }],
+      })
       .mockResolvedValueOnce({ rows: [{ status: 'active' }] }); // status guard
     mocks.issuerMock.mint.mockResolvedValueOnce(mintedFixture());
 

--- a/services/auth/src/grpc/handlers.ts
+++ b/services/auth/src/grpc/handlers.ts
@@ -20,7 +20,7 @@
 //     calls it. It does JWT verify + denylist check ONLY; no user-row
 //     fetch unless the JWT signature already validated.
 
-import { randomUUID } from 'node:crypto';
+import { createHash, randomUUID } from 'node:crypto';
 
 import { verifySync } from 'otplib';
 
@@ -155,13 +155,20 @@ export type UserRow = {
 };
 
 type RefreshTokenRow = {
-  token: string;
+  token_hash: string;
   user_id: string;
   family_id: string;
   expires_at: Date;
   revoked_at: Date | null;
   is_revoked: boolean;
 };
+
+// Refresh tokens are long-lived bearer credentials — only their SHA-256
+// hash is persisted (ADS-884). The raw value is still sent to the client
+// over TLS as before; only at-rest storage changed.
+function hashRefreshToken(token: string): string {
+  return createHash('sha256').update(token).digest('hex');
+}
 
 export function rowToProtoUser(row: UserRow): AuthUser {
   return {
@@ -516,10 +523,10 @@ export async function login(
   await withTransaction(deps, async ({ client, publish }) => {
     await client.query(
       `
-      INSERT INTO auth.refresh_tokens (token, user_id, expires_at, revoked_at, created_at, updated_at)
+      INSERT INTO auth.refresh_tokens (token_hash, user_id, expires_at, revoked_at, created_at, updated_at)
       VALUES ($1, $2, $3, NULL, now(), now())
       `,
-      [minted.pair.refreshToken, user.user_id, minted.refreshExpiresAt]
+      [hashRefreshToken(minted.pair.refreshToken), user.user_id, minted.refreshExpiresAt]
     );
     await client.query(
       `UPDATE auth.users SET last_login_at = now(), login_attempts = 0, locked_until = NULL, updated_at = now() WHERE user_id = $1`,
@@ -609,8 +616,8 @@ export async function logout(
       [claims.jti, claims.sub, new Date(claims.exp * 1000)]
     );
     await client.query(
-      `UPDATE auth.refresh_tokens SET revoked_at = now(), is_revoked = true, updated_at = now() WHERE token = $1 AND revoked_at IS NULL`,
-      [req.refreshToken]
+      `UPDATE auth.refresh_tokens SET revoked_at = now(), is_revoked = true, updated_at = now() WHERE token_hash = $1 AND revoked_at IS NULL`,
+      [hashRefreshToken(req.refreshToken)]
     );
 
     publish({
@@ -660,9 +667,10 @@ export async function refreshToken(
   // columns historically diverged — checking only `revoked_at` let a
   // session revoked via RevokeSession keep refreshing (it sets is_revoked
   // but never revoked_at). Honour both.
+  const incomingTokenHash = hashRefreshToken(req.refreshToken);
   const stored = await deps.pool.query<RefreshTokenRow>(
-    `SELECT * FROM auth.refresh_tokens WHERE token = $1`,
-    [req.refreshToken]
+    `SELECT * FROM auth.refresh_tokens WHERE token_hash = $1`,
+    [incomingTokenHash]
   );
   if (stored.rows.length === 0 || stored.rows[0].revoked_at !== null || stored.rows[0].is_revoked) {
     tokenRefreshCounter.inc({ outcome: 'token_revoked' });
@@ -691,8 +699,8 @@ export async function refreshToken(
     const revoke = await client.query(
       `UPDATE auth.refresh_tokens
        SET revoked_at = now(), is_revoked = true, updated_at = now()
-       WHERE token = $1 AND revoked_at IS NULL AND is_revoked = false`,
-      [req.refreshToken]
+       WHERE token_hash = $1 AND revoked_at IS NULL AND is_revoked = false`,
+      [incomingTokenHash]
     );
     if (revoke.rowCount === 0) {
       // The token was already rotated/revoked between our read and this
@@ -715,10 +723,10 @@ export async function refreshToken(
     // chain in one shot. The new row is the active head of the family.
     await client.query(
       `
-      INSERT INTO auth.refresh_tokens (token, user_id, family_id, expires_at, revoked_at, is_revoked, created_at, updated_at)
+      INSERT INTO auth.refresh_tokens (token_hash, user_id, family_id, expires_at, revoked_at, is_revoked, created_at, updated_at)
       VALUES ($1, $2, $3, $4, NULL, false, now(), now())
       `,
-      [minted.pair.refreshToken, claims.sub, familyId, minted.refreshExpiresAt]
+      [hashRefreshToken(minted.pair.refreshToken), claims.sub, familyId, minted.refreshExpiresAt]
     );
 
     publish({

--- a/services/auth/src/migrations/025_hash_refresh_tokens.ts
+++ b/services/auth/src/migrations/025_hash_refresh_tokens.ts
@@ -1,0 +1,37 @@
+import type { MigrationBuilder } from 'node-pg-migrate';
+
+// ADS-884: store SHA-256 hashes of refresh tokens instead of the raw bearer
+// strings, mirroring the pattern 024 already applied to the users table's
+// verification/reset tokens (ADS-883) and the jti-only auth.revoked_tokens /
+// token_hash-only auth.user_invitations tables.
+//
+// Refresh tokens are long-lived bearer credentials — a single read of
+// auth.refresh_tokens.token was a ready-made set of valid sessions. Insert
+// and lookup sites now write/query only the hash (see grpc/handlers.ts);
+// this migration adds the column and backfills existing rows so in-flight
+// sessions survive the deploy. The raw `token` column and its unique index
+// are left in place for now (no longer written by the app) and will be
+// dropped in a follow-up migration once this has been live for a release
+// cycle, in case of rollback.
+export const up = async (pgm: MigrationBuilder): Promise<void> => {
+  pgm.addColumns('refresh_tokens', {
+    token_hash: { type: 'varchar(64)' },
+  });
+
+  pgm.sql(`
+    UPDATE auth.refresh_tokens
+    SET token_hash = encode(sha256(token::bytea), 'hex')
+    WHERE token IS NOT NULL AND token_hash IS NULL
+  `);
+
+  pgm.createIndex('refresh_tokens', 'token_hash', {
+    name: 'refresh_tokens_token_hash_uq',
+    unique: true,
+    where: 'token_hash IS NOT NULL',
+  });
+};
+
+export const down = async (pgm: MigrationBuilder): Promise<void> => {
+  pgm.dropIndex('refresh_tokens', 'token_hash', { name: 'refresh_tokens_token_hash_uq' });
+  pgm.dropColumns('refresh_tokens', ['token_hash']);
+};

--- a/turbo.json
+++ b/turbo.json
@@ -27,16 +27,25 @@
         "test/**/*.tsx",
         "vitest.config.ts",
         "package.json",
-        "$TURBO_ROOT$/vitest.shared.config.ts"
+        "$TURBO_ROOT$/vitest.shared.config.ts",
+        "$TURBO_ROOT$/tsconfig.base.json"
       ]
     },
     "test:coverage": {
       "dependsOn": ["^build"],
       "outputs": ["coverage/**"],
-      "inputs": ["src/**/*.tsx", "src/**/*.ts", "test/**/*.ts", "test/**/*.tsx"]
+      "inputs": [
+        "src/**/*.tsx",
+        "src/**/*.ts",
+        "test/**/*.ts",
+        "test/**/*.tsx",
+        "$TURBO_ROOT$/vitest.shared.config.ts",
+        "$TURBO_ROOT$/tsconfig.base.json"
+      ]
     },
     "lint": {
-      "outputs": []
+      "outputs": [],
+      "inputs": ["src/**", "*.config.{js,ts,mjs}", "$TURBO_ROOT$/eslint.config.js"]
     },
     "format": {
       "outputs": [],
@@ -48,7 +57,7 @@
     },
     "type-check": {
       "dependsOn": ["^build"],
-      "outputs": []
+      "outputs": ["**/.tsbuildinfo", "dist/**/*.d.ts"]
     },
     "clean": {
       "cache": false


### PR DESCRIPTION
## Summary

Works through every open High-priority issue on the Linear board (ADS-892, ADS-896, ADS-893, ADS-890, ADS-889, ADS-884). One High-priority issue, ADS-671 (GHCR deploy token scope), is a GitHub secret-rotation task rather than a code change and is called out separately below rather than attempted here.

- **ADS-892** — Fixed `turbo.json` cache config: `type-check` now declares `outputs` for `.tsbuildinfo`/`.d.ts`, `lint` gained proper `inputs`, and `test`/`test:coverage` now include `tsconfig.base.json` so a shared config bump invalidates cached runs.
- **ADS-896** — `docs/DOCKER.md` and `e2e/README.md` referenced a `docker-compose.ci.yml` overlay that doesn't exist. Replaced those sections with the actual CI E2E flow (`docker-compose.yml --profile full` via `docker buildx bake`), verified against `.github/workflows/ci.yml`.
- **ADS-893** — Restructured `.env.example`: added a quick-start banner, documented previously-missing `REDIS_HOST_PORT` and `WATCHPACK_POLLING`, and resolved the contradictory OPTIONAL vs CRITICAL section wording (without breaking `scripts/check-env-example.mjs`'s banner-format guard).
- **ADS-890** — `app-admin`/`app-client`/`app-rescue` now `depends_on: service-gateway` (`condition: service_healthy`, `required: false`) so first-boot doesn't serve 502s while the gateway is still starting. Verified with `docker compose config` that both `--profile full` and single-app profiles (e.g. `--profile client`) still resolve correctly.
- **ADS-889** — Devcontainer `postCreateCommand` now runs `corepack enable && pnpm setup` instead of `npm run setup`, and the stale `service.backend` port label is renamed to `gRPC services`.
- **ADS-884** (security) — `auth.refresh_tokens` stored the raw bearer refresh token in plaintext. Added a `token_hash` column (SHA-256), backfilled it from the existing `token` column, and switched every insert/lookup site (login, logout, refresh rotation) to write/query only the hash — mirroring the pattern already used for reset/verification tokens (ADS-883). The raw `token` column is intentionally left in place for now per the ticket's phased-rollout plan; a follow-up migration will drop it after a release cycle.

## Not addressed in this PR

- **ADS-671** (GHCR deploy token has excessive permissions) is a GitHub-side PAT rotation + repo secret update, not a code change — the workflow comments documenting the required scope are already correct. Flagging for manual action rather than attempting it here.

## Changes

- `turbo.json`
- `docs/DOCKER.md`, `e2e/README.md`
- `.env.example`
- `docker-compose.yml`
- `.devcontainer/devcontainer.json`
- `services/auth/src/migrations/025_hash_refresh_tokens.ts` (new)
- `services/auth/src/grpc/handlers.ts`, `services/auth/src/grpc/handlers.test.ts`

## Before requesting review

- [x] If touching `.env` requirements, updated `.env.example`'s REQUIRED block
- [ ] Ran `pnpm ci:local:quick` locally — **not run**, this sandbox has no installed dependencies (no `node_modules`); see test plan below.

## Test plan

- [ ] `pnpm test` — not run in this environment (no installed dependencies); the auth handler changes add new unit tests (`handlers.test.ts`) asserting the raw refresh token is never persisted/queried, only its SHA-256 hash.
- [x] `turbo.json`: validated as valid JSON and dry-run with `npx turbo type-check --dry=json` against a real package.
- [x] `docker-compose.yml`: validated with `docker compose -f docker-compose.yml --profile client config` and `--profile full config` (with a stub `.env`) to confirm the new `depends_on` resolves correctly in both single-app and full-stack profiles.
- [x] `.devcontainer/devcontainer.json`: validated as valid JSON.
- [ ] No TypeScript errors / lint — not run (no installed dependencies in this sandbox).

## Related

- ADS-892, ADS-896, ADS-893, ADS-890, ADS-889, ADS-884, ADS-671 (Linear, `AdoptDontShop` team)


---
_Generated by [Claude Code](https://claude.ai/code/session_01QTAGCzXmY17kCEJPTgTqoY)_