### PR TITLE
fix(security): chat & support authorization — identity forgery, arbitrary chat opens, participant deletes (ADS-917/918/923)

### DIFF
--- a/services/chat/src/config.test.ts
+++ b/services/chat/src/config.test.ts
@@ -16,6 +16,8 @@ describe('loadConfig', () => {
     expect(config.databaseUrl).toBe(REQUIRED.DATABASE_URL);
     expect(config.schema).toBe('chat');
     expect(config.natsUrl).toBe('nats://nats:4222');
+    expect(config.applicationsGrpcUrl).toBe('service-applications:6005');
+    expect(config.rescueGrpcUrl).toBe('service-rescue:6004');
   });
 
   it('honours all env overrides when set', () => {
@@ -27,6 +29,8 @@ describe('loadConfig', () => {
       NODE_ENV: 'production',
       DATABASE_URL: 'postgres://prod:secret@db.example.com:5432/chat',
       NATS_URL: 'nats://nats.internal:4222',
+      APPLICATIONS_GRPC_URL: 'service-applications.internal:6005',
+      RESCUE_GRPC_URL: 'service-rescue.internal:6004',
     });
 
     expect(config.port).toBe(5500);
@@ -36,6 +40,8 @@ describe('loadConfig', () => {
     expect(config.schema).toBe('chat_test');
     expect(config.databaseUrl).toBe('postgres://prod:secret@db.example.com:5432/chat');
     expect(config.natsUrl).toBe('nats://nats.internal:4222');
+    expect(config.applicationsGrpcUrl).toBe('service-applications.internal:6005');
+    expect(config.rescueGrpcUrl).toBe('service-rescue.internal:6004');
   });
 
   it('rejects a non-numeric CHAT_PORT', () => {

--- a/services/chat/src/config.ts
+++ b/services/chat/src/config.ts
@@ -25,6 +25,13 @@ export type ChatConfig = {
   // WS subscriber fans these out to connected Socket.IO clients so
   // open chats receive messages in real time.
   natsUrl: string;
+  // ADS-918: OpenChat resolves applicationId → {adopterId, rescueId} via
+  // service.applications before creating a chat, so a caller can't stamp
+  // an arbitrary rescueId or DM someone unrelated to the application.
+  applicationsGrpcUrl: string;
+  // ADS-918: OpenChat verifies otherUserId is actually rescue staff (the
+  // adopter-initiates-chat direction) via service.rescue's staff list.
+  rescueGrpcUrl: string;
 };
 
 const DEFAULT_PORT = 5006;
@@ -32,6 +39,8 @@ const DEFAULT_GRPC_PORT = 6006;
 const DEFAULT_HOST = '0.0.0.0';
 const DEFAULT_SCHEMA = 'chat';
 const DEFAULT_NATS_URL = 'nats://nats:4222';
+const DEFAULT_APPLICATIONS_GRPC_URL = 'service-applications:6005';
+const DEFAULT_RESCUE_GRPC_URL = 'service-rescue:6004';
 
 export const loadConfig = (env: NodeJS.ProcessEnv = process.env): ChatConfig => {
   const port = parsePort(env.CHAT_PORT, DEFAULT_PORT, 'CHAT_PORT');
@@ -47,5 +56,7 @@ export const loadConfig = (env: NodeJS.ProcessEnv = process.env): ChatConfig => 
     databaseUrl,
     schema: env.CHAT_SCHEMA?.trim() || DEFAULT_SCHEMA,
     natsUrl: env.NATS_URL?.trim() || DEFAULT_NATS_URL,
+    applicationsGrpcUrl: env.APPLICATIONS_GRPC_URL?.trim() || DEFAULT_APPLICATIONS_GRPC_URL,
+    rescueGrpcUrl: env.RESCUE_GRPC_URL?.trim() || DEFAULT_RESCUE_GRPC_URL,
   };
 };

--- a/services/chat/src/grpc/applications-client.test.ts
+++ b/services/chat/src/grpc/applications-client.test.ts
@@ -1,0 +1,205 @@
+// Behaviour tests for the chat → applications gRPC client (ADS-918):
+//   1. A server that never responds → DEADLINE_EXCEEDED within the
+//      configured deadline (bounded by time, not just error code).
+//   2. A server that fails once with UNAVAILABLE then succeeds →
+//      the call resolves and exactly 2 handler invocations occurred.
+//   3. A server that always returns PERMISSION_DENIED → no retry,
+//      error propagates after exactly 1 attempt.
+//   4. Caller-supplied metadata (the forwarded principal) reaches the
+//      server unchanged.
+//
+// Each test binds a real @grpc/grpc-js Server to 127.0.0.1:0 so there
+// are no port conflicts; the server is torn down in afterEach. Direct
+// port of services/notifications/src/grpc/auth-client.test.ts.
+
+import {
+  Metadata,
+  Server,
+  ServerCredentials,
+  ServerUnaryCall,
+  sendUnaryData,
+  ServiceError,
+  status,
+} from '@grpc/grpc-js';
+
+import {
+  ApplicationsV1,
+  type GetApplicationRequest,
+  type GetApplicationResponse,
+} from '@adopt-dont-shop/proto';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { createApplicationsClient } from './applications-client.js';
+
+// ── helpers ──────────────────────────────────────────────────────────
+
+const makeServiceError = (code: number, details: string): ServiceError => {
+  const err = new Error(details) as ServiceError;
+  err.code = code;
+  err.details = details;
+  err.metadata = new Metadata();
+  return err;
+};
+
+const GET_REQUEST: GetApplicationRequest = {
+  applicationId: 'app-1',
+  includeTimeline: false,
+};
+
+const successResponse: GetApplicationResponse = {
+  application: ApplicationsV1.Application.fromPartial({
+    applicationId: 'app-1',
+    adopterId: 'usr-adopter',
+    rescueId: 'rsc-1',
+  }),
+  timeline: [],
+};
+
+// ── test suite ───────────────────────────────────────────────────────
+
+describe('createApplicationsClient (chat) — deadline + retry behaviour', () => {
+  let server: Server;
+
+  beforeEach(() => {
+    server = new Server();
+  });
+
+  afterEach(async () => {
+    await new Promise<void>(resolve => server.tryShutdown(() => resolve()));
+  });
+
+  const startServer = async (): Promise<number> =>
+    new Promise<number>((resolve, reject) => {
+      server.bindAsync('127.0.0.1:0', ServerCredentials.createInsecure(), (err, boundPort) =>
+        err ? reject(err) : resolve(boundPort)
+      );
+    });
+
+  it('rejects with DEADLINE_EXCEEDED when the server never responds, within the deadline window', async () => {
+    server.addService(ApplicationsV1.ApplicationServiceService, {
+      get: (
+        _call: ServerUnaryCall<GetApplicationRequest, GetApplicationResponse>,
+        _cb: sendUnaryData<GetApplicationResponse>
+      ) => {
+        // Intentionally never call _cb — simulates a hung server.
+      },
+    });
+
+    const port = await startServer();
+    const client = createApplicationsClient({
+      address: `127.0.0.1:${port}`,
+      deadlineMs: 200,
+      maxRetries: 0, // no retries so the test is fast
+    });
+
+    const start = Date.now();
+    try {
+      await client.getApplication(GET_REQUEST, new Metadata());
+      expect.fail('expected rejection');
+    } catch (err: unknown) {
+      const elapsed = Date.now() - start;
+      expect((err as { code?: number }).code).toBe(status.DEADLINE_EXCEEDED);
+      // Should finish near the deadline — allow generous upper bound for CI.
+      expect(elapsed).toBeLessThan(2_000);
+    } finally {
+      client.close();
+    }
+  });
+
+  it('resolves on the second attempt when the first attempt returns UNAVAILABLE', async () => {
+    let callCount = 0;
+
+    server.addService(ApplicationsV1.ApplicationServiceService, {
+      get: (
+        _call: ServerUnaryCall<GetApplicationRequest, GetApplicationResponse>,
+        cb: sendUnaryData<GetApplicationResponse>
+      ) => {
+        callCount += 1;
+        if (callCount === 1) {
+          cb(makeServiceError(status.UNAVAILABLE, 'service unavailable'), null);
+        } else {
+          cb(null, successResponse);
+        }
+      },
+    });
+
+    const port = await startServer();
+    const client = createApplicationsClient({
+      address: `127.0.0.1:${port}`,
+      deadlineMs: 2_000,
+      maxRetries: 2,
+    });
+
+    try {
+      const result = await client.getApplication(GET_REQUEST, new Metadata());
+      expect(result.application?.applicationId).toBe('app-1');
+      expect(result.application?.adopterId).toBe('usr-adopter');
+      expect(result.application?.rescueId).toBe('rsc-1');
+      expect(callCount).toBe(2);
+    } finally {
+      client.close();
+    }
+  });
+
+  it('does not retry PERMISSION_DENIED and propagates the error after exactly 1 attempt', async () => {
+    let callCount = 0;
+
+    server.addService(ApplicationsV1.ApplicationServiceService, {
+      get: (
+        _call: ServerUnaryCall<GetApplicationRequest, GetApplicationResponse>,
+        cb: sendUnaryData<GetApplicationResponse>
+      ) => {
+        callCount += 1;
+        cb(makeServiceError(status.PERMISSION_DENIED, 'not yours'), null);
+      },
+    });
+
+    const port = await startServer();
+    const client = createApplicationsClient({
+      address: `127.0.0.1:${port}`,
+      deadlineMs: 2_000,
+      maxRetries: 2,
+    });
+
+    try {
+      await client.getApplication(GET_REQUEST, new Metadata());
+      expect.fail('expected rejection');
+    } catch (err: unknown) {
+      expect((err as { code?: number }).code).toBe(status.PERMISSION_DENIED);
+      expect(callCount).toBe(1);
+    } finally {
+      client.close();
+    }
+  });
+
+  it('forwards the caller-supplied metadata (the principal) to the server', async () => {
+    const captured: Metadata[] = [];
+
+    server.addService(ApplicationsV1.ApplicationServiceService, {
+      get: (
+        call: ServerUnaryCall<GetApplicationRequest, GetApplicationResponse>,
+        cb: sendUnaryData<GetApplicationResponse>
+      ) => {
+        captured.push(call.metadata);
+        cb(null, successResponse);
+      },
+    });
+
+    const port = await startServer();
+    const client = createApplicationsClient({ address: `127.0.0.1:${port}` });
+
+    const metadata = new Metadata();
+    metadata.set('x-user-id', 'usr-adopter');
+    metadata.set('x-user-roles', 'adopter');
+
+    try {
+      await client.getApplication(GET_REQUEST, metadata);
+      expect(captured).toHaveLength(1);
+      expect(captured[0].get('x-user-id')).toEqual(['usr-adopter']);
+      expect(captured[0].get('x-user-roles')).toEqual(['adopter']);
+    } finally {
+      client.close();
+    }
+  });
+});

--- a/services/chat/src/grpc/applications-client.ts
+++ b/services/chat/src/grpc/applications-client.ts
@@ -1,0 +1,108 @@
+// Service-to-service gRPC client for service.applications.
+//
+// OpenChat is the only ChatService RPC that needs a cross-vertical lookup
+// (ADS-918): the request carries an applicationId + otherUserId with no
+// server-side guarantee either belongs together, so the handler resolves
+// the real application (adopterId + rescueId) via ApplicationService.Get
+// before creating the chat, and rejects otherUserId values that don't
+// match the resolved relationship.
+//
+// Only the Get RPC is wrapped. The interface is exported so the gRPC
+// server boot can inject a real client and tests can substitute a stub.
+// Direct port of services/applications/src/grpc/pets-client.ts.
+
+import { credentials, status, type CallOptions, type Metadata } from '@grpc/grpc-js';
+
+import {
+  ApplicationsV1,
+  type GetApplicationRequest,
+  type GetApplicationResponse,
+} from '@adopt-dont-shop/proto';
+
+export type ApplicationsClient = {
+  getApplication(req: GetApplicationRequest, metadata: Metadata): Promise<GetApplicationResponse>;
+  close(): void;
+};
+
+export type CreateApplicationsClientOptions = {
+  address: string;
+  // Per-call deadline in milliseconds. Without one, a hung downstream
+  // service would hang this request forever; 5s caps the blast radius
+  // and lets the caller fail fast with DEADLINE_EXCEEDED.
+  deadlineMs?: number;
+  // Maximum additional attempts after the first. Only UNAVAILABLE and
+  // DEADLINE_EXCEEDED trigger a retry (both are safe for idempotent
+  // reads). Defaults to 2 (i.e. up to 3 total attempts).
+  maxRetries?: number;
+};
+
+const DEFAULT_DEADLINE_MS = 5_000;
+const DEFAULT_MAX_RETRIES = 2;
+// Retry-eligible status codes for idempotent reads.
+const RETRYABLE_CODES = new Set([status.UNAVAILABLE, status.DEADLINE_EXCEEDED]);
+
+const isRetryableError = (err: unknown): boolean => {
+  if (err === null || typeof err !== 'object') {
+    return false;
+  }
+  const code = (err as { code?: unknown }).code;
+  return typeof code === 'number' && RETRYABLE_CODES.has(code);
+};
+
+const sleep = (ms: number): Promise<void> => new Promise(resolve => setTimeout(resolve, ms));
+
+const jitteredBackoff = (attempt: number, baseMs: number): number => {
+  // Exponential backoff with ±25% jitter: 100ms, 200ms (base defaults).
+  const base = baseMs * Math.pow(2, attempt - 1);
+  return base * (0.75 + Math.random() * 0.5);
+};
+
+export const createApplicationsClient = (
+  opts: CreateApplicationsClientOptions
+): ApplicationsClient => {
+  const stub = new ApplicationsV1.ApplicationServiceClient(
+    opts.address,
+    credentials.createInsecure()
+  );
+  const deadlineMs = opts.deadlineMs ?? DEFAULT_DEADLINE_MS;
+  const maxRetries = opts.maxRetries ?? DEFAULT_MAX_RETRIES;
+
+  const callWithRetry = <Req, Res>(
+    fn: (
+      req: Req,
+      metadata: Metadata,
+      options: Partial<CallOptions>,
+      cb: (err: unknown, res: Res) => void
+    ) => unknown,
+    req: Req,
+    metadata: Metadata
+  ): Promise<Res> => {
+    const attempt = (remaining: number): Promise<Res> =>
+      new Promise<Res>((resolve, reject) => {
+        const options: Partial<CallOptions> = {
+          deadline: new Date(Date.now() + deadlineMs),
+        };
+        fn.call(stub, req, metadata, options, (err: unknown, res: Res) => {
+          if (err) {
+            if (remaining > 0 && isRetryableError(err)) {
+              const retryIndex = maxRetries - remaining + 1;
+              sleep(jitteredBackoff(retryIndex, 100))
+                .then(() => attempt(remaining - 1))
+                .then(resolve, reject);
+            } else {
+              reject(err);
+            }
+            return;
+          }
+          resolve(res);
+        });
+      });
+
+    return attempt(maxRetries);
+  };
+
+  return {
+    getApplication: (req, metadata) => callWithRetry(stub.get, req, metadata),
+    close: () => stub.close(),
+  };
+};

--- a/services/chat/src/grpc/handlers.coverage.test.ts
+++ b/services/chat/src/grpc/handlers.coverage.test.ts
@@ -379,13 +379,15 @@ describe('post-commit INTERNAL guards', () => {
   });
 
   it('deleteChat throws INTERNAL when the UPDATE returns no rows', async () => {
-    mocks.poolScript.push({ rows: [{ chat_participant_id: 'p-1' }] }); // participant
+    // Deleting is a staff/safety-team primitive (ADS-923) — use the
+    // super_admin fixture so the privilege gate passes without needing
+    // a participant-membership lookup.
     mocks.poolScript.push({ rows: [{ ...chatRowFixture(), deleted_at: null }] }); // existing
     mocks.clientScript.push({ rows: [] }); // UPDATE → no rows
     mocks.clientScript.push({ rows: [{ participant_id: 'usr-adopter' }] }); // participants
 
     await expect(
-      deleteChat(mocks.deps, ADOPTER_PRINCIPAL, { chatId: 'chat-1' })
+      deleteChat(mocks.deps, SUPER_ADMIN_PRINCIPAL, { chatId: 'chat-1' })
     ).rejects.toMatchObject({ code: 'INTERNAL' });
   });
 });

--- a/services/chat/src/grpc/handlers.coverage.test.ts
+++ b/services/chat/src/grpc/handlers.coverage.test.ts
@@ -4,25 +4,53 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { Principal } from '@adopt-dont-shop/authz';
 import type { Permission, UserId } from '@adopt-dont-shop/lib.types';
-import type {
-  ListChatsRequest,
-  ListMessagesRequest,
-  MarkReadRequest,
-  OpenChatRequest,
-  ReactRequest,
-  SendMessageRequest,
+import {
+  ApplicationsV1,
+  RescueV1,
+  type ListChatsRequest,
+  type ListMessagesRequest,
+  type MarkReadRequest,
+  type OpenChatRequest,
+  type ReactRequest,
+  type SendMessageRequest,
 } from '@adopt-dont-shop/proto';
 
+import type { ApplicationsClient } from './applications-client.js';
+import type { RescueClient } from './rescue-client.js';
 import {
   deleteChat,
   deleteMessage,
   listChats,
   listMessages,
+  makeOpenChat,
   markRead,
-  openChat,
   react,
   sendMessage,
 } from './handlers.js';
+
+// Stubbed cross-service clients for makeOpenChat (ADS-918): app-1
+// belongs to usr-adopter at rescue rsc-1, whose staff list contains
+// usr-rescue. Mirrors handlers.test.ts.
+const makeOpenChatWithStubs = (): ReturnType<typeof makeOpenChat> => {
+  const applicationsClient: ApplicationsClient = {
+    getApplication: vi.fn().mockResolvedValue({
+      application: ApplicationsV1.Application.fromPartial({
+        applicationId: 'app-1',
+        adopterId: 'usr-adopter',
+        rescueId: 'rsc-1',
+      }),
+      timeline: [],
+    }),
+    close: vi.fn(),
+  };
+  const rescueClient: RescueClient = {
+    listStaffMembers: vi.fn().mockResolvedValue({
+      staffMembers: [RescueV1.StaffMember.fromPartial({ userId: 'usr-rescue', rescueId: 'rsc-1' })],
+    }),
+    close: vi.fn(),
+  };
+  return makeOpenChat(applicationsClient, rescueClient);
+};
 
 // Additional behavioural coverage for the gRPC handlers — focused on the
 // branches the primary handlers.test.ts leaves open: missing-argument
@@ -127,9 +155,11 @@ describe('handler argument validation', () => {
 
   it('openChat rejects a missing other_user_id', async () => {
     const req: OpenChatRequest = { applicationId: 'app-1', otherUserId: '' };
-    await expect(openChat(mocks.deps, ADOPTER_PRINCIPAL, req)).rejects.toMatchObject({
-      code: 'INVALID_ARGUMENT',
-    });
+    await expect(makeOpenChatWithStubs()(mocks.deps, ADOPTER_PRINCIPAL, req)).rejects.toMatchObject(
+      {
+        code: 'INVALID_ARGUMENT',
+      }
+    );
   });
 
   it('sendMessage rejects a missing chat_id', async () => {
@@ -377,7 +407,10 @@ describe('openChat insert guard', () => {
     mocks.clientScript.push({ rows: [] }); // INSERT participants
 
     await expect(
-      openChat(mocks.deps, ADOPTER_PRINCIPAL, { applicationId: 'app-1', otherUserId: 'usr-rescue' })
+      makeOpenChatWithStubs()(mocks.deps, ADOPTER_PRINCIPAL, {
+        applicationId: 'app-1',
+        otherUserId: 'usr-rescue',
+      })
     ).rejects.toMatchObject({ code: 'INTERNAL' });
   });
 });

--- a/services/chat/src/grpc/handlers.test.ts
+++ b/services/chat/src/grpc/handlers.test.ts
@@ -3,22 +3,26 @@ import type { Pool, PoolClient } from 'pg';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { Principal } from '@adopt-dont-shop/authz';
-import type { Permission, UserId } from '@adopt-dont-shop/lib.types';
-import type {
-  ListChatsRequest,
-  ListMessagesRequest,
-  MarkReadRequest,
-  OpenChatRequest,
-  ReactRequest,
-  SendMessageRequest,
+import type { Permission, RescueId, UserId } from '@adopt-dont-shop/lib.types';
+import {
+  ApplicationsV1,
+  RescueV1,
+  type ListChatsRequest,
+  type ListMessagesRequest,
+  type MarkReadRequest,
+  type OpenChatRequest,
+  type ReactRequest,
+  type SendMessageRequest,
 } from '@adopt-dont-shop/proto';
 
+import type { ApplicationsClient } from './applications-client.js';
+import type { RescueClient } from './rescue-client.js';
 import {
   HandlerError,
   listChats,
   listMessages,
+  makeOpenChat,
   markRead,
-  openChat,
   react,
   deleteChat,
   deleteMessage,
@@ -44,6 +48,13 @@ const UNPRIVILEGED_PRINCIPAL: Principal = {
   userId: 'usr-noperm' as UserId,
   roles: ['adopter'],
   permissions: [],
+};
+
+const OTHER_RESCUE_STAFF_PRINCIPAL: Principal = {
+  userId: 'usr-other-staff' as UserId,
+  roles: ['rescue_staff'],
+  permissions: ['chats.read' as Permission, 'chats.create' as Permission],
+  rescueId: 'rsc-other' as RescueId,
 };
 
 // --- Row fixtures ----------------------------------------------------
@@ -125,10 +136,40 @@ const BASE_OPEN: OpenChatRequest = {
   otherUserId: 'usr-rescue',
 };
 
+// The rescue that owns application app-1 in the stubbed cross-service
+// world below. usr-adopter is its adopter; usr-rescue is on its staff.
+const APP_RESCUE_ID = 'rsc-1';
+
+// Stub the two cross-service clients OpenChat consults (ADS-918):
+// service.applications resolves app-1 → {usr-adopter, rsc-1} and
+// service.rescue lists rsc-1's staff (just usr-rescue).
+function makeCrossServiceStubs() {
+  const getApplication = vi.fn().mockResolvedValue({
+    application: ApplicationsV1.Application.fromPartial({
+      applicationId: 'app-1',
+      adopterId: 'usr-adopter',
+      rescueId: APP_RESCUE_ID,
+    }),
+    timeline: [],
+  });
+  const listStaffMembers = vi.fn().mockResolvedValue({
+    staffMembers: [
+      RescueV1.StaffMember.fromPartial({ userId: 'usr-rescue', rescueId: APP_RESCUE_ID }),
+    ],
+  });
+  const applicationsClient: ApplicationsClient = { getApplication, close: vi.fn() };
+  const rescueClient: RescueClient = { listStaffMembers, close: vi.fn() };
+  return { applicationsClient, rescueClient, getApplication, listStaffMembers };
+}
+
 describe('openChat', () => {
   let mocks: ReturnType<typeof makeMocks>;
+  let stubs: ReturnType<typeof makeCrossServiceStubs>;
+  let openChat: ReturnType<typeof makeOpenChat>;
   beforeEach(() => {
     mocks = makeMocks();
+    stubs = makeCrossServiceStubs();
+    openChat = makeOpenChat(stubs.applicationsClient, stubs.rescueClient);
   });
   afterEach(() => {
     vi.resetAllMocks();
@@ -202,10 +243,12 @@ describe('openChat', () => {
     return call[1];
   };
 
-  it('persists the rescueId from the request on the new chat row', async () => {
+  // ADS-918: rescue_id always comes from the resolved application — a
+  // request-supplied rescueId (cross-tenant pollution vector) is ignored.
+  it('stamps the application’s rescue_id on the new chat, ignoring a mismatched request rescueId', async () => {
     mocks.poolScript.push({ rows: [] });
     mocks.clientScript.push({
-      rows: [chatRowFixture({ chat_id: 'new-chat', rescue_id: 'rsc-1' })],
+      rows: [chatRowFixture({ chat_id: 'new-chat', rescue_id: APP_RESCUE_ID })],
     });
     mocks.clientScript.push({ rows: [] });
     mocks.poolScript.push({
@@ -213,23 +256,94 @@ describe('openChat', () => {
     });
     mocks.poolScript.push({ rows: [] });
 
-    await openChat(mocks.deps, ADOPTER_PRINCIPAL, { ...BASE_OPEN, rescueId: 'rsc-1' });
+    await openChat(mocks.deps, ADOPTER_PRINCIPAL, { ...BASE_OPEN, rescueId: 'rsc-victim' });
 
-    expect(insertChatParams(mocks)).toContain('rsc-1');
+    expect(insertChatParams(mocks)).toContain(APP_RESCUE_ID);
+    expect(insertChatParams(mocks)).not.toContain('rsc-victim');
   });
 
-  it('falls back to the null-UUID placeholder when no rescueId is supplied', async () => {
+  // ADS-918: an adopter may only open a chat with staff of the rescue
+  // that owns their application — any other user id is rejected before
+  // any DB write happens.
+  it('rejects an adopter whose other_user_id is not on the rescue’s staff list', async () => {
+    await expect(
+      openChat(mocks.deps, ADOPTER_PRINCIPAL, { ...BASE_OPEN, otherUserId: 'usr-random' })
+    ).rejects.toMatchObject({ code: 'INVALID_ARGUMENT' });
+    expect(mocks.poolMock.query).not.toHaveBeenCalled();
+    expect(mocks.clientMock.query).not.toHaveBeenCalled();
+  });
+
+  it('rejects a caller who is neither the application adopter nor staff of its rescue', async () => {
+    const stranger: Principal = {
+      userId: 'usr-stranger' as UserId,
+      roles: ['adopter'],
+      permissions: ['chats.create' as Permission, 'chats.read' as Permission],
+    };
+    await expect(openChat(mocks.deps, stranger, BASE_OPEN)).rejects.toMatchObject({
+      code: 'PERMISSION_DENIED',
+    });
+    expect(mocks.poolMock.query).not.toHaveBeenCalled();
+  });
+
+  it('lets staff of the application’s rescue open a chat with the adopter', async () => {
+    const staff: Principal = {
+      userId: 'usr-rescue' as UserId,
+      roles: ['rescue_staff'],
+      permissions: ['chats.create' as Permission, 'chats.read' as Permission],
+      rescueId: APP_RESCUE_ID as RescueId,
+    };
     mocks.poolScript.push({ rows: [] });
-    mocks.clientScript.push({ rows: [chatRowFixture({ chat_id: 'new-chat' })] });
+    mocks.clientScript.push({
+      rows: [chatRowFixture({ chat_id: 'new-chat', rescue_id: APP_RESCUE_ID })],
+    });
     mocks.clientScript.push({ rows: [] });
     mocks.poolScript.push({
-      rows: [{ participant_id: 'usr-adopter' }, { participant_id: 'usr-rescue' }],
+      rows: [{ participant_id: 'usr-rescue' }, { participant_id: 'usr-adopter' }],
     });
     mocks.poolScript.push({ rows: [] });
 
-    await openChat(mocks.deps, ADOPTER_PRINCIPAL, { ...BASE_OPEN, rescueId: '' });
+    const res = await openChat(mocks.deps, staff, { ...BASE_OPEN, otherUserId: 'usr-adopter' });
+    expect(res.created).toBe(true);
+    // Staff never need the staff-list lookup — the adopter check is
+    // against the resolved application directly.
+    expect(stubs.listStaffMembers).not.toHaveBeenCalled();
+  });
 
-    expect(insertChatParams(mocks)).toContain('00000000-0000-0000-0000-000000000000');
+  it('rejects staff opening a chat with someone other than the application adopter', async () => {
+    const staff: Principal = {
+      userId: 'usr-rescue' as UserId,
+      roles: ['rescue_staff'],
+      permissions: ['chats.create' as Permission, 'chats.read' as Permission],
+      rescueId: APP_RESCUE_ID as RescueId,
+    };
+    await expect(
+      openChat(mocks.deps, staff, { ...BASE_OPEN, otherUserId: 'usr-unrelated' })
+    ).rejects.toMatchObject({ code: 'INVALID_ARGUMENT' });
+    expect(mocks.poolMock.query).not.toHaveBeenCalled();
+  });
+
+  it('rejects staff of a different rescue than the application’s', async () => {
+    await expect(
+      openChat(mocks.deps, OTHER_RESCUE_STAFF_PRINCIPAL, {
+        ...BASE_OPEN,
+        otherUserId: 'usr-adopter',
+      })
+    ).rejects.toMatchObject({ code: 'PERMISSION_DENIED' });
+    expect(mocks.poolMock.query).not.toHaveBeenCalled();
+  });
+
+  it('maps an application NOT_FOUND to INVALID_ARGUMENT', async () => {
+    stubs.getApplication.mockRejectedValueOnce({ code: 5 });
+    await expect(openChat(mocks.deps, ADOPTER_PRINCIPAL, BASE_OPEN)).rejects.toMatchObject({
+      code: 'INVALID_ARGUMENT',
+    });
+  });
+
+  it('propagates a PERMISSION_DENIED from the applications service', async () => {
+    stubs.getApplication.mockRejectedValueOnce({ code: 7 });
+    await expect(openChat(mocks.deps, ADOPTER_PRINCIPAL, BASE_OPEN)).rejects.toMatchObject({
+      code: 'PERMISSION_DENIED',
+    });
   });
 });
 

--- a/services/chat/src/grpc/handlers.test.ts
+++ b/services/chat/src/grpc/handlers.test.ts
@@ -359,6 +359,41 @@ describe('openChat', () => {
       code: 'PERMISSION_DENIED',
     });
   });
+
+  it('maps any other applications-service failure to INTERNAL', async () => {
+    stubs.getApplication.mockRejectedValueOnce({ code: 14 });
+    await expect(openChat(mocks.deps, ADOPTER_PRINCIPAL, BASE_OPEN)).rejects.toMatchObject({
+      code: 'INTERNAL',
+    });
+  });
+
+  it('treats a response without an application as INVALID_ARGUMENT', async () => {
+    stubs.getApplication.mockResolvedValueOnce({ application: undefined, timeline: [] });
+    await expect(openChat(mocks.deps, ADOPTER_PRINCIPAL, BASE_OPEN)).rejects.toMatchObject({
+      code: 'INVALID_ARGUMENT',
+    });
+  });
+
+  it('lets super_admin open a chat without an adopter/staff relationship', async () => {
+    const root: Principal = {
+      userId: 'usr-root' as UserId,
+      roles: ['super_admin'],
+      permissions: [],
+    };
+    mocks.poolScript.push({ rows: [] });
+    mocks.clientScript.push({
+      rows: [chatRowFixture({ chat_id: 'new-chat', rescue_id: APP_RESCUE_ID })],
+    });
+    mocks.clientScript.push({ rows: [] });
+    mocks.poolScript.push({
+      rows: [{ participant_id: 'usr-root' }, { participant_id: 'usr-rescue' }],
+    });
+    mocks.poolScript.push({ rows: [] });
+
+    const res = await openChat(mocks.deps, root, { ...BASE_OPEN, otherUserId: 'usr-anyone' });
+    expect(res.created).toBe(true);
+    expect(stubs.listStaffMembers).not.toHaveBeenCalled();
+  });
 });
 
 // --- SendMessage ----------------------------------------------------

--- a/services/chat/src/grpc/handlers.test.ts
+++ b/services/chat/src/grpc/handlers.test.ts
@@ -57,6 +57,20 @@ const OTHER_RESCUE_STAFF_PRINCIPAL: Principal = {
   rescueId: 'rsc-other' as RescueId,
 };
 
+// Staff of the rescue the chatRowFixture below belongs to (null-UUID).
+const RESCUE_STAFF_PRINCIPAL: Principal = {
+  userId: 'usr-staff' as UserId,
+  roles: ['rescue_staff'],
+  permissions: ['chats.read' as Permission, 'chats.create' as Permission],
+  rescueId: '00000000-0000-0000-0000-000000000000' as RescueId,
+};
+
+const MODERATOR_PRINCIPAL: Principal = {
+  userId: 'usr-moderator' as UserId,
+  roles: ['moderator'],
+  permissions: ['chats.read' as Permission],
+};
+
 // --- Row fixtures ----------------------------------------------------
 
 const chatRowFixture = (overrides: Record<string, unknown> = {}) => ({
@@ -1124,23 +1138,41 @@ describe('deleteChat', () => {
     ).rejects.toMatchObject({ code: 'PERMISSION_DENIED' });
   });
 
-  it('returns NOT_FOUND (no enumeration) when caller is not a participant', async () => {
+  it('returns NOT_FOUND when the chat row is gone', async () => {
     mocks.poolMock.query.mockResolvedValueOnce({ rows: [] });
     await expect(
       deleteChat(mocks.deps, ADOPTER_PRINCIPAL, { chatId: 'chat-1' })
     ).rejects.toMatchObject({ code: 'NOT_FOUND' });
   });
 
-  it('returns NOT_FOUND when the chat row is gone', async () => {
-    mocks.poolMock.query.mockResolvedValueOnce({ rows: [{ chat_participant_id: 'p-1' }] });
-    mocks.poolMock.query.mockResolvedValueOnce({ rows: [] });
+  it('returns NOT_FOUND (no enumeration) when a non-privileged, non-participant caller tries to delete', async () => {
+    mocks.poolMock.query.mockResolvedValueOnce({ rows: [chatRowFixture()] }); // chat exists
+    mocks.poolMock.query.mockResolvedValueOnce({ rows: [] }); // not a participant
     await expect(
       deleteChat(mocks.deps, ADOPTER_PRINCIPAL, { chatId: 'chat-1' })
+    ).rejects.toMatchObject({ code: 'NOT_FOUND' });
+  });
+
+  // ADS-923: an adopter participant must not be able to erase the whole
+  // chat, even though they hold chats.read and are a genuine participant.
+  it('rejects an adopter participant with PERMISSION_DENIED (cannot erase shared evidence)', async () => {
+    mocks.poolMock.query.mockResolvedValueOnce({ rows: [chatRowFixture()] }); // chat exists
+    mocks.poolMock.query.mockResolvedValueOnce({ rows: [{ chat_participant_id: 'p-1' }] }); // is a participant
+    await expect(
+      deleteChat(mocks.deps, ADOPTER_PRINCIPAL, { chatId: 'chat-1' })
+    ).rejects.toMatchObject({ code: 'PERMISSION_DENIED' });
+    expect(mocks.clientMock.query).not.toHaveBeenCalled();
+  });
+
+  it('rejects rescue staff from a different rescue than the chat (NOT_FOUND, non-participant)', async () => {
+    mocks.poolMock.query.mockResolvedValueOnce({ rows: [chatRowFixture()] }); // chat exists
+    mocks.poolMock.query.mockResolvedValueOnce({ rows: [] }); // not a participant either
+    await expect(
+      deleteChat(mocks.deps, OTHER_RESCUE_STAFF_PRINCIPAL, { chatId: 'chat-1' })
     ).rejects.toMatchObject({ code: 'NOT_FOUND' });
   });
 
   it('is idempotent on an already-deleted chat (no write, no publish)', async () => {
-    mocks.poolMock.query.mockResolvedValueOnce({ rows: [{ chat_participant_id: 'p-1' }] });
     mocks.poolMock.query.mockResolvedValueOnce({
       rows: [{ ...chatRowFixture(), deleted_at: new Date('2026-06-05T12:00:00Z') }],
     });
@@ -1150,14 +1182,13 @@ describe('deleteChat', () => {
     });
     mocks.poolMock.query.mockResolvedValueOnce({ rows: [] });
 
-    const res = await deleteChat(mocks.deps, ADOPTER_PRINCIPAL, { chatId: 'chat-1' });
+    const res = await deleteChat(mocks.deps, MODERATOR_PRINCIPAL, { chatId: 'chat-1' });
     expect(res.chat?.chatId).toBe('chat-1');
     expect(mocks.clientMock.query).not.toHaveBeenCalled();
     expect(mocks.natsMock.publish).not.toHaveBeenCalled();
   });
 
-  it('soft-deletes inside withTransaction and publishes chat.deleted', async () => {
-    mocks.poolMock.query.mockResolvedValueOnce({ rows: [{ chat_participant_id: 'p-1' }] });
+  it('rescue staff of the chat’s own rescue can soft-delete and publish chat.deleted', async () => {
     mocks.poolMock.query.mockResolvedValueOnce({
       rows: [{ ...chatRowFixture(), deleted_at: null }],
     });
@@ -1172,7 +1203,7 @@ describe('deleteChat', () => {
     });
     mocks.poolMock.query.mockResolvedValueOnce({ rows: [] });
 
-    const res = await deleteChat(mocks.deps, ADOPTER_PRINCIPAL, {
+    const res = await deleteChat(mocks.deps, RESCUE_STAFF_PRINCIPAL, {
       chatId: 'chat-1',
       reason: 'cleanup',
     });
@@ -1187,5 +1218,23 @@ describe('deleteChat', () => {
     };
     expect(envelope.payload.reason).toBe('cleanup');
     expect(envelope.payload.participantUserIds).toEqual(['usr-adopter', 'usr-rescue']);
+  });
+
+  it('a moderator can soft-delete a chat they are not a participant of', async () => {
+    mocks.poolMock.query.mockResolvedValueOnce({
+      rows: [{ ...chatRowFixture(), deleted_at: null }],
+    });
+    mocks.clientScript.push({ rows: [chatRowFixture()] });
+    mocks.clientScript.push({
+      rows: [{ participant_id: 'usr-adopter' }, { participant_id: 'usr-rescue' }],
+    });
+    mocks.poolMock.query.mockResolvedValueOnce({
+      rows: [{ participant_id: 'usr-adopter' }, { participant_id: 'usr-rescue' }],
+    });
+    mocks.poolMock.query.mockResolvedValueOnce({ rows: [] });
+
+    const res = await deleteChat(mocks.deps, MODERATOR_PRINCIPAL, { chatId: 'chat-1' });
+    expect(res.chat?.chatId).toBe('chat-1');
+    expect(mocks.natsMock.publish).toHaveBeenCalledTimes(1);
   });
 });

--- a/services/chat/src/grpc/handlers.ts
+++ b/services/chat/src/grpc/handlers.ts
@@ -1153,13 +1153,9 @@ export async function deleteChat(
   if (!hasPermission(principal, CHAT_READ)) {
     throw new HandlerError('PERMISSION_DENIED', `'${CHAT_READ}' required`);
   }
-  // Participant-or-admin gate. Non-participants get NOT_FOUND posture
-  // so the row's existence isn't enumerable.
-  if (!(await isParticipantOrAdmin(deps, principal, req.chatId))) {
-    throw new HandlerError('NOT_FOUND', `chat ${req.chatId} not found`);
-  }
 
-  // Fetch the row to decide idempotent vs first-time delete.
+  // Fetch the row first — the rescue-staff privilege check below needs
+  // its rescue_id.
   const existing = await deps.pool.query<ChatRow & { deleted_at: Date | null }>(
     `SELECT * FROM chats WHERE chat_id = $1 LIMIT 1`,
     [req.chatId]
@@ -1168,6 +1164,32 @@ export async function deleteChat(
     throw new HandlerError('NOT_FOUND', `chat ${req.chatId} not found`);
   }
   const row = existing.rows[0];
+
+  // ADS-923: chat-wide delete erases the thread for every participant —
+  // a plain adopter participant could use it to destroy adoption-workflow
+  // evidence the rescue relies on. Deleting is now a staff/safety-team
+  // primitive: super_admin, a moderator/admin, or rescue-staff whose home
+  // rescue matches this chat's rescue_id. A regular participant (e.g. the
+  // adopter) is denied even though they can otherwise read the chat.
+  const isPrivilegedDeleter =
+    principal.roles.includes('super_admin') ||
+    principal.roles.includes('moderator') ||
+    principal.roles.includes('admin') ||
+    (principal.roles.includes('rescue_staff') &&
+      principal.rescueId !== undefined &&
+      principal.rescueId === row.rescue_id);
+  if (!isPrivilegedDeleter) {
+    // Non-participants still get NOT_FOUND posture so the row's
+    // existence isn't enumerable; a participant who simply lacks the
+    // role learns the real reason.
+    if (!(await isParticipantOrAdmin(deps, principal, req.chatId))) {
+      throw new HandlerError('NOT_FOUND', `chat ${req.chatId} not found`);
+    }
+    throw new HandlerError(
+      'PERMISSION_DENIED',
+      'only rescue staff of this chat, or a moderator/admin, may delete a chat'
+    );
+  }
 
   // Idempotent — already deleted.
   if (row.deleted_at) {

--- a/services/chat/src/grpc/handlers.ts
+++ b/services/chat/src/grpc/handlers.ts
@@ -13,15 +13,23 @@
 //     remove is idempotent (no row → no-op).
 //   - MarkRead: idempotent — repeated calls just re-stamp read_at.
 //
-// Cross-schema reads (auth.users for sender name lookups, applications
-// for app validation) live in the gateway / consumers. This service
-// validates participant membership inside its own schema only.
+// Cross-schema reads (auth.users for sender name lookups) live in the
+// gateway / consumers. Everything else validates participant membership
+// inside its own schema only — EXCEPT OpenChat (ADS-918), which resolves
+// the applicationId → {adopterId, rescueId} relationship via a
+// service.applications gRPC call (+ service.rescue for the
+// adopter-initiates-chat direction) before creating a chat, because
+// nothing in this schema can otherwise confirm the caller and
+// other_user_id actually belong together.
 
 import { randomUUID } from 'node:crypto';
 
 import { hasPermission, type Principal } from '@adopt-dont-shop/authz';
 import { withTransaction, type WithTransactionDeps } from '@adopt-dont-shop/events';
 import type { Permission } from '@adopt-dont-shop/lib.types';
+import { principalToMetadata } from '@adopt-dont-shop/service-bootstrap';
+import type { ApplicationsClient } from './applications-client.js';
+import type { RescueClient } from './rescue-client.js';
 import type {
   Chat,
   DeleteChatRequest,
@@ -269,96 +277,170 @@ const messageRowToProto = (row: MessageRow, reactions: MessageReaction[]): Messa
 
 // --- OpenChat --------------------------------------------------------
 
-export async function openChat(
-  deps: HandlerDeps,
-  principal: Principal,
-  req: OpenChatRequest
-): Promise<OpenChatResponse> {
-  if (!req.applicationId) {
-    throw new HandlerError('INVALID_ARGUMENT', 'application_id is required');
-  }
-  if (!req.otherUserId) {
-    throw new HandlerError('INVALID_ARGUMENT', 'other_user_id is required');
-  }
-  if (req.otherUserId === principal.userId) {
-    throw new HandlerError('INVALID_ARGUMENT', 'cannot open a chat with yourself');
-  }
-  if (!hasPermission(principal, CHAT_CREATE)) {
-    throw new HandlerError('PERMISSION_DENIED', `'${CHAT_CREATE}' required`);
-  }
+// gRPC numeric status codes surfaced by the cross-service calls below —
+// mapped onto our own HandlerError codes the same way
+// services/applications/src/grpc/handlers.ts maps service.pets errors.
+const CROSS_SERVICE_GRPC_NOT_FOUND = 5;
+const CROSS_SERVICE_GRPC_PERMISSION_DENIED = 7;
 
-  // Idempotency: look up an existing chat for this application + pair.
-  const existing = await deps.pool.query<ChatRow>(
-    `
-    SELECT c.*
-    FROM chats c
-    WHERE c.application_id = $1
-      AND c.deleted_at IS NULL
-      AND EXISTS (
-        SELECT 1 FROM chat_participants p1
-        WHERE p1.chat_id = c.chat_id AND p1.participant_id = $2 AND p1.deleted_at IS NULL
-      )
-      AND EXISTS (
-        SELECT 1 FROM chat_participants p2
-        WHERE p2.chat_id = c.chat_id AND p2.participant_id = $3 AND p2.deleted_at IS NULL
-      )
-    LIMIT 1
-    `,
-    [req.applicationId, principal.userId, req.otherUserId]
-  );
-  if (existing.rows[0]) {
-    const chat = await chatRowToProto(deps, existing.rows[0]);
-    return { chat, created: false };
-  }
+export function makeOpenChat(
+  applicationsClient: ApplicationsClient,
+  rescueClient: RescueClient
+): (deps: HandlerDeps, principal: Principal, req: OpenChatRequest) => Promise<OpenChatResponse> {
+  return async (deps, principal, req) => {
+    if (!req.applicationId) {
+      throw new HandlerError('INVALID_ARGUMENT', 'application_id is required');
+    }
+    if (!req.otherUserId) {
+      throw new HandlerError('INVALID_ARGUMENT', 'other_user_id is required');
+    }
+    if (req.otherUserId === principal.userId) {
+      throw new HandlerError('INVALID_ARGUMENT', 'cannot open a chat with yourself');
+    }
+    if (!hasPermission(principal, CHAT_CREATE)) {
+      throw new HandlerError('PERMISSION_DENIED', `'${CHAT_CREATE}' required`);
+    }
 
-  const chatId = randomUUID();
-  let inserted: ChatRow | undefined;
-  await withTransaction(deps, async ({ client, publish }) => {
-    // rescue_id is required (NOT NULL) by the schema. The gateway resolves
-    // it from the caller's rescue context and threads it on the request so
-    // the chat row records its owning rescue — rescue-scoped chat search
-    // then matches gRPC-created chats. When the caller has no rescue
-    // context (e.g. an adopter), fall back to the NULL-UUID placeholder so
-    // the NOT NULL constraint still holds.
-    const placeholderRescue = '00000000-0000-0000-0000-000000000000';
-    const rescueId = req.rescueId || placeholderRescue;
-    const inserted0 = await client.query<ChatRow>(
-      `
-      INSERT INTO chats (chat_id, application_id, rescue_id, created_at, updated_at)
-      VALUES ($1, $2, $3, now(), now())
-      RETURNING *
-      `,
-      [chatId, req.applicationId, rescueId]
-    );
-    inserted = inserted0.rows[0];
-
-    // Two participant rows. Roles default to 'member' — the gateway/
-    // service.rescue can promote a rescue-staff participant via a
-    // future update.
-    await client.query(
-      `
-      INSERT INTO chat_participants (chat_participant_id, chat_id, participant_id, role)
-      VALUES ($1, $2, $3, 'member'), ($4, $2, $5, 'member')
-      `,
-      [randomUUID(), chatId, principal.userId, randomUUID(), req.otherUserId]
+    // ADS-918: never trust applicationId/otherUserId/rescueId verbatim.
+    // Resolve the real application and derive rescue_id from it —
+    // req.rescueId is ignored entirely — and verify other_user_id is the
+    // legitimate other party (rescue staff for an adopter caller, the
+    // adopter for a rescue-staff caller).
+    const rescueId = await resolveOpenChatRescueId(
+      applicationsClient,
+      rescueClient,
+      principal,
+      req.applicationId,
+      req.otherUserId
     );
 
-    publish({
-      type: 'chat.created',
-      id: `chat.created.${chatId}`,
-      payload: {
-        chatId,
-        applicationId: req.applicationId,
-        participantUserIds: [principal.userId, req.otherUserId],
-      },
+    // Idempotency: look up an existing chat for this application + pair.
+    const existing = await deps.pool.query<ChatRow>(
+      `
+      SELECT c.*
+      FROM chats c
+      WHERE c.application_id = $1
+        AND c.deleted_at IS NULL
+        AND EXISTS (
+          SELECT 1 FROM chat_participants p1
+          WHERE p1.chat_id = c.chat_id AND p1.participant_id = $2 AND p1.deleted_at IS NULL
+        )
+        AND EXISTS (
+          SELECT 1 FROM chat_participants p2
+          WHERE p2.chat_id = c.chat_id AND p2.participant_id = $3 AND p2.deleted_at IS NULL
+        )
+      LIMIT 1
+      `,
+      [req.applicationId, principal.userId, req.otherUserId]
+    );
+    if (existing.rows[0]) {
+      const chat = await chatRowToProto(deps, existing.rows[0]);
+      return { chat, created: false };
+    }
+
+    const chatId = randomUUID();
+    let inserted: ChatRow | undefined;
+    await withTransaction(deps, async ({ client, publish }) => {
+      const inserted0 = await client.query<ChatRow>(
+        `
+        INSERT INTO chats (chat_id, application_id, rescue_id, created_at, updated_at)
+        VALUES ($1, $2, $3, now(), now())
+        RETURNING *
+        `,
+        [chatId, req.applicationId, rescueId]
+      );
+      inserted = inserted0.rows[0];
+
+      // Two participant rows. Roles default to 'member' — the gateway/
+      // service.rescue can promote a rescue-staff participant via a
+      // future update.
+      await client.query(
+        `
+        INSERT INTO chat_participants (chat_participant_id, chat_id, participant_id, role)
+        VALUES ($1, $2, $3, 'member'), ($4, $2, $5, 'member')
+        `,
+        [randomUUID(), chatId, principal.userId, randomUUID(), req.otherUserId]
+      );
+
+      publish({
+        type: 'chat.created',
+        id: `chat.created.${chatId}`,
+        payload: {
+          chatId,
+          applicationId: req.applicationId,
+          participantUserIds: [principal.userId, req.otherUserId],
+        },
+      });
     });
-  });
 
-  if (!inserted) {
-    throw new HandlerError('INTERNAL', 'insert returned no rows');
+    if (!inserted) {
+      throw new HandlerError('INTERNAL', 'insert returned no rows');
+    }
+    const chat = await chatRowToProto(deps, inserted);
+    return { chat, created: true };
+  };
+}
+
+// Resolves the application referenced by OpenChatRequest and validates
+// that other_user_id is the legitimate other party:
+//   - Caller is the application's adopter → other_user_id MUST be a
+//     staff member of the application's rescue.
+//   - Caller is staff of the application's rescue → other_user_id MUST
+//     be the application's adopter.
+//   - Caller is super_admin → trusted bypass (still pins rescue_id).
+// GetApplication's own authz (adopter-owns OR rescue-staff-of-rescue OR
+// super_admin) rejects everyone else before we get here, so the final
+// throw below is defence in depth, not the primary gate.
+async function resolveOpenChatRescueId(
+  applicationsClient: ApplicationsClient,
+  rescueClient: RescueClient,
+  principal: Principal,
+  applicationId: string,
+  otherUserId: string
+): Promise<string> {
+  let res;
+  try {
+    res = await applicationsClient.getApplication(
+      { applicationId, includeTimeline: false },
+      principalToMetadata(principal)
+    );
+  } catch (err) {
+    const code = (err as { code?: number }).code;
+    if (code === CROSS_SERVICE_GRPC_NOT_FOUND) {
+      throw new HandlerError('INVALID_ARGUMENT', `application ${applicationId} not found`);
+    }
+    if (code === CROSS_SERVICE_GRPC_PERMISSION_DENIED) {
+      throw new HandlerError('PERMISSION_DENIED', 'not authorized for this application');
+    }
+    throw new HandlerError('INTERNAL', 'failed to resolve application');
   }
-  const chat = await chatRowToProto(deps, inserted);
-  return { chat, created: true };
+
+  const app = res.application;
+  if (!app) {
+    throw new HandlerError('INVALID_ARGUMENT', `application ${applicationId} not found`);
+  }
+
+  if (principal.userId === app.adopterId) {
+    const staff = await rescueClient.listStaffMembers({ rescueId: app.rescueId });
+    const isStaff = staff.staffMembers.some(member => member.userId === otherUserId);
+    if (!isStaff) {
+      throw new HandlerError('INVALID_ARGUMENT', 'other_user_id must be rescue staff');
+    }
+    return app.rescueId;
+  }
+
+  if (principal.rescueId !== undefined && principal.rescueId === app.rescueId) {
+    if (otherUserId !== app.adopterId) {
+      throw new HandlerError('INVALID_ARGUMENT', 'other_user_id must be the application adopter');
+    }
+    return app.rescueId;
+  }
+
+  if (principal.roles.includes('super_admin')) {
+    return app.rescueId;
+  }
+
+  throw new HandlerError('PERMISSION_DENIED', 'not authorized to open a chat for this application');
 }
 
 // --- SendMessage -----------------------------------------------------

--- a/services/chat/src/grpc/rescue-client.test.ts
+++ b/services/chat/src/grpc/rescue-client.test.ts
@@ -1,0 +1,244 @@
+// Behaviour tests for the chat → rescue gRPC client (ADS-918):
+//   1. A server that never responds → DEADLINE_EXCEEDED within the
+//      configured deadline (bounded by time, not just error code).
+//   2. A server that fails once with UNAVAILABLE then succeeds →
+//      the call resolves and exactly 2 handler invocations occurred.
+//   3. A server that always returns PERMISSION_DENIED → no retry,
+//      error propagates after exactly 1 attempt.
+//   4. The client stamps its scoped SYSTEM principal on every call —
+//      x-user-* headers always, plus a verifiable x-principal-token
+//      when PRINCIPAL_SIGNING_KEY is configured (ADS-800).
+//
+// Each test binds a real @grpc/grpc-js Server to 127.0.0.1:0 so there
+// are no port conflicts; the server is torn down in afterEach. Direct
+// port of services/notifications/src/grpc/auth-client.test.ts.
+
+import {
+  Metadata,
+  Server,
+  ServerCredentials,
+  ServerUnaryCall,
+  sendUnaryData,
+  ServiceError,
+  status,
+} from '@grpc/grpc-js';
+
+import {
+  RescueV1,
+  type ListStaffMembersRequest,
+  type ListStaffMembersResponse,
+} from '@adopt-dont-shop/proto';
+import {
+  PRINCIPAL_TOKEN_HEADER,
+  resetDefaultPrincipalSigningKeyForTests,
+  verifyPrincipalToken,
+} from '@adopt-dont-shop/service-bootstrap';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { createRescueClient } from './rescue-client.js';
+
+// ── helpers ──────────────────────────────────────────────────────────
+
+const makeServiceError = (code: number, details: string): ServiceError => {
+  const err = new Error(details) as ServiceError;
+  err.code = code;
+  err.details = details;
+  err.metadata = new Metadata();
+  return err;
+};
+
+const LIST_REQUEST: ListStaffMembersRequest = { rescueId: 'rsc-1' };
+
+const successResponse: ListStaffMembersResponse = {
+  staffMembers: [RescueV1.StaffMember.fromPartial({ userId: 'usr-rescue', rescueId: 'rsc-1' })],
+};
+
+// ── test suite ───────────────────────────────────────────────────────
+
+describe('createRescueClient (chat) — deadline + retry behaviour', () => {
+  let server: Server;
+
+  beforeEach(() => {
+    server = new Server();
+  });
+
+  afterEach(async () => {
+    await new Promise<void>(resolve => server.tryShutdown(() => resolve()));
+  });
+
+  const startServer = async (): Promise<number> =>
+    new Promise<number>((resolve, reject) => {
+      server.bindAsync('127.0.0.1:0', ServerCredentials.createInsecure(), (err, boundPort) =>
+        err ? reject(err) : resolve(boundPort)
+      );
+    });
+
+  it('rejects with DEADLINE_EXCEEDED when the server never responds, within the deadline window', async () => {
+    server.addService(RescueV1.RescueServiceService, {
+      listStaffMembers: (
+        _call: ServerUnaryCall<ListStaffMembersRequest, ListStaffMembersResponse>,
+        _cb: sendUnaryData<ListStaffMembersResponse>
+      ) => {
+        // Intentionally never call _cb — simulates a hung server.
+      },
+    });
+
+    const port = await startServer();
+    const client = createRescueClient({
+      address: `127.0.0.1:${port}`,
+      deadlineMs: 200,
+      maxRetries: 0, // no retries so the test is fast
+    });
+
+    const start = Date.now();
+    try {
+      await client.listStaffMembers(LIST_REQUEST);
+      expect.fail('expected rejection');
+    } catch (err: unknown) {
+      const elapsed = Date.now() - start;
+      expect((err as { code?: number }).code).toBe(status.DEADLINE_EXCEEDED);
+      // Should finish near the deadline — allow generous upper bound for CI.
+      expect(elapsed).toBeLessThan(2_000);
+    } finally {
+      client.close();
+    }
+  });
+
+  it('resolves on the second attempt when the first attempt returns UNAVAILABLE', async () => {
+    let callCount = 0;
+
+    server.addService(RescueV1.RescueServiceService, {
+      listStaffMembers: (
+        _call: ServerUnaryCall<ListStaffMembersRequest, ListStaffMembersResponse>,
+        cb: sendUnaryData<ListStaffMembersResponse>
+      ) => {
+        callCount += 1;
+        if (callCount === 1) {
+          cb(makeServiceError(status.UNAVAILABLE, 'service unavailable'), null);
+        } else {
+          cb(null, successResponse);
+        }
+      },
+    });
+
+    const port = await startServer();
+    const client = createRescueClient({
+      address: `127.0.0.1:${port}`,
+      deadlineMs: 2_000,
+      maxRetries: 2,
+    });
+
+    try {
+      const result = await client.listStaffMembers(LIST_REQUEST);
+      expect(result.staffMembers).toHaveLength(1);
+      expect(result.staffMembers[0].userId).toBe('usr-rescue');
+      expect(callCount).toBe(2);
+    } finally {
+      client.close();
+    }
+  });
+
+  it('does not retry PERMISSION_DENIED and propagates the error after exactly 1 attempt', async () => {
+    let callCount = 0;
+
+    server.addService(RescueV1.RescueServiceService, {
+      listStaffMembers: (
+        _call: ServerUnaryCall<ListStaffMembersRequest, ListStaffMembersResponse>,
+        cb: sendUnaryData<ListStaffMembersResponse>
+      ) => {
+        callCount += 1;
+        cb(makeServiceError(status.PERMISSION_DENIED, 'not allowed'), null);
+      },
+    });
+
+    const port = await startServer();
+    const client = createRescueClient({
+      address: `127.0.0.1:${port}`,
+      deadlineMs: 2_000,
+      maxRetries: 2,
+    });
+
+    try {
+      await client.listStaffMembers(LIST_REQUEST);
+      expect.fail('expected rejection');
+    } catch (err: unknown) {
+      expect((err as { code?: number }).code).toBe(status.PERMISSION_DENIED);
+      expect(callCount).toBe(1);
+    } finally {
+      client.close();
+    }
+  });
+});
+
+describe('createRescueClient — signed system principal (ADS-800)', () => {
+  const SIGNING_KEY = 'chat-rescue-client-test-signing-key';
+  let server: Server;
+
+  beforeEach(() => {
+    server = new Server();
+  });
+
+  afterEach(async () => {
+    delete process.env.PRINCIPAL_SIGNING_KEY;
+    resetDefaultPrincipalSigningKeyForTests();
+    await new Promise<void>(resolve => server.tryShutdown(() => resolve()));
+  });
+
+  const startCapturingServer = async (): Promise<{ port: number; captured: Metadata[] }> => {
+    const captured: Metadata[] = [];
+    server.addService(RescueV1.RescueServiceService, {
+      listStaffMembers: (
+        call: ServerUnaryCall<ListStaffMembersRequest, ListStaffMembersResponse>,
+        cb: sendUnaryData<ListStaffMembersResponse>
+      ) => {
+        captured.push(call.metadata);
+        cb(null, successResponse);
+      },
+    });
+    const port = await new Promise<number>((resolve, reject) => {
+      server.bindAsync('127.0.0.1:0', ServerCredentials.createInsecure(), (err, boundPort) =>
+        err ? reject(err) : resolve(boundPort)
+      );
+    });
+    return { port, captured };
+  };
+
+  it('stamps a verifiable x-principal-token over the system principal when PRINCIPAL_SIGNING_KEY is set', async () => {
+    process.env.PRINCIPAL_SIGNING_KEY = SIGNING_KEY;
+    resetDefaultPrincipalSigningKeyForTests();
+
+    const { port, captured } = await startCapturingServer();
+    const client = createRescueClient({ address: `127.0.0.1:${port}` });
+    try {
+      await client.listStaffMembers(LIST_REQUEST);
+      expect(captured).toHaveLength(1);
+      const meta = captured[0];
+      // Legacy headers still present for services running without the key.
+      expect(meta.get('x-user-id')).toEqual(['svc-chat']);
+      expect(meta.get('x-user-roles')).toEqual(['admin']);
+      expect(meta.get('x-user-permissions')).toEqual(['staff.read,admin.security.manage']);
+      // And the signed token carries the same principal.
+      const token = String(meta.get(PRINCIPAL_TOKEN_HEADER)[0]);
+      const principal = verifyPrincipalToken(token, SIGNING_KEY);
+      expect(principal.userId).toBe('svc-chat');
+      expect(principal.roles).toEqual(['admin']);
+      expect(principal.permissions).toEqual(['staff.read', 'admin.security.manage']);
+    } finally {
+      client.close();
+    }
+  });
+
+  it('does not stamp x-principal-token when no signing key is configured', async () => {
+    const { port, captured } = await startCapturingServer();
+    const client = createRescueClient({ address: `127.0.0.1:${port}` });
+    try {
+      await client.listStaffMembers(LIST_REQUEST);
+      expect(captured).toHaveLength(1);
+      expect(captured[0].get(PRINCIPAL_TOKEN_HEADER)).toHaveLength(0);
+      expect(captured[0].get('x-user-id')).toEqual(['svc-chat']);
+    } finally {
+      client.close();
+    }
+  });
+});

--- a/services/chat/src/grpc/rescue-client.ts
+++ b/services/chat/src/grpc/rescue-client.ts
@@ -1,0 +1,135 @@
+// Service-to-service gRPC client for service.rescue.
+//
+// OpenChat (ADS-918) needs to confirm that the user an adopter wants to
+// chat with is actually a staff member of the rescue that owns the
+// resolved application — otherwise an adopter could pass any user_id as
+// otherUserId and get an unsolicited DM through. That check
+// (RescueService.ListStaffMembers) is itself gated on `staff.read` +
+// same-rescue membership, which the calling adopter never holds, so this
+// client stamps a narrowly-scoped SYSTEM principal (same pattern as
+// services/notifications/src/grpc/auth-client.ts) rather than forwarding
+// the caller's own principal.
+
+import { credentials, status, type CallOptions, Metadata } from '@grpc/grpc-js';
+
+import {
+  RescueV1,
+  type ListStaffMembersRequest,
+  type ListStaffMembersResponse,
+} from '@adopt-dont-shop/proto';
+import {
+  getDefaultPrincipalSigningKey,
+  PRINCIPAL_TOKEN_HEADER,
+  signPrincipalToken,
+} from '@adopt-dont-shop/service-bootstrap';
+
+export type RescueClient = {
+  listStaffMembers(req: ListStaffMembersRequest): Promise<ListStaffMembersResponse>;
+  close(): void;
+};
+
+export type CreateRescueClientOptions = {
+  address: string;
+  // Per-call deadline in milliseconds. Without one, a hung downstream
+  // service would hang this request forever; 5s caps the blast radius
+  // and lets the caller fail fast with DEADLINE_EXCEEDED.
+  deadlineMs?: number;
+  // Maximum additional attempts after the first. Only UNAVAILABLE and
+  // DEADLINE_EXCEEDED trigger a retry (both are safe for idempotent
+  // reads). Defaults to 2 (i.e. up to 3 total attempts).
+  maxRetries?: number;
+};
+
+const DEFAULT_DEADLINE_MS = 5_000;
+const DEFAULT_MAX_RETRIES = 2;
+// Retry-eligible status codes for idempotent reads.
+const RETRYABLE_CODES = new Set([status.UNAVAILABLE, status.DEADLINE_EXCEEDED]);
+
+const isRetryableError = (err: unknown): boolean => {
+  if (err === null || typeof err !== 'object') {
+    return false;
+  }
+  const code = (err as { code?: unknown }).code;
+  return typeof code === 'number' && RETRYABLE_CODES.has(code);
+};
+
+const sleep = (ms: number): Promise<void> => new Promise(resolve => setTimeout(resolve, ms));
+
+const jitteredBackoff = (attempt: number, baseMs: number): number => {
+  // Exponential backoff with ±25% jitter: 100ms, 200ms (base defaults).
+  const base = baseMs * Math.pow(2, attempt - 1);
+  return base * (0.75 + Math.random() * 0.5);
+};
+
+// System principal used ONLY for the ListStaffMembers cross-rescue lookup
+// below. `staff.read` clears listStaffMembers' base permission gate;
+// `admin.security.manage` clears its own-rescue-membership check so an
+// explicit rescue_id (any rescue, not just the caller's) is honoured —
+// see services/rescue/src/grpc/staff-foster-handlers.ts listStaffMembers.
+const SYSTEM_USER_ID = 'svc-chat';
+const SYSTEM_ROLES = ['admin'];
+const SYSTEM_PERMISSIONS = ['staff.read', 'admin.security.manage'];
+
+export const createRescueClient = (opts: CreateRescueClientOptions): RescueClient => {
+  const stub = new RescueV1.RescueServiceClient(opts.address, credentials.createInsecure());
+  const deadlineMs = opts.deadlineMs ?? DEFAULT_DEADLINE_MS;
+  const maxRetries = opts.maxRetries ?? DEFAULT_MAX_RETRIES;
+
+  // Built per attempt, not once at client creation: the signed
+  // x-principal-token (ADS-800) carries a short TTL.
+  const buildSystemMetadata = (): Metadata => {
+    const meta = new Metadata();
+    meta.set('x-user-id', SYSTEM_USER_ID);
+    meta.set('x-user-roles', SYSTEM_ROLES.join(','));
+    meta.set('x-user-permissions', SYSTEM_PERMISSIONS.join(','));
+    const signingKey = getDefaultPrincipalSigningKey();
+    if (signingKey) {
+      meta.set(
+        PRINCIPAL_TOKEN_HEADER,
+        signPrincipalToken(
+          { userId: SYSTEM_USER_ID, roles: SYSTEM_ROLES, permissions: SYSTEM_PERMISSIONS },
+          signingKey
+        )
+      );
+    }
+    return meta;
+  };
+
+  const callWithRetry = <Req, Res>(
+    fn: (
+      req: Req,
+      metadata: Metadata,
+      options: Partial<CallOptions>,
+      cb: (err: unknown, res: Res) => void
+    ) => unknown,
+    req: Req
+  ): Promise<Res> => {
+    const attempt = (remaining: number): Promise<Res> =>
+      new Promise<Res>((resolve, reject) => {
+        const options: Partial<CallOptions> = {
+          deadline: new Date(Date.now() + deadlineMs),
+        };
+        fn.call(stub, req, buildSystemMetadata(), options, (err: unknown, res: Res) => {
+          if (err) {
+            if (remaining > 0 && isRetryableError(err)) {
+              const retryIndex = maxRetries - remaining + 1;
+              sleep(jitteredBackoff(retryIndex, 100))
+                .then(() => attempt(remaining - 1))
+                .then(resolve, reject);
+            } else {
+              reject(err);
+            }
+            return;
+          }
+          resolve(res);
+        });
+      });
+
+    return attempt(maxRetries);
+  };
+
+  return {
+    listStaffMembers: req => callWithRetry(stub.listStaffMembers, req),
+    close: () => stub.close(),
+  };
+};

--- a/services/chat/src/grpc/server.test.ts
+++ b/services/chat/src/grpc/server.test.ts
@@ -1,0 +1,114 @@
+import type { NatsConnection } from 'nats';
+import type { Pool } from 'pg';
+import { describe, expect, it } from 'vitest';
+
+import { ChatV1 } from '@adopt-dont-shop/proto';
+
+import type { ChatConfig } from '../config.js';
+
+import { createGrpcServer, startGrpcServer } from './server.js';
+
+const quietLogger = {
+  info: () => undefined,
+  error: () => undefined,
+  warn: () => undefined,
+  debug: () => undefined,
+  silly: () => undefined,
+} as unknown as ReturnType<typeof import('@adopt-dont-shop/observability').createLogger>;
+
+const config: ChatConfig = {
+  port: 5006,
+  grpcPort: 6006,
+  host: '127.0.0.1',
+  environment: 'test',
+  databaseUrl: 'postgres://test',
+  schema: 'chat',
+  natsUrl: 'nats://localhost:4222',
+  applicationsGrpcUrl: 'service-applications:6005',
+  rescueGrpcUrl: 'service-rescue:6004',
+};
+
+const pool = {} as unknown as Pool;
+const nats = {} as unknown as NatsConnection;
+// Inject stub cross-service clients so the test doesn't construct real
+// gRPC channels just to assert handler registration (ADS-918).
+const applicationsClient = {
+  getApplication: () => Promise.reject(new Error('not used')),
+  close: () => undefined,
+} as unknown as Parameters<typeof createGrpcServer>[0]['applicationsClient'];
+const rescueClient = {
+  listStaffMembers: () => Promise.reject(new Error('not used')),
+  close: () => undefined,
+} as unknown as Parameters<typeof createGrpcServer>[0]['rescueClient'];
+
+describe('createGrpcServer', () => {
+  it('registers all 11 ChatService methods on the grpc.Server', () => {
+    const server = createGrpcServer({
+      config,
+      pool,
+      nats,
+      logger: quietLogger,
+      applicationsClient,
+      rescueClient,
+    });
+    const handlers = (server as unknown as { handlers: Map<string, unknown> }).handlers;
+
+    const base = '/adopt_dont_shop.chat.v1.ChatService';
+    for (const method of [
+      'OpenChat',
+      'SendMessage',
+      'ListMessages',
+      'ListChats',
+      'MarkRead',
+      'React',
+      'SearchChats',
+      'GetChatUnreadCount',
+      'DeleteMessage',
+      'GetChat',
+      'DeleteChat',
+    ]) {
+      expect(handlers.has(`${base}/${method}`)).toBe(true);
+    }
+  });
+
+  it('matches every path from the canonical ChatServiceService Definition table', () => {
+    const definition = ChatV1.ChatServiceService;
+    const expectedPaths = Object.values(definition).map(d => (d as { path: string }).path);
+
+    const server = createGrpcServer({
+      config,
+      pool,
+      nats,
+      logger: quietLogger,
+      applicationsClient,
+      rescueClient,
+    });
+    const handlers = (server as unknown as { handlers: Map<string, unknown> }).handlers;
+
+    for (const p of expectedPaths) {
+      expect(handlers.has(p)).toBe(true);
+    }
+  });
+
+  it('builds lazy cross-service clients when none are injected', () => {
+    // No applicationsClient / rescueClient — createGrpcServer constructs
+    // them from config. gRPC channels connect lazily, so nothing dials.
+    const server = createGrpcServer({ config, pool, nats, logger: quietLogger });
+    const handlers = (server as unknown as { handlers: Map<string, unknown> }).handlers;
+    expect(handlers.has('/adopt_dont_shop.chat.v1.ChatService/OpenChat')).toBe(true);
+  });
+});
+
+describe('startGrpcServer', () => {
+  it('binds, owns the cross-service clients, and shuts down cleanly', async () => {
+    const running = await startGrpcServer({
+      // Port 0 → OS-assigned, so parallel test runs can't collide.
+      config: { ...config, grpcPort: 0 },
+      pool,
+      nats,
+      logger: quietLogger,
+    });
+    expect(running.port).toBeGreaterThan(0);
+    await expect(running.shutdown()).resolves.toBeUndefined();
+  });
+});

--- a/services/chat/src/grpc/server.ts
+++ b/services/chat/src/grpc/server.ts
@@ -18,6 +18,8 @@ import { ChatV1 } from '@adopt-dont-shop/proto';
 import type { ChatConfig } from '../config.js';
 
 import { adapt } from './adapter.js';
+import { createApplicationsClient, type ApplicationsClient } from './applications-client.js';
+import { createRescueClient, type RescueClient } from './rescue-client.js';
 import {
   deleteChat,
   deleteMessage,
@@ -25,8 +27,8 @@ import {
   getChatUnreadCount,
   listChats,
   listMessages,
+  makeOpenChat,
   markRead,
-  openChat,
   react,
   searchChats,
   sendMessage,
@@ -37,6 +39,12 @@ export type CreateGrpcServerOptions = {
   pool: Pool;
   nats: NatsConnection;
   logger: Logger;
+  // Injected for OpenChat's application/staff relationship checks
+  // (ADS-918). Optional: when omitted (createGrpcServer called directly,
+  // e.g. in tests) lazy clients are built from config. startGrpcServer
+  // always builds + owns them so it can close them on shutdown.
+  applicationsClient?: ApplicationsClient;
+  rescueClient?: RescueClient;
 };
 
 export type { RunningGrpcServer };
@@ -45,9 +53,12 @@ export const createGrpcServer = (opts: CreateGrpcServerOptions): Server => {
   const { config, pool, nats, logger } = opts;
   const server = new Server();
   const deps = { pool, nats };
+  const applicationsClient =
+    opts.applicationsClient ?? createApplicationsClient({ address: config.applicationsGrpcUrl });
+  const rescueClient = opts.rescueClient ?? createRescueClient({ address: config.rescueGrpcUrl });
 
   server.addService(ChatV1.ChatServiceService, {
-    openChat: adapt(openChat, { deps, logger }),
+    openChat: adapt(makeOpenChat(applicationsClient, rescueClient), { deps, logger }),
     sendMessage: adapt(sendMessage, { deps, logger }),
     listMessages: adapt(listMessages, { deps, logger }),
     listChats: adapt(listChats, { deps, logger }),
@@ -84,6 +95,30 @@ export const startGrpcServer = async (
   opts: CreateGrpcServerOptions
 ): Promise<RunningGrpcServer> => {
   const { config, logger } = opts;
-  const server = createGrpcServer(opts);
-  return startGrpcServerShared(server, config, logger);
+  // Build + own the cross-service clients here so they're closed on
+  // shutdown (mirrors services/applications/src/grpc/server.ts).
+  const applicationsClient =
+    opts.applicationsClient ?? createApplicationsClient({ address: config.applicationsGrpcUrl });
+  const rescueClient = opts.rescueClient ?? createRescueClient({ address: config.rescueGrpcUrl });
+  const server = createGrpcServer({ ...opts, applicationsClient, rescueClient });
+  const running = await startGrpcServerShared(server, config, logger);
+
+  return {
+    ...running,
+    shutdown: () =>
+      new Promise<void>(resolve => {
+        server.tryShutdown(err => {
+          if (err) {
+            logger.error('gRPC server shutdown error', { err });
+          }
+          try {
+            applicationsClient.close();
+            rescueClient.close();
+          } catch (closeErr) {
+            logger.error('cross-service client close error', { err: closeErr });
+          }
+          resolve();
+        });
+      }),
+  };
 };

--- a/services/moderation/src/grpc/ticket-handlers.test.ts
+++ b/services/moderation/src/grpc/ticket-handlers.test.ts
@@ -154,6 +154,37 @@ describe('openSupportTicket', () => {
     const publish = (deps as { _publish?: ReturnType<typeof vi.fn> })._publish!;
     expect(publish.mock.calls[0][0]).toMatchObject({ type: 'moderation.ticketOpened' });
   });
+
+  // ADS-917: a non-admin caller must never be able to stamp an
+  // arbitrary user_id onto the ticket row / audit event.
+  it('non-admin caller supplying a mismatched user_id → PERMISSION_DENIED', async () => {
+    const { deps } = makeDeps([]);
+    await expect(
+      openSupportTicket(deps, makePrincipal({ userId: 'alice', permissions: [] }), {
+        ...VALID_OPEN,
+        userId: 'bob',
+      } as OpenSupportTicketRequest)
+    ).rejects.toMatchObject({ code: 'PERMISSION_DENIED' });
+  });
+
+  it('non-admin caller supplying their own user_id is a no-op (allowed)', async () => {
+    const { deps, query } = makeDeps([{ rows: [ticketRow()] }]);
+    await openSupportTicket(deps, makePrincipal({ userId: 'alice', permissions: [] }), {
+      ...VALID_OPEN,
+      userId: 'alice',
+    } as OpenSupportTicketRequest);
+    expect(query.mock.calls[0][1][1]).toBe('alice');
+  });
+
+  it('staff holding moderation.tickets.manage can open a ticket on behalf of another user', async () => {
+    const { deps, query } = makeDeps([{ rows: [ticketRow()] }]);
+    await openSupportTicket(
+      deps,
+      makePrincipal({ userId: 'staff-1', permissions: ['moderation.tickets.manage'] }),
+      { ...VALID_OPEN, userId: 'bob' } as OpenSupportTicketRequest
+    );
+    expect(query.mock.calls[0][1][1]).toBe('bob');
+  });
 });
 
 describe('getSupportTicket', () => {

--- a/services/moderation/src/grpc/ticket-handlers.ts
+++ b/services/moderation/src/grpc/ticket-handlers.ts
@@ -93,10 +93,29 @@ export async function openSupportTicket(
 
   const priorityDb = ticketPriorityToDb(req.priority);
   const categoryDb = ticketCategoryToDb(req.category);
-  // Prefer the request's explicit user_id; fall back to the
-  // principal. Unauthenticated opens pass neither — column is
-  // nullable.
-  const userId = req.userId !== undefined && req.userId !== '' ? req.userId : principal.userId;
+  // Identity is always derived from the authenticated principal — a
+  // caller-supplied user_id is trusted ONLY when the caller holds
+  // MODERATION_TICKETS_MANAGE (staff opening a ticket on a user's
+  // behalf during support-agent-assisted intake). Anyone else passing
+  // a user_id that doesn't match their own is rejected outright rather
+  // than silently overridden, so the caller finds out immediately
+  // instead of assuming the impersonation succeeded. (ADS-917: a
+  // caller-supplied user_id previously won unconditionally, letting
+  // any authenticated user forge another user's identity onto the
+  // ticket row and the moderation.ticketOpened audit event.)
+  const canProxy = requirePermission(principal, MODERATION_TICKETS_MANAGE);
+  if (
+    !canProxy &&
+    req.userId !== undefined &&
+    req.userId !== '' &&
+    req.userId !== principal.userId
+  ) {
+    throw new HandlerError(
+      'PERMISSION_DENIED',
+      `'${MODERATION_TICKETS_MANAGE}' required to open a ticket on behalf of another user`
+    );
+  }
+  const userId = canProxy && req.userId ? req.userId : principal.userId;
   const tags = req.tags ?? [];
 
   return withTransaction(deps, async ({ client, publish }) => {


### PR DESCRIPTION
## Summary

- **ADS-917 (High)**: `openSupportTicket` no longer trusts caller-supplied identity — `user_id` is always taken from the authenticated principal; a body `userId` is honoured only for holders of `moderation.tickets.manage` (staff on-behalf-of proxy), otherwise mismatches get `PERMISSION_DENIED`. Note: the ticket's `userEmail` criterion isn't enforceable today because the signed `Principal` carries no email — extending the principal wire format is out of scope and the forgery impact is closed by the `user_id` fix
- **ADS-918 (High)**: `openChat` now validates the relationship before any write — the referenced application is resolved via `service.applications.Get` (with the caller's principal, so downstream authz applies), adopters may only open chats with staff of the owning rescue, staff only with the app's adopter within their own rescue, and `chats.rescue_id` is always derived from the application (`req.rescueId` ignored)
- **ADS-923 (Medium)**: `deleteChat` is restricted to super_admin/moderator/admin or rescue_staff of the chat's own rescue; adopter participants get `PERMISSION_DENIED`, non-participants keep the NOT_FOUND posture. The ticket's optional per-participant `hideChat` is an additive feature (new RPC + migration) and is flagged as follow-up, not included

## Changes

- `services/moderation/src/grpc/ticket-handlers.ts` (+tests) — principal-derived identity with explicit staff proxy path
- `services/chat/src/grpc/handlers.ts` — `openChat` factory with relationship checks; `deleteChat` role gate
- `services/chat/src/grpc/applications-client.ts`, `rescue-client.ts` (new) — scoped gRPC clients, injected and closed by `server.ts`
- `services/chat/src/config.ts` — `APPLICATIONS_GRPC_URL` / `RESCUE_GRPC_URL` with compose-convention defaults

## Before requesting review

- [x] Tests for new behaviour added (TDD) — 16 new behaviour tests across the two services
- [ ] If touching `.env` requirements — new env vars have compose-convention defaults; no REQUIRED block change needed
- [x] If touching a `lib.*` — verified `lib.support-tickets` needs no change (adopter route never forwarded a body userId)

## Test plan

- [x] service.moderation: 319 tests green; service.chat: 134 tests green
- [x] New coverage: impersonation denied / staff proxy allowed; spoofed rescueId ignored; adopter→arbitrary-user rejected; cross-rescue staff rejected; adopter delete denied; moderator + own-rescue staff delete allowed
- [x] Type-check and lint clean on both services
- [ ] Reviewer note: `deleteChat` uses direct role checks because no `chats.delete` permission exists in the RBAC matrix — seeding one was judged a larger change than the fix warrants (rationale in commit body)

## Screenshots / recordings

Not applicable — backend authorization changes.

## Related

- Linear: ADS-917, ADS-918, ADS-923
- Follow-up flagged: per-participant `hideChat` (ADS-923's optional part); principal email claim (ADS-917's userEmail criterion)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q5FhHDPvEtBYRDwMAV3rtv

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q5FhHDPvEtBYRDwMAV3rtv)_