### PR TITLE
docs: fact-check documentation across root, /docs, services, packages

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -23,7 +23,7 @@ See [workflows/README.md](./workflows/README.md) for the full reference. The hig
 
 ## Lib Build Artifact Caching (ADS-390)
 
-`ci.yml` uses a dedicated `build-libs` job that compiles all `lib.*/dist` outputs once, then uploads them as a single `lib-dist` artifact via `actions/upload-artifact@v7`. Downstream jobs (`test-backend`, `test-frontend`, `test-libs`) use `actions/download-artifact@v8` to retrieve the pre-built artifacts instead of rebuilding.
+`ci.yml` uses a dedicated `build-libs` job that compiles all `lib.*/dist` outputs once, then uploads them as a single `lib-dist` artifact via `actions/upload-artifact@v7`. Downstream jobs (`test-services`, `test-frontend`, `test-libs`, `test-contracts`) use `actions/download-artifact@v8` to retrieve the pre-built artifacts instead of rebuilding.
 
 This eliminates the ~4x redundant `pnpm build:libs` calls that previously occurred across parallel jobs (~10 minutes of duplicated work per run).
 
@@ -43,6 +43,6 @@ This covers all workspace packages via the deduplicated `pnpm-lock.yaml`.
 
 ## E2E Gate (ADS-386 / ADS-419)
 
-The `test-e2e` job in `ci.yml` is a blocking signal — a failure fails the PR check. The previous `continue-on-error: true` escape hatch was removed by ADS-419; see the comment block at `ci.yml:398`.
+The `test-e2e` job in `ci.yml` is opt-in per PR — it runs on push to `main`, on `workflow_dispatch`, or when the PR carries the `run-e2e` label (see the `if:` gate around `.github/workflows/ci.yml:440`). When it runs, a failure fails the PR check; when it is skipped (unlabelled PRs) the `ci-required` aggregator treats the skip as success so E2E never blocks in-progress work. See [`workflows/README.md`](./workflows/README.md#-continuous-integration-workflow-ciyml) for the full policy.
 
 Playwright is configured with `retries: 2` in CI (see `e2e/playwright.config.ts`). Flaky-retry counts are surfaced in the "Report E2E retry counts" step after each run.

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -48,7 +48,7 @@ the full Playwright suite when:
 
 On any other PR `test-e2e` is **skipped**, which the `ci-required` aggregator
 treats as success — so E2E never blocks an in-progress PR. Unit/integration
-coverage still runs on every PR via `test-backend`, `test-frontend`, and
+coverage still runs on every PR via `test-services`, `test-frontend`, and
 `test-libs`. Tag a test with `@smoke` and run `pnpm test:e2e:smoke` locally for a
 quick critical-path subset.
 
@@ -83,7 +83,7 @@ quick critical-path subset.
 
 **Triggers**:
 
-- **Pull request**: only on changes to Dockerfiles, `docker-compose*.yml`, or `.dockerignore`. Source-only PRs are validated by `ci.yml` (`test-frontend`/`test-backend` run native `pnpm build`, and `test-e2e` brings the dev stack up via `docker compose up --build`).
+- **Pull request**: only on changes to Dockerfiles, `docker-compose*.yml`, or `.dockerignore`. Source-only PRs are validated by `ci.yml` (`test-frontend`/`test-services` run native `pnpm build`, and `test-e2e` brings the dev stack up via `docker compose up --build`).
 - **Push to main/develop**: triggers on the broader source path set so a regression that only manifests inside a container is caught before deploy. Production images and the Trivy scan run only on this branch — `deploy.yml` is the consumer.
 
 **Note**: the previous `test-compose` job (a container `/health` probe) was removed; `ci.yml`'s `test-e2e` brings up the full stack and is a strict superset of that signal.
@@ -128,7 +128,7 @@ GitHub Releases themselves are produced by `release-please.yml` from conventiona
 
 - **Concurrency Control**: Cancels old runs when new commits are pushed
 - **Matrix Builds**: Parallel execution for multiple projects
-- **Lib dist caching (ADS-390)**: The `build-libs` job caches compiled `lib.*/dist` artifacts across runs via `actions/cache@v4`. On a cache hit the build step is skipped entirely; on a miss the libs are compiled and the cache is saved for the next run. Within a single run, the compiled artifacts are shared to consumer jobs (`test-backend`, `test-frontend`, `test-libs`, `test-e2e`) via `upload-artifact`/`download-artifact`, eliminating redundant builds across the matrix.
+- **Lib dist caching (ADS-390)**: The `build-libs` job caches compiled `lib.*/dist` artifacts across runs via `actions/cache@v5.0.5` (pinned by SHA in `ci.yml`). On a cache hit the build step is skipped entirely; on a miss the libs are compiled and the cache is saved for the next run. Within a single run, the compiled artifacts are shared to consumer jobs (`test-services`, `test-frontend`, `test-libs`, `test-contracts`) via `upload-artifact`/`download-artifact`, eliminating redundant builds across the matrix. `test-e2e` builds its own images via `docker compose up --build` and does not consume the artifact.
 - **pnpm store caching**: the `setup-workspace` composite action installs pnpm via Corepack and caches the pnpm store (keyed on `pnpm-lock.yaml`) between runs
 - **Docker layer caching**: BuildKit layer cache in `docker.yml` for image rebuilds
 - **Path Filters**: Only runs when relevant files change

--- a/DESIGN_TOKENS.md
+++ b/DESIGN_TOKENS.md
@@ -2,7 +2,7 @@
 
 All visual styling in this monorepo flows from a single source of truth: the
 theme contract defined in
-[`lib.components/src/styles/theme.css.ts`](./lib.components/src/styles/theme.css.ts).
+[`lib.components/src/styles/theme.css.ts`](./packages/lib.components/src/styles/theme.css.ts).
 Three themes derive from the same contract: `lightThemeClass`,
 `normalThemeClass`, and `darkThemeClass`.
 
@@ -128,7 +128,7 @@ vars.zIndex.dropdown | sticky | overlay | modal | popover | toast | tooltip
 ## Reusable components first
 
 Before writing your own CSS, check whether
-[`lib.components`](./lib.components/src/index.ts) already exports what you
+[`lib.components`](./packages/lib.components/src/index.ts) already exports what you
 need. Frequently overlooked:
 
 - **`Stack`** / **`Container`** — layout primitives instead of manual flex/grid

--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ pnpm docker:dev:build         # rebuild images from scratch
 
 Common issues:
 
-- **Port conflict** — check 3000-3002 (apps), 4000 (gateway), 5001-5010 (services), 5432 (Postgres), 6379 (Redis), 4222/8222 (NATS) are free
+- **Port conflict** — check 3000-3002 (apps), 4000 (gateway), 5001-5009 (services), 5432 (Postgres), 6379 (Redis), 4222/8222 (NATS) are free
 - **HMR not firing** — verify `CHOKIDAR_USEPOLLING=true` is set in container env (it is by default in `docker-compose.yml`)
 - **Slow builds** — ensure BuildKit is on: `export DOCKER_BUILDKIT=1`
 

--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -38,7 +38,7 @@ Both Dockerfiles use multi-stage builds for optimal image size and cache reuse:
 | `build` | Compile TypeScript / bundle assets |
 | `production` | Minimal runtime image (Node for backend, nginx for frontend) |
 
-Each microservice under `services/` has its own `Dockerfile.service` (shared build template). All three frontend apps share [Dockerfile.app](../Dockerfile.app) and select their app via the `APP_NAME` build arg.
+Every microservice under `services/` is built from a single parameterised [`Dockerfile.service`](../Dockerfile.service) at the repo root; each service is selected via the `SERVICE` and `SERVICE_DIR` build args. All three frontend apps share [Dockerfile.app](../Dockerfile.app) and select their app via the `APP_NAME` build arg.
 
 ### Services
 
@@ -48,7 +48,7 @@ Each microservice under `services/` has its own `Dockerfile.service` (shared bui
 - `nginx` — Reverse proxy with subdomain routing (api, admin, rescue)
 
 **Application**
-- `service-gateway` — Fastify API gateway on port 4000 (health: `/health`)
+- `service-gateway` — Fastify API gateway on port 4000 (health: `/health/simple`)
 - `app-client` — Public portal on 3000
 - `app-admin` — Admin dashboard on 3001
 - `app-rescue` — Rescue portal on 3002
@@ -142,8 +142,8 @@ For a destructive reset (drop DB + re-init):
 
 ```bash
 pnpm docker:reset             # WIPES VOLUMES
-pnpm docker:dev:detach
-pnpm db:reset
+pnpm docker:dev:detach        # each service re-migrates its schema on start
+pnpm db:seed                  # (optional) reload dev seed data
 ```
 
 ### Debugging
@@ -212,7 +212,7 @@ VITE_WS_BASE_URL=wss://api.your-domain.com
 
 ### Health Checks
 
-- Gateway: `GET http://localhost:4000/health` → 200
+- Gateway: `GET http://localhost:4000/health/simple` → 200
 - Frontend (nginx): `GET http://localhost/health` → 200
 - Database: `pg_isready` (Docker healthcheck)
 
@@ -323,8 +323,8 @@ docker compose build --no-cache service-gateway
 pnpm docker:ps                # is database "healthy"?
 docker compose logs database     # check init logs
 pnpm docker:reset             # last resort — WIPES DATA
-pnpm docker:dev:detach
-pnpm db:reset
+pnpm docker:dev:detach        # each service re-migrates its schema on start
+pnpm db:seed                  # (optional) reload dev seed data
 ```
 
 ### Cleanup

--- a/docs/README.md
+++ b/docs/README.md
@@ -47,6 +47,7 @@ Documentation for the adopt-don't-shop monorepo, organized by audience. The root
 - [ADR 0002 — applications strangler cutover](./adr/0002-applications-strangler-cutover.md) — _superseded_: historical plan to move `/api/v1/applications/*` to the microservice (cutover flags removed)
 - [ADR 0003 — idempotent event consumers](./adr/0003-idempotent-event-consumers.md) — at-least-once delivery + idempotent-consumer convention
 - [ADR 0004 — Postgres read-replica routing](./adr/0004-postgres-read-replica-routing.md) — optional read-replica pool in `@adopt-dont-shop/db`
+- [ADR 0005 — Pact contract tests](./adr/0005-pact-contract-tests.md) — contract-testing model for gateway ↔ service boundaries
 - [ADR — sticky sessions for Socket.IO](./architecture/adr-socket-sticky-sessions.md) — connection-cap mitigation for the WebSocket edge
 - [Frontend technical architecture](./frontend/technical-architecture.md) — app shells, routing, state, styling
 - [Backend implementation guide](./backend/implementation-guide.md) — gateway routes → gRPC handlers → services wiring
@@ -55,6 +56,10 @@ Documentation for the adopt-don't-shop monorepo, organized by audience. The root
 - [Microservices standards](./infrastructure/MICROSERVICES-STANDARDS.md) — boundaries, contracts, ownership
 - [Dependency graph](./dependency-graph.md) — Turbo build/dependency graph reference
 - [Data standards](./DATA-STANDARDS.md) — naming, identifiers, timestamp / locale conventions
+- [Backbone infra review](./backbone-infra-review.md) — audit of the shared backend substrate (`packages/{db,events,proto,storage,observability,authz}`, `services/gateway`, `service-bootstrap`)
+- [Frontend libs quality review](./frontend-libs-quality-review.md) — audit of the frontend `lib.*` packages
+- [Services code quality review](./services-code-quality-review.md) — audit of the microservices (first pass)
+- [Services code quality review — pass 2](./services-code-quality-review-pass-2.md) — follow-up audit of the microservices
 
 ## Frontend development
 

--- a/docs/dependency-graph.md
+++ b/docs/dependency-graph.md
@@ -40,9 +40,9 @@ If you want to see this in action, generate the graph and trace the inbound edge
 The CI workflows mirror the same layered ordering:
 
 ```
-build-libs  ->  (test-backend || test-frontend || test-libs)  ->  test-e2e
+build-libs  ->  (test-services || test-frontend || test-libs)  ->  test-e2e
 ```
 
 1. **build-libs** — compile every `lib.*` first so downstream jobs can consume the built artefacts.
-2. **test-backend / test-frontend / test-libs** — run in parallel once the libraries are built; none of them depend on each other.
+2. **test-services / test-frontend / test-libs** — run in parallel once the libraries are built; none of them depend on each other.
 3. **test-e2e** — runs last, after backend + frontend test jobs pass, since it exercises the full stack.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -16,19 +16,20 @@ Each backend service owns its own `vitest.config.ts` under
 
 ## E2E gating
 
-The Playwright job in `.github/workflows/ci.yml` is no longer
-`continue-on-error: true` (ADS-419) — broken integration tests now block
-PR merges. Add `test-e2e` as a required status check in branch
-protection once it has shipped.
+The Playwright `test-e2e` job in `.github/workflows/ci.yml` is opt-in per
+PR — it runs only when the PR carries the `run-e2e` label (or on `main`
+push / manual dispatch). When it runs it is a required check and blocks
+merge on failure; unlabelled PRs skip the job entirely to keep the
+default CI path fast. See CONTRIBUTING.md for the label workflow.
 
 ## Scope: payment / donation processing — out of scope
 
 A repo-wide search for `stripe`, `paypal`, `payment`, and `donation`
 returns no production code paths that handle money:
 
-- The single `payment` reference in `models/SupportTicket.ts` is the
-  enum value `PAYMENT_ISSUE` used to categorise support tickets — there
-  is no payment processing behind it.
+- The single `payment` reference in `packages/lib.support-tickets/src/schemas.ts`
+  is the enum value `'payment_issue'` used to categorise support tickets
+  — there is no payment processing behind it.
 - No service file touches a card processor SDK.
 - No frontend route renders a checkout/donation form.
 
@@ -49,8 +50,10 @@ The full ruleset lives in `.claude/CLAUDE.md`. The tactical reminders
 that come up most often:
 
 - No `as any`, no private-method spies, no implementation-detail tests.
-- Test through public APIs; for routes, that means supertest against
-  the Express router with `vi.mock()` on the service layer.
+- Test through public APIs; for gateway routes that means Fastify's
+  `inject()` with `vi.mock()` on the downstream gRPC clients; for gRPC
+  handlers, invoke the handler function directly with a synthetic
+  context.
 - 100% coverage of behaviour is the aspiration, but coverage thresholds
   (see `vitest.config.ts`) define the *enforced* floor.
 

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -116,8 +116,9 @@ The microservice stack ships no data on a fresh boot. The dev/e2e seed recreates
 
 ```bash
 pnpm db:seed        # root orchestrator: docker compose exec into
-                       # service-auth → service-rescue → service-pets,
-                       # running each service's db:seed in dependency order
+                       # service-auth → service-rescue → service-pets →
+                       # service-applications → service-chat, running each
+                       # service's db:seed in dependency order
 ```
 
 `pnpm db:seed` is safe to re-run at any time. Per-service overrides are available too (`docker compose exec service-auth pnpm db:seed`).

--- a/packages/events/README.md
+++ b/packages/events/README.md
@@ -36,7 +36,7 @@ import { subscribe } from '@adopt-dont-shop/events';
 
 subscribe<{ petId: string }>(
   nats,
-  { subject: 'pets.created', queue: 'notification-workers', onError: logger.warn },
+  { subject: 'pets.created', durable: 'notification-workers', onError: logger.warn },
   async (payload, { id }) => {
     // De-dupe on the event id — every handler should be idempotent.
     if (await alreadyProcessed(id)) return;
@@ -46,17 +46,33 @@ subscribe<{ petId: string }>(
 );
 ```
 
+The `durable` name is REQUIRED — it's the JetStream consumer identity.
+Two replicas that share a durable name load-share the subject's messages
+(the classic queue-group semantics); replicas that must each see every
+message (e.g. the gateway WS fan-out) use DISTINCT durable names. See
+`SubscribeOptions` in `src/subscribe.ts` for the full option surface,
+including the `deliverNew` flag for realtime consumers that must not
+replay backlog on reconnect.
+
 Errors thrown from the handler are reported via `onError` and the loop
 keeps draining. Malformed JSON is also a clean skip. Unknown id / wrong
 state / concurrency failures (the CAD list) are caller-side concerns —
 the handler should treat them as skip-not-throw.
 
-## What's NOT here yet
+## Other exports
 
-- **Durable consumers / replay-on-reconnect.** Current helpers use core
-  NATS (best-effort delivery). When a service ships JetStream durable
-  consumers, the API adds an `opts.durable` flag and the subscribe loop
-  switches to `JetStreamClient.consume(...)`. CAD's Phase 5+ backlog
-  item; not yet a blocker.
+Beyond `publish` / `subscribe`, this package also exposes:
+
+- `ensureStream`, `DOMAIN_STREAM`, `DOMAIN_SUBJECTS` — the shared
+  `DOMAIN_EVENTS` JetStream topology helpers.
+- `claimEvent` + `CONSUMER_REGISTRY` — the idempotent-consumer helper
+  (dedup by event id) used by every subscriber.
+- `GDPR_ERASURE_REQUESTED`, `GDPR_ERASURE_COMPLETED`,
+  `EXPECTED_GDPR_SERVICES`, `registerGdprSubscriber` — the GDPR erasure
+  saga primitives coordinated by service.audit.
+- `redactAuditPayload` — payload-side redaction for audit publishes.
+
+## Not here
+
 - **Connection management.** Callers own the `NatsConnection` lifecycle
   (`connect()` / `drain()`). The helpers expect a live connection.

--- a/packages/lib.api/README.md
+++ b/packages/lib.api/README.md
@@ -124,7 +124,7 @@ type ApiServiceConfig = {
 
 ## Data Transformation
 
-Responses that contain pet objects are automatically normalised from API snake_case to camelCase, and PostGIS geometry is converted to a readable `"lat, lng"` string. The mapping is inlined in `src/services/api-service.ts` (search for `normalizePet`).
+Pet response payloads land as the `ApiPet` / `TransformedPet` types in `src/types/`; the client passes them through unchanged and consumers destructure the fields they need. There is no in-service snake_case→camelCase or PostGIS-geometry transformer at the moment — the example below shows the shapes involved, not a mapping the client applies.
 
 ```typescript
 // API Response (snake_case)

--- a/packages/lib.auth/README.md
+++ b/packages/lib.auth/README.md
@@ -111,9 +111,9 @@ Two-factor:
 
 Token storage (local):
 
-- `getToken(): null` — kept for compatibility; always returns `null`. The access token lives in an httpOnly cookie managed by the backend and is not readable from JavaScript. HTTP requests send it automatically via `credentials: 'include'`; Socket.IO uses the same cookie on the WebSocket upgrade.
-- `setToken(token: string | null | undefined): void` — no-op for the same reason.
-- `clearTokens(): void`
+- `getToken(): string | null` — returns the stored access token from `localStorage`. `lib.api` calls this via its `getAuthToken` hook to attach `Authorization: Bearer <token>` to HTTP requests; the Socket.IO clients read it the same way.
+- `setToken(token: string | null | undefined): void` — writes (or clears) the access token in `localStorage`.
+- `clearTokens(): void` — removes both the access token and refresh token from `localStorage`. Called on logout after the gateway revokes the refresh token, and when a session is found to be invalid.
 
 ## useAuth hook
 

--- a/packages/lib.observability/README.md
+++ b/packages/lib.observability/README.md
@@ -67,5 +67,5 @@ Or from `lib.observability/`: `pnpm build`, `pnpm test`, `pnpm lint`.
 ## See also
 
 - [`lib.legal`](../lib.legal/README.md) — cookie banner that owns the consent UI and toggles this gate
-- [`docs/legal/cookies.md`](../docs/legal/cookies.md) — cookie category definitions; explains why Sentry is exempt
-- [`docs/observability-alerting.md`](../docs/observability-alerting.md) — how Sentry events feed alerting
+- [`docs/legal/cookies.md`](../../docs/legal/cookies.md) — cookie category definitions; explains why Sentry is exempt
+- [`docs/observability-alerting.md`](../../docs/observability-alerting.md) — how Sentry events feed alerting

--- a/packages/observability/README.md
+++ b/packages/observability/README.md
@@ -90,13 +90,15 @@ logger.info('booted', { port: 4000 });
 
 ### What this package does NOT include (yet)
 
-- **PII / secret redaction inside log payloads.** `service.backend`'s
-  logger has it via a `redactLogPayload` helper. Port that into here
-  when the redact module migrates to a shared package.
 - **`AsyncLocalStorage` correlation-id stamping.** Coupled to each
   service's request-context middleware. Callers attach
   `correlationId` / `traceparent` to log payloads as fields when they
   have them.
+
+Note: PII / secret redaction of log and telemetry payloads IS included —
+`redactSecretFields`, `REDACTED`, `SECRET_KEY_PATTERN` are exported from
+`src/index.ts` (the recursive redactor is in `src/redact.ts` and matches
+`password|token|secret|otp|authorization|cookie|api[_-]?key`).
 - **`loggerHelpers` bundle** (`logRequest`, `logAuth`, `logBusiness`,
   `logSecurity`, …). Middleware concerns — they live with each
   service's own request pipeline.

--- a/packages/proto/README.md
+++ b/packages/proto/README.md
@@ -17,7 +17,7 @@ The plugin path lives in `buf.gen.yaml`:
 ```yaml
 plugins:
   - plugin: ts_proto
-    path: ../../node_modules/.bin/protoc-gen-ts_proto
+    path: node_modules/.bin/protoc-gen-ts_proto
 ```
 
 No remote dependency, no buf.build account, no auth tokens. Every CI
@@ -68,23 +68,20 @@ namespace alias.
 
 ## What's here today
 
-- `proto/adopt_dont_shop/v1/ping.proto` — smoke target so the toolchain
-  has something to compile, even before any real service exists.
-- `proto/adopt_dont_shop/notifications/v1/notification.proto` —
-  `NotificationService.{Create, List, Dismiss}` plus the Notification
-  message and the five Postgres-ENUM-mirrored enums. Added in Phase 1.3a.
+Every microservice domain has a versioned proto namespace under
+`proto/adopt_dont_shop/<domain>/v1/`. Value + flat-type re-exports for all
+of them are wired in `src/index.ts`:
+
+- `PingV1` — smoke target.
+- `NotificationsV1` — `NotificationService.{Create, List, Dismiss, …}`.
+- `AuthV1`, `PetsV1`, `RescueV1`, `ApplicationsV1`, `ChatV1`, `MatchingV1`,
+  `ModerationV1`, `AuditV1`, `CmsV1` — one namespace per service.
 
 `buf.gen.yaml` is configured with **`outputServices=grpc-js`** — both
 server-side Definition tables (consumed by `server.addService(...)`)
 and client constructors are emitted. `@grpc/grpc-js` is a runtime
 dependency on this package; services that import any namespace get it
 transitively.
-
-## What's NOT here yet
-
-- **Real domain protos beyond notifications.** Auth, pets, applications,
-  chat, etc. land in their respective phase commits, each following the
-  same naming pattern: `proto/adopt_dont_shop/<domain>/v1/*.proto`.
 
 ## Commands
 

--- a/scripts/seed.mjs
+++ b/scripts/seed.mjs
@@ -5,9 +5,11 @@
  * Runs each owning service's `db:seed` script in dependency order against
  * the running docker-compose stack:
  *
- *   1. service-auth   — canonical personas (john.smith + admin + rescue staff)
- *   2. service-rescue — rescue orgs + staff_member links (reference auth ids)
- *   3. service-pets   — pet catalogue (reference rescue ids)
+ *   1. service-auth         — canonical personas (john.smith + admin + rescue staff)
+ *   2. service-rescue       — rescue orgs + staff_member links (reference auth ids)
+ *   3. service-pets         — pet catalogue (reference rescue ids)
+ *   4. service-applications — application read-model (references user/pet/rescue ids)
+ *   5. service-chat         — adopter↔rescue chat + participants (references user/rescue ids)
  *
  * This is a HOST-side orchestrator: it must NOT import any
  * @adopt-dont-shop/* workspace package (CAD lesson — host scripts that pull

--- a/services/audit/README.md
+++ b/services/audit/README.md
@@ -81,11 +81,11 @@ timing out / retrying stuck sagas, and exporting saga-state metrics. Schema:
 | `saved_reports` | User-created custom audit-report definitions. |
 | `report_templates` | Seed/migration-owned report template library. |
 
-Migrations: `services/audit/src/migrations/001`–`007`.
+Migrations: `services/audit/src/migrations/001`–`008`.
 
 ### gRPC RPCs
 
-`AuditService` — **read-only** (no write RPCs; writes happen via NATS
+`AuditQueryService` — **read-only** (no write RPCs; writes happen via NATS
 consumers). `super_admin` bypasses.
 
 | RPC | Permission |

--- a/services/auth/README.md
+++ b/services/auth/README.md
@@ -206,7 +206,7 @@ the gateway validates on every request. Schema: `auth`.
 | `user_privacy_prefs` | Per-user privacy preferences. |
 | `field_permissions` | Overrides to the default field-level access matrix. |
 
-Migrations: `services/auth/src/migrations/001`–`022`.
+Migrations: `services/auth/src/migrations/001`–`025`.
 
 ### gRPC RPCs
 
@@ -242,9 +242,13 @@ for others).
 **Emits** (publish-after-commit): `auth.userLoggedIn`, `auth.tokenRevoked`,
 `auth.tokenRefreshed`, `auth.roleAssigned`, `auth.userRegistered`,
 `auth.emailVerified`, `auth.passwordResetRequested`, `auth.passwordChanged`,
-`auth.sessionRevoked`, `auth.privacyPrefsReset`, `auth.userDeactivated`,
-`auth.userReactivated`, `auth.userUpdatedByAdmin`. Plus `gdpr.erasureCompleted`
-as a saga participant.
+`auth.sessionRevoked`, `auth.privacyPrefsReset`, `auth.userUpdatedByAdmin`,
+`auth.userInvited`, `auth.invitationRedeemed`, `auth.actionTaken` (feeds the
+audit stream), `auth.accountDeletionRequested`, `auth.accountLockedByAdmin`,
+`auth.accountUnlockedByAdmin`, `auth.allSessionsRevokedByAdmin`,
+`auth.sessionRevokedByAdmin`, `auth.passwordResetByAdmin`,
+`auth.ipRuleCreated`, `auth.ipRuleDeleted`. Plus `gdpr.erasureCompleted` as
+a saga participant.
 
 **Consumes:** `gdpr.erasureRequested` (durable `gdpr-auth`).
 

--- a/services/notifications/README.md
+++ b/services/notifications/README.md
@@ -148,14 +148,16 @@ permission. `super_admin` bypasses.
 ### NATS subjects
 
 **Emits** (publish-after-commit): `notifications.created` (Create),
-`notifications.dismissed` (Dismiss). Plus `gdpr.erasureCompleted` as a saga
-participant.
+`notifications.dismissed` (Dismiss), `notifications.deleted` (Delete),
+`notifications.allRead` (MarkAllRead), `notifications.prefsReset`
+(ResetPreferences), `notifications.broadcastSent` (Broadcast). Plus
+`gdpr.erasureCompleted` as a saga participant.
 
 **Consumes:** `applications.{submitted,approved,rejected,adopted,
-homeVisitScheduled,homeVisitCompleted}`, `auth.{roleAssigned,userLoggedIn}`,
+homeVisitScheduled,homeVisitCompleted}`, `auth.{roleAssigned,userLoggedIn,userInvited}`,
 `chat.messageCreated`, `pets.{statusChanged,deleted}`,
-`rescue.{verified,rejected,staffInvited}`, and `gdpr.erasureRequested` (durable
-`gdpr-notifications`).
+`rescue.{verified,rejected,staffInvited,staffInvitationCancelled}`, and
+`gdpr.erasureRequested` (durable `gdpr-notifications`).
 
 ### Dependencies
 

--- a/services/pets/README.md
+++ b/services/pets/README.md
@@ -7,10 +7,12 @@ PetStatusTransition) and exposes `PetService` over gRPC.
 
 CAD Phase 3 equivalent — first service in the migration where event
 sourcing pays off. Pet status transitions
-(`available → reserved → adopted → unavailable`, plus `deceased`,
-`returned`) form a real state machine with multi-consumer audit needs
-(matching, notifications, moderation, applications). Pure `apply`/`fold`
-domain + publish-after-commit on `pets.statusChanged`.
+(`available` → `pending` → `adopted`, plus `foster`, `medical_hold`,
+`behavioral_hold`, `not_available`, `deceased` — see the `pet_status`
+enum in `migrations/002_create_pets.ts`) form a real state machine with
+multi-consumer audit needs (matching, notifications, moderation,
+applications). Pure `apply`/`fold` domain + publish-after-commit on
+`pets.statusChanged`.
 
 ## What's shipped so far
 
@@ -143,7 +145,7 @@ pnpm start
 
 Owns the pet listing catalogue: classical CRUD plus an event-sourced status
 state machine (`available` → `pending` → `adopted`, plus
-`foster`/`medical_hold`/`behavioral_hold`/`deceased`). Each status transition
+`foster`/`medical_hold`/`behavioral_hold`/`not_available`/`deceased`). Each status transition
 appends an audit row and publishes `pets.statusChanged`. Serves privilege-aware
 reads (internal notes + off-market statuses hidden from public readers),
 favourite/rating aggregates, and per-rescue stats. Schema: `pets`.

--- a/services/rescue/README.md
+++ b/services/rescue/README.md
@@ -7,9 +7,9 @@ Invitation, FosterPlacement, ApplicationQuestion) and exposes
 `RescueService` over gRPC.
 
 Classical (no event sourcing — mostly CRUD with a few status
-transitions). Subscribes to `auth.userCreated` to maintain
-staff-member denormalisation (CAD-style cross-service maintained
-read model).
+transitions). The `staff_members` join row denormalises `user_id` +
+`rescue_id` without a cross-schema FK; see
+`migrations/003_create_staff_members.ts` for the ownership rationale.
 
 ## What's shipped so far
 
@@ -173,7 +173,7 @@ foster pet ownership via a gRPC call to service.pets. Schema: `rescue`.
 | `foster_placements` | Foster assignments — rescue, pet, foster user, dates, status. |
 | `application_questions` | Custom adoption-application questions a rescue defines. |
 
-Migrations: `services/rescue/src/migrations/001`–`008`.
+Migrations: `services/rescue/src/migrations/001`–`010`.
 
 ### gRPC RPCs
 


### PR DESCRIPTION
## Summary

- Doc-accuracy sweep across the monorepo — four thematic commits, each fact-checked against source or config before touching a line. No content invented; every change points at an evidence file the reviewer can grep. See commit messages for the per-file rationale.

## Batches (each = one commit)

1. **Root + `/docs` + `lib.auth`** (`892ee13`) — port range in `README.md`, broken relative paths in `DESIGN_TOKENS.md`, `pnpm db:reset` (doesn't exist) and `/health` (should be `/health/simple`) in `docs/DOCKER.md`, `PAYMENT_ISSUE` casing / Express-vs-Fastify / E2E gating in `docs/testing.md`, CI job name in `docs/dependency-graph.md`, orphaned audit docs in `docs/README.md`, and the misleading httpOnly-cookie claim in `packages/lib.auth/README.md` (the code reads/writes localStorage).
2. **CI job names, cache pin, seed scope** (`a7189cb`) — `test-backend` → `test-services` in `.github/README.md` and `.github/workflows/README.md`; `actions/cache@v4` → `v5.0.5`; corrected `test-e2e` artifact-consumer claim; corrected the E2E-gate description (opt-in via `run-e2e` label); `db:seed` orchestrator actually iterates 5 services (`e2e/README.md`, `scripts/seed.mjs`).
3. **Service READMEs** (`5c44d93`) — migration ranges (auth `001–025`, rescue `001–010`, audit `001–008`); `pets` state-machine values match the `pet_status` enum; `AuditQueryService` (not `AuditService`); expanded auth Emits list; dropped the stale `auth.userCreated` subscriber claim in rescue; expanded notifications Emits / Consumes.
4. **Package READMEs** (`9a5932e`) — `packages/proto` domain list (11 shipped V1 namespaces, not "ping + notifications only"); `packages/events` `subscribe()` takes `durable`, not `queue`; `packages/observability` payload redactor IS shipped; `packages/lib.observability` relative doc links (`../docs/...` → `../../docs/...`); `packages/lib.api` drops the non-existent `normalizePet` pointer.

## Changes

Files touched (docs + one JSDoc header only — no product code changes):

- `README.md`, `DESIGN_TOKENS.md`
- `docs/DOCKER.md`, `docs/README.md`, `docs/dependency-graph.md`, `docs/testing.md`
- `.github/README.md`, `.github/workflows/README.md`
- `e2e/README.md`
- `scripts/seed.mjs` (header JSDoc)
- `services/{auth,audit,notifications,pets,rescue}/README.md`
- `packages/{events,observability,proto}/README.md`, `packages/{lib.api,lib.auth,lib.observability}/README.md`

## Before requesting review

- [x] Docs-only — no product tests to add or run
- [x] All fixed claims cross-referenced against actual source; each commit message lists the specific files that back the change
- [ ] `pnpm ci:local:quick` — deferred (format/prettier is the only relevant gate for markdown; CI runs it)

## Test plan

- [x] Sources cross-checked: `package.json`, `docker-compose*.yml`, `.github/workflows/ci.yml`, `services/*/src/config.ts`, `services/*/src/migrations/`, `services/*/src/grpc/`, `packages/lib.*/src/index.ts`, `packages/events/src/subscribe.ts`, `packages/proto/{buf.gen.yaml,src/index.ts}`, `packages/observability/src/index.ts`.
- [x] Relative-link fixes verified against the actual filesystem tree.
- [ ] Nothing else — docs-only.

## Related

- Doc-index CI check (`scripts/check-docs-index.mjs`) will now find the previously-orphaned audit docs. If it was failing silently, batch 1 will turn it green.