### PR TITLE
fix(reports): return partial results when a widget RPC fails (ADS-937)

### DIFF
--- a/services/gateway/src/routes/reports.test.ts
+++ b/services/gateway/src/routes/reports.test.ts
@@ -355,6 +355,41 @@ describe('/api/v1/reports gateway routes', () => {
     expect(res.statusCode).toBe(400);
   });
 
+  it('POST /execute returns 200 with per-widget status when one widget RPC fails', async () => {
+    petsMocks.getAdoptionTrend.mockResolvedValue({
+      points: [{ date: '2026-01-01', count: 5 }],
+    });
+    applicationsMocks.getStats.mockRejectedValue(new Error('service unavailable'));
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/v1/reports/execute',
+      headers: ADMIN_HEADERS,
+      payload: {
+        config: {
+          filters: {},
+          widgets: [
+            { id: 'w-ok', metric: 'adoption', chartType: 'line', options: {} },
+            { id: 'w-fail', metric: 'application', chartType: 'bar', options: {} },
+          ],
+        },
+      },
+    });
+    expect(res.statusCode).toBe(200);
+    const body = res.json() as {
+      data: {
+        widgets: Array<{ id: string; status: string; data: unknown[]; error?: string }>;
+      };
+    };
+    const [ok, failed] = body.data.widgets;
+    expect(ok.id).toBe('w-ok');
+    expect(ok.status).toBe('ok');
+    expect(ok.data).toEqual([{ date: '2026-01-01', count: 5 }]);
+    expect(failed.id).toBe('w-fail');
+    expect(failed.status).toBe('error');
+    expect(failed.error).toBe('service unavailable');
+    expect(failed.data).toEqual([]);
+  });
+
   // ── execute (saved) ──────────────────────────────────────────────────
 
   it('POST /:id/execute loads the saved config and computes widgets', async () => {

--- a/services/gateway/src/routes/reports.ts
+++ b/services/gateway/src/routes/reports.ts
@@ -308,11 +308,12 @@ async function computeWidgetData(
 async function executeConfig(
   config: ReportConfigInput,
   clients: AggregationClients,
-  metadata: Metadata
+  metadata: Metadata,
+  log: { error: (obj: Record<string, unknown>, msg: string) => void }
 ): Promise<Record<string, unknown>> {
   const filters = config.filters ?? {};
   const widgets = config.widgets ?? [];
-  const widgetResults = await Promise.all(
+  const settled = await Promise.allSettled(
     widgets.map(async widget => ({
       id: typeof widget.id === 'string' ? widget.id : '',
       data: await computeWidgetData(widget, filters, clients, metadata),
@@ -323,6 +324,28 @@ async function executeConfig(
       },
     }))
   );
+  const widgetResults = settled.map((result, i) => {
+    if (result.status === 'fulfilled') {
+      return { ...result.value, status: 'ok' };
+    }
+    const widget = widgets[i];
+    const widgetId = typeof widget?.id === 'string' ? widget.id : '';
+    const metric = typeof widget?.metric === 'string' ? widget.metric : '';
+    const errorMessage =
+      result.reason instanceof Error ? result.reason.message : String(result.reason ?? 'unknown');
+    log.error({ widgetId, metric, error: errorMessage }, 'Widget aggregation failed');
+    return {
+      id: widgetId,
+      data: [],
+      meta: {
+        metric,
+        chartType: typeof widget?.chartType === 'string' ? widget.chartType : '',
+        computedAt: new Date().toISOString(),
+      },
+      status: 'error',
+      error: errorMessage,
+    };
+  });
   return {
     widgets: widgetResults,
     filters,
@@ -710,7 +733,8 @@ export const registerReportsRoutes = async (
         const result = await executeConfig(
           config as ReportConfigInput,
           aggregationClients,
-          buildMetadata(req)
+          buildMetadata(req),
+          req.log
         );
         return reply.send({ success: true, data: result });
       } catch (err) {
@@ -749,7 +773,7 @@ export const registerReportsRoutes = async (
           return reply.code(404).send({ success: false, error: 'not found' });
         }
         const config = parseConfig(res.report.configJson);
-        const result = await executeConfig(config, aggregationClients, metadata);
+        const result = await executeConfig(config, aggregationClients, metadata, req.log);
         return reply.send({ success: true, data: result });
       } catch (err) {
         return handleGrpcError(err, reply);


### PR DESCRIPTION
## Summary

- Switch `POST /api/v1/reports/execute` and `POST /api/v1/reports/:id/execute` from `Promise.all` to `Promise.allSettled` so a single failing widget RPC no longer aborts the entire request with a 500.
- Each widget in the response now carries `status: 'ok'` or `status: 'error'`; failed widgets include an `error` message for the SPA to render a per-widget error state.
- Failed widgets are logged server-side (widget id + metric) so operators can trace them.

## Changes

- `services/gateway/src/routes/reports.ts` — `executeConfig`: `Promise.all` → `Promise.allSettled`, per-widget status mapping, server-side error logging via `req.log`.
- `services/gateway/src/routes/reports.test.ts` — new test covering the mixed-outcome path (1 ok + 1 failing widget → 200 with per-widget status).

## Before requesting review

- [x] Tests for new behaviour added (TDD)
- [x] Existing tests pass (`pnpm test` — 951/951)
- [x] No new TypeScript errors in changed files

## Test plan

- [x] Existing tests pass (`pnpm test`)
- [x] New behaviour is covered by tests — `POST /execute returns 200 with per-widget status when one widget RPC fails`
- [x] No TypeScript errors in changed files (`pnpm type-check` — errors are pre-existing in unbuilt shared packages, none in changed files)
- [x] Lint passes (pre-commit hook ran Prettier + Turbo lint)

## Related

Closes [ADS-937](https://linear.app/ideasquared/issue/ADS-937/reports-execute-one-widget-failure-fails-the-whole-preview-promiseall)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TjxJNXzVfkTNnbekdyJRmu)_