### PR TITLE
feat(gateway): add Zod validation to events routes (ADS-938)

### DIFF
--- a/services/gateway/src/routes/events.schemas.ts
+++ b/services/gateway/src/routes/events.schemas.ts
@@ -1,0 +1,122 @@
+// Zod schemas for the event CRUD routes (ADS-938).
+// Follows the same pattern as auth.schemas.ts: accept both camelCase and
+// snake_case keys via normalize helpers, validate with safeParse, return
+// toValidationFailure on failure.
+
+import { z } from 'zod';
+
+export type ValidationFailure = {
+  error: string;
+  details: { path: string; message: string }[];
+};
+
+export const toValidationFailure = (error: z.ZodError): ValidationFailure => ({
+  error: 'Invalid request body',
+  details: error.issues.map(issue => ({ path: issue.path.join('.'), message: issue.message })),
+});
+
+const pickRaw = (body: Record<string, unknown>, keys: readonly string[]): unknown => {
+  for (const key of keys) {
+    if (body[key] !== undefined && body[key] !== null) {
+      return body[key];
+    }
+  }
+  return undefined;
+};
+
+const EventTypeEnum = z.enum(['adoption', 'fundraising', 'volunteer', 'community']);
+const EventStatusEnum = z.enum(['draft', 'published', 'in_progress', 'completed', 'cancelled']);
+
+const EventLocationSchema = z.object({
+  type: z.string().min(1),
+  address: z.string().max(500).optional(),
+  city: z.string().max(100).optional(),
+  postcode: z.string().max(16).optional(),
+  virtualLink: z.string().max(2048).optional(),
+  venue: z.string().max(256).optional(),
+});
+
+export const CreateEventBodySchema = z.object({
+  name: z.string().trim().min(1, 'name is required').max(256),
+  description: z.string().trim().max(4000).default(''),
+  type: EventTypeEnum.optional().default('community'),
+  startDate: z.string().trim().min(1, 'startDate is required'),
+  endDate: z.string().trim().min(1, 'endDate is required'),
+  location: EventLocationSchema.optional(),
+  capacity: z.number().int().positive().optional(),
+  registrationRequired: z.boolean().default(false),
+  featuredPets: z.array(z.string().uuid()).default([]),
+  assignedStaff: z.array(z.string().uuid()).default([]),
+  isPublic: z.boolean().default(true),
+  imageUrl: z.string().max(2048).optional(),
+});
+
+export type CreateEventBody = z.infer<typeof CreateEventBodySchema>;
+
+export const normalizeCreateEventBody = (
+  body: Record<string, unknown>
+): Record<string, unknown> => ({
+  name: body.name,
+  description: body.description,
+  type: body.type,
+  startDate: pickRaw(body, ['startDate', 'start_date']),
+  endDate: pickRaw(body, ['endDate', 'end_date']),
+  location: body.location,
+  capacity: body.capacity,
+  registrationRequired: pickRaw(body, ['registrationRequired', 'registration_required']),
+  featuredPets: pickRaw(body, ['featuredPets', 'featured_pets']),
+  assignedStaff: pickRaw(body, ['assignedStaff', 'assigned_staff']),
+  isPublic: pickRaw(body, ['isPublic', 'is_public']),
+  imageUrl: pickRaw(body, ['imageUrl', 'image_url']),
+});
+
+export const UpdateEventBodySchema = z.object({
+  name: z.string().trim().min(1).max(256).optional(),
+  description: z.string().trim().max(4000).optional(),
+  type: EventTypeEnum.optional(),
+  startDate: z.string().trim().min(1).optional(),
+  endDate: z.string().trim().min(1).optional(),
+  location: EventLocationSchema.optional(),
+  capacity: z.number().int().positive().optional(),
+  registrationRequired: z.boolean().optional(),
+  featuredPets: z.array(z.string().uuid()).optional(),
+  assignedStaff: z.array(z.string().uuid()).optional(),
+  isPublic: z.boolean().optional(),
+  imageUrl: z.string().max(2048).optional(),
+  status: EventStatusEnum.optional(),
+});
+
+export type UpdateEventBody = z.infer<typeof UpdateEventBodySchema>;
+
+export const normalizeUpdateEventBody = (
+  body: Record<string, unknown>
+): Record<string, unknown> => ({
+  name: body.name,
+  description: body.description,
+  type: body.type,
+  startDate: pickRaw(body, ['startDate', 'start_date']),
+  endDate: pickRaw(body, ['endDate', 'end_date']),
+  location: body.location,
+  capacity: body.capacity,
+  registrationRequired: pickRaw(body, ['registrationRequired', 'registration_required']),
+  featuredPets: pickRaw(body, ['featuredPets', 'featured_pets']),
+  assignedStaff: pickRaw(body, ['assignedStaff', 'assigned_staff']),
+  isPublic: pickRaw(body, ['isPublic', 'is_public']),
+  imageUrl: pickRaw(body, ['imageUrl', 'image_url']),
+  status: body.status,
+});
+
+export const AddAttendeeBodySchema = z.object({
+  userId: z.string().uuid('userId must be a valid UUID'),
+  name: z.string().trim().min(1, 'name is required').max(256),
+  email: z.string().trim().min(1, 'email is required').max(254).email('email must be valid'),
+  notes: z.string().trim().max(1000).optional(),
+});
+
+export type AddAttendeeBody = z.infer<typeof AddAttendeeBodySchema>;
+
+export const PatchStatusBodySchema = z.object({
+  status: EventStatusEnum,
+});
+
+export type PatchStatusBody = z.infer<typeof PatchStatusBodySchema>;

--- a/services/gateway/src/routes/events.test.ts
+++ b/services/gateway/src/routes/events.test.ts
@@ -1,5 +1,5 @@
 import Fastify, { type FastifyInstance } from 'fastify';
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import type { RescueClient } from '../grpc-clients/rescue-client.js';
 

--- a/services/gateway/src/routes/events.test.ts
+++ b/services/gateway/src/routes/events.test.ts
@@ -1,0 +1,495 @@
+import Fastify, { type FastifyInstance } from 'fastify';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { RescueClient } from '../grpc-clients/rescue-client.js';
+
+import { registerEventRoutes } from './events.js';
+
+const MOCK_EVENT = {
+  id: 'evt-1',
+  rescueId: 'rsc-1',
+  name: 'Adoption Day',
+  description: 'Come meet our animals',
+  type: 2, // EVENT_TYPE_ADOPTION
+  startDate: '2026-08-01T10:00:00Z',
+  endDate: '2026-08-01T16:00:00Z',
+  location: undefined,
+  capacity: 50,
+  registrationRequired: true,
+  status: 1, // EVENT_STATUS_DRAFT
+  featuredPets: [],
+  assignedStaff: [],
+  isPublic: true,
+  imageUrl: undefined,
+  currentAttendance: 0,
+  createdAt: '2026-07-01T00:00:00Z',
+  updatedAt: '2026-07-01T00:00:00Z',
+  createdBy: 'usr-1',
+};
+
+const VALID_UUID = '123e4567-e89b-12d3-a456-426614174000';
+
+const MOCK_ATTENDEE = {
+  eventId: 'evt-1',
+  userId: VALID_UUID,
+  name: 'Jane Doe',
+  email: 'jane@example.com',
+  checkedIn: false,
+  notes: undefined,
+};
+
+function makeClient() {
+  const createEventMock = vi.fn().mockResolvedValue({ event: MOCK_EVENT });
+  const updateEventMock = vi.fn().mockResolvedValue({ event: MOCK_EVENT });
+  const deleteEventMock = vi.fn().mockResolvedValue({});
+  const listEventsMock = vi.fn().mockResolvedValue({ events: [] });
+  const getEventMock = vi.fn().mockResolvedValue({ event: MOCK_EVENT });
+  const getEventAttendeesMock = vi.fn().mockResolvedValue({ attendees: [] });
+  const addEventAttendeeMock = vi.fn().mockResolvedValue({ attendee: MOCK_ATTENDEE });
+  const checkInAttendeeMock = vi.fn().mockResolvedValue({ attendee: MOCK_ATTENDEE });
+  const getEventAnalyticsMock = vi.fn().mockResolvedValue({ analytics: {} });
+
+  const client: RescueClient = {
+    create: vi.fn(),
+    get: vi.fn(),
+    list: vi.fn(),
+    update: vi.fn(),
+    updateRescuePlan: vi.fn(),
+    getRescueStatistics: vi.fn(),
+    countRescues: vi.fn(),
+    sendRescueEmail: vi.fn(),
+    verify: vi.fn(),
+    inviteStaff: vi.fn(),
+    getMyStaffMembership: vi.fn(),
+    listStaffMembers: vi.fn(),
+    removeStaffMember: vi.fn(),
+    listRescueInvitations: vi.fn(),
+    cancelRescueInvitation: vi.fn(),
+    createFosterPlacement: vi.fn(),
+    listFosterPlacements: vi.fn(),
+    getFosterPlacement: vi.fn(),
+    endFosterPlacement: vi.fn(),
+    getInvitationByToken: vi.fn(),
+    acceptInvitation: vi.fn(),
+    listApplicationQuestions: vi.fn(),
+    createApplicationQuestion: vi.fn(),
+    deleteApplicationQuestion: vi.fn(),
+    listEvents: listEventsMock,
+    getEvent: getEventMock,
+    createEvent: createEventMock,
+    updateEvent: updateEventMock,
+    deleteEvent: deleteEventMock,
+    getEventAttendees: getEventAttendeesMock,
+    addEventAttendee: addEventAttendeeMock,
+    checkInAttendee: checkInAttendeeMock,
+    getEventAnalytics: getEventAnalyticsMock,
+    close: vi.fn(),
+  };
+
+  return {
+    client,
+    createEventMock,
+    updateEventMock,
+    addEventAttendeeMock,
+  };
+}
+
+async function makeApp(client: RescueClient): Promise<FastifyInstance> {
+  const app = Fastify({ logger: false });
+  await registerEventRoutes(app, { client });
+  return app;
+}
+
+// ─── POST /api/v1/events ─────────────────────────────────────────────────────
+
+describe('POST /api/v1/events', () => {
+  it('creates an event with camelCase body and returns 201', async () => {
+    const { client, createEventMock } = makeClient();
+    const app = await makeApp(client);
+    try {
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/v1/events',
+        payload: {
+          name: 'Adoption Day',
+          startDate: '2026-08-01T10:00:00Z',
+          endDate: '2026-08-01T16:00:00Z',
+          type: 'adoption',
+          capacity: 50,
+          registrationRequired: true,
+          featuredPets: [],
+          assignedStaff: [],
+          isPublic: true,
+        },
+      });
+      expect(res.statusCode).toBe(201);
+      expect(res.json()).toMatchObject({ success: true });
+      expect(createEventMock).toHaveBeenCalledOnce();
+      expect(createEventMock.mock.calls[0][0]).toMatchObject({
+        name: 'Adoption Day',
+        startDate: '2026-08-01T10:00:00Z',
+        endDate: '2026-08-01T16:00:00Z',
+        capacity: 50,
+        registrationRequired: true,
+        isPublic: true,
+      });
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('accepts snake_case aliases and resolves them to the same canonical fields', async () => {
+    const { client, createEventMock } = makeClient();
+    const app = await makeApp(client);
+    try {
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/v1/events',
+        payload: {
+          name: 'Foster Fair',
+          start_date: '2026-09-01T09:00:00Z',
+          end_date: '2026-09-01T15:00:00Z',
+          registration_required: false,
+          featured_pets: [],
+          assigned_staff: [],
+          is_public: false,
+          image_url: 'https://example.com/img.png',
+        },
+      });
+      expect(res.statusCode).toBe(201);
+      expect(createEventMock).toHaveBeenCalledOnce();
+      const grpcArg = createEventMock.mock.calls[0][0];
+      expect(grpcArg.startDate).toBe('2026-09-01T09:00:00Z');
+      expect(grpcArg.endDate).toBe('2026-09-01T15:00:00Z');
+      expect(grpcArg.registrationRequired).toBe(false);
+      expect(grpcArg.isPublic).toBe(false);
+      expect(grpcArg.imageUrl).toBe('https://example.com/img.png');
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('rejects a missing name with 400 and does not call gRPC', async () => {
+    const { client, createEventMock } = makeClient();
+    const app = await makeApp(client);
+    try {
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/v1/events',
+        payload: {
+          startDate: '2026-08-01T10:00:00Z',
+          endDate: '2026-08-01T16:00:00Z',
+        },
+      });
+      expect(res.statusCode).toBe(400);
+      expect(res.json()).toMatchObject({ error: 'Invalid request body' });
+      expect(createEventMock).not.toHaveBeenCalled();
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('rejects a non-integer capacity with 400', async () => {
+    const { client, createEventMock } = makeClient();
+    const app = await makeApp(client);
+    try {
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/v1/events',
+        payload: {
+          name: 'Test',
+          startDate: '2026-08-01T10:00:00Z',
+          endDate: '2026-08-01T16:00:00Z',
+          capacity: 'twenty',
+        },
+      });
+      expect(res.statusCode).toBe(400);
+      expect(res.json()).toMatchObject({ error: 'Invalid request body' });
+      expect(createEventMock).not.toHaveBeenCalled();
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('rejects an invalid event type enum with 400', async () => {
+    const { client, createEventMock } = makeClient();
+    const app = await makeApp(client);
+    try {
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/v1/events',
+        payload: {
+          name: 'Test',
+          startDate: '2026-08-01T10:00:00Z',
+          endDate: '2026-08-01T16:00:00Z',
+          type: 'party',
+        },
+      });
+      expect(res.statusCode).toBe(400);
+      expect(res.json()).toMatchObject({ error: 'Invalid request body' });
+      expect(createEventMock).not.toHaveBeenCalled();
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('rejects a non-uuid in featuredPets with 400', async () => {
+    const { client, createEventMock } = makeClient();
+    const app = await makeApp(client);
+    try {
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/v1/events',
+        payload: {
+          name: 'Test',
+          startDate: '2026-08-01T10:00:00Z',
+          endDate: '2026-08-01T16:00:00Z',
+          featuredPets: ['not-a-uuid'],
+        },
+      });
+      expect(res.statusCode).toBe(400);
+      expect(createEventMock).not.toHaveBeenCalled();
+    } finally {
+      await app.close();
+    }
+  });
+});
+
+// ─── PUT /api/v1/events/:id ───────────────────────────────────────────────────
+
+describe('PUT /api/v1/events/:id', () => {
+  it('updates an event with camelCase body and returns 200', async () => {
+    const { client, updateEventMock } = makeClient();
+    const app = await makeApp(client);
+    try {
+      const res = await app.inject({
+        method: 'PUT',
+        url: '/api/v1/events/evt-1',
+        payload: {
+          name: 'Updated Name',
+          startDate: '2026-08-02T10:00:00Z',
+          endDate: '2026-08-02T16:00:00Z',
+          isPublic: false,
+        },
+      });
+      expect(res.statusCode).toBe(200);
+      expect(res.json()).toMatchObject({ success: true });
+      expect(updateEventMock).toHaveBeenCalledOnce();
+      expect(updateEventMock.mock.calls[0][0]).toMatchObject({
+        id: 'evt-1',
+        name: 'Updated Name',
+        startDate: '2026-08-02T10:00:00Z',
+        isPublic: false,
+      });
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('accepts snake_case aliases in PUT body', async () => {
+    const { client, updateEventMock } = makeClient();
+    const app = await makeApp(client);
+    try {
+      const res = await app.inject({
+        method: 'PUT',
+        url: '/api/v1/events/evt-1',
+        payload: {
+          name: 'Snake Update',
+          start_date: '2026-08-03T10:00:00Z',
+          end_date: '2026-08-03T16:00:00Z',
+          assigned_staff: [],
+          featured_pets: [],
+          registration_required: true,
+        },
+      });
+      expect(res.statusCode).toBe(200);
+      expect(updateEventMock).toHaveBeenCalledOnce();
+      const grpcArg = updateEventMock.mock.calls[0][0];
+      expect(grpcArg.startDate).toBe('2026-08-03T10:00:00Z');
+      expect(grpcArg.endDate).toBe('2026-08-03T16:00:00Z');
+      expect(grpcArg.registrationRequired).toBe(true);
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('rejects an invalid capacity type with 400 and does not call gRPC', async () => {
+    const { client, updateEventMock } = makeClient();
+    const app = await makeApp(client);
+    try {
+      const res = await app.inject({
+        method: 'PUT',
+        url: '/api/v1/events/evt-1',
+        payload: { capacity: 'lots' },
+      });
+      expect(res.statusCode).toBe(400);
+      expect(res.json()).toMatchObject({ error: 'Invalid request body' });
+      expect(updateEventMock).not.toHaveBeenCalled();
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('rejects an invalid status enum in PUT body with 400', async () => {
+    const { client, updateEventMock } = makeClient();
+    const app = await makeApp(client);
+    try {
+      const res = await app.inject({
+        method: 'PUT',
+        url: '/api/v1/events/evt-1',
+        payload: { status: 'unknown_status' },
+      });
+      expect(res.statusCode).toBe(400);
+      expect(updateEventMock).not.toHaveBeenCalled();
+    } finally {
+      await app.close();
+    }
+  });
+});
+
+// ─── PATCH /api/v1/events/:id/status ─────────────────────────────────────────
+
+describe('PATCH /api/v1/events/:id/status', () => {
+  it('updates status with a valid enum value and returns 200', async () => {
+    const { client, updateEventMock } = makeClient();
+    const app = await makeApp(client);
+    try {
+      const res = await app.inject({
+        method: 'PATCH',
+        url: '/api/v1/events/evt-1/status',
+        payload: { status: 'published' },
+      });
+      expect(res.statusCode).toBe(200);
+      expect(updateEventMock).toHaveBeenCalledOnce();
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('rejects a missing status field with 400', async () => {
+    const { client, updateEventMock } = makeClient();
+    const app = await makeApp(client);
+    try {
+      const res = await app.inject({
+        method: 'PATCH',
+        url: '/api/v1/events/evt-1/status',
+        payload: {},
+      });
+      expect(res.statusCode).toBe(400);
+      expect(res.json()).toMatchObject({ error: 'Invalid request body' });
+      expect(updateEventMock).not.toHaveBeenCalled();
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('rejects an invalid status value with 400', async () => {
+    const { client, updateEventMock } = makeClient();
+    const app = await makeApp(client);
+    try {
+      const res = await app.inject({
+        method: 'PATCH',
+        url: '/api/v1/events/evt-1/status',
+        payload: { status: 'active' },
+      });
+      expect(res.statusCode).toBe(400);
+      expect(updateEventMock).not.toHaveBeenCalled();
+    } finally {
+      await app.close();
+    }
+  });
+});
+
+// ─── POST /api/v1/events/:id/attendees ───────────────────────────────────────
+
+describe('POST /api/v1/events/:id/attendees', () => {
+  it('registers an attendee with valid camelCase body and returns 201', async () => {
+    const { client, addEventAttendeeMock } = makeClient();
+    const app = await makeApp(client);
+    try {
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/v1/events/evt-1/attendees',
+        payload: {
+          userId: VALID_UUID,
+          name: 'Jane Doe',
+          email: 'jane@example.com',
+          notes: 'Allergic to cats',
+        },
+      });
+      expect(res.statusCode).toBe(201);
+      expect(addEventAttendeeMock).toHaveBeenCalledOnce();
+      expect(addEventAttendeeMock.mock.calls[0][0]).toMatchObject({
+        eventId: 'evt-1',
+        userId: VALID_UUID,
+        name: 'Jane Doe',
+        email: 'jane@example.com',
+        notes: 'Allergic to cats',
+      });
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('rejects a non-UUID userId with 400', async () => {
+    const { client, addEventAttendeeMock } = makeClient();
+    const app = await makeApp(client);
+    try {
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/v1/events/evt-1/attendees',
+        payload: {
+          userId: 'not-a-uuid',
+          name: 'Jane',
+          email: 'jane@example.com',
+        },
+      });
+      expect(res.statusCode).toBe(400);
+      expect(res.json()).toMatchObject({ error: 'Invalid request body' });
+      expect(addEventAttendeeMock).not.toHaveBeenCalled();
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('rejects an invalid email with 400', async () => {
+    const { client, addEventAttendeeMock } = makeClient();
+    const app = await makeApp(client);
+    try {
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/v1/events/evt-1/attendees',
+        payload: {
+          userId: VALID_UUID,
+          name: 'Jane',
+          email: 'not-an-email',
+        },
+      });
+      expect(res.statusCode).toBe(400);
+      expect(res.json()).toMatchObject({ error: 'Invalid request body' });
+      expect(addEventAttendeeMock).not.toHaveBeenCalled();
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('rejects a missing required field with 400', async () => {
+    const { client, addEventAttendeeMock } = makeClient();
+    const app = await makeApp(client);
+    try {
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/v1/events/evt-1/attendees',
+        payload: {
+          userId: VALID_UUID,
+          email: 'jane@example.com',
+          // name is missing
+        },
+      });
+      expect(res.statusCode).toBe(400);
+      expect(addEventAttendeeMock).not.toHaveBeenCalled();
+    } finally {
+      await app.close();
+    }
+  });
+});

--- a/services/gateway/src/routes/events.ts
+++ b/services/gateway/src/routes/events.ts
@@ -11,6 +11,15 @@ import { RescueV1, type CreateEventRequest, type UpdateEventRequest } from '@ado
 import type { RescueClient } from '../grpc-clients/rescue-client.js';
 import { buildMetadata } from '../middleware/metadata.js';
 import { handleGrpcError } from '../middleware/grpc-error.js';
+import {
+  toValidationFailure,
+  CreateEventBodySchema,
+  normalizeCreateEventBody,
+  UpdateEventBodySchema,
+  normalizeUpdateEventBody,
+  AddAttendeeBodySchema,
+  PatchStatusBodySchema,
+} from './events.schemas.js';
 
 export type EventRoutesOptions = {
   client: RescueClient;
@@ -219,33 +228,25 @@ export const registerEventRoutes = async (
       },
     },
     async (req, reply) => {
-      const body = (req.body ?? {}) as {
-        name?: string;
-        description?: string;
-        type?: string;
-        start_date?: string;
-        end_date?: string;
-        location?: RescueV1.EventLocation;
-        capacity?: number;
-        registration_required?: boolean;
-        featured_pets?: string[];
-        assigned_staff?: string[];
-        is_public?: boolean;
-        image_url?: string;
-      };
+      const b = (req.body ?? {}) as Record<string, unknown>;
+      const parsed = CreateEventBodySchema.safeParse(normalizeCreateEventBody(b));
+      if (!parsed.success) {
+        return reply.code(400).send(toValidationFailure(parsed.error));
+      }
+      const body = parsed.data;
       const grpcReq: CreateEventRequest = {
-        name: body.name ?? '',
-        description: body.description ?? '',
+        name: body.name,
+        description: body.description,
         type: eventTypeFromString(body.type),
-        startDate: body.start_date ?? '',
-        endDate: body.end_date ?? '',
+        startDate: body.startDate,
+        endDate: body.endDate,
         location: body.location,
         capacity: body.capacity,
-        registrationRequired: body.registration_required ?? false,
-        featuredPets: body.featured_pets ?? [],
-        assignedStaff: body.assigned_staff ?? [],
-        isPublic: body.is_public ?? true,
-        imageUrl: body.image_url,
+        registrationRequired: body.registrationRequired,
+        featuredPets: body.featuredPets,
+        assignedStaff: body.assignedStaff,
+        isPublic: body.isPublic,
+        imageUrl: body.imageUrl,
       };
       try {
         const res = await client.createEvent(grpcReq, buildMetadata(req));
@@ -278,37 +279,28 @@ export const registerEventRoutes = async (
       },
     },
     async (req, reply) => {
-      const body = (req.body ?? {}) as {
-        name?: string;
-        description?: string;
-        type?: string;
-        start_date?: string;
-        end_date?: string;
-        location?: RescueV1.EventLocation;
-        capacity?: number;
-        registration_required?: boolean;
-        featured_pets?: string[];
-        assigned_staff?: string[];
-        is_public?: boolean;
-        image_url?: string;
-        status?: string;
-      };
+      const b = (req.body ?? {}) as Record<string, unknown>;
+      const parsed = UpdateEventBodySchema.safeParse(normalizeUpdateEventBody(b));
+      if (!parsed.success) {
+        return reply.code(400).send(toValidationFailure(parsed.error));
+      }
+      const body = parsed.data;
       const grpcReq: UpdateEventRequest = {
         id: req.params.id,
         name: body.name,
         description: body.description,
         type: body.type !== undefined ? eventTypeFromString(body.type) : undefined,
-        startDate: body.start_date,
-        endDate: body.end_date,
+        startDate: body.startDate,
+        endDate: body.endDate,
         location: body.location,
         capacity: body.capacity,
-        registrationRequired: body.registration_required,
-        featuredPets: body.featured_pets ?? [],
-        hasFeaturedPets: body.featured_pets !== undefined,
-        assignedStaff: body.assigned_staff ?? [],
-        hasAssignedStaff: body.assigned_staff !== undefined,
-        isPublic: body.is_public,
-        imageUrl: body.image_url,
+        registrationRequired: body.registrationRequired,
+        featuredPets: body.featuredPets ?? [],
+        hasFeaturedPets: body.featuredPets !== undefined,
+        assignedStaff: body.assignedStaff ?? [],
+        hasAssignedStaff: body.assignedStaff !== undefined,
+        isPublic: body.isPublic,
+        imageUrl: body.imageUrl,
         status: body.status !== undefined ? eventStatusFromString(body.status) : undefined,
       };
       try {
@@ -364,14 +356,18 @@ export const registerEventRoutes = async (
       },
     },
     async (req, reply) => {
-      const body = (req.body ?? {}) as { status?: string };
+      const b = (req.body ?? {}) as Record<string, unknown>;
+      const parsed = PatchStatusBodySchema.safeParse(b);
+      if (!parsed.success) {
+        return reply.code(400).send(toValidationFailure(parsed.error));
+      }
       const grpcReq: UpdateEventRequest = {
         id: req.params.id,
         featuredPets: [],
         hasFeaturedPets: false,
         assignedStaff: [],
         hasAssignedStaff: false,
-        status: eventStatusFromString(body.status),
+        status: eventStatusFromString(parsed.data.status),
       };
       try {
         const res = await client.updateEvent(grpcReq, buildMetadata(req));
@@ -440,19 +436,19 @@ export const registerEventRoutes = async (
       },
     },
     async (req, reply) => {
-      const body = (req.body ?? {}) as {
-        userId?: string;
-        name?: string;
-        email?: string;
-        notes?: string;
-      };
+      const b = (req.body ?? {}) as Record<string, unknown>;
+      const parsed = AddAttendeeBodySchema.safeParse(b);
+      if (!parsed.success) {
+        return reply.code(400).send(toValidationFailure(parsed.error));
+      }
+      const body = parsed.data;
       try {
         const res = await client.addEventAttendee(
           {
             eventId: req.params.id,
-            userId: body.userId ?? '',
-            name: body.name ?? '',
-            email: body.email ?? '',
+            userId: body.userId,
+            name: body.name,
+            email: body.email,
             notes: body.notes,
           },
           buildMetadata(req)


### PR DESCRIPTION
## Summary

- Replace unsafe `as { ... }` body casts on the four mutating event routes with Zod schemas and `toValidationFailure`, following the pattern established for auth routes in ADS-879
- Add snake_case ↔ camelCase alias normalisation so both client conventions resolve to the same canonical camelCase fields at the gateway boundary
- Invalid input now returns structured `400 { error, details }` before any gRPC call is made, instead of silently forwarding empty/wrong-typed values to the proto encoder

## Changes

- `services/gateway/src/routes/events.schemas.ts` — new file with `CreateEventBodySchema`, `UpdateEventBodySchema`, `AddAttendeeBodySchema`, `PatchStatusBodySchema`, `normalize*` helpers, and `toValidationFailure`
- `services/gateway/src/routes/events.ts` — replaced `as { ... }` casts in `POST /events`, `PUT /events/:id`, `PATCH /events/:id/status`, and `POST /events/:id/attendees` with `safeParse` + schema-derived types
- `services/gateway/src/routes/events.test.ts` — new file, 17 tests covering happy-path, snake/camel alias resolution, and invalid-type rejection for all four mutating routes

## Before requesting review

- [x] Tests for new behaviour added (TDD)
- [ ] Ran `pnpm ci:local:quick` locally (or installed the pre-push hook — see CONTRIBUTING.md)
- [ ] If touching `.env` requirements, updated `.env.example`'s REQUIRED block
- [x] If touching a `lib.*`, considered consumer impact across `app.*` and `service.backend`

## Test plan

- [x] Existing tests pass (`pnpm test`) — 967/967 gateway tests pass
- [x] New behaviour is covered by tests — 17 new tests in `events.test.ts`
- [ ] Tested manually (describe how)
- [x] No TypeScript errors (`pnpm type-check`) — no errors in the events files
- [x] Lint passes (`pnpm lint`) — pre-commit hook ran Prettier + Turbo lint

## Related

Closes [ADS-938](https://linear.app/ideasquared/issue/ADS-938/events-rest-routes-skip-zod-validation-and-use-inconsistent-snakecamel)

---
_Generated by [Claude Code](https://claude.ai/code/session_013GkNXhiAwrbWi3H7DLaY5d)_