### PR TITLE
fix(rescue): derive attendanceRate from checked_in count (ADS-935)

### DIFF
--- a/.lintstagedrc.mjs
+++ b/.lintstagedrc.mjs
@@ -12,7 +12,7 @@
 export default {
   '**/*.{ts,tsx}': files => [
     `prettier --write ${files.map(f => JSON.stringify(f)).join(' ')}`,
-    'pnpm exec turbo run lint --filter="...[HEAD]" --continue',
+    'pnpm exec turbo run lint --filter=...[HEAD] --continue',
   ],
   '**/*.{js,jsx,json,md,css}': ['prettier --write'],
 };

--- a/services/rescue/src/grpc/event-handlers.test.ts
+++ b/services/rescue/src/grpc/event-handlers.test.ts
@@ -543,14 +543,34 @@ describe('getEventAnalytics', () => {
     );
   });
 
-  it('returns computed analytics for an event', async () => {
+  it('returns 100% attendanceRate when all registrants checked in', async () => {
     mocks.poolMock.query
-      .mockResolvedValueOnce({ rows: [eventRow({ current_attendance: 30, status: 'completed' })] })
-      .mockResolvedValueOnce({ rows: [{ total: '40' }] });
+      .mockResolvedValueOnce({ rows: [eventRow({ status: 'completed' })] })
+      .mockResolvedValueOnce({ rows: [{ total: '1', checked_in: '1' }] });
     const res = await getEventAnalytics(mocks.deps, STAFF, { eventId: EVENT_ID });
-    expect(res.analytics?.eventId).toBe(EVENT_ID);
-    expect(res.analytics?.totalRegistrations).toBe(40);
-    expect(res.analytics?.actualAttendance).toBe(30);
+    expect(res.analytics?.totalRegistrations).toBe(1);
+    expect(res.analytics?.actualAttendance).toBe(1);
+    expect(res.analytics?.attendanceRate).toBe(100);
+  });
+
+  it('returns 50% attendanceRate when half of registrants checked in', async () => {
+    mocks.poolMock.query
+      .mockResolvedValueOnce({ rows: [eventRow({ status: 'active' })] })
+      .mockResolvedValueOnce({ rows: [{ total: '2', checked_in: '1' }] });
+    const res = await getEventAnalytics(mocks.deps, STAFF, { eventId: EVENT_ID });
+    expect(res.analytics?.totalRegistrations).toBe(2);
+    expect(res.analytics?.actualAttendance).toBe(1);
+    expect(res.analytics?.attendanceRate).toBe(50);
+  });
+
+  it('returns 0% attendanceRate when no registrants', async () => {
+    mocks.poolMock.query
+      .mockResolvedValueOnce({ rows: [eventRow()] })
+      .mockResolvedValueOnce({ rows: [{ total: '0', checked_in: '0' }] });
+    const res = await getEventAnalytics(mocks.deps, STAFF, { eventId: EVENT_ID });
+    expect(res.analytics?.totalRegistrations).toBe(0);
+    expect(res.analytics?.actualAttendance).toBe(0);
+    expect(res.analytics?.attendanceRate).toBe(0);
   });
 
   it('rejects principal with events.read but no rescueId', async () => {

--- a/services/rescue/src/grpc/event-handlers.ts
+++ b/services/rescue/src/grpc/event-handlers.ts
@@ -695,12 +695,14 @@ export async function getEventAnalytics(
   }
   assertRescueAccess(principal, row.rescue_id, EVENTS_READ);
 
-  const countRes = await deps.pool.query<{ total: string }>(
-    `SELECT COUNT(*) AS total FROM rescue.event_attendees WHERE event_id = $1`,
+  const countRes = await deps.pool.query<{ total: string; checked_in: string }>(
+    `SELECT COUNT(*) AS total,
+            COUNT(*) FILTER (WHERE checked_in) AS checked_in
+       FROM rescue.event_attendees WHERE event_id = $1`,
     [req.eventId]
   );
   const totalRegistrations = parseInt(countRes.rows[0]?.total ?? '0', 10);
-  const actualAttendance = row.current_attendance;
+  const actualAttendance = parseInt(countRes.rows[0]?.checked_in ?? '0', 10);
   const attendanceRate = totalRegistrations > 0 ? (actualAttendance / totalRegistrations) * 100 : 0;
 
   const analytics: RescueEventAnalytics = {


### PR DESCRIPTION
## Summary

- Fixes `attendanceRate` always reporting 0% in event analytics (`GET /api/v1/events/:id/analytics`)
- The `current_attendance` column on `rescue.events` was initialised to 0 at migration time and never updated by any handler, so `actualAttendance` was always 0
- Replaces the stale column read with `COUNT(*) FILTER (WHERE checked_in)` against `event_attendees` — the same table that `checkInAttendee` already writes to correctly

## Changes

- `services/rescue/src/grpc/event-handlers.ts` — updated `getEventAnalytics` to query `checked_in` count from `event_attendees` in a single query alongside `total`
- `services/rescue/src/grpc/event-handlers.test.ts` — replaced the stale `current_attendance`-based test with three behaviour-driven cases (100%, 50%, 0%) matching the acceptance criteria in ADS-935
- `.lintstagedrc.mjs` — removed unnecessary shell-style double quotes from the turbo `--filter` argument; lint-staged does not use a shell so the quotes were passed literally to turbo, causing pre-commit hooks to fail

## Before requesting review

- [x] Tests for new behaviour added (TDD)
- [x] No `.env` changes
- [x] No `lib.*` changes

## Test plan

- [x] Existing tests pass (`pnpm test` — 228 tests, all pass)
- [x] New behaviour is covered by tests
  - `returns 100% attendanceRate when all registrants checked in`
  - `returns 50% attendanceRate when half of registrants checked in`
  - `returns 0% attendanceRate when no registrants`
- [x] Lint passes

## Related

Fixes [ADS-935](https://linear.app/ideasquared/issue/ADS-935/event-analytics-attendancerate-is-always-0percent-current-attendance)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QP6jrTuRG54iP4ocWAq5eq)_