### PR TITLE
fix(auth): revoke token family on refresh-token reuse detection (ADS-913)

### DIFF
--- a/services/auth/src/grpc/auth-metrics.ts
+++ b/services/auth/src/grpc/auth-metrics.ts
@@ -24,7 +24,8 @@ export type TokenRefreshOutcome =
   | 'success'
   | 'invalid_token'
   | 'token_revoked'
-  | 'concurrent_reuse';
+  | 'concurrent_reuse'
+  | 'family_revoked_on_reuse';
 
 export type AuthMetrics = {
   loginCounter: InstanceType<typeof Counter<'outcome'>>;

--- a/services/auth/src/grpc/handlers.test.ts
+++ b/services/auth/src/grpc/handlers.test.ts
@@ -661,7 +661,12 @@ describe('refreshToken', () => {
     });
     mocks.poolMock.query
       .mockResolvedValueOnce({ rows: [] }) // not denylisted
-      .mockResolvedValueOnce({ rows: [{ token: 'tok', revoked_at: new Date() }] });
+      .mockResolvedValueOnce({
+        rows: [
+          { token: 'tok', revoked_at: new Date(), is_revoked: true, family_id: 'fam-revoked' },
+        ],
+      });
+    mocks.clientMock.query.mockResolvedValue({ rows: [], rowCount: 1 });
     await expect(refreshToken(mocks.deps, null, { refreshToken: 'tok' })).rejects.toMatchObject({
       code: 'UNAUTHENTICATED',
     });
@@ -682,11 +687,12 @@ describe('refreshToken', () => {
       .mockResolvedValueOnce({
         rows: [{ token: 'tok', user_id: 'u', revoked_at: null, is_revoked: true, family_id: 'f' }],
       });
+    mocks.clientMock.query.mockResolvedValue({ rows: [], rowCount: 1 });
     await expect(refreshToken(mocks.deps, null, { refreshToken: 'tok' })).rejects.toMatchObject({
       code: 'UNAUTHENTICATED',
     });
-    // No rotation transaction is opened.
-    expect(mocks.clientMock.query).not.toHaveBeenCalled();
+    // Family revocation transaction runs but no new tokens are minted.
+    expect(mocks.issuerMock.mint).not.toHaveBeenCalled();
   });
 
   it('UNAUTHENTICATED when the user has been deactivated — refresh cannot extend access', async () => {
@@ -829,7 +835,17 @@ describe('refreshToken', () => {
     // modelling the loser of a rotation race.
     mocks.poolMock.query
       .mockResolvedValueOnce({ rows: [] }) // not denylisted
-      .mockResolvedValueOnce({ rows: [{ token: 'tok', user_id: 'usr-1', revoked_at: null }] })
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            token: 'tok',
+            user_id: 'usr-1',
+            revoked_at: null,
+            is_revoked: false,
+            family_id: 'fam-race',
+          },
+        ],
+      })
       .mockResolvedValueOnce({ rows: [{ status: 'active' }] }); // status guard
     mocks.issuerMock.mint.mockResolvedValueOnce(mintedFixture());
 
@@ -848,9 +864,158 @@ describe('refreshToken', () => {
       code: 'UNAUTHENTICATED',
     });
 
-    // Critically: NO new refresh row is inserted and NO event is published.
+    // No new refresh row is inserted.
     expect(sqls).not.toContain('INSERT');
-    expect(mocks.natsMock.publish).not.toHaveBeenCalled();
+    // auth.tokenReuseDetected is published after the transaction commits (ADS-913).
+    expect(mocks.natsMock.publish).toHaveBeenCalledWith(
+      'auth.tokenReuseDetected',
+      expect.any(Uint8Array),
+      expect.any(Object)
+    );
+  });
+
+  // --- ADS-913: token-family revocation on reuse detection ---------------
+
+  it('ADS-913: revokes whole family and stamps tokens_valid_from when pre-rotated token presented (path 1)', async () => {
+    mocks.issuerMock.verifyRefresh.mockResolvedValueOnce({
+      sub: 'usr-attacker-victim',
+      jti: 'old-jti',
+      iat: 0,
+      exp: 9_000_000_000,
+    });
+    // Token was already rotated (attacker used it first)
+    mocks.poolMock.query
+      .mockResolvedValueOnce({ rows: [] }) // not denylisted
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            token_hash: 'h',
+            user_id: 'usr-attacker-victim',
+            revoked_at: new Date(),
+            is_revoked: true,
+            family_id: 'fam-stolen',
+          },
+        ],
+      });
+
+    const clientCalls: Array<{ sql: string; params: unknown[] }> = [];
+    mocks.clientMock.query.mockImplementation(async (sql: string, params: unknown[] = []) => {
+      clientCalls.push({ sql, params });
+      return { rows: [], rowCount: 1 };
+    });
+
+    await expect(
+      refreshToken(mocks.deps, null, { refreshToken: 'stolen-tok' })
+    ).rejects.toMatchObject({ code: 'UNAUTHENTICATED' });
+
+    // Family-wide revoke UPDATE fires
+    const familyRevoke = clientCalls.find(
+      c => c.sql.includes('family_id') && c.sql.includes('is_revoked = false')
+    );
+    expect(familyRevoke).toBeDefined();
+    expect(familyRevoke?.params).toContain('fam-stolen');
+
+    // tokens_valid_from watermark stamped on the user
+    const watermark = clientCalls.find(c => c.sql.includes('tokens_valid_from'));
+    expect(watermark).toBeDefined();
+    expect(watermark?.params).toContain('usr-attacker-victim');
+
+    // No new tokens minted
+    expect(mocks.issuerMock.mint).not.toHaveBeenCalled();
+  });
+
+  it('ADS-913: publishes auth.tokenReuseDetected when pre-rotated token presented (path 1)', async () => {
+    mocks.issuerMock.verifyRefresh.mockResolvedValueOnce({
+      sub: 'usr-victim',
+      jti: 'stolen-jti',
+      iat: 0,
+      exp: 9_000_000_000,
+    });
+    mocks.poolMock.query
+      .mockResolvedValueOnce({ rows: [] }) // not denylisted
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            token_hash: 'h',
+            user_id: 'usr-victim',
+            revoked_at: new Date(),
+            is_revoked: true,
+            family_id: 'fam-reuse-event',
+          },
+        ],
+      });
+    mocks.clientMock.query.mockResolvedValue({ rows: [], rowCount: 1 });
+
+    await expect(refreshToken(mocks.deps, null, { refreshToken: 'tok' })).rejects.toMatchObject({
+      code: 'UNAUTHENTICATED',
+    });
+
+    expect(mocks.natsMock.publish).toHaveBeenCalledWith(
+      'auth.tokenReuseDetected',
+      expect.any(Uint8Array),
+      expect.any(Object)
+    );
+    const envelope = JSON.parse(
+      new TextDecoder().decode(mocks.natsMock.publish.mock.calls[0][1] as Uint8Array)
+    );
+    expect(envelope.payload).toMatchObject({
+      userId: 'usr-victim',
+      familyId: 'fam-reuse-event',
+      jti: 'stolen-jti',
+    });
+  });
+
+  it('ADS-913: revokes family and stamps tokens_valid_from on concurrent reuse (path 2)', async () => {
+    mocks.issuerMock.verifyRefresh.mockResolvedValueOnce({
+      sub: 'usr-conc',
+      jti: 'conc-jti',
+      iat: 0,
+      exp: 9_000_000_000,
+    });
+    mocks.poolMock.query
+      .mockResolvedValueOnce({ rows: [] }) // not denylisted
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            token: 'tok',
+            user_id: 'usr-conc',
+            revoked_at: null,
+            is_revoked: false,
+            family_id: 'fam-conc-steal',
+          },
+        ],
+      })
+      .mockResolvedValueOnce({ rows: [{ status: 'active' }] }); // status guard
+    mocks.issuerMock.mint.mockResolvedValueOnce(mintedFixture());
+
+    const clientCalls: Array<{ sql: string; params: unknown[] }> = [];
+    mocks.clientMock.query.mockImplementation(async (sql: string, params: unknown[] = []) => {
+      const verb = sql.trim().split(/\s+/)[0];
+      clientCalls.push({ sql, params });
+      // First UPDATE is the rotation gate; return 0 rows to trigger concurrent-reuse path.
+      const updateCount = clientCalls.filter(c => c.sql.trim().startsWith('UPDATE')).length;
+      if (verb === 'UPDATE' && updateCount === 1) {
+        return { rows: [], rowCount: 0 };
+      }
+      return { rows: [], rowCount: 1 };
+    });
+
+    await expect(refreshToken(mocks.deps, null, { refreshToken: 'tok' })).rejects.toMatchObject({
+      code: 'UNAUTHENTICATED',
+    });
+
+    // Family revoke fired for the concurrent-reuse path
+    const familyRevoke = clientCalls.find(
+      c => c.sql.includes('family_id') && c.sql.includes('is_revoked = false')
+    );
+    expect(familyRevoke?.params).toContain('fam-conc-steal');
+
+    // tokens_valid_from stamped
+    const watermark = clientCalls.find(c => c.sql.includes('tokens_valid_from'));
+    expect(watermark?.params).toContain('usr-conc');
+
+    // No new refresh row
+    expect(clientCalls.map(c => c.sql.trim().split(/\s+/)[0])).not.toContain('INSERT');
   });
 });
 

--- a/services/auth/src/grpc/handlers.ts
+++ b/services/auth/src/grpc/handlers.ts
@@ -674,6 +674,31 @@ export async function refreshToken(
   );
   if (stored.rows.length === 0 || stored.rows[0].revoked_at !== null || stored.rows[0].is_revoked) {
     tokenRefreshCounter.inc({ outcome: 'token_revoked' });
+    // When a revoked token row exists, it was either already rotated (reuse
+    // attack) or explicitly revoked. Either way, revoking the entire family
+    // is safe: it kicks the attacker's live tokens and is a no-op if the
+    // family was already fully revoked at logout. (ADS-913)
+    if (stored.rows.length > 0) {
+      const reuseFamily = stored.rows[0].family_id;
+      await withTransaction(deps, async ({ client, publish }) => {
+        await client.query(
+          `UPDATE auth.refresh_tokens
+           SET is_revoked = true, revoked_at = now(), updated_at = now()
+           WHERE family_id = $1 AND is_revoked = false`,
+          [reuseFamily]
+        );
+        await client.query(
+          `UPDATE auth.users SET tokens_valid_from = now(), updated_at = now() WHERE user_id = $1`,
+          [claims.sub]
+        );
+        publish({
+          type: 'auth.tokenReuseDetected',
+          id: `auth.tokenReuseDetected.${claims.jti}`,
+          payload: { userId: claims.sub, familyId: reuseFamily, jti: claims.jti },
+        });
+      });
+      tokenRefreshCounter.inc({ outcome: 'family_revoked_on_reuse' });
+    }
     throw new HandlerError('UNAUTHENTICATED', 'refresh token revoked');
   }
   const familyId = stored.rows[0].family_id;
@@ -703,9 +728,26 @@ export async function refreshToken(
       [incomingTokenHash]
     );
     if (revoke.rowCount === 0) {
-      // The token was already rotated/revoked between our read and this
-      // write — concurrent reuse. Deny without issuing new tokens.
+      // The token was already rotated between our read and this write —
+      // concurrent reuse. Revoke the entire family so the attacker's branch
+      // cannot retain access with its fresh pair. (ADS-913)
+      await client.query(
+        `UPDATE auth.refresh_tokens
+         SET is_revoked = true, revoked_at = now(), updated_at = now()
+         WHERE family_id = $1 AND is_revoked = false`,
+        [familyId]
+      );
+      await client.query(
+        `UPDATE auth.users SET tokens_valid_from = now(), updated_at = now() WHERE user_id = $1`,
+        [claims.sub]
+      );
+      publish({
+        type: 'auth.tokenReuseDetected',
+        id: `auth.tokenReuseDetected.${claims.jti}`,
+        payload: { userId: claims.sub, familyId, jti: claims.jti },
+      });
       tokenRefreshCounter.inc({ outcome: 'concurrent_reuse' });
+      tokenRefreshCounter.inc({ outcome: 'family_revoked_on_reuse' });
       return false;
     }
 


### PR DESCRIPTION
## Summary

- Closes ADS-913: refresh-token reuse is detected but the attacker's fresh token pair survives
- On both reuse-detection paths in `refreshToken`, revoke every non-revoked row in the same `family_id` and stamp `tokens_valid_from` so the attacker's live access token is also invalidated
- Publish `auth.tokenReuseDetected` after commit so audit / security-ops notifications can alert the affected user

## Changes

- `services/auth/src/grpc/handlers.ts` — two reuse-detection paths hardened:
  - **Path 1 (pre-check SELECT)**: when an already-rotated/revoked row is found, a new `withTransaction` block runs before throwing `UNAUTHENTICATED` to revoke all remaining family tokens and stamp the watermark
  - **Path 2 (conditional UPDATE rowCount=0)**: inside the existing transaction, family revoke + watermark stamp added before `return false`
  - Both paths publish `auth.tokenReuseDetected` (subject, userId, familyId, jti)
- `services/auth/src/grpc/auth-metrics.ts` — added `family_revoked_on_reuse` to `TokenRefreshOutcome`; incremented on every family-wide revocation

## Before requesting review

- [x] Tests for new behaviour added (TDD)
- [ ] If touching `.env` requirements, updated `.env.example`'s REQUIRED block
- [x] If touching a `lib.*`, considered consumer impact across `app.*` and `service.backend`

## Test plan

- [x] Existing tests pass (`pnpm test` — 307 passed)
- [x] New behaviour is covered by tests
  - `ADS-913: revokes whole family and stamps tokens_valid_from when pre-rotated token presented (path 1)`
  - `ADS-913: publishes auth.tokenReuseDetected when pre-rotated token presented (path 1)`
  - `ADS-913: revokes family and stamps tokens_valid_from on concurrent reuse (path 2)`
- [x] No TypeScript errors (`tsc --noEmit` clean after building `lib.types`)
- [x] Lint passes (pre-commit hook clean)

## Screenshots / recordings

N/A — backend-only change

## Related

- Linear: [ADS-913](https://linear.app/ideasquared/issue/ADS-913/security-refresh-token-reuse-detected-but-token-family-not-revoked)
- Composes with ADS-919 (localStorage token storage) — ADS-913 closes the server-side gap; ADS-919 closes the client-side gap

---
_Generated by [Claude Code](https://claude.ai/code/session_01H2Z2oxkGyq5cRtF3MBvj3c)_