### PR TITLE
fix(auth): remove email from ALREADY_EXISTS error in adminCreateUser (ADS-885)

### DIFF
--- a/services/auth/src/grpc/admin-handlers.test.ts
+++ b/services/auth/src/grpc/admin-handlers.test.ts
@@ -985,6 +985,18 @@ describe('adminCreateUser', () => {
     expect(mocks.clientMock.query).not.toHaveBeenCalled();
   });
 
+  it('does not include the email address in the ALREADY_EXISTS error message', async () => {
+    mocks.poolMock.query.mockResolvedValueOnce({ rows: [{ exists: 1 }] });
+    let caught: unknown;
+    try {
+      await adminCreateUser(mocks.deps, ADMIN_CREATOR, baseReq);
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeDefined();
+    expect((caught as { message: string }).message).not.toContain(baseReq.email);
+  });
+
   it('creates a pending user + invitation and emits auth.userInvited with the token', async () => {
     mocks.poolMock.query.mockResolvedValueOnce({ rows: [] }); // no existing email
     mocks.clientScript.push({

--- a/services/auth/src/grpc/admin-handlers.ts
+++ b/services/auth/src/grpc/admin-handlers.ts
@@ -252,7 +252,7 @@ export async function adminCreateUser(
     [req.email]
   );
   if (existing.rows.length > 0) {
-    throw new HandlerError('ALREADY_EXISTS', `a user with email ${req.email} already exists`);
+    throw new HandlerError('ALREADY_EXISTS', 'a user with that email already exists');
   }
 
   // Pending users carry no usable credential until they redeem the invite;


### PR DESCRIPTION
## Summary

- `adminCreateUser` was echoing the caller-supplied email back in the `ALREADY_EXISTS` error message, giving any admin-level token a user-enumeration oracle
- Replace the interpolated message with a static `'a user with that email already exists'` — the error code still communicates the conflict for UX, but no PII is returned

## Changes

- `services/auth/src/grpc/admin-handlers.ts:255` — remove `${req.email}` from the error string
- `services/auth/src/grpc/admin-handlers.test.ts` — add assertion that the error message does not contain the probed email address

## Before requesting review

- [x] Tests for new behaviour added (TDD)
- [x] No `.env` changes
- [x] No `lib.*` touched

## Test plan

- [x] Existing tests pass — all 65 `adminCreateUser` / admin-handler tests green
- [x] New test added: `does not include the email address in the ALREADY_EXISTS error message`
- [x] Pre-existing `field-permission-handlers.test.ts` and `server.test.ts` failures confirmed present on `main` before this change (unrelated)
- [x] No TypeScript errors
- [x] Lint passes (pre-commit hook ran)

## Related

Fixes [ADS-885](https://linear.app/ideasquared/issue/ADS-885/security-admincreateuser-leaks-user-existence-via-already-exists-error)

---
_Generated by [Claude Code](https://claude.ai/code/session_017v8fa6sjUutvdBfmDNPqPp)_