### PR TITLE
fix(auth): block role elevation via adminUpdateUser — privilege escalation to super_admin

### DIFF
--- a/services/auth/src/grpc/admin-handlers.test.ts
+++ b/services/auth/src/grpc/admin-handlers.test.ts
@@ -287,6 +287,80 @@ describe('adminUpdateUser', () => {
     expect(res.user?.userId).toBe('usr-1');
     expect(mocks.clientMock.query).not.toHaveBeenCalled();
   });
+
+  it('blocks a plain admin from elevating another user to admin', async () => {
+    await expect(
+      adminUpdateUser(mocks.deps, ADMIN, {
+        userId: 'usr-other',
+        userType: AuthV1.UserRole.USER_ROLE_ADMIN,
+      })
+    ).rejects.toMatchObject({ code: 'PERMISSION_DENIED' });
+  });
+
+  it('blocks a plain admin from elevating another user to super_admin', async () => {
+    await expect(
+      adminUpdateUser(mocks.deps, ADMIN, {
+        userId: 'usr-other',
+        userType: AuthV1.UserRole.USER_ROLE_SUPER_ADMIN,
+      })
+    ).rejects.toMatchObject({ code: 'PERMISSION_DENIED' });
+  });
+
+  it('blocks a plain admin from elevating another user to moderator', async () => {
+    await expect(
+      adminUpdateUser(mocks.deps, ADMIN, {
+        userId: 'usr-other',
+        userType: AuthV1.UserRole.USER_ROLE_MODERATOR,
+      })
+    ).rejects.toMatchObject({ code: 'PERMISSION_DENIED' });
+  });
+
+  it('blocks self-role-change via adminUpdateUser', async () => {
+    await expect(
+      adminUpdateUser(mocks.deps, ADMIN, {
+        userId: ADMIN.userId,
+        userType: AuthV1.UserRole.USER_ROLE_SUPER_ADMIN,
+      })
+    ).rejects.toMatchObject({ code: 'INVALID_ARGUMENT' });
+  });
+
+  it('allows super_admin to assign an elevated role and records role change in audit event', async () => {
+    // SELECT previous role, then UPDATE returning new row
+    mocks.clientScript.push({ rows: [{ user_type: 'adopter' }] });
+    mocks.clientScript.push({ rows: [userRow({ user_type: 'admin' })] });
+
+    const res = await adminUpdateUser(mocks.deps, SUPER_ADMIN, {
+      userId: 'usr-1',
+      userType: AuthV1.UserRole.USER_ROLE_ADMIN,
+    });
+
+    expect(res.user?.userType).toBe(AuthV1.UserRole.USER_ROLE_ADMIN);
+    const publishCall = mocks.natsMock.publish.mock.calls[0] as [string, Uint8Array];
+    const event = JSON.parse(new TextDecoder().decode(publishCall[1])) as {
+      payload: { roleChange: { before: string; after: string } };
+    };
+    expect(event.payload.roleChange).toEqual({ before: 'adopter', after: 'admin' });
+  });
+
+  it('allows admin.users.update to change non-role fields without elevation guard', async () => {
+    mocks.clientScript.push({ rows: [userRow({ first_name: 'Bob' })] });
+
+    const res = await adminUpdateUser(mocks.deps, ADMIN, {
+      userId: 'usr-1',
+      firstName: 'Bob',
+    });
+
+    expect(res.user?.firstName).toBe('Bob');
+    // No SELECT for previous role should have been issued
+    const updateCall = (mocks.clientMock.query.mock.calls as Array<[string, unknown[]]>).find(
+      ([sql]) => sql.includes('UPDATE auth.users')
+    );
+    expect(updateCall).toBeDefined();
+    const selectCall = (mocks.clientMock.query.mock.calls as Array<[string, unknown[]]>).find(
+      ([sql]) => sql.trim().startsWith('SELECT user_type')
+    );
+    expect(selectCall).toBeUndefined();
+  });
 });
 
 // --- deactivateUser / reactivateUser ---------------------------------

--- a/services/auth/src/grpc/admin-handlers.ts
+++ b/services/auth/src/grpc/admin-handlers.ts
@@ -338,9 +338,21 @@ export async function adminUpdateUser(
     sets.push(`status = $${params.length + 1}`);
     params.push(statusToDb(req.status));
   }
+  let roleChange: { newRole: string } | undefined;
   if (req.userType !== undefined && req.userType !== AuthV1.UserRole.USER_ROLE_UNSPECIFIED) {
+    if (req.userId === principal.userId) {
+      throw new HandlerError('INVALID_ARGUMENT', 'cannot change your own user_type');
+    }
+    const targetRole = roleToDb(req.userType);
+    if (ELEVATED_ROLES.has(targetRole) && !principal.roles.includes('super_admin')) {
+      throw new HandlerError(
+        'PERMISSION_DENIED',
+        'only a super_admin may assign admin, moderator, or super_admin roles'
+      );
+    }
+    roleChange = { newRole: targetRole };
     sets.push(`user_type = $${params.length + 1}`);
-    params.push(roleToDb(req.userType));
+    params.push(targetRole);
   }
   if (req.emailVerified !== undefined) {
     sets.push(`email_verified = $${params.length + 1}`);
@@ -365,6 +377,18 @@ export async function adminUpdateUser(
 
   let updated: UserRow | undefined;
   await withTransaction(deps, async ({ client, publish }) => {
+    let previousRole: string | undefined;
+    if (roleChange) {
+      const prevRes = await client.query<{ user_type: string }>(
+        `SELECT user_type FROM auth.users WHERE user_id = $1 AND deleted_at IS NULL`,
+        [req.userId]
+      );
+      if (prevRes.rows.length === 0) {
+        throw new HandlerError('NOT_FOUND', `user ${req.userId} not found`);
+      }
+      previousRole = prevRes.rows[0].user_type;
+    }
+
     const res = await client.query<UserRow>(
       `
       UPDATE auth.users
@@ -382,7 +406,11 @@ export async function adminUpdateUser(
     publish({
       type: 'auth.userUpdatedByAdmin',
       id: `auth.userUpdatedByAdmin.${req.userId}.${Date.now()}`,
-      payload: { userId: req.userId, updatedBy: principal.userId },
+      payload: {
+        userId: req.userId,
+        updatedBy: principal.userId,
+        ...(roleChange && { roleChange: { before: previousRole, after: roleChange.newRole } }),
+      },
     });
   });
 


### PR DESCRIPTION
## Summary

- `adminUpdateUser` accepted `userType` from the request and wrote it directly to `auth.users.user_type` with no elevation or self-target check, allowing any holder of `admin.users.update` to promote themselves or others to `super_admin`
- Ports the `ELEVATED_ROLES` guard from `adminCreateUser` and the self-target guard from `deactivateUser`/`bulkUpdateUsers` into `adminUpdateUser`, applied only when `userType` is being changed
- Captures the previous `user_type` within the same transaction and includes a `roleChange: { before, after }` delta in the `auth.userUpdatedByAdmin` event

## Changes

- `services/auth/src/grpc/admin-handlers.ts` — added self-target guard and `ELEVATED_ROLES` elevation guard to `adminUpdateUser`; added pre-UPDATE SELECT inside transaction to capture previous role; enriched event payload with role-change delta
- `services/auth/src/grpc/admin-handlers.test.ts` — 6 new regression tests covering self-elevation, cross-user elevation to admin/moderator/super_admin, allowed non-role updates, and audit event payload for a super_admin role assignment

## Before requesting review

- [x] Tests for new behaviour added (TDD)
- [ ] If touching `.env` requirements, updated `.env.example`'s REQUIRED block
- [x] If touching a `lib.*`, considered consumer impact across `app.*` and `service.backend`

## Test plan

- [x] Existing tests pass (`pnpm test` — 70/70 in `admin-handlers.test.ts`)
- [x] New behaviour is covered by tests
- [x] No TypeScript errors (`pnpm type-check`)
- [x] Lint passes (`pnpm lint`)

## Related

Closes [ADS-912](https://linear.app/ideasquared/issue/ADS-912/security-adminupdateuser-missing-role-elevation-self-target-guards)

---
_Generated by [Claude Code](https://claude.ai/code/session_019qngUvvAoCi777fWEdUfeh)_