### PR TITLE
fix(gateway): scope user-metric report widget to platform admins (ADS-939)

### DIFF
--- a/services/gateway/src/routes/reports.test.ts
+++ b/services/gateway/src/routes/reports.test.ts
@@ -62,6 +62,13 @@ const ADMIN_HEADERS = {
   'x-user-permissions': 'reports.read,reports.create,reports.update,reports.delete',
 };
 
+const RESCUE_HEADERS = {
+  'x-user-id': 'usr-rescue-staff',
+  'x-user-roles': 'rescue_staff',
+  'x-user-permissions': 'reports.read,reports.create',
+  'x-rescue-id': 'rescue-1',
+};
+
 const REPORT_FIXTURE = {
   savedReportId: 'rep-1',
   userId: 'usr-1',
@@ -343,6 +350,61 @@ describe('/api/v1/reports gateway routes', () => {
         { status: 'approved', count: 3 },
       ])
     );
+  });
+
+  it('POST /execute returns the platform-wide count for a platform-admin principal', async () => {
+    authMocks.getUserStatistics.mockResolvedValue({
+      total: 10,
+      verified: 8,
+      newThisMonth: 1,
+      byStatus: [{ status: AuthV1.UserStatus.USER_STATUS_ACTIVE, count: 7 }],
+      byType: [],
+    });
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/v1/reports/execute',
+      headers: ADMIN_HEADERS,
+      payload: {
+        config: {
+          filters: {},
+          widgets: [
+            { id: 'w1', metric: 'user', chartType: 'metric-card', options: { valueKey: 'active' } },
+          ],
+        },
+      },
+    });
+    expect(res.statusCode).toBe(200);
+    const body = res.json() as { data: { widgets: Array<{ data: unknown[] }> } };
+    expect(body.data.widgets[0].data).toEqual([{ active: 7 }]);
+    expect(authMocks.getUserStatistics).toHaveBeenCalled();
+  });
+
+  it('POST /execute drops the user-metric widget for a rescue-scoped principal instead of leaking platform counts', async () => {
+    authMocks.getUserStatistics.mockResolvedValue({
+      total: 10,
+      verified: 8,
+      newThisMonth: 1,
+      byStatus: [{ status: AuthV1.UserStatus.USER_STATUS_ACTIVE, count: 7 }],
+      byType: [],
+    });
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/v1/reports/execute',
+      headers: RESCUE_HEADERS,
+      payload: {
+        config: {
+          filters: {},
+          widgets: [
+            { id: 'w1', metric: 'user', chartType: 'metric-card', options: { valueKey: 'active' } },
+          ],
+        },
+      },
+    });
+    expect(res.statusCode).toBe(200);
+    const body = res.json() as { data: { widgets: Array<{ data: unknown[]; status: string }> } };
+    expect(body.data.widgets[0].data).toEqual([]);
+    expect(body.data.widgets[0].status).toBe('ok');
+    expect(authMocks.getUserStatistics).not.toHaveBeenCalled();
   });
 
   it('POST /execute returns 400 when config is missing', async () => {

--- a/services/gateway/src/routes/reports.ts
+++ b/services/gateway/src/routes/reports.ts
@@ -14,6 +14,14 @@
 // Any other metric/chartType combination (custom widgets outside the
 // 5 presets) returns an empty data array rather than erroring.
 //
+// ADS-939: GetUserStatistics has no rescue filter (the RPC returns
+// platform-wide counts only), unlike the pets/applications aggregations
+// above which all accept `rescueIdFilter`. Rather than adding a filter
+// to the auth service (option 1 in the ticket), we take the interim
+// gateway-side drop (option 2): a non-platform-admin principal gets the
+// empty-array default instead of the RPC's platform totals, logged at
+// INFO so the drop is visible. See callerIsPlatformAdmin below.
+//
 // Known gaps (no backing RPC exists yet, so these are intentionally
 // unimplemented rather than half-built):
 //   - rescue-leaderboard rows expose {rescueId, adoptions} only — there
@@ -211,13 +219,31 @@ type AggregationClients = {
   authClient: AuthClient;
 };
 
+// Same shape as dashboard.ts's ADMIN_ROLES/callerIsAdmin — x-user-roles is
+// stamped by the gateway's authenticate middleware from the validated
+// principal (see middleware/authenticate.ts SPOOFABLE_HEADERS), so it
+// can't be forged by the client.
+const PLATFORM_ADMIN_ROLES = new Set(['admin', 'super_admin']);
+
+function callerIsPlatformAdmin(metadata: Metadata): boolean {
+  const raw = metadata.get('x-user-roles');
+  const value = typeof raw[0] === 'string' ? raw[0] : '';
+  return value
+    .split(',')
+    .map(r => r.trim())
+    .some(r => PLATFORM_ADMIN_ROLES.has(r));
+}
+
+type WidgetLogger = { info: (obj: Record<string, unknown>, msg: string) => void };
+
 // Widget → aggregation RPC dispatch. See the file-header comment for the
 // full metric/chartType → RPC mapping table.
 async function computeWidgetData(
   widget: ReportWidgetInput,
   filters: ReportFiltersInput,
   clients: AggregationClients,
-  metadata: Metadata
+  metadata: Metadata,
+  log: WidgetLogger
 ): Promise<unknown[]> {
   const metric = typeof widget.metric === 'string' ? widget.metric : '';
   const chartType = typeof widget.chartType === 'string' ? widget.chartType : '';
@@ -293,6 +319,13 @@ async function computeWidgetData(
   }
 
   if (metric === 'user' && chartType === 'metric-card') {
+    if (!callerIsPlatformAdmin(metadata)) {
+      log.info(
+        { widgetId: typeof widget.id === 'string' ? widget.id : '' },
+        'Dropping user-statistics widget for non-platform-admin principal (ADS-939)'
+      );
+      return [];
+    }
     const res = await clients.authClient.getUserStatistics({}, metadata);
     const valueKey = sanitizeKey(
       typeof options.valueKey === 'string' ? options.valueKey : 'value',
@@ -309,14 +342,14 @@ async function executeConfig(
   config: ReportConfigInput,
   clients: AggregationClients,
   metadata: Metadata,
-  log: { error: (obj: Record<string, unknown>, msg: string) => void }
+  log: WidgetLogger & { error: (obj: Record<string, unknown>, msg: string) => void }
 ): Promise<Record<string, unknown>> {
   const filters = config.filters ?? {};
   const widgets = config.widgets ?? [];
   const settled = await Promise.allSettled(
     widgets.map(async widget => ({
       id: typeof widget.id === 'string' ? widget.id : '',
-      data: await computeWidgetData(widget, filters, clients, metadata),
+      data: await computeWidgetData(widget, filters, clients, metadata, log),
       meta: {
         metric: typeof widget.metric === 'string' ? widget.metric : '',
         chartType: typeof widget.chartType === 'string' ? widget.chartType : '',


### PR DESCRIPTION
## Summary

- **ADS-939 (Medium, Security)**: the `metric=user` report widget called `GetUserStatistics` unconditionally, returning platform-wide user counts to any caller — including rescue admins who should only see their own tenant. Non-platform-admin principals now get the widget's existing empty-array fallback instead of the RPC's platform totals
- Because `GetUserStatisticsRequest` is an empty proto (no filter field — adding one is a cross-service proto + auth change), this takes the ticket's sanctioned interim approach: a **gateway-side drop** using the same non-forgeable role check (`x-user-roles`, stamped by `authenticate.ts`) that `dashboard.ts` already uses, mirrored here as `PLATFORM_ADMIN_ROLES`/`callerIsPlatformAdmin`
- **ADS-937** (one-widget-failure fails the whole preview) is **already fixed on main** via PR #1207 (`executeConfig` uses `Promise.allSettled` with per-widget ok/error results) — verified, no change; its ticket is already Done

## Changes

- `services/gateway/src/routes/reports.ts` — `callerIsPlatformAdmin` helper; `computeWidgetData`/`executeConfig` thread a logger; the `metric=user` branch short-circuits to the empty fallback (with an info log) for non-admins; widget-mapping comment documents the decision

## Before requesting review

- [x] Tests for new behaviour added (TDD — the rescue-scoped test was confirmed red before the fix)
- [ ] If touching `.env` requirements — not applicable
- [x] If touching a `lib.*` — not applicable (gateway route only)

## Test plan

- [x] `service.gateway test:coverage`: 72 files / 970 tests green, thresholds satisfied
- [x] New coverage: platform admin (`x-user-roles: admin`) still gets the real count; rescue-scoped principal (`rescue_staff` + `x-rescue-id`) gets `data: []`, `status: 'ok'`, and `getUserStatistics` is never called
- [x] Type-check and lint clean

## Screenshots / recordings

Not applicable — backend authorization scoping.

## Related

- Linear: ADS-939 (fixed here) · ADS-937 (already fixed via #1207)
- Follow-up: a proper `rescueId` filter on `GetUserStatistics` would let rescue admins see their own scoped user counts rather than an empty widget — noted as the non-interim fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q5FhHDPvEtBYRDwMAV3rtv

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q5FhHDPvEtBYRDwMAV3rtv)_