### PR TITLE
fix(lib.chat): attachment preview security — drop Google Viewer, sandbox + MIME allowlist (ADS-927/928)

### DIFF
--- a/packages/lib.chat/src/components/MessageBubbleComponent.tsx
+++ b/packages/lib.chat/src/components/MessageBubbleComponent.tsx
@@ -64,6 +64,7 @@ export function MessageBubbleComponent({
   const [pdfPreviewOpen, setPdfPreviewOpen] = useState(false);
   const [pdfPreviewUrl, setPdfPreviewUrl] = useState('');
   const [pdfPreviewFilename, setPdfPreviewFilename] = useState('');
+  const [pdfPreviewMimeType, setPdfPreviewMimeType] = useState('');
 
   const imageAttachments = message.attachments?.filter((att) => isImageFile(att.mimeType)) || [];
 
@@ -84,6 +85,7 @@ export function MessageBubbleComponent({
     if (resolvedUrl) {
       setPdfPreviewUrl(resolvedUrl);
       setPdfPreviewFilename(attachment.filename);
+      setPdfPreviewMimeType(attachment.mimeType);
       setPdfPreviewOpen(true);
 
       logEvent('pdf_viewer_opened', 1, {
@@ -280,6 +282,7 @@ export function MessageBubbleComponent({
       <PDFPreview
         url={pdfPreviewUrl}
         filename={pdfPreviewFilename}
+        mimeType={pdfPreviewMimeType}
         isOpen={pdfPreviewOpen}
         onClose={() => setPdfPreviewOpen(false)}
       />

--- a/packages/lib.chat/src/components/PDFPreview.css.ts
+++ b/packages/lib.chat/src/components/PDFPreview.css.ts
@@ -114,15 +114,6 @@ export const pdfContent = style({
   overflow: 'hidden',
 });
 
-export const pdfEmbed = style({
-  width: '100%',
-  height: '100%',
-  border: 'none',
-  borderRadius: '8px',
-  transformOrigin: 'center',
-  transition: 'transform 0.2s ease',
-});
-
 export const pdfIframe = style({
   width: '100%',
   height: '100%',

--- a/packages/lib.chat/src/components/PDFPreview.tsx
+++ b/packages/lib.chat/src/components/PDFPreview.tsx
@@ -6,11 +6,25 @@ import * as styles from './PDFPreview.css';
 interface PDFPreviewProps {
   url: string;
   filename: string;
+  mimeType: string;
   isOpen: boolean;
   onClose: () => void;
 }
 
-export const PDFPreview: React.FC<PDFPreviewProps> = ({ url, filename, isOpen, onClose }) => {
+// The "is this a PDF?" mimeType is client-declared (set by whoever created
+// the message record), not verified against the served bytes. Only render
+// an inline preview for a strict allowlist, and treat everything else as
+// download-only — never trust an unverified mimeType to pick an embedded
+// renderer.
+const PREVIEWABLE_MIME_TYPES: readonly string[] = ['application/pdf'];
+
+export const PDFPreview: React.FC<PDFPreviewProps> = ({
+  url,
+  filename,
+  mimeType,
+  isOpen,
+  onClose,
+}) => {
   const [zoom, setZoom] = useState(1);
 
   useEffect(() => {
@@ -62,19 +76,37 @@ export const PDFPreview: React.FC<PDFPreviewProps> = ({ url, filename, isOpen, o
   const handleZoomIn = () => setZoom((prev) => Math.min(prev + 0.25, 2));
   const handleZoomOut = () => setZoom((prev) => Math.max(prev - 0.25, 0.5));
 
-  // Rendered with the browser's native PDF viewer (embed/pdf.js). We never
-  // hand the attachment URL — which for a signed-URL scheme carries the
-  // signature and expiry — to a third-party viewer such as Google Docs
-  // Viewer; there is no fallback path that does so.
-  const renderPDFContent = () => (
-    <embed
-      className={styles.pdfEmbed}
-      style={{ transform: `scale(${zoom})` }}
-      src={url}
-      type="application/pdf"
-      title={filename}
-    />
-  );
+  const canPreviewInline = PREVIEWABLE_MIME_TYPES.includes(mimeType);
+
+  // Rendered with the browser's native PDF viewer. We never hand the
+  // attachment URL — which for a signed-URL scheme carries the signature
+  // and expiry — to a third-party viewer such as Google Docs Viewer; there
+  // is no fallback path that does so.
+  //
+  // The frame is sandboxed without allow-scripts/allow-same-origin: if the
+  // server ever serves bytes that don't match the declared mimeType (e.g.
+  // an HTML file registered as application/pdf), any script it contains
+  // cannot execute or read this origin's cookies/DOM. The URL itself is
+  // passed through untouched — no string-concatenated fragment.
+  const renderPDFContent = () => {
+    if (!canPreviewInline) {
+      return (
+        <div className={styles.pdfError}>
+          <p>Preview isn&apos;t available for this file type. Use the download button above.</p>
+        </div>
+      );
+    }
+
+    return (
+      <iframe
+        className={styles.pdfIframe}
+        style={{ transform: `scale(${zoom})` }}
+        src={url}
+        title={filename}
+        sandbox=""
+      />
+    );
+  };
 
   return createPortal(
     <div
@@ -96,16 +128,24 @@ export const PDFPreview: React.FC<PDFPreviewProps> = ({ url, filename, isOpen, o
         <div className={styles.pdfHeader}>
           <h3 className={styles.pdfTitle}>{filename}</h3>
           <div className={styles.pdfControls}>
-            <button
-              className={styles.pdfButtonDefault}
-              onClick={handleZoomOut}
-              disabled={zoom <= 0.5}
-            >
-              <MdZoomOut size={18} />
-            </button>
-            <button className={styles.pdfButtonDefault} onClick={handleZoomIn} disabled={zoom >= 2}>
-              <MdZoomIn size={18} />
-            </button>
+            {canPreviewInline && (
+              <>
+                <button
+                  className={styles.pdfButtonDefault}
+                  onClick={handleZoomOut}
+                  disabled={zoom <= 0.5}
+                >
+                  <MdZoomOut size={18} />
+                </button>
+                <button
+                  className={styles.pdfButtonDefault}
+                  onClick={handleZoomIn}
+                  disabled={zoom >= 2}
+                >
+                  <MdZoomIn size={18} />
+                </button>
+              </>
+            )}
             <a
               className={styles.pdfButtonPrimary}
               href={url}

--- a/packages/lib.chat/src/components/PDFPreview.tsx
+++ b/packages/lib.chat/src/components/PDFPreview.tsx
@@ -12,8 +12,6 @@ interface PDFPreviewProps {
 
 export const PDFPreview: React.FC<PDFPreviewProps> = ({ url, filename, isOpen, onClose }) => {
   const [zoom, setZoom] = useState(1);
-  // Default to inline embed; fall back to Google Viewer only when the embed errors.
-  const [viewMethod, setViewMethod] = useState<'embed' | 'iframe' | 'google'>('embed');
 
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
@@ -64,46 +62,19 @@ export const PDFPreview: React.FC<PDFPreviewProps> = ({ url, filename, isOpen, o
   const handleZoomIn = () => setZoom((prev) => Math.min(prev + 0.25, 2));
   const handleZoomOut = () => setZoom((prev) => Math.max(prev - 0.25, 0.5));
 
-  const renderPDFContent = () => {
-    if (viewMethod === 'google') {
-      const googleViewerUrl = `https://docs.google.com/viewer?url=${encodeURIComponent(url)}&embedded=true`;
-      return (
-        <iframe
-          className={styles.pdfIframe}
-          style={{ transform: `scale(${zoom})` }}
-          src={googleViewerUrl}
-          title={filename}
-          onError={() => {
-            // Google Viewer failed — fall back to a download prompt via
-            // the download link in the header.
-          }}
-        />
-      );
-    }
-
-    if (viewMethod === 'iframe') {
-      return (
-        <iframe
-          className={styles.pdfIframe}
-          style={{ transform: `scale(${zoom})` }}
-          src={`${url}#toolbar=1&navpanes=1&scrollbar=1&view=FitH`}
-          title={filename}
-          onError={() => setViewMethod('google')}
-        />
-      );
-    }
-
-    // Default: inline <embed>. Falls back to Google Viewer on error.
-    return (
-      <embed
-        className={styles.pdfEmbed}
-        style={{ transform: `scale(${zoom})` }}
-        src={url}
-        type="application/pdf"
-        title={filename}
-      />
-    );
-  };
+  // Rendered with the browser's native PDF viewer (embed/pdf.js). We never
+  // hand the attachment URL — which for a signed-URL scheme carries the
+  // signature and expiry — to a third-party viewer such as Google Docs
+  // Viewer; there is no fallback path that does so.
+  const renderPDFContent = () => (
+    <embed
+      className={styles.pdfEmbed}
+      style={{ transform: `scale(${zoom})` }}
+      src={url}
+      type="application/pdf"
+      title={filename}
+    />
+  );
 
   return createPortal(
     <div
@@ -134,13 +105,6 @@ export const PDFPreview: React.FC<PDFPreviewProps> = ({ url, filename, isOpen, o
             </button>
             <button className={styles.pdfButtonDefault} onClick={handleZoomIn} disabled={zoom >= 2}>
               <MdZoomIn size={18} />
-            </button>
-            <button
-              className={styles.pdfButtonDefault}
-              onClick={() => setViewMethod('google')}
-              title="Open with Google Viewer"
-            >
-              &#128196;
             </button>
             <a
               className={styles.pdfButtonPrimary}

--- a/packages/lib.chat/src/components/__tests__/PDFPreview.test.tsx
+++ b/packages/lib.chat/src/components/__tests__/PDFPreview.test.tsx
@@ -1,6 +1,9 @@
 import { render, screen } from '@testing-library/react';
 import { PDFPreview } from '../PDFPreview';
 
+// PDFPreview renders via createPortal(..., document.body), so assertions
+// query the document (via `screen`, which is document-scoped) rather than
+// the RTL render() container.
 const baseProps = {
   url: 'https://files.example.com/attachments/adoption-form.pdf?sig=abc123&expires=999',
   filename: 'adoption-form.pdf',
@@ -11,12 +14,11 @@ const baseProps = {
 
 describe('PDFPreview', () => {
   it('never sends the attachment URL to a third-party viewer (docs.google.com)', () => {
-    const { container } = render(<PDFPreview {...baseProps} />);
+    render(<PDFPreview {...baseProps} />);
 
-    // No element anywhere in the preview should reference the Google
-    // Docs Viewer — no iframe src, no embed src, no link.
-    const html = container.innerHTML;
-    expect(html).not.toContain('docs.google.com');
+    // No element anywhere in the document should reference the Google Docs
+    // Viewer — no iframe src, no embed src, no link.
+    expect(document.body.innerHTML).not.toContain('docs.google.com');
 
     // No control should offer to open the file with a third-party viewer.
     expect(screen.queryByTitle(/google viewer/i)).toBeNull();
@@ -24,8 +26,9 @@ describe('PDFPreview', () => {
   });
 
   it('renders nothing when closed', () => {
-    const { container } = render(<PDFPreview {...baseProps} isOpen={false} />);
-    expect(container.innerHTML).toBe('');
+    render(<PDFPreview {...baseProps} isOpen={false} />);
+    expect(screen.queryByText(baseProps.filename)).toBeNull();
+    expect(document.body.querySelector('iframe')).toBeNull();
   });
 
   it('offers a direct download link for the attachment', () => {
@@ -34,4 +37,33 @@ describe('PDFPreview', () => {
     expect(downloadLink).toHaveAttribute('href', baseProps.url);
     expect(downloadLink).toHaveAttribute('download', baseProps.filename);
   });
+
+  it('renders an inline preview for a verified application/pdf attachment', () => {
+    render(<PDFPreview {...baseProps} mimeType="application/pdf" />);
+    const iframe = document.body.querySelector('iframe');
+    expect(iframe).not.toBeNull();
+    // The URL is passed through untouched — no string-concatenated
+    // #toolbar fragment that could interfere with a signed URL.
+    expect(iframe).toHaveAttribute('src', baseProps.url);
+  });
+
+  it('sandboxes the inline preview so embedded content cannot script this origin', () => {
+    render(<PDFPreview {...baseProps} mimeType="application/pdf" />);
+    const iframe = document.body.querySelector('iframe');
+    expect(iframe).toHaveAttribute('sandbox');
+    const sandboxTokens = (iframe?.getAttribute('sandbox') ?? '').split(/\s+/).filter(Boolean);
+    expect(sandboxTokens).not.toContain('allow-scripts');
+    expect(sandboxTokens).not.toContain('allow-same-origin');
+  });
+
+  it.each(['text/html', 'image/svg+xml', 'application/octet-stream'])(
+    'does not render an inline preview for a non-allowlisted client-declared mimeType (%s)',
+    (mimeType) => {
+      render(<PDFPreview {...baseProps} mimeType={mimeType} />);
+      expect(document.body.querySelector('iframe')).toBeNull();
+      expect(document.body.querySelector('embed')).toBeNull();
+      // Download remains the only way to access the file.
+      expect(screen.getByRole('link')).toHaveAttribute('href', baseProps.url);
+    }
+  );
 });

--- a/packages/lib.chat/src/components/__tests__/PDFPreview.test.tsx
+++ b/packages/lib.chat/src/components/__tests__/PDFPreview.test.tsx
@@ -1,0 +1,37 @@
+import { render, screen } from '@testing-library/react';
+import { PDFPreview } from '../PDFPreview';
+
+const baseProps = {
+  url: 'https://files.example.com/attachments/adoption-form.pdf?sig=abc123&expires=999',
+  filename: 'adoption-form.pdf',
+  mimeType: 'application/pdf',
+  isOpen: true,
+  onClose: () => {},
+};
+
+describe('PDFPreview', () => {
+  it('never sends the attachment URL to a third-party viewer (docs.google.com)', () => {
+    const { container } = render(<PDFPreview {...baseProps} />);
+
+    // No element anywhere in the preview should reference the Google
+    // Docs Viewer — no iframe src, no embed src, no link.
+    const html = container.innerHTML;
+    expect(html).not.toContain('docs.google.com');
+
+    // No control should offer to open the file with a third-party viewer.
+    expect(screen.queryByTitle(/google viewer/i)).toBeNull();
+    expect(screen.queryByText(/google/i)).toBeNull();
+  });
+
+  it('renders nothing when closed', () => {
+    const { container } = render(<PDFPreview {...baseProps} isOpen={false} />);
+    expect(container.innerHTML).toBe('');
+  });
+
+  it('offers a direct download link for the attachment', () => {
+    render(<PDFPreview {...baseProps} />);
+    const downloadLink = screen.getByRole('link');
+    expect(downloadLink).toHaveAttribute('href', baseProps.url);
+    expect(downloadLink).toHaveAttribute('download', baseProps.filename);
+  });
+});


### PR DESCRIPTION
## Summary

- **ADS-927 (Medium)**: the PDF preview could embed `docs.google.com/viewer?url=<attachment-url>` (via a manual button and automatically on embed error), leaking private — possibly signed — attachment URLs to Google. The Google Viewer path is removed entirely; only the browser's native PDF rendering remains
- **ADS-928 (Medium)**: rendering was decided purely by the client-declared MIME type. Inline preview is now gated on a strict allowlist (`application/pdf` only; anything else becomes download-only), and the embed is a `<iframe sandbox="">` (no `allow-scripts`, no `allow-same-origin`) so even a mislabelled HTML upload can't execute script or touch this origin

## Changes

- `packages/lib.chat/src/components/PDFPreview.tsx` — Google Viewer removed; `mimeType` prop + allowlist; sandboxed iframe replaces `<embed>`; URL passed through untouched (no string-concatenated `#toolbar` fragment)
- `packages/lib.chat/src/components/MessageBubbleComponent.tsx` — threads `attachment.mimeType` through
- `packages/lib.chat/src/components/PDFPreview.css.ts` — orphaned `pdfEmbed` style removed
- `packages/lib.chat/src/components/__tests__/PDFPreview.test.tsx` — new behaviour tests; also fixed two pre-existing tests that asserted against the RTL `container` even though the component portals into `document.body` (they passed vacuously before)

## Before requesting review

- [x] Tests for new behaviour added (TDD)
- [ ] If touching `.env` requirements — not applicable
- [x] If touching a `lib.*`, considered consumer impact — no app imports `PDFPreview` directly; `MessageBubbleComponent`'s public props are unchanged, so no consuming-app updates needed

## Test plan

- [x] `pnpm --filter @adopt-dont-shop/lib.chat test`: 172/172 green (the one failing suite on this package, `admin-chat-hooks.test.tsx`, fails identically on `origin/main` — pre-existing, unrelated, confirmed via stash)
- [x] Type-check, lint, and build clean for lib.chat
- [x] New coverage: non-PDF MIME gets download-only; PDF renders in a sandboxed iframe; no code path emits the attachment URL to a third-party host

## Screenshots / recordings

No visual change for legitimate PDFs (native browser viewer, as before, minus the Google fallback button).

## Related

- Linear: ADS-927, ADS-928

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q5FhHDPvEtBYRDwMAV3rtv

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q5FhHDPvEtBYRDwMAV3rtv)_