### PR TITLE
fix(lib.validation): reject placeholder REDIS_PASSWORD at startup (ADS-886)

### DIFF
--- a/.lintstagedrc.mjs
+++ b/.lintstagedrc.mjs
@@ -12,7 +12,12 @@
 export default {
   '**/*.{ts,tsx}': files => [
     `prettier --write ${files.map(f => JSON.stringify(f)).join(' ')}`,
-    'pnpm exec turbo run lint --filter="...[HEAD]" --continue',
+    // No surrounding quotes: lint-staged (string-argv + tinyexec) spawns this
+    // command without a shell, so quotes are never stripped and are passed
+    // to turbo literally (`--filter='"...[HEAD]"'`), breaking every
+    // pre-commit run. No shell also means no glob risk from `[HEAD]`, so the
+    // quotes were unnecessary as well as broken.
+    'pnpm exec turbo run lint --filter=...[HEAD] --continue',
   ],
   '**/*.{js,jsx,json,md,css}': ['prettier --write'],
 };

--- a/packages/lib.validation/src/schemas/env.test.ts
+++ b/packages/lib.validation/src/schemas/env.test.ts
@@ -51,6 +51,27 @@ describe('envBaseSchema', () => {
     expect(result.success).toBe(false);
   });
 
+  it('rejects a placeholder REDIS_PASSWORD', () => {
+    const result = envBaseSchema.safeParse({
+      ...validBaseEnv,
+      REDIS_PASSWORD: 'CHANGE_THIS_SECURE_REDIS_PASSWORD',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('accepts an unset REDIS_PASSWORD', () => {
+    const result = envBaseSchema.safeParse(validBaseEnv);
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts a strong REDIS_PASSWORD', () => {
+    const result = envBaseSchema.safeParse({
+      ...validBaseEnv,
+      REDIS_PASSWORD: 'R'.repeat(40),
+    });
+    expect(result.success).toBe(true);
+  });
+
   it('rejects non-hex ENCRYPTION_KEY', () => {
     const result = envBaseSchema.safeParse({ ...validBaseEnv, ENCRYPTION_KEY: 'z'.repeat(64) });
     expect(result.success).toBe(false);
@@ -203,6 +224,29 @@ describe('validateEnv', () => {
       const result = validateEnv(env);
       expect(result.ok).toBe(false);
       expect(errorMessages(result)).toContain('must not use the default placeholder value');
+    });
+
+    it('flags a placeholder REDIS_PASSWORD as an error from the schema (ADS-886)', () => {
+      const env = validDevEnv();
+      env.REDIS_PASSWORD = 'CHANGE_THIS_SECURE_REDIS_PASSWORD';
+      const result = validateEnv(env);
+      expect(result.ok).toBe(false);
+      expect(errorPaths(result)).toContain('REDIS_PASSWORD');
+      expect(errorMessages(result)).toContain('must not use the default placeholder value');
+    });
+
+    it('stays valid when REDIS_PASSWORD is unset', () => {
+      const env = validDevEnv();
+      env.REDIS_PASSWORD = undefined;
+      const result = validateEnv(env);
+      expect(result.ok).toBe(true);
+    });
+
+    it('accepts a strong REDIS_PASSWORD', () => {
+      const env = validDevEnv();
+      env.REDIS_PASSWORD = 'R'.repeat(40);
+      const result = validateEnv(env);
+      expect(result.ok).toBe(true);
     });
 
     it('flags a non-hex ENCRYPTION_KEY as an error', () => {

--- a/packages/lib.validation/src/schemas/env.ts
+++ b/packages/lib.validation/src/schemas/env.ts
@@ -95,6 +95,14 @@ export const envBaseSchema = z.object({
 
   // Optional in all envs
   REDIS_URL: z.string().url().optional(),
+  // ADS-886: Redis --requirepass value (docker-compose.yml, ADS-878/ADS-886
+  // file-mounted secrets). Optional — REDIS_URL alone is a valid connection
+  // method — but when set it must not be the .env.example placeholder.
+  // generate-secrets.mjs / bootstrap.mjs emit a 48-char hex value and
+  // docs/SECRETS-MANAGEMENT.md recommends `openssl rand -base64 32`, both
+  // well above the shared 32-char secret minimum, so optionalSecretField
+  // matches real setups.
+  REDIS_PASSWORD: optionalSecretField('REDIS_PASSWORD'),
   JWT_REPORT_SHARE_SECRET: optionalSecretField('JWT_REPORT_SHARE_SECRET'),
   WORKER_ENABLED: booleanString('WORKER_ENABLED').optional(),
   BCRYPT_ROUNDS: numericString('BCRYPT_ROUNDS').optional(),


### PR DESCRIPTION
## Summary

- Closes the last open acceptance criterion of ADS-886: `REDIS_PASSWORD` was not validated against the `CHANGE_THIS_*` placeholder prefix, so `.env.example`'s `CHANGE_THIS_SECURE_REDIS_PASSWORD` default would pass startup validation (the compose-side file-mounted-secret fix already shipped in #1186)
- Adds `REDIS_PASSWORD` to the shared env schema as an optional secret: unset stays valid (`REDIS_URL` alone is a supported connection method), but when set it must be ≥32 chars and not a placeholder — matching what `generate-secrets.mjs` / `bootstrap.mjs` (48-char hex) and `docs/SECRETS-MANAGEMENT.md` (`openssl rand -base64 32`) actually produce, so no existing valid setup breaks
- Also fixes a pre-existing broken pre-commit hook discovered while committing: lint-staged v17 spawns commands without a shell, so the quotes in `--filter="...[HEAD]"` reached turbo literally and failed every pre-commit run (`No package found with name '"...[HEAD]"'`) — kept as a separate commit for easy drop/re-review

## Changes

- `packages/lib.validation/src/schemas/env.ts` — `REDIS_PASSWORD: optionalSecretField('REDIS_PASSWORD')` added to `envBaseSchema`
- `packages/lib.validation/src/schemas/env.test.ts` — 6 new behaviour tests (schema level + `validateEnv` level): placeholder rejected, unset valid, strong value accepted
- `.lintstagedrc.mjs` — remove literal quotes from the turbo filter so the pre-commit lint step runs again (separate `fix(tooling)` commit)

## Before requesting review

- [x] Tests for new behaviour added (TDD — tests written first)
- [x] If touching `.env` requirements, updated `.env.example`'s REQUIRED block — no change needed: `REDIS_PASSWORD` remains optional, and `pnpm setup` already replaces the placeholder with a generated value
- [x] If touching a `lib.*`, considered consumer impact across `app.*` and `service.backend` — `lib.validation` env schema is consumed by the validate-env CLI/boot path; the new field is optional so no consumer needs changes

## Test plan

- [x] Existing tests pass — `pnpm --filter @adopt-dont-shop/lib.validation test`: 7 test files, 229 tests, all green
- [x] New behaviour is covered by tests (6 new cases)
- [x] No TypeScript errors (`tsc --noEmit` clean for the package)
- [x] Lint passes (0 errors; 6 pre-existing warnings in unrelated files)
- [ ] Tested manually — not applicable beyond the test suite (pure schema change)

## Screenshots / recordings

Not applicable — backend validation change.

## Related

- Linear: [ADS-886](https://linear.app/ideasquared/issue/ADS-886/security-production-redis-password-is-exposed-via-environment-block) — this completes the remaining acceptance criterion; the compose changes shipped via #1186
- Prior work: ADS-752 / ADS-878 (file-mounted secret pattern)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q5FhHDPvEtBYRDwMAV3rtv

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q5FhHDPvEtBYRDwMAV3rtv)_