### PR TITLE
fix(security): move prod Redis password to file-mounted Docker secret (ADS-886)

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -127,17 +127,19 @@ services:
     ports: []  # Don't expose Redis port to host in production
     volumes:
       - redis_data:/data
-    command: "redis-server --appendonly yes --requirepass ${REDIS_PASSWORD:?Error: REDIS_PASSWORD required in production}"
-    # REDIS_PASSWORD must be in the container env (not just interpolated into
-    # `command`) so the healthcheck's `redis-cli -a "$$REDIS_PASSWORD"` can
-    # authenticate — without it the check gets NOAUTH and never goes healthy.
-    environment:
-      REDIS_PASSWORD: ${REDIS_PASSWORD}
+    secrets:
+      - redis_password
+    # ADS-886: the password is read from the file-mounted secret at container
+    # start rather than interpolated into `environment:`, which `docker
+    # inspect` can read back in plaintext. The deploy workflow materialises
+    # ./secrets/redis_password from the host .env's REDIS_PASSWORD.
+    command: >
+      sh -c 'redis-server --appendonly yes --requirepass "$$(cat /run/secrets/redis_password)"'
     # Healthcheck so dependent services can wait for service_healthy. Without
     # this the backend may start before Redis is ready and crash on first
     # connection. [ADS-431]
     healthcheck:
-      test: ['CMD-SHELL', 'redis-cli -a "$$REDIS_PASSWORD" ping | grep -q PONG']
+      test: ['CMD-SHELL', 'redis-cli -a "$$(cat /run/secrets/redis_password)" ping | grep -q PONG']
       interval: 10s
       timeout: 5s
       retries: 5
@@ -571,6 +573,8 @@ secrets:
     file: ./secrets/database_url
   redis_url:
     file: ./secrets/redis_url
+  redis_password:
+    file: ./secrets/redis_password
   jwt_secret:
     file: ./secrets/jwt_secret
   jwt_refresh_secret:


### PR DESCRIPTION
## Summary

- Production Redis container was leaking the password via `docker inspect` (`Config.Env` + `Config.Cmd`) and `/proc/<pid>/cmdline`
- Replaces env-var interpolation with a file-mounted Docker secret — matching the pattern already applied to staging (ADS-878) and Postgres (ADS-752)
- Deploy workflow already materialises `secrets/redis_password` from `$REDIS_PASSWORD` (no workflow change needed)

## Changes

- `docker-compose.prod.yml` — redis service: remove `environment: REDIS_PASSWORD`, add `secrets: [redis_password]`, rewrite `command:` to read from `/run/secrets/redis_password`, rewrite healthcheck to read from the same file
- `docker-compose.prod.yml` — top-level `secrets:` block: add `redis_password: file: ./secrets/redis_password`

## Before requesting review

- [ ] Ran `pnpm ci:local:quick` locally (or installed the pre-push hook — see CONTRIBUTING.md)
- [ ] Tests for new behaviour added (TDD)
- [ ] If touching `.env` requirements, updated `.env.example`'s REQUIRED block
- [ ] If touching a `lib.*`, considered consumer impact across `app.*` and `service.backend`

## Test plan

- [ ] Existing tests pass (`pnpm test`)
- [ ] New behaviour is covered by tests
- [ ] Tested manually (describe how)
- [ ] No TypeScript errors (`pnpm type-check`)
- [ ] Lint passes (`pnpm lint`)

Manual verification after deploy: `docker inspect ads_prod_redis | jq '.[].Config.Env, .[].Config.Cmd'` — neither field should contain the Redis password.

## Screenshots / recordings

N/A — infrastructure-only change.

## Related

- Linear: https://linear.app/ideasquared/issue/ADS-886/security-production-redis-password-is-exposed-via-environment-block
- Prior work (Postgres): ADS-752, ADS-878
- Staging already uses this pattern (`docker-compose.staging.yml:114-123`)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TK8wym5KbG764RhyVTugUT)_