### PR TITLE
fix(gateway): abuse hardening — XFF trust, per-email login limit, socket cap (ADS-915/916/888)

### DIFF
--- a/deploy/gateway/nginx.conf
+++ b/deploy/gateway/nginx.conf
@@ -39,6 +39,15 @@ http {
     limit_req_zone $binary_remote_addr zone=api:10m rate=10r/s;
     limit_req_zone $binary_remote_addr zone=login:10m rate=5r/m;
 
+    # ADS-915: this file is the PUBLIC edge — it terminates connections
+    # directly from the internet, so it is the trust boundary for
+    # X-Forwarded-For. Every proxy_set_header X-Forwarded-For below sets
+    # $remote_addr (the real connecting IP), NOT $proxy_add_x_forwarded_for —
+    # the latter APPENDS to whatever XFF value the client sent, letting an
+    # attacker prepend an arbitrary spoofed IP that the gateway would then
+    # trust. Overwriting discards the client-supplied value entirely so the
+    # gateway (trustProxy: 1, one hop) always sees the real client.
+
     # WebSocket upgrade map
     map $http_upgrade $connection_upgrade {
         default upgrade;
@@ -142,7 +151,7 @@ http {
             proxy_pass http://prod_backend;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
-            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-For $remote_addr;
             proxy_set_header X-Forwarded-Proto $scheme;
             proxy_http_version 1.1;
         }
@@ -152,7 +161,7 @@ http {
             proxy_pass http://prod_backend;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
-            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-For $remote_addr;
             proxy_set_header X-Forwarded-Proto $scheme;
         }
 
@@ -163,7 +172,7 @@ http {
             proxy_set_header Connection $connection_upgrade;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
-            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-For $remote_addr;
             proxy_set_header X-Forwarded-Proto $scheme;
             proxy_read_timeout 86400;
         }
@@ -172,7 +181,7 @@ http {
             proxy_pass http://prod_client;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
-            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-For $remote_addr;
             proxy_set_header X-Forwarded-Proto $scheme;
         }
     }
@@ -210,7 +219,7 @@ http {
             proxy_set_header Connection $connection_upgrade;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
-            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-For $remote_addr;
             proxy_set_header X-Forwarded-Proto $scheme;
             proxy_read_timeout 86400;
         }
@@ -220,7 +229,7 @@ http {
             proxy_pass http://prod_backend;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
-            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-For $remote_addr;
             proxy_set_header X-Forwarded-Proto $scheme;
             proxy_http_version 1.1;
             proxy_read_timeout 60s;
@@ -231,7 +240,7 @@ http {
             proxy_pass http://prod_backend;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
-            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-For $remote_addr;
             proxy_set_header X-Forwarded-Proto $scheme;
         }
     }
@@ -260,7 +269,7 @@ http {
             proxy_pass http://prod_backend;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
-            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-For $remote_addr;
             proxy_set_header X-Forwarded-Proto $scheme;
             proxy_http_version 1.1;
         }
@@ -270,7 +279,7 @@ http {
             proxy_pass http://prod_backend;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
-            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-For $remote_addr;
             proxy_set_header X-Forwarded-Proto $scheme;
         }
 
@@ -281,7 +290,7 @@ http {
             proxy_set_header Connection $connection_upgrade;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
-            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-For $remote_addr;
             proxy_set_header X-Forwarded-Proto $scheme;
             proxy_read_timeout 86400;
         }
@@ -290,7 +299,7 @@ http {
             proxy_pass http://prod_admin;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
-            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-For $remote_addr;
             proxy_set_header X-Forwarded-Proto $scheme;
         }
     }
@@ -319,7 +328,7 @@ http {
             proxy_pass http://prod_backend;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
-            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-For $remote_addr;
             proxy_set_header X-Forwarded-Proto $scheme;
             proxy_http_version 1.1;
         }
@@ -329,7 +338,7 @@ http {
             proxy_pass http://prod_backend;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
-            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-For $remote_addr;
             proxy_set_header X-Forwarded-Proto $scheme;
         }
 
@@ -340,7 +349,7 @@ http {
             proxy_set_header Connection $connection_upgrade;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
-            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-For $remote_addr;
             proxy_set_header X-Forwarded-Proto $scheme;
             proxy_read_timeout 86400;
         }
@@ -349,7 +358,7 @@ http {
             proxy_pass http://prod_rescue;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
-            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-For $remote_addr;
             proxy_set_header X-Forwarded-Proto $scheme;
         }
     }
@@ -379,7 +388,7 @@ http {
             proxy_pass http://staging_backend;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
-            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-For $remote_addr;
             proxy_set_header X-Forwarded-Proto $scheme;
             proxy_http_version 1.1;
         }
@@ -389,7 +398,7 @@ http {
             proxy_pass http://staging_backend;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
-            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-For $remote_addr;
             proxy_set_header X-Forwarded-Proto $scheme;
         }
 
@@ -400,7 +409,7 @@ http {
             proxy_set_header Connection $connection_upgrade;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
-            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-For $remote_addr;
             proxy_set_header X-Forwarded-Proto $scheme;
             proxy_read_timeout 86400;
         }
@@ -409,7 +418,7 @@ http {
             proxy_pass http://staging_client;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
-            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-For $remote_addr;
             proxy_set_header X-Forwarded-Proto $scheme;
         }
     }
@@ -447,7 +456,7 @@ http {
             proxy_set_header Connection $connection_upgrade;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
-            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-For $remote_addr;
             proxy_set_header X-Forwarded-Proto $scheme;
             proxy_read_timeout 86400;
         }
@@ -457,7 +466,7 @@ http {
             proxy_pass http://staging_backend;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
-            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-For $remote_addr;
             proxy_set_header X-Forwarded-Proto $scheme;
             proxy_http_version 1.1;
             proxy_read_timeout 60s;
@@ -468,7 +477,7 @@ http {
             proxy_pass http://staging_backend;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
-            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-For $remote_addr;
             proxy_set_header X-Forwarded-Proto $scheme;
         }
     }
@@ -498,7 +507,7 @@ http {
             proxy_pass http://staging_backend;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
-            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-For $remote_addr;
             proxy_set_header X-Forwarded-Proto $scheme;
             proxy_http_version 1.1;
         }
@@ -508,7 +517,7 @@ http {
             proxy_pass http://staging_backend;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
-            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-For $remote_addr;
             proxy_set_header X-Forwarded-Proto $scheme;
         }
 
@@ -519,7 +528,7 @@ http {
             proxy_set_header Connection $connection_upgrade;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
-            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-For $remote_addr;
             proxy_set_header X-Forwarded-Proto $scheme;
             proxy_read_timeout 86400;
         }
@@ -528,7 +537,7 @@ http {
             proxy_pass http://staging_admin;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
-            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-For $remote_addr;
             proxy_set_header X-Forwarded-Proto $scheme;
         }
     }
@@ -558,7 +567,7 @@ http {
             proxy_pass http://staging_backend;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
-            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-For $remote_addr;
             proxy_set_header X-Forwarded-Proto $scheme;
             proxy_http_version 1.1;
         }
@@ -568,7 +577,7 @@ http {
             proxy_pass http://staging_backend;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
-            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-For $remote_addr;
             proxy_set_header X-Forwarded-Proto $scheme;
         }
 
@@ -579,7 +588,7 @@ http {
             proxy_set_header Connection $connection_upgrade;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
-            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-For $remote_addr;
             proxy_set_header X-Forwarded-Proto $scheme;
             proxy_read_timeout 86400;
         }
@@ -588,7 +597,7 @@ http {
             proxy_pass http://staging_rescue;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
-            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-For $remote_addr;
             proxy_set_header X-Forwarded-Proto $scheme;
         }
     }

--- a/services/gateway/src/routes/auth.test.ts
+++ b/services/gateway/src/routes/auth.test.ts
@@ -1276,6 +1276,115 @@ describe('auth rate limiting (ADS-844)', () => {
   });
 });
 
+describe('auth rate limiting — per-email login cap (ADS-916)', () => {
+  it('throttles a per-EMAIL login flood spread across many IPs', async () => {
+    const m = makeClient();
+    m.loginMock.mockResolvedValue(LOGIN_RES);
+    const app = Fastify({ logger: false, trustProxy: true });
+    const loginEmailRateLimiter = createEmailRateLimiter({ max: 5, windowMs: 5 * 60_000 });
+    // The per-IP @fastify/rate-limit plugin is intentionally NOT registered
+    // here — only the per-email preHandler can produce a 429, proving the
+    // cap holds even when every request comes from a distinct IP.
+    await registerAuthRoutes(app, { client: m.client, loginEmailRateLimiter });
+    try {
+      const hit = (ip: string) =>
+        app.inject({
+          method: 'POST',
+          url: '/api/v1/auth/login',
+          headers: { 'x-forwarded-for': ip },
+          payload: { email: 'victim@example.com', password: 'guess' },
+        });
+
+      const statuses: number[] = [];
+      for (let i = 0; i < 6; i += 1) {
+        statuses.push((await hit(`1.1.1.${i}`)).statusCode);
+      }
+
+      // First 5 (the cap) pass; the 6th — same email, different IP — is 429.
+      expect(statuses.slice(0, 5)).toEqual([200, 200, 200, 200, 200]);
+      expect(statuses[5]).toBe(429);
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('does not throttle logins for a DIFFERENT email once one account trips the cap', async () => {
+    const m = makeClient();
+    m.loginMock.mockResolvedValue(LOGIN_RES);
+    const app = Fastify({ logger: false, trustProxy: true });
+    const loginEmailRateLimiter = createEmailRateLimiter({ max: 1, windowMs: 5 * 60_000 });
+    await registerAuthRoutes(app, { client: m.client, loginEmailRateLimiter });
+    try {
+      await app.inject({
+        method: 'POST',
+        url: '/api/v1/auth/login',
+        payload: { email: 'victim@example.com', password: 'guess' },
+      });
+      const tripped = await app.inject({
+        method: 'POST',
+        url: '/api/v1/auth/login',
+        payload: { email: 'victim@example.com', password: 'guess' },
+      });
+      const other = await app.inject({
+        method: 'POST',
+        url: '/api/v1/auth/login',
+        payload: { email: 'someone-else@example.com', password: 'guess' },
+      });
+
+      expect(tripped.statusCode).toBe(429);
+      expect(other.statusCode).toBe(200);
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('calls onLoginEmailRateLimitTrip when the login per-email cap trips', async () => {
+    const m = makeClient();
+    m.loginMock.mockResolvedValue(LOGIN_RES);
+    const onLoginEmailRateLimitTrip = vi.fn();
+    const app = Fastify({ logger: false, trustProxy: true });
+    const loginEmailRateLimiter = createEmailRateLimiter({ max: 1, windowMs: 60_000 });
+    await registerAuthRoutes(app, {
+      client: m.client,
+      loginEmailRateLimiter,
+      onLoginEmailRateLimitTrip,
+    });
+    try {
+      await app.inject({
+        method: 'POST',
+        url: '/api/v1/auth/login',
+        payload: { email: 'victim2@example.com', password: 'guess' },
+      });
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/v1/auth/login',
+        payload: { email: 'victim2@example.com', password: 'guess' },
+      });
+
+      expect(res.statusCode).toBe(429);
+      expect(onLoginEmailRateLimitTrip).toHaveBeenCalledTimes(1);
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('does not throttle login when no loginEmailRateLimiter is wired', async () => {
+    const m = makeClient();
+    m.loginMock.mockResolvedValue(LOGIN_RES);
+    const app = await makeApp(m.client);
+    try {
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/v1/auth/login',
+        payload: { email: 'victim3@example.com', password: 'guess' },
+      });
+      expect(res.statusCode).toBe(200);
+    } finally {
+      await app.close();
+    }
+  });
+});
+
 describe('two-factor routes', () => {
   it('POST /auth/2fa/setup returns the secret + otpauth URL', async () => {
     const m = makeClient();

--- a/services/gateway/src/routes/auth.ts
+++ b/services/gateway/src/routes/auth.ts
@@ -62,6 +62,19 @@ export type AuthRoutesOptions = {
   // @fastify/rate-limit cap. Optional so tests / dev that don't wire it keep
   // the per-IP-only behaviour.
   emailRateLimiter?: EmailRateLimiter;
+  // Stricter per-email rate limiter for the login route only (ADS-916).
+  // Mirrors the ADS-844 pattern but with a tighter cap/window, so a
+  // credential-stuffing attack spread across many source IPs (or a rotating
+  // X-Forwarded-For) is still capped per targeted account. Separate from
+  // emailRateLimiter because login's threshold (matching the auth-service
+  // soft-lock) is deliberately tighter than register/forgot-password's.
+  // Optional so tests / dev that don't wire it keep the per-IP-only
+  // behaviour.
+  loginEmailRateLimiter?: EmailRateLimiter;
+  // Called each time the login per-email cap trips. Lets the caller (server.ts)
+  // increment a Prometheus counter without this route module reaching into
+  // the metrics registry directly.
+  onLoginEmailRateLimitTrip?: () => void;
 };
 
 // Body shapes accepted by the REST surface. Kept narrow + explicit
@@ -128,17 +141,20 @@ export const registerAuthRoutes = async (
   app: FastifyInstance,
   opts: AuthRoutesOptions
 ): Promise<void> => {
-  const { client, emailRateLimiter } = opts;
+  const { client, emailRateLimiter, loginEmailRateLimiter, onLoginEmailRateLimitTrip } = opts;
 
   // Build a preHandler that caps attempts per normalized email (ADS-844).
   // `extractEmail` pulls the email out of the (already-parsed) body. When no
-  // limiter is wired, or the body carries no email, the handler is a no-op so
-  // behaviour is unchanged. A throttled request gets 429 before reaching the
-  // gRPC call.
+  // limiter is supplied (defaults to the shared emailRateLimiter), or the
+  // body carries no email, the handler is a no-op so behaviour is unchanged.
+  // A throttled request gets 429 before reaching the gRPC call. `onTrip` is
+  // an optional metrics hook (ADS-916) fired each time the cap trips.
   const emailRateLimit = (
-    extractEmail: (body: Record<string, unknown>) => unknown
+    extractEmail: (body: Record<string, unknown>) => unknown,
+    limiter: EmailRateLimiter | undefined = emailRateLimiter,
+    onTrip?: () => void
   ): RouteShorthandOptions['preHandler'] => {
-    if (!emailRateLimiter) {
+    if (!limiter) {
       return undefined;
     }
     return async (req: FastifyRequest, reply: FastifyReply) => {
@@ -146,8 +162,9 @@ export const registerAuthRoutes = async (
       if (email === undefined) {
         return;
       }
-      const allowed = await emailRateLimiter.consume(email);
+      const allowed = await limiter.consume(email);
       if (!allowed) {
+        onTrip?.();
         return reply.code(429).send({ error: 'Too many requests for this email' });
       }
     };
@@ -162,6 +179,10 @@ export const registerAuthRoutes = async (
     '/api/v1/auth/login',
     {
       config: { rateLimit: AUTH_RATE_LIMITS.login },
+      // Per-email cap layered on top of the per-IP limit above (ADS-916) —
+      // catches a credential-stuffing flood against one account spread
+      // across many source IPs, which the per-IP cap alone misses.
+      preHandler: emailRateLimit(b => b.email, loginEmailRateLimiter, onLoginEmailRateLimitTrip),
       schema: {
         tags: ['auth'],
         summary: 'Exchange email + password for an access token',

--- a/services/gateway/src/server.test.ts
+++ b/services/gateway/src/server.test.ts
@@ -407,6 +407,39 @@ describe('createServer — Prometheus rate-limit counter', () => {
       await server.close();
     }
   });
+
+  it('exposes gateway_login_email_ratelimit_trips_total metric after a per-email login trip (ADS-916)', async () => {
+    const server = await createServer({
+      config: {
+        ...baseConfig,
+        rateLimit: { redisUrl: undefined, max: 100, timeWindow: '1 minute' },
+      },
+      logger: quietLogger,
+      authClient: makeLoginAuthClient(),
+    });
+    try {
+      const postLogin = (ip: string) =>
+        server.inject({
+          method: 'POST',
+          url: '/api/v1/auth/login',
+          headers: { 'x-forwarded-for': ip },
+          payload: { email: 'victim@example.com', password: 'guess' },
+        });
+
+      // The per-email login cap is 5/5min — spread across distinct IPs so
+      // the per-IP limiter (10/min) doesn't trip first.
+      for (let i = 0; i < 5; i++) {
+        await postLogin(`20.0.0.${i}`);
+      }
+      const sixth = await postLogin('20.0.0.99');
+      expect(sixth.statusCode).toBe(429);
+
+      const metrics = await server.inject({ method: 'GET', url: '/metrics' });
+      expect(metrics.body).toContain('gateway_login_email_ratelimit_trips_total');
+    } finally {
+      await server.close();
+    }
+  });
 });
 
 // Domain routes register whenever their gRPC client is wired — there is

--- a/services/gateway/src/server.test.ts
+++ b/services/gateway/src/server.test.ts
@@ -204,10 +204,12 @@ describe('createServer — global rate limit', () => {
   });
 });
 
-describe('createServer — per-route rate limit override (auth login)', () => {
-  let server: FastifyInstance;
-
-  const authClient = {
+// Minimal login-capable auth client stub, shared by every describe block
+// below that needs a real /api/v1/auth/login round trip through createServer
+// (as opposed to the domain-route-registration smoke tests further down,
+// which only need a single method wired).
+function makeLoginAuthClient(): Parameters<typeof createServer>[0]['authClient'] {
+  return {
     login: () =>
       Promise.resolve({
         user: {
@@ -273,6 +275,12 @@ describe('createServer — per-route rate limit override (auth login)', () => {
       }),
     close: () => undefined,
   } as unknown as Parameters<typeof createServer>[0]['authClient'];
+}
+
+describe('createServer — per-route rate limit override (auth login)', () => {
+  let server: FastifyInstance;
+
+  const authClient = makeLoginAuthClient();
 
   afterEach(async () => {
     await server?.close();
@@ -303,6 +311,51 @@ describe('createServer — per-route rate limit override (auth login)', () => {
       lastStatus = r.statusCode;
     }
     // The 11th request must have been rate-limited (login cap is 10/min).
+    expect(lastStatus).toBe(429);
+  });
+});
+
+// ADS-915: nginx now overwrites (not appends to) X-Forwarded-For at the
+// public edge, and the gateway trusts exactly one hop (trustProxy: 1) —
+// matching that single-nginx-hop topology. A client-supplied XFF entry
+// beyond that one trusted hop must NOT be able to rotate req.ip and reset
+// the per-IP login limiter.
+describe('createServer — X-Forwarded-For trust boundary (ADS-915)', () => {
+  let server: FastifyInstance;
+
+  afterEach(async () => {
+    await server?.close();
+  });
+
+  it('does not let a rotating client-supplied XFF prefix bypass the per-IP login limiter', async () => {
+    server = await createServer({
+      config: {
+        ...baseConfig,
+        rateLimit: { redisUrl: undefined, max: 100, timeWindow: '1 minute' },
+      },
+      logger: quietLogger,
+      authClient: makeLoginAuthClient(),
+    });
+
+    // The rightmost entry (9.9.9.9) models what a correctly-configured nginx
+    // sets — constant across requests. The leftmost entry rotates per
+    // request, modelling an attacker who controls the client-supplied part
+    // of the header. With trustProxy bounded to 1 hop, only the rightmost
+    // entry may influence req.ip, so every request must resolve to the same
+    // client and the limiter must still trip at the 11th request.
+    const postLogin = (attackerClaimedIp: string) =>
+      server.inject({
+        method: 'POST',
+        url: '/api/v1/auth/login',
+        headers: { 'x-forwarded-for': `${attackerClaimedIp}, 9.9.9.9` },
+        payload: { email: 'a@b.com', password: 'pw' },
+      });
+
+    let lastStatus = 0;
+    for (let i = 0; i < 11; i++) {
+      const r = await postLogin(`10.0.0.${i}`);
+      lastStatus = r.statusCode;
+    }
     expect(lastStatus).toBe(429);
   });
 });

--- a/services/gateway/src/server.ts
+++ b/services/gateway/src/server.ts
@@ -180,10 +180,16 @@ export const createServer = async (opts: CreateServerOptions): Promise<FastifyIn
   // double-log on top of the OTel auto-instrumentation.
   const server = Fastify({
     logger: false,
-    // Trust the proxy chain in front of us (nginx) so request.ip is the
-    // real client, not the loopback. Required for any future rate
-    // limiting / IP-rule middleware to gate on the right address.
-    trustProxy: true,
+    // Trust exactly ONE hop of X-Forwarded-For — nginx, the only proxy
+    // between the public internet and this service (gateway:4000 is not
+    // published to the host; see docker-compose.prod.yml `expose`). request.ip
+    // then resolves to the value nginx itself sets on XFF (deploy/gateway/
+    // nginx.conf overwrites it with $remote_addr — see ADS-915), not
+    // whatever a client sends. `trustProxy: true` (trust the WHOLE header,
+    // unbounded) let a client-supplied XFF prefix pass straight through and
+    // rotate req.ip on every request, bypassing every per-IP rate limiter
+    // (login brute-force, GDPR spam) — ADS-915.
+    trustProxy: 1,
   });
 
   // Tag every error that escapes a route — the only winston call site

--- a/services/gateway/src/server.ts
+++ b/services/gateway/src/server.ts
@@ -117,6 +117,26 @@ const getOrCreateRateLimitCounter = (): Counter<'route'> => {
   return counter;
 };
 
+// Login per-email rate-limit trip counter (ADS-916). Same lazily-created,
+// registry-change-aware singleton pattern as getOrCreateRateLimitCounter
+// above, so ops can distinguish a real credential-stuffing wave (many trips)
+// from noise.
+let _loginEmailCounterEntry: { registryRef: object; counter: Counter } | null = null;
+
+const getOrCreateLoginEmailRateLimitCounter = (): Counter => {
+  const reg = getMetricsRegistry();
+  if (_loginEmailCounterEntry && _loginEmailCounterEntry.registryRef === reg) {
+    return _loginEmailCounterEntry.counter;
+  }
+  const counter = new Counter({
+    name: 'gateway_login_email_ratelimit_trips_total',
+    help: 'Total number of login attempts rejected by the per-email rate limit (ADS-916).',
+    registers: [reg],
+  });
+  _loginEmailCounterEntry = { registryRef: reg, counter };
+  return counter;
+};
+
 export type CreateServerOptions = {
   config: GatewayConfig;
   // Optional logger injection — tests pass a quiet logger so the
@@ -417,8 +437,25 @@ export const createServer = async (opts: CreateServerOptions): Promise<FastifyIn
     redis: rateLimitRedis,
   });
 
+  // Stricter per-email cap for login only (ADS-916). Separate limiter/window
+  // from emailRateLimiter above — login's threshold matches the auth-service
+  // soft-lock (5 attempts / 5 minutes), tighter than register/forgot-password's
+  // 5/minute, so a credential-stuffing attack spread across many IPs (or a
+  // rotating X-Forwarded-For) is still capped per targeted account.
+  const loginEmailRateLimiter = createEmailRateLimiter({
+    max: 5,
+    windowMs: 5 * 60_000,
+    redis: rateLimitRedis,
+  });
+  const loginEmailRateLimitTripsTotal = getOrCreateLoginEmailRateLimitCounter();
+
   if (opts.authClient) {
-    await registerAuthRoutes(server, { client: opts.authClient, emailRateLimiter });
+    await registerAuthRoutes(server, {
+      client: opts.authClient,
+      emailRateLimiter,
+      loginEmailRateLimiter,
+      onLoginEmailRateLimitTrip: () => loginEmailRateLimitTripsTotal.inc(),
+    });
     // /api/v1/sessions/* — list/revoke. Same auth client because it's the
     // same identity surface from the SPA's POV.
     await registerSessionsRoutes(server, { client: opts.authClient });

--- a/services/gateway/src/ws/socket-server.test.ts
+++ b/services/gateway/src/ws/socket-server.test.ts
@@ -384,3 +384,69 @@ describe('maxHttpBufferSize (ADS-887)', () => {
     expect(registry.socketsFor('usr-normal')).toHaveLength(1);
   });
 });
+
+describe('per-user connection cap (ADS-888)', () => {
+  it('evicts the oldest socket when the same user opens an 11th connection', async () => {
+    const { url, registry } = await startServer({
+      logger: quietLogger(),
+      allowUnauthenticated: true,
+    });
+
+    const flood: ClientSocket[] = [];
+    for (let i = 0; i < 10; i++) {
+      const client = connectClient(url, { auth: { userId: 'usr-flood' } });
+      expect(await awaitConnectOutcome(client)).toBe(true);
+      flood.push(client);
+    }
+    expect(registry.socketsFor('usr-flood')).toHaveLength(10);
+
+    const oldestDisconnected = new Promise<string>(resolve => {
+      flood[0].on('disconnect', reason => resolve(reason));
+    });
+
+    const eleventh = connectClient(url, { auth: { userId: 'usr-flood' } });
+    expect(await awaitConnectOutcome(eleventh)).toBe(true);
+
+    await expect(oldestDisconnected).resolves.toBeTruthy();
+
+    // Give the server a tick to process the evicted socket's disconnect
+    // event and remove it from the registry.
+    await new Promise(resolve => setTimeout(resolve, 50));
+    expect(registry.socketsFor('usr-flood')).toHaveLength(10);
+  });
+
+  it('does not evict sockets belonging to a DIFFERENT user', async () => {
+    const { url, registry } = await startServer({
+      logger: quietLogger(),
+      allowUnauthenticated: true,
+    });
+
+    for (let i = 0; i < 10; i++) {
+      const client = connectClient(url, { auth: { userId: 'usr-a' } });
+      expect(await awaitConnectOutcome(client)).toBe(true);
+    }
+
+    const other = connectClient(url, { auth: { userId: 'usr-b' } });
+    expect(await awaitConnectOutcome(other)).toBe(true);
+
+    expect(registry.socketsFor('usr-a')).toHaveLength(10);
+    expect(registry.socketsFor('usr-b')).toHaveLength(1);
+  });
+
+  it('allows a user to hold up to (and including) the cap without eviction', async () => {
+    const { url, registry } = await startServer({
+      logger: quietLogger(),
+      allowUnauthenticated: true,
+    });
+
+    const flood: ClientSocket[] = [];
+    for (let i = 0; i < 10; i++) {
+      const client = connectClient(url, { auth: { userId: 'usr-at-cap' } });
+      expect(await awaitConnectOutcome(client)).toBe(true);
+      flood.push(client);
+    }
+
+    expect(flood.every(c => c.connected)).toBe(true);
+    expect(registry.socketsFor('usr-at-cap')).toHaveLength(10);
+  });
+});

--- a/services/gateway/src/ws/socket-server.ts
+++ b/services/gateway/src/ws/socket-server.ts
@@ -56,6 +56,17 @@ import type { SocketRegistry } from './socket-registry.js';
 // tests can supply a one-method stub, mirroring authenticate.ts.
 type SocketAuthClient = Pick<AuthClient, 'validateToken'>;
 
+// Per-user connection cap (ADS-888). Bounds how many concurrent sockets one
+// authenticated user can hold on THIS replica, closing an authenticated
+// socket-flood DoS: without a cap, a single compromised credential can open
+// unbounded connections, each holding a file descriptor, a Redis-adapter
+// room subscription, and multiplying fan-out volume for that user. A
+// legitimate user has at most a handful of tabs open; 10 is generous
+// headroom. Per-replica only (the registry is in-process) — see the module
+// comment on SocketRegistry for why a cross-replica Redis-backed cap isn't
+// worth the added complexity here.
+const MAX_SOCKETS_PER_USER = 10;
+
 // The slim Redis pub/sub surface the @socket.io/redis-adapter broadcast path
 // uses. Parameters are intentionally widened (ioredis' publish/subscribe carry
 // variadic + callback overloads) so both ioredis' Redis and a test double are
@@ -173,6 +184,19 @@ export const attachSocketServer = (opts: AttachSocketServerOptions): IOServer =>
       });
       socket.disconnect(true);
       return;
+    }
+
+    // Per-user connection cap (ADS-888): evict the oldest socket before
+    // registering this one so a legitimate reconnect after a network blip
+    // doesn't get the NEW socket killed and leave the user stuck on a stale
+    // one.
+    const existing = registry.socketsFor(userId);
+    if (existing.length >= MAX_SOCKETS_PER_USER) {
+      existing[0]?.disconnect(true);
+      logger.warn('socket cap exceeded — evicted oldest', {
+        userId,
+        cap: MAX_SOCKETS_PER_USER,
+      });
     }
 
     registry.add(userId, socket);


### PR DESCRIPTION
## Summary

- **ADS-915 (High)**: the public edge nginx appended attacker-supplied `X-Forwarded-For` (`$proxy_add_x_forwarded_for`) and the gateway used `trustProxy: true`, so any direct client could rotate identities past every per-IP rate limit. The edge now overwrites XFF with `$remote_addr` and Fastify trusts exactly one proxy hop (`trustProxy: 1` — gateway:4000 is only `expose`d, never host-published)
- **ADS-916 (High)**: `/api/v1/auth/login` gains a per-email rate limit (5 attempts / 5 min, matching the auth service's soft-lock) on top of the per-IP limit, reusing the ADS-844 `emailRateLimit` pattern with the same enumeration-safe 429 shape, plus a `gateway_login_email_ratelimit_trips_total` counter
- **ADS-888 (Low)**: Socket.IO connections are capped at 10 per user per replica — at cap, the oldest socket is evicted with a warn log before the new one registers

## Changes

- `deploy/gateway/nginx.conf` — XFF overwritten with `$remote_addr` at the public edge (all proxy locations)
- `services/gateway/src/server.ts` — `trustProxy: 1`; login route wired with the per-email limiter
- `services/gateway/src/routes/auth.ts` — `emailRateLimit` generalised to take an explicit limiter + trip callback; `loginEmailRateLimiter`
- `services/gateway/src/ws/socket-server.ts` — `MAX_SOCKETS_PER_USER` eviction on connect
- Tests: `auth.test.ts` (+4), `server.test.ts` (+1 XFF-rotation regression proving the bypass is closed, +…), `socket-server.test.ts` (+3)

## Before requesting review

- [x] Tests for new behaviour added (TDD — failing test first per ticket)
- [ ] If touching `.env` requirements — not applicable (no new env vars)
- [ ] If touching a `lib.*` — not applicable (gateway + edge nginx only)

## Test plan

- [x] Existing tests pass — `pnpm --filter @adopt-dont-shop/service.gateway test`: 71 files, 950 tests green
- [x] New behaviour covered: XFF-rotation no longer bypasses the login per-IP limiter; 6th login attempt for the same email 429s; 11th socket for a user evicts the oldest
- [x] No TypeScript errors (`tsc --noEmit`), lint clean
- [ ] Reviewer note: `nginx/nginx.prod.conf` (per-stack nginx) intentionally untouched per the ticket scope — the fix is at the public edge + Fastify trust boundary. Rate limiting still falls open on Redis outage (pre-existing, unchanged behaviour)

## Screenshots / recordings

Not applicable — backend security hardening.

## Related

- Linear: ADS-915, ADS-916, ADS-888
- Prior art: ADS-844 (per-email limiter pattern), ADS-887 (socket message-size cap)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q5FhHDPvEtBYRDwMAV3rtv

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q5FhHDPvEtBYRDwMAV3rtv)_