### PR TITLE
fix(rescue): fail-closed rescue scoping in event handlers (ADS-934)

### DIFF
--- a/services/rescue/src/grpc/event-handlers.test.ts
+++ b/services/rescue/src/grpc/event-handlers.test.ts
@@ -42,6 +42,18 @@ const STAFF_READ_ONLY: Principal = {
   rescueId: RESCUE_ID as RescueId,
 };
 
+const STAFF_NO_RESCUE: Principal = {
+  userId: USER_ID as UserId,
+  roles: ['rescue_staff'],
+  permissions: [
+    'events.read' as Permission,
+    'events.create' as Permission,
+    'events.update' as Permission,
+    'events.delete' as Permission,
+  ],
+  // rescueId intentionally absent — simulates stale token / role misconfiguration
+};
+
 const UNPRIVILEGED: Principal = {
   userId: 'usr-nobody' as UserId,
   roles: ['adopter'],
@@ -159,6 +171,12 @@ describe('listEvents', () => {
     const res = await listEvents(mocks.deps, SUPER_ADMIN, {});
     expect(res.events).toHaveLength(1);
   });
+
+  it('rejects non-super-admin with events.read but no rescueId', async () => {
+    await expect(listEvents(mocks.deps, STAFF_NO_RESCUE, {})).rejects.toMatchObject({
+      code: 'PERMISSION_DENIED',
+    });
+  });
 });
 
 // ── GetEvent ────────────────────────────────────────────────────────────
@@ -200,6 +218,13 @@ describe('getEvent', () => {
   it('rejects missing id argument', async () => {
     await expect(getEvent(mocks.deps, STAFF, { id: '' })).rejects.toMatchObject({
       code: 'INVALID_ARGUMENT',
+    });
+  });
+
+  it('rejects principal with events.read but no rescueId', async () => {
+    mocks.poolMock.query.mockResolvedValueOnce({ rows: [eventRow()] });
+    await expect(getEvent(mocks.deps, STAFF_NO_RESCUE, { id: EVENT_ID })).rejects.toMatchObject({
+      code: 'PERMISSION_DENIED',
     });
   });
 });
@@ -306,6 +331,13 @@ describe('updateEvent', () => {
       code: 'PERMISSION_DENIED',
     });
   });
+
+  it('rejects principal with events.update but no rescueId', async () => {
+    mocks.poolMock.query.mockResolvedValueOnce({ rows: [eventRow()] });
+    await expect(updateEvent(mocks.deps, STAFF_NO_RESCUE, { id: EVENT_ID })).rejects.toMatchObject({
+      code: 'PERMISSION_DENIED',
+    });
+  });
 });
 
 // ── DeleteEvent ─────────────────────────────────────────────────────────
@@ -342,6 +374,13 @@ describe('deleteEvent', () => {
       code: 'PERMISSION_DENIED',
     });
   });
+
+  it('rejects principal with events.delete but no rescueId', async () => {
+    mocks.poolMock.query.mockResolvedValueOnce({ rows: [eventRow()] });
+    await expect(deleteEvent(mocks.deps, STAFF_NO_RESCUE, { id: EVENT_ID })).rejects.toMatchObject({
+      code: 'PERMISSION_DENIED',
+    });
+  });
 });
 
 // ── GetEventAttendees ───────────────────────────────────────────────────
@@ -373,6 +412,13 @@ describe('getEventAttendees', () => {
     expect(res.attendees).toHaveLength(1);
     expect(res.attendees[0].userId).toBe('usr-attendee');
     expect(res.attendees[0].checkedIn).toBe(false);
+  });
+
+  it('rejects principal with events.read but no rescueId', async () => {
+    mocks.poolMock.query.mockResolvedValueOnce({ rows: [eventRow()] });
+    await expect(
+      getEventAttendees(mocks.deps, STAFF_NO_RESCUE, { eventId: EVENT_ID })
+    ).rejects.toMatchObject({ code: 'PERMISSION_DENIED' });
   });
 });
 
@@ -419,6 +465,18 @@ describe('addEventAttendee', () => {
     expect(res.attendee?.userId).toBe('usr-attendee');
     expect(res.attendee?.checkedIn).toBe(false);
   });
+
+  it('rejects principal with events.update but no rescueId', async () => {
+    mocks.poolMock.query.mockResolvedValueOnce({ rows: [eventRow()] });
+    await expect(
+      addEventAttendee(mocks.deps, STAFF_NO_RESCUE, {
+        eventId: EVENT_ID,
+        userId: 'usr-attendee',
+        name: 'Alice',
+        email: 'alice@example.com',
+      })
+    ).rejects.toMatchObject({ code: 'PERMISSION_DENIED' });
+  });
 });
 
 // ── CheckInAttendee ─────────────────────────────────────────────────────
@@ -455,6 +513,13 @@ describe('checkInAttendee', () => {
     });
     expect(res.attendee?.checkedIn).toBe(true);
   });
+
+  it('rejects principal with events.update but no rescueId', async () => {
+    mocks.poolMock.query.mockResolvedValueOnce({ rows: [eventRow()] });
+    await expect(
+      checkInAttendee(mocks.deps, STAFF_NO_RESCUE, { eventId: EVENT_ID, userId: 'usr-attendee' })
+    ).rejects.toMatchObject({ code: 'PERMISSION_DENIED' });
+  });
 });
 
 // ── GetEventAnalytics ───────────────────────────────────────────────────
@@ -486,5 +551,12 @@ describe('getEventAnalytics', () => {
     expect(res.analytics?.eventId).toBe(EVENT_ID);
     expect(res.analytics?.totalRegistrations).toBe(40);
     expect(res.analytics?.actualAttendance).toBe(30);
+  });
+
+  it('rejects principal with events.read but no rescueId', async () => {
+    mocks.poolMock.query.mockResolvedValueOnce({ rows: [eventRow()] });
+    await expect(
+      getEventAnalytics(mocks.deps, STAFF_NO_RESCUE, { eventId: EVENT_ID })
+    ).rejects.toMatchObject({ code: 'PERMISSION_DENIED' });
   });
 });

--- a/services/rescue/src/grpc/event-handlers.ts
+++ b/services/rescue/src/grpc/event-handlers.ts
@@ -220,7 +220,10 @@ function assertRescueAccess(
   if (!hasPermission(principal, permission)) {
     throw new HandlerError('PERMISSION_DENIED', `'${permission}' required`);
   }
-  if (principal.rescueId && principal.rescueId !== eventRescueId) {
+  if (!principal.rescueId) {
+    throw new HandlerError('PERMISSION_DENIED', 'rescue context required');
+  }
+  if (principal.rescueId !== eventRescueId) {
     throw new HandlerError('PERMISSION_DENIED', 'you may only access events for your own rescue');
   }
 }
@@ -240,7 +243,12 @@ export async function listEvents(
   const params: unknown[] = [];
 
   // Rescue scoping: staff are pinned to their own rescue; super_admin sees all.
-  if (!isSuperAdmin(principal) && principal.rescueId) {
+  // Fail closed: a non-super-admin without a rescueId gets PERMISSION_DENIED rather
+  // than silently seeing every rescue's events.
+  if (!isSuperAdmin(principal)) {
+    if (!principal.rescueId) {
+      throw new HandlerError('PERMISSION_DENIED', 'rescue context required');
+    }
     params.push(principal.rescueId);
     conditions.push(`rescue_id = $${params.length}`);
   }


### PR DESCRIPTION
## Summary

- Fixes a cross-tenant data leak where a non-super-admin principal with `events.read` but no `rescueId` could list every rescue's events, attendees, and analytics (including PII: names and emails)
- `listEvents` now throws `PERMISSION_DENIED` when the caller is not `super_admin` and has no `rescueId`, instead of silently omitting the `rescue_id` filter
- `assertRescueAccess` (used by `getEvent`, `updateEvent`, `deleteEvent`, `getEventAttendees`, `addEventAttendee`, `checkInAttendee`, `getEventAnalytics`) now requires `rescueId` unconditionally for non-super-admins rather than short-circuiting to allow-all when it is falsy

## Changes

- `services/rescue/src/grpc/event-handlers.ts` — fix `listEvents` scoping guard and `assertRescueAccess` to fail-closed
- `services/rescue/src/grpc/event-handlers.test.ts` — add `STAFF_NO_RESCUE` principal fixture and 8 new tests (one per handler) covering the missing-rescue-context rejection

## Before requesting review

- [x] Tests for new behaviour added (TDD)
- [x] If touching `.env` requirements, updated `.env.example`'s REQUIRED block — N/A
- [x] If touching a `lib.*`, considered consumer impact across `app.*` and `service.backend` — N/A, change is within `service.rescue`

## Test plan

- [x] Existing tests pass (`pnpm test`) — 226/226 passing
- [x] New behaviour is covered by tests — 8 new tests, one per affected handler
- [ ] Tested manually (describe how) — handlers require a running stack; unit tests cover the security paths
- [ ] No TypeScript errors (`pnpm type-check`)
- [ ] Lint passes (`pnpm lint`)

## Related

- Linear: https://linear.app/ideasquared/issue/ADS-934/events-listevents-leaks-all-rescues-events-when-principal-has-events

---
_Generated by [Claude Code](https://claude.ai/code/session_015zo1pMZabQGXHCTQS4ehkr)_