### PR TITLE
fix(security): service authz & input validation — favoriter enumeration, document URL, audit ip/ua (ADS-922/930/931)

### DIFF
--- a/packages/service-bootstrap/src/adapter.test.ts
+++ b/packages/service-bootstrap/src/adapter.test.ts
@@ -63,6 +63,29 @@ describe('adapt — happy path', () => {
   });
 });
 
+describe('adapt — call metadata forwarding (ADS-931)', () => {
+  it('passes the call metadata as the fourth handler argument', async () => {
+    const handler = vi.fn(
+      async (_d: HandlerDeps, _principal: unknown, _req: unknown, metadata: Metadata) => ({
+        clientIp: metadata.get('x-client-ip')[0] ?? null,
+      })
+    );
+    const { logger } = makeLogger();
+    const wrapped = adapt('service.test', handler, { deps, logger });
+
+    const callback = vi.fn() as unknown as sendUnaryData<unknown>;
+    wrapped(
+      makeCall({}, buildMetadata({ ...VALID_HEADERS, 'x-client-ip': '203.0.113.9' })),
+      callback
+    );
+    await new Promise(r => setImmediate(r));
+
+    const [err, res] = vi.mocked(callback).mock.calls[0];
+    expect(err).toBeNull();
+    expect(res).toEqual({ clientIp: '203.0.113.9' });
+  });
+});
+
 describe('adapt — error code mapping (canonical CODE_TO_GRPC table)', () => {
   it('UNAUTHENTICATED when principal headers are missing', async () => {
     const handler = vi.fn();

--- a/packages/service-bootstrap/src/adapter.ts
+++ b/packages/service-bootstrap/src/adapter.ts
@@ -80,10 +80,15 @@ const CODE_TO_GRPC: Record<HandlerErrorCode, number> = {
   INTERNAL: status.INTERNAL,
 };
 
+// Handlers may declare a fourth `metadata` parameter to read
+// gateway-stamped call metadata (e.g. x-client-ip / x-client-user-agent
+// for forensic columns — ADS-931). Three-parameter handlers remain
+// assignable, so existing services are unaffected.
 export type UnaryHandler<Deps, Req, Res> = (
   deps: Deps,
   principal: Principal,
-  req: Req
+  req: Req,
+  metadata: Metadata
 ) => Promise<Res>;
 
 export type UnaryHandlerUnauth<Deps, Req, Res> = (
@@ -125,7 +130,7 @@ export function adapt<Deps, Req, Res>(
     void runWithRequestId(requestId, async () => {
       try {
         const principal = extractPrincipal(call.metadata, verification);
-        const response = await handler(deps, principal, call.request);
+        const response = await handler(deps, principal, call.request, call.metadata);
         stop(status.OK);
         callback(null, response);
       } catch (err) {

--- a/services/applications/src/grpc/document-handlers.test.ts
+++ b/services/applications/src/grpc/document-handlers.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { HandlerError, type HandlerDeps } from './adapter.js';
 import { addDocument, listDocuments, removeDocument } from './document-handlers.js';
@@ -36,7 +36,7 @@ const documentRow = {
   application_id: 'app-1',
   type: 'reference',
   filename: 'ref.pdf',
-  url: 'https://files/ref.pdf',
+  url: '/uploads/documents/ref.pdf',
   size: 2048,
   mime_type: 'application/pdf',
   created_at: new Date('2026-06-06T10:00:00.000Z'),
@@ -51,7 +51,7 @@ describe('addDocument', () => {
         applicationId: 'app-1',
         type: 'reference',
         filename: 'ref.pdf',
-        url: 'https://files/ref.pdf',
+        url: '/uploads/documents/ref.pdf',
       })
     ).rejects.toBeInstanceOf(HandlerError);
   });
@@ -63,7 +63,7 @@ describe('addDocument', () => {
         applicationId: '',
         type: 'reference',
         filename: 'ref.pdf',
-        url: 'https://files/ref.pdf',
+        url: '/uploads/documents/ref.pdf',
       })
     ).rejects.toBeInstanceOf(HandlerError);
     expect(query).not.toHaveBeenCalled();
@@ -77,7 +77,7 @@ describe('addDocument', () => {
         applicationId: 'missing',
         type: 'reference',
         filename: 'ref.pdf',
-        url: 'https://files/ref.pdf',
+        url: '/uploads/documents/ref.pdf',
       })
     ).rejects.toMatchObject({ code: 'NOT_FOUND' });
     // Never reaches the INSERT.
@@ -92,7 +92,7 @@ describe('addDocument', () => {
         applicationId: 'app-1',
         type: 'reference',
         filename: 'ref.pdf',
-        url: 'https://files/ref.pdf',
+        url: '/uploads/documents/ref.pdf',
       })
     ).rejects.toMatchObject({ code: 'PERMISSION_DENIED' });
     expect(query).toHaveBeenCalledTimes(1);
@@ -109,7 +109,7 @@ describe('addDocument', () => {
           applicationId: 'app-1',
           type: 'reference',
           filename: 'ref.pdf',
-          url: 'https://files/ref.pdf',
+          url: '/uploads/documents/ref.pdf',
         }
       )
     ).rejects.toMatchObject({ code: 'PERMISSION_DENIED' });
@@ -126,7 +126,7 @@ describe('addDocument', () => {
       applicationId: 'app-1',
       type: 'reference',
       filename: 'ref.pdf',
-      url: 'https://files/ref.pdf',
+      url: '/uploads/documents/ref.pdf',
       size: 2048,
       mimeType: 'application/pdf',
     });
@@ -137,7 +137,7 @@ describe('addDocument', () => {
       'app-1',
       'reference',
       'ref.pdf',
-      'https://files/ref.pdf',
+      '/uploads/documents/ref.pdf',
       2048,
       'application/pdf',
       'usr-9',
@@ -147,7 +147,7 @@ describe('addDocument', () => {
       applicationId: 'app-1',
       type: 'reference',
       filename: 'ref.pdf',
-      url: 'https://files/ref.pdf',
+      url: '/uploads/documents/ref.pdf',
       size: 2048,
       mimeType: 'application/pdf',
       uploadedAt: '2026-06-06T10:00:00.000Z',
@@ -167,7 +167,7 @@ describe('addDocument', () => {
         applicationId: 'app-1',
         type: 'reference',
         filename: 'ref.pdf',
-        url: 'https://files/ref.pdf',
+        url: '/uploads/documents/ref.pdf',
       }
     );
 
@@ -184,7 +184,7 @@ describe('addDocument', () => {
       applicationId: 'app-1',
       type: 'reference',
       filename: 'ref.pdf',
-      url: 'https://files/ref.pdf',
+      url: '/uploads/documents/ref.pdf',
     });
 
     const params = query.mock.calls[1][1] as unknown[];
@@ -192,6 +192,147 @@ describe('addDocument', () => {
     expect(params[6]).toBeNull();
     expect(res.document?.size).toBeUndefined();
     expect(res.document?.mimeType).toBeUndefined();
+  });
+});
+
+describe('addDocument — url validation (ADS-930)', () => {
+  afterEach(() => {
+    delete process.env.CLOUDFRONT_DOMAIN;
+    delete process.env.S3_BUCKET_NAME;
+    delete process.env.S3_REGION;
+  });
+
+  it('rejects a javascript: url without touching the database', async () => {
+    const { deps, query } = makeDeps();
+    await expect(
+      addDocument(deps, makePrincipal(), {
+        applicationId: 'app-1',
+        type: 'reference',
+        filename: 'ref.pdf',
+        url: 'javascript:alert(1)',
+      })
+    ).rejects.toMatchObject({ code: 'INVALID_ARGUMENT' });
+    expect(query).not.toHaveBeenCalled();
+  });
+
+  it('rejects a data: url', async () => {
+    const { deps } = makeDeps();
+    await expect(
+      addDocument(deps, makePrincipal(), {
+        applicationId: 'app-1',
+        type: 'reference',
+        filename: 'ref.pdf',
+        url: 'data:text/html,<script>alert(1)</script>',
+      })
+    ).rejects.toMatchObject({ code: 'INVALID_ARGUMENT' });
+  });
+
+  it('rejects a plain http url (not https)', async () => {
+    process.env.CLOUDFRONT_DOMAIN = 'cdn.adoptdontshop.com';
+    const { deps } = makeDeps();
+    await expect(
+      addDocument(deps, makePrincipal(), {
+        applicationId: 'app-1',
+        type: 'reference',
+        filename: 'ref.pdf',
+        url: 'http://cdn.adoptdontshop.com/apps/aa/ref.pdf',
+      })
+    ).rejects.toMatchObject({ code: 'INVALID_ARGUMENT' });
+  });
+
+  it('rejects an attacker-controlled https host', async () => {
+    process.env.CLOUDFRONT_DOMAIN = 'cdn.adoptdontshop.com';
+    const { deps } = makeDeps();
+    await expect(
+      addDocument(deps, makePrincipal(), {
+        applicationId: 'app-1',
+        type: 'reference',
+        filename: 'ref.pdf',
+        url: 'https://evil.example/x',
+      })
+    ).rejects.toMatchObject({ code: 'INVALID_ARGUMENT' });
+  });
+
+  it('rejects a protocol-relative url (off-origin in disguise)', async () => {
+    const { deps } = makeDeps();
+    await expect(
+      addDocument(deps, makePrincipal(), {
+        applicationId: 'app-1',
+        type: 'reference',
+        filename: 'ref.pdf',
+        url: '//evil.example/x',
+      })
+    ).rejects.toMatchObject({ code: 'INVALID_ARGUMENT' });
+  });
+
+  it('rejects any absolute https url when no storage host is configured', async () => {
+    const { deps } = makeDeps();
+    await expect(
+      addDocument(deps, makePrincipal(), {
+        applicationId: 'app-1',
+        type: 'reference',
+        filename: 'ref.pdf',
+        url: 'https://storage.adoptdontshop.com/apps/aa/ref.pdf',
+      })
+    ).rejects.toMatchObject({ code: 'INVALID_ARGUMENT' });
+  });
+
+  it('accepts an https url on the configured CDN host', async () => {
+    process.env.CLOUDFRONT_DOMAIN = 'storage.adoptdontshop.com';
+    const { deps, query } = makeDeps();
+    query.mockResolvedValueOnce({ rows: [ownerRow({ user_id: 'usr-1' })] }).mockResolvedValueOnce({
+      rows: [{ ...documentRow, url: 'https://storage.adoptdontshop.com/apps/aa/ref.pdf' }],
+    });
+
+    const res = await addDocument(deps, makePrincipal(), {
+      applicationId: 'app-1',
+      type: 'reference',
+      filename: 'ref.pdf',
+      url: 'https://storage.adoptdontshop.com/apps/aa/ref.pdf',
+    });
+
+    expect(res.document?.url).toBe('https://storage.adoptdontshop.com/apps/aa/ref.pdf');
+  });
+
+  it('accepts an https url on the configured S3 bucket host', async () => {
+    process.env.S3_BUCKET_NAME = 'adoptdontshop-uploads';
+    process.env.S3_REGION = 'us-east-1';
+    const { deps, query } = makeDeps();
+    query.mockResolvedValueOnce({ rows: [ownerRow({ user_id: 'usr-1' })] }).mockResolvedValueOnce({
+      rows: [
+        {
+          ...documentRow,
+          url: 'https://adoptdontshop-uploads.s3.us-east-1.amazonaws.com/apps/aa/ref.pdf',
+        },
+      ],
+    });
+
+    const res = await addDocument(deps, makePrincipal(), {
+      applicationId: 'app-1',
+      type: 'reference',
+      filename: 'ref.pdf',
+      url: 'https://adoptdontshop-uploads.s3.us-east-1.amazonaws.com/apps/aa/ref.pdf',
+    });
+
+    expect(res.document?.url).toBe(
+      'https://adoptdontshop-uploads.s3.us-east-1.amazonaws.com/apps/aa/ref.pdf'
+    );
+  });
+
+  it('accepts a same-origin relative path (local storage default)', async () => {
+    const { deps, query } = makeDeps();
+    query
+      .mockResolvedValueOnce({ rows: [ownerRow({ user_id: 'usr-1' })] })
+      .mockResolvedValueOnce({ rows: [documentRow] });
+
+    const res = await addDocument(deps, makePrincipal(), {
+      applicationId: 'app-1',
+      type: 'reference',
+      filename: 'ref.pdf',
+      url: '/uploads/documents/ref.pdf',
+    });
+
+    expect(res.document?.url).toBe('/uploads/documents/ref.pdf');
   });
 });
 

--- a/services/applications/src/grpc/document-handlers.ts
+++ b/services/applications/src/grpc/document-handlers.ts
@@ -102,6 +102,49 @@ function assertOwnerOrRescue(principal: Principal, owner: OwnerRow, permission: 
   }
 }
 
+// Document URLs must reference either same-origin local storage (a
+// relative path — how STORAGE_PROVIDER=local, the dev/CI default, serves
+// uploads: packages/storage's local provider returns `${publicPath}/...`)
+// or the platform's own storage / CDN host — never an arbitrary scheme
+// (`javascript:`, `data:`, ...) or an attacker-controlled https host that
+// would turn a "document link" in the reviewer UI into a phishing / XSS
+// vector (ADS-930). The host allowlist tracks the same env vars
+// packages/storage's S3 provider uses to build public URLs, so it stays
+// correct as storage config changes without a second source of truth.
+function allowedDocumentHosts(env: NodeJS.ProcessEnv = process.env): Set<string> {
+  const hosts = new Set<string>();
+  const cloudFrontDomain = env.CLOUDFRONT_DOMAIN?.trim();
+  if (cloudFrontDomain) {
+    hosts.add(cloudFrontDomain);
+  }
+  const bucket = env.S3_BUCKET_NAME?.trim();
+  if (bucket) {
+    const region = env.S3_REGION?.trim() || 'us-east-1';
+    hosts.add(`${bucket}.s3.${region}.amazonaws.com`);
+  }
+  return hosts;
+}
+
+function assertValidDocumentUrl(url: string): void {
+  // `//host/...` is protocol-relative — browsers resolve it off-origin, so
+  // it's excluded from the same-origin relative-path allowance below.
+  if (url.startsWith('/') && !url.startsWith('//')) {
+    return;
+  }
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    throw new HandlerError('INVALID_ARGUMENT', 'url must be https or a platform-relative path');
+  }
+  if (parsed.protocol !== 'https:') {
+    throw new HandlerError('INVALID_ARGUMENT', 'url must be https or a platform-relative path');
+  }
+  if (!allowedDocumentHosts().has(parsed.host)) {
+    throw new HandlerError('INVALID_ARGUMENT', 'url must point to platform storage');
+  }
+}
+
 // --- AddDocument -----------------------------------------------------
 
 export async function addDocument(
@@ -112,6 +155,7 @@ export async function addDocument(
   if (req.applicationId === '') {
     throw new HandlerError('INVALID_ARGUMENT', 'application_id is required');
   }
+  assertValidDocumentUrl(req.url);
   const owner = await loadOwnerOrThrow(deps, req.applicationId);
   assertOwnerOrRescue(principal, owner, APPLICATIONS_UPDATE);
 

--- a/services/auth/src/migrations/026_seed_favoriters_list_permission.ts
+++ b/services/auth/src/migrations/026_seed_favoriters_list_permission.ts
@@ -1,0 +1,35 @@
+import type { MigrationBuilder } from 'node-pg-migrate';
+
+// Seed `pets.favoriters.list:any` — the ListFavoriters gate (ADS-922).
+//
+// PetService.ListFavoriters enumerates the user_ids of everyone who
+// favourited a pet. It previously gated on plain `pets.read`, which every
+// adopter holds, so any adopter could enumerate other users' favourite
+// activity (cross-tenant PII / stalking vector). The handler now requires
+// `pets.favoriters.list:any` instead.
+//
+// Deliberately granted to NO user-facing role: the only expected caller is
+// the notifications service's signed system principal (see
+// services/notifications/src/grpc/pets-client.ts), which carries the
+// permission in its x-principal-token rather than resolving it from these
+// tables. Seeding the permission row keeps the RBAC tables the single
+// registry of permission names without widening any role's grants.
+// super_admin still passes the gate via the role short-circuit in authz.
+const PERMISSION = 'pets.favoriters.list:any';
+
+export const up = async (pgm: MigrationBuilder): Promise<void> => {
+  pgm.sql(
+    `INSERT INTO auth.permissions (permission_name) VALUES ('${PERMISSION}')
+     ON CONFLICT (permission_name) DO NOTHING`
+  );
+};
+
+export const down = async (pgm: MigrationBuilder): Promise<void> => {
+  pgm.sql(
+    `DELETE FROM auth.role_permissions
+     WHERE permission_id = (
+       SELECT permission_id FROM auth.permissions WHERE permission_name = '${PERMISSION}'
+     )`
+  );
+  pgm.sql(`DELETE FROM auth.permissions WHERE permission_name = '${PERMISSION}'`);
+};

--- a/services/gateway/src/middleware/metadata.test.ts
+++ b/services/gateway/src/middleware/metadata.test.ts
@@ -4,9 +4,12 @@ import type { FastifyRequest } from 'fastify';
 
 import { buildMetadata } from './metadata.js';
 
-// buildMetadata only reads req.headers — a plain object is enough.
-function makeRequest(headers: Record<string, string | string[] | undefined>): FastifyRequest {
-  return { headers } as unknown as FastifyRequest;
+// buildMetadata reads req.headers + req.ip — a plain object is enough.
+function makeRequest(
+  headers: Record<string, string | string[] | undefined>,
+  ip?: string
+): FastifyRequest {
+  return { headers, ip } as unknown as FastifyRequest;
 }
 
 describe('buildMetadata', () => {
@@ -41,5 +44,28 @@ describe('buildMetadata', () => {
     const m = buildMetadata(makeRequest({ authorization: 'Bearer secret', cookie: 'a=b' }));
     expect(m.get('authorization')).toHaveLength(0);
     expect(m.get('cookie')).toHaveLength(0);
+  });
+
+  // ADS-931: the gateway stamps the connection-derived client context so
+  // backend services can persist forensic ip/user-agent columns without
+  // trusting the request body.
+  it('stamps x-client-ip from the connection ip and x-client-user-agent from the UA header', () => {
+    const m = buildMetadata(makeRequest({ 'user-agent': 'Mozilla/5.0 (real)' }, '203.0.113.9'));
+    expect(m.get('x-client-ip')).toEqual(['203.0.113.9']);
+    expect(m.get('x-client-user-agent')).toEqual(['Mozilla/5.0 (real)']);
+  });
+
+  it('derives x-client-ip from the gateway, ignoring a client-sent x-client-ip header', () => {
+    const m = buildMetadata(
+      makeRequest({ 'x-client-ip': '1.2.3.4', 'x-client-user-agent': 'forged' }, '203.0.113.9')
+    );
+    expect(m.get('x-client-ip')).toEqual(['203.0.113.9']);
+    expect(m.get('x-client-user-agent')).toHaveLength(0);
+  });
+
+  it('omits client context when the connection carries none', () => {
+    const m = buildMetadata(makeRequest({}));
+    expect(m.get('x-client-ip')).toHaveLength(0);
+    expect(m.get('x-client-user-agent')).toHaveLength(0);
   });
 });

--- a/services/gateway/src/middleware/metadata.ts
+++ b/services/gateway/src/middleware/metadata.ts
@@ -10,6 +10,10 @@
 //     the middleware strips any client-supplied value first)
 //   - x-request-id (stamped by the request-id middleware; either
 //     mirrored from the inbound header or minted as a UUID)
+//   - x-client-ip / x-client-user-agent (ADS-931 — stamped from the
+//     gateway's OWN connection context, never forwarded from
+//     client-supplied headers, so callers can't forge the forensic
+//     ip/user-agent columns backend services persist)
 //
 // Downstream gRPC adapters read x-request-id off `call.metadata` and
 // attach it to their logger context so a single id traces through every
@@ -27,6 +31,13 @@ const FORWARDED_HEADERS = [
   'x-request-id',
 ] as const;
 
+// Client-context metadata (ADS-931). req.ip is fastify's
+// trust-proxy-resolved connection address; the User-Agent header is the
+// connection's own. A client-sent x-client-ip / x-client-user-agent
+// header is NOT in FORWARDED_HEADERS, so it can never reach a backend.
+const CLIENT_IP_HEADER = 'x-client-ip';
+const CLIENT_USER_AGENT_HEADER = 'x-client-user-agent';
+
 export const buildMetadata = (req: FastifyRequest): Metadata => {
   const m = new Metadata();
   const headers = req.headers as Record<string, string | string[] | undefined>;
@@ -35,6 +46,13 @@ export const buildMetadata = (req: FastifyRequest): Metadata => {
     if (typeof raw === 'string' && raw.length > 0) {
       m.set(key, raw);
     }
+  }
+  if (typeof req.ip === 'string' && req.ip.length > 0) {
+    m.set(CLIENT_IP_HEADER, req.ip);
+  }
+  const userAgent = headers['user-agent'];
+  if (typeof userAgent === 'string' && userAgent.length > 0) {
+    m.set(CLIENT_USER_AGENT_HEADER, userAgent);
   }
   return m;
 };

--- a/services/gateway/src/routes/matching.ts
+++ b/services/gateway/src/routes/matching.ts
@@ -66,11 +66,13 @@ const MATCHING_RATE_LIMITS = {
   topPicks: { max: 60, timeWindow: '1 minute' },
 } as const;
 
+// userAgent / ipAddress are deliberately NOT accepted from the body:
+// they are forensic columns, stamped from the gateway's own connection
+// context via buildMetadata's x-client-ip / x-client-user-agent
+// (ADS-931). The matching handler ignores the proto body fields too.
 type StartSessionBody = {
   filtersJson?: string;
   deviceType?: string;
-  userAgent?: string;
-  ipAddress?: string;
 };
 
 type RecordSwipeBody = {
@@ -100,8 +102,6 @@ export const registerMatchingRoutes = async (
           properties: {
             filtersJson: { type: 'string' },
             deviceType: { type: 'string' },
-            userAgent: { type: 'string' },
-            ipAddress: { type: 'string' },
           },
         },
         response: {
@@ -115,8 +115,6 @@ export const registerMatchingRoutes = async (
       const grpcReq: StartSessionRequest = {
         filtersJson: body.filtersJson ?? '',
         deviceType: parseDeviceType(body.deviceType),
-        userAgent: body.userAgent,
-        ipAddress: body.ipAddress,
       };
       try {
         const res = await client.startSession(grpcReq, buildMetadata(req));
@@ -697,13 +695,13 @@ function parseTopPicksLimit(raw: string | undefined): number {
 
 // Implicit-session helper: when the SPA doesn't carry a sessionId on
 // /discovery/queue, mint one via StartSession (web device by default).
+// ip / user-agent flow via buildMetadata's x-client-ip /
+// x-client-user-agent, not the request body (ADS-931).
 async function openSession(
   client: MatchingClient,
   req: FastifyRequest,
   filtersJson: string
 ): Promise<string> {
-  const headers = req.headers as Record<string, string | string[] | undefined>;
-  const ua = typeof headers['user-agent'] === 'string' ? headers['user-agent'] : undefined;
   const res = await client.startSession(
     {
       filtersJson,
@@ -711,8 +709,6 @@ async function openSession(
       // bucket the proto offers (no DEVICE_TYPE_WEB exists). Caller can
       // override by calling /matching/sessions explicitly with `deviceType`.
       deviceType: MatchingV1.DeviceType.DEVICE_TYPE_DESKTOP,
-      userAgent: ua,
-      ipAddress: req.ip,
     },
     buildMetadata(req)
   );

--- a/services/matching/src/grpc/adapter.ts
+++ b/services/matching/src/grpc/adapter.ts
@@ -9,7 +9,7 @@ import {
 
 import type { WithTransactionDeps } from '@adopt-dont-shop/events';
 import type { Principal } from '@adopt-dont-shop/authz';
-import type { ServerUnaryCall, sendUnaryData } from '@grpc/grpc-js';
+import type { Metadata, ServerUnaryCall, sendUnaryData } from '@grpc/grpc-js';
 import type { Logger } from 'winston';
 
 const SERVICE_NAME = 'service.matching';
@@ -19,8 +19,11 @@ export type HandlerDeps = WithTransactionDeps;
 export type { HandlerErrorCode };
 export { HandlerError };
 
+// Handlers may declare a fourth `metadata` parameter to read
+// gateway-stamped call metadata (ADS-931 — startSession's forensic
+// ip/user-agent columns). Three-parameter handlers remain assignable.
 export function adapt<Req, Res>(
-  handler: (deps: HandlerDeps, principal: Principal, req: Req) => Promise<Res>,
+  handler: (deps: HandlerDeps, principal: Principal, req: Req, metadata: Metadata) => Promise<Res>,
   opts: { deps: HandlerDeps; logger: Logger }
 ): (call: ServerUnaryCall<Req, Res>, callback: sendUnaryData<Res>) => void {
   return adaptShared<HandlerDeps, Req, Res>(SERVICE_NAME, handler, opts);

--- a/services/matching/src/grpc/handlers.test.ts
+++ b/services/matching/src/grpc/handlers.test.ts
@@ -1,3 +1,4 @@
+import { Metadata } from '@grpc/grpc-js';
 import { describe, expect, it, vi } from 'vitest';
 
 import {
@@ -154,6 +155,38 @@ describe('startSession', () => {
     await startSession(deps, makePrincipal(), { filtersJson: '' } as StartSessionRequest);
     const insertCall = deps.pool.query as unknown as ReturnType<typeof vi.fn>;
     expect(insertCall.mock.calls[1][1][2]).toBe('{}');
+  });
+
+  // ADS-931: ip_address / user_agent are forensic columns. They must come
+  // from the gateway-stamped call metadata (connection origin), never from
+  // the caller-controlled request body — otherwise any adopter can forge
+  // the abuse-investigation signal.
+  it('ignores caller-supplied ipAddress/userAgent in the request body', async () => {
+    const { deps, query } = makeDeps([{ rows: [] }, { rows: [sessionRow()] }]);
+    await startSession(deps, makePrincipal(), {
+      ipAddress: '1.2.3.4',
+      userAgent: 'forged-agent',
+    } as StartSessionRequest);
+    const insertParams = query.mock.calls[1][1] as unknown[];
+    // INSERT params: session_id, user_id, filters, ip_address, user_agent, device_type
+    expect(insertParams[3]).toBeNull();
+    expect(insertParams[4]).toBeNull();
+  });
+
+  it('persists ip/user-agent from gateway-stamped call metadata', async () => {
+    const { deps, query } = makeDeps([{ rows: [] }, { rows: [sessionRow()] }]);
+    const metadata = new Metadata();
+    metadata.set('x-client-ip', '203.0.113.9');
+    metadata.set('x-client-user-agent', 'Mozilla/5.0 (real)');
+    await startSession(
+      deps,
+      makePrincipal(),
+      { ipAddress: '1.2.3.4', userAgent: 'forged-agent' } as StartSessionRequest,
+      metadata
+    );
+    const insertParams = query.mock.calls[1][1] as unknown[];
+    expect(insertParams[3]).toBe('203.0.113.9');
+    expect(insertParams[4]).toBe('Mozilla/5.0 (real)');
   });
 });
 

--- a/services/matching/src/grpc/handlers.ts
+++ b/services/matching/src/grpc/handlers.ts
@@ -17,6 +17,8 @@
 
 import { randomUUID } from 'node:crypto';
 
+import type { Metadata } from '@grpc/grpc-js';
+
 import { hasPermission, requirePermission, type Principal } from '@adopt-dont-shop/authz';
 import { withTransaction } from '@adopt-dont-shop/events';
 import { PETS_VIEW } from '@adopt-dont-shop/lib.types';
@@ -52,12 +54,33 @@ function ensureSwipePermission(principal: Principal): void {
   }
 }
 
+// ip_address / user_agent are forensic columns (abuse investigation,
+// fraud review). They must reflect the connection origin, so they are
+// read from the metadata the GATEWAY stamps at the edge (x-client-ip /
+// x-client-user-agent, from its own connection context in
+// buildMetadata) — never from the caller-controlled request body, which
+// any adopter could forge (ADS-931). Absent metadata → NULL, not a body
+// fallback. The proto's ip_address / user_agent fields are deliberately
+// ignored.
+const CLIENT_IP_HEADER = 'x-client-ip';
+const CLIENT_USER_AGENT_HEADER = 'x-client-user-agent';
+
+function metadataHeader(metadata: Metadata | undefined, key: string): string | null {
+  const values = metadata?.get(key) ?? [];
+  if (values.length === 0) {
+    return null;
+  }
+  const first = values[0];
+  return typeof first === 'string' ? first : first.toString();
+}
+
 // --- StartSession ----------------------------------------------------
 
 export async function startSession(
   deps: HandlerDeps,
   principal: Principal,
-  req: StartSessionRequest
+  req: StartSessionRequest,
+  metadata?: Metadata
 ): Promise<StartSessionResponse> {
   ensureSwipePermission(principal);
 
@@ -104,8 +127,8 @@ export async function startSession(
         sessionId,
         principal.userId,
         filtersJson,
-        req.ipAddress ?? null,
-        req.userAgent ?? null,
+        metadataHeader(metadata, CLIENT_IP_HEADER),
+        metadataHeader(metadata, CLIENT_USER_AGENT_HEADER),
         deviceTypeDb,
       ]
     );

--- a/services/notifications/src/grpc/pets-client.test.ts
+++ b/services/notifications/src/grpc/pets-client.test.ts
@@ -143,7 +143,7 @@ describe('createPetsClient — signed system principal (ADS-800)', () => {
     return { port, captured };
   };
 
-  it('stamps a verifiable x-principal-token carrying pets.read', async () => {
+  it('stamps a verifiable x-principal-token carrying pets.favoriters.list:any', async () => {
     process.env.PRINCIPAL_SIGNING_KEY = SIGNING_KEY;
     resetDefaultPrincipalSigningKeyForTests();
 
@@ -155,7 +155,7 @@ describe('createPetsClient — signed system principal (ADS-800)', () => {
       const token = String(captured[0].get(PRINCIPAL_TOKEN_HEADER)[0]);
       const principal = verifyPrincipalToken(token, SIGNING_KEY);
       expect(principal.userId).toBe('svc-notifications');
-      expect(principal.permissions).toEqual(['pets.read']);
+      expect(principal.permissions).toEqual(['pets.favoriters.list:any']);
     } finally {
       client.close();
     }

--- a/services/notifications/src/grpc/pets-client.ts
+++ b/services/notifications/src/grpc/pets-client.ts
@@ -20,9 +20,11 @@ import {
 export type CreatePetsClientOptions = {
   address: string;
   // System principal metadata — PetService.ListFavoriters gates on
-  // `pets.read`. The notifications service runs as `svc-notifications`;
-  // stamping the permission here means the fan-out handler doesn't thread
-  // metadata through.
+  // `pets.favoriters.list:any` (ADS-922), a permission no user-facing role
+  // holds; only this service's signed system principal carries it. The
+  // notifications service runs as `svc-notifications`; stamping the
+  // permission here means the fan-out handler doesn't thread metadata
+  // through.
   systemUserId?: string;
   systemRoles?: string;
   systemPermissions?: string;
@@ -69,9 +71,11 @@ export function createPetsClient(opts: CreatePetsClientOptions): PetsFavoritersC
   const systemPrincipal = {
     userId: opts.systemUserId ?? 'svc-notifications',
     roles: splitList(opts.systemRoles ?? 'admin'),
-    // pets.read → ListFavoriters (recipient discovery for the
-    // pets.statusChanged fan-out).
-    permissions: splitList(opts.systemPermissions ?? 'pets.read'),
+    // pets.favoriters.list:any → ListFavoriters (recipient discovery for
+    // the pets.statusChanged fan-out). ADS-922: this permission is
+    // deliberately not granted to any user-facing role, so only this
+    // signed system principal can call ListFavoriters.
+    permissions: splitList(opts.systemPermissions ?? 'pets.favoriters.list:any'),
   };
 
   // Built per attempt — the signed x-principal-token (ADS-800) carries a

--- a/services/pets/README.md
+++ b/services/pets/README.md
@@ -177,7 +177,7 @@ bypass the scope.
 | `UpdateStatus` | `pets.update` (scoped; appends a status transition) |
 | `Delete` | `pets.delete` (scoped; soft-delete) |
 | `GetStats` | `pets.read` (self-scoped; `pets.read:any` to override rescue filter) |
-| `ListFavoriters` | `pets.read` (service-to-service read) |
+| `ListFavoriters` | `pets.favoriters.list:any` (system-principal-only service-to-service read; no user role holds it — ADS-922) |
 
 ### NATS subjects
 

--- a/services/pets/src/grpc/handlers.test.ts
+++ b/services/pets/src/grpc/handlers.test.ts
@@ -59,6 +59,16 @@ const ADOPTER: Principal = {
   permissions: ['pets.read' as Permission],
 };
 
+// The notifications service's signed system principal (see
+// services/notifications/src/grpc/pets-client.ts) — the only caller
+// meant to reach listFavoriters (ADS-922). Not a super_admin or plain
+// admin grant: pets.favoriters.list:any is held by this principal alone.
+const SERVICE_NOTIFICATIONS: Principal = {
+  userId: 'svc-notifications' as UserId,
+  roles: ['admin'],
+  permissions: ['pets.favoriters.list:any' as Permission],
+};
+
 const SUPER_ADMIN: Principal = {
   userId: 'usr-super' as UserId,
   roles: ['super_admin'],
@@ -1095,7 +1105,7 @@ describe('listFavoriters', () => {
     mocks.poolMock.query.mockResolvedValueOnce({
       rows: [{ user_id: 'usr-1' }, { user_id: 'usr-2' }],
     });
-    const res = await listFavoriters(mocks.deps, ADOPTER, { petId: 'pet-1' });
+    const res = await listFavoriters(mocks.deps, SERVICE_NOTIFICATIONS, { petId: 'pet-1' });
     expect(res.userIds).toEqual(['usr-1', 'usr-2']);
 
     const [sql, params] = mocks.poolMock.query.mock.calls[0] as [string, unknown[]];
@@ -1108,17 +1118,19 @@ describe('listFavoriters', () => {
 
   it('returns an empty list when the pet has no favouriters', async () => {
     mocks.poolMock.query.mockResolvedValueOnce({ rows: [] });
-    const res = await listFavoriters(mocks.deps, ADOPTER, { petId: 'pet-1' });
+    const res = await listFavoriters(mocks.deps, SERVICE_NOTIFICATIONS, { petId: 'pet-1' });
     expect(res.userIds).toEqual([]);
   });
 
   it('INVALID_ARGUMENT when pet_id is missing', async () => {
-    await expect(listFavoriters(mocks.deps, ADOPTER, { petId: '' })).rejects.toMatchObject({
+    await expect(
+      listFavoriters(mocks.deps, SERVICE_NOTIFICATIONS, { petId: '' })
+    ).rejects.toMatchObject({
       code: 'INVALID_ARGUMENT',
     });
   });
 
-  it('PERMISSION_DENIED for a principal without pets.read', async () => {
+  it('PERMISSION_DENIED for a principal without pets.favoriters.list:any', async () => {
     const noPerms: Principal = {
       userId: 'usr-noperms' as UserId,
       roles: ['adopter'],
@@ -1127,6 +1139,16 @@ describe('listFavoriters', () => {
     await expect(listFavoriters(mocks.deps, noPerms, { petId: 'pet-1' })).rejects.toMatchObject({
       code: 'PERMISSION_DENIED',
     });
+  });
+
+  // ADS-922 regression: an ordinary adopter holds plain pets.read (every
+  // adopter does — see the ADOPTER fixture) but must NOT be able to
+  // enumerate who else favourited a pet.
+  it('PERMISSION_DENIED for an adopter with only pets.read', async () => {
+    await expect(listFavoriters(mocks.deps, ADOPTER, { petId: 'pet-1' })).rejects.toMatchObject({
+      code: 'PERMISSION_DENIED',
+    });
+    expect(mocks.poolMock.query).not.toHaveBeenCalled();
   });
 });
 

--- a/services/pets/src/grpc/handlers.ts
+++ b/services/pets/src/grpc/handlers.ts
@@ -1162,11 +1162,19 @@ export async function getTopBreedsByAdoptions(
 // --- ListFavoriters --------------------------------------------------
 
 // Recipient-discovery read for service.notifications: the user_ids of
-// every adopter with an ACTIVE favourite on the pet. Gated on plain
-// pets.read (same as Get / List) — no rescue scope, because favouriters
-// are cross-rescue and the caller is a trusted system principal fanning
-// out a pets.statusChanged event. A missing/soft-deleted pet just yields
-// an empty list (no NOT_FOUND): the caller only cares about recipients.
+// every adopter with an ACTIVE favourite on the pet. This enumerates
+// OTHER users' favourite activity — a cross-tenant PII / stalking-vector
+// read (ADS-922) — so it does NOT reuse plain pets.read (every adopter
+// holds that). It's gated on pets.favoriters.list:any, a permission no
+// user-facing role is ever granted (seeded to no role by migration 026);
+// only the notifications service's signed system principal carries it
+// (services/notifications/src/grpc/pets-client.ts). No rescue scope,
+// because favouriters are cross-rescue and the caller fans out a
+// pets.statusChanged event platform-wide. A missing/soft-deleted pet
+// just yields an empty list (no NOT_FOUND): the caller only cares about
+// recipients.
+const PETS_FAVORITERS_LIST_ANY: Permission = 'pets.favoriters.list:any' as Permission;
+
 export async function listFavoriters(
   deps: HandlerDeps,
   principal: Principal,
@@ -1175,8 +1183,8 @@ export async function listFavoriters(
   if (!req.petId) {
     throw new HandlerError('INVALID_ARGUMENT', 'pet_id is required');
   }
-  if (!hasPermission(principal, PETS_READ)) {
-    throw new HandlerError('PERMISSION_DENIED', `'${PETS_READ}' required`);
+  if (!hasPermission(principal, PETS_FAVORITERS_LIST_ANY)) {
+    throw new HandlerError('PERMISSION_DENIED', `'${PETS_FAVORITERS_LIST_ANY}' required`);
   }
 
   const result = await deps.pool.query<{ user_id: string }>(


### PR DESCRIPTION
## Summary

- **ADS-922 (Medium)**: `ListFavoriters` on service.pets was gated on plain `pets.read`, so any adopter could enumerate who favourited a pet. It now requires a new system-only permission `pets.favoriters.list:any` — seeded with **zero** role grants (no user-facing role holds it), carried only in the notifications service's signed system principal; `super_admin` still passes via the authz role short-circuit
- **ADS-930 (Low)**: `applicationDocuments.addDocument` wrote the caller's `url` verbatim. A write-boundary validator now rejects `javascript:`/`data:`/`http:`/protocol-relative URLs and any https host not on the platform-storage allowlist (derived from the real storage config — CloudFront domain / S3 bucket — matching `packages/storage`'s `buildUrl`); same-origin `/uploads/...` relative paths (local/dev shape) are allowed
- **ADS-931 (Low)**: matching `startSession` took `ipAddress`/`userAgent` from the request body (audit-log forgery). It now reads gateway-stamped `x-client-ip`/`x-client-user-agent` metadata and ignores the body fields; the gateway stamps these from its trust-proxy-resolved `req.ip` and the connection UA, and never forwards client-sent `x-client-*` headers

## Changes

- `services/pets/src/grpc/handlers.ts`, `services/notifications/src/grpc/pets-client.ts`, `services/auth/src/migrations/026_seed_favoriters_list_permission.ts`, `services/pets/README.md`
- `services/applications/src/grpc/document-handlers.ts` — `assertValidDocumentUrl`
- `services/matching` (`startSession`), `services/gateway` (`buildMetadata` + `/matching/sessions` schema), `packages/service-bootstrap` (`adapt` now forwards `call.metadata` as an optional 4th handler arg — 3-param handlers stay assignable, full-repo type-check confirms zero fallout)

## Before requesting review

- [x] Tests for new behaviour added (TDD red→green)
- [ ] If touching `.env` requirements — no new required vars (validator reuses existing storage config)
- [x] If touching a `lib.*`/shared package — `service-bootstrap` change is additive (optional param); repo-wide type-check green

## Test plan

- [x] Per-package `test:coverage` all green with thresholds passing: pets 171, notifications 280, auth 324, applications 277, service-bootstrap 79, matching 174, gateway 953
- [x] Full-repo `turbo type-check` green (82/82)
- [x] New coverage: adopter with only `pets.read` → PERMISSION_DENIED on ListFavoriters (no query run); `javascript:`/off-allowlist document URLs rejected; forged body ip/ua persist NULL while gateway metadata persists
- [ ] Reviewer notes: (1) the new auth migration (`026`) seeds a permission with no role grants — intentional, it's system-principal-only; (2) `x-client-*` metadata rides the same gateway-trust channel as `x-user-*` — signing these values into the principal token is deferred to the ADS-915 trust-boundary work this ticket references

## Screenshots / recordings

Not applicable — backend authz/validation.

## Related

- Linear: ADS-922, ADS-930, ADS-931
- Depends conceptually on ADS-915 (gateway trust boundary, already merged) for the ip/ua metadata trust

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q5FhHDPvEtBYRDwMAV3rtv

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q5FhHDPvEtBYRDwMAV3rtv)_