### PR TITLE
fix(gateway): cap Socket.IO maxHttpBufferSize to 64 KB (ADS-887)

### DIFF
--- a/services/gateway/src/ws/socket-server.test.ts
+++ b/services/gateway/src/ws/socket-server.test.ts
@@ -313,6 +313,28 @@ describe('attachSocketServer — origin allowlist (ADS-843)', () => {
   });
 });
 
+describe('attachSocketServer — per-message size limit (ADS-887)', () => {
+  it('disconnects a client that emits a payload exceeding the 64 KB limit', async () => {
+    const { url } = await startServer({
+      logger: quietLogger(),
+      allowUnauthenticated: true,
+    });
+
+    const client = connectClient(url, { auth: { userId: 'usr-dos' } });
+    expect(await awaitConnectOutcome(client)).toBe(true);
+
+    const disconnected = new Promise<void>(resolve => {
+      client.on('disconnect', () => resolve());
+    });
+
+    // 65 KB string exceeds the 64_000-byte cap; the server must close the connection.
+    client.emit('test', 'x'.repeat(65_000));
+
+    await disconnected;
+    expect(client.connected).toBe(false);
+  });
+});
+
 describe('emitToUser — adapter-backed cross-instance fan-out (ADS-818)', () => {
   it('delivers an event to a user connected on a DIFFERENT adapter-backed instance', async () => {
     const bus = createInMemoryRedisBus();

--- a/services/gateway/src/ws/socket-server.ts
+++ b/services/gateway/src/ws/socket-server.ts
@@ -115,6 +115,11 @@ export const attachSocketServer = (opts: AttachSocketServerOptions): IOServer =>
     // The same /socket.io path the existing app uses, so the React
     // clients don't need to rebind during the strangler overlap.
     path: '/socket.io',
+    // ADS-887: cap inbound message size to prevent an authenticated client from
+    // flooding the gateway with ~1 MB frames that the Redis adapter fans to every
+    // replica. Notification and chat payloads are well under 1 KB; 64 KB is
+    // intentionally generous to survive any future richening of chat messages.
+    maxHttpBufferSize: 64_000,
   });
 
   // Multi-instance adapter (ADS-818). Binding the Redis adapter makes


### PR DESCRIPTION
## Summary

- Sets an explicit `maxHttpBufferSize` of 64 KB on the Socket.IO server to close a DoS vector (ADS-887)
- An authenticated client could previously send ~1 MB frames; the Redis adapter would fan each to every gateway replica, amplifying memory pressure fleet-wide
- 64 KB is intentionally generous — notification and chat payloads are well under 1 KB

## Changes

- `services/gateway/src/ws/socket-server.ts` — add `maxHttpBufferSize: 64_000` to the `IOServer` constructor options
- `services/gateway/src/ws/socket-server.test.ts` — new test asserting that a client emitting a payload over the limit is disconnected

## Before requesting review

- [x] Tests for new behaviour added (TDD)
- [x] If touching a `lib.*`, considered consumer impact across `app.*` and `service.backend` (not applicable — gateway-internal change)

## Test plan

- [x] Existing tests pass (`pnpm test`) — all 940 gateway tests green
- [x] New behaviour is covered by tests — `attachSocketServer — per-message size limit (ADS-887) > disconnects a client that emits a payload exceeding the 64 KB limit`
- [x] No TypeScript errors
- [x] Lint passes

## Screenshots / recordings

Not applicable — backend security hardening.

## Related

- Linear: ADS-887 — Security: Socket.IO server has no `maxHttpBufferSize` override — DoS via 1 MB messages

---
_Generated by [Claude Code](https://claude.ai/code/session_01GVRUW75nJCeVV3hyQopZf6)_