### PR TITLE
fix(rescue): close adoption-policies lost-update race + remove dead auth code (ADS-936/940)

### DIFF
--- a/packages/proto/proto/adopt_dont_shop/rescue/v1/rescue.proto
+++ b/packages/proto/proto/adopt_dont_shop/rescue/v1/rescue.proto
@@ -286,6 +286,11 @@ message Rescue {
   string plan = 27;
   // Optional ISO-8601 plan expiry. Unset = no expiry.
   optional string plan_expires_at = 28;
+  // Optimistic-concurrency version — bumped on every Update. Optional
+  // (rather than a plain scalar) so existing callers that construct a
+  // Rescue without it — fixtures, stub servers — keep working; only
+  // fetchRescue's real row-to-proto mapping is expected to set it.
+  optional uint32 version = 29;
 }
 
 // Invitation mirrors the rescue.invitations row — the pending-staff
@@ -387,6 +392,11 @@ message UpdateRescueRequest {
   optional string contact_phone = 15;
   // Replaces the settings JSON blob wholesale when present.
   optional string settings_json = 16;
+  // Optimistic-concurrency guard — the caller's last-known version.
+  // The service rejects with FAILED_PRECONDITION when the row has
+  // moved beyond this version. Unset = no check (last-write-wins,
+  // the pre-existing behaviour).
+  optional uint32 expected_version = 17;
 }
 
 message UpdateRescueResponse {

--- a/packages/proto/src/generated/proto/adopt_dont_shop/rescue/v1/rescue.ts
+++ b/packages/proto/src/generated/proto/adopt_dont_shop/rescue/v1/rescue.ts
@@ -416,6 +416,13 @@ export interface Rescue {
   plan: string;
   /** Optional ISO-8601 plan expiry. Unset = no expiry. */
   planExpiresAt?: string | undefined;
+  /**
+   * Optimistic-concurrency version — bumped on every Update. Optional
+   * (rather than a plain scalar) so existing callers that construct a
+   * Rescue without it — fixtures, stub servers — keep working; only
+   * fetchRescue's real row-to-proto mapping is expected to set it.
+   */
+  version?: number | undefined;
 }
 
 /**
@@ -517,6 +524,13 @@ export interface UpdateRescueRequest {
   contactPhone?: string | undefined;
   /** Replaces the settings JSON blob wholesale when present. */
   settingsJson?: string | undefined;
+  /**
+   * Optimistic-concurrency guard — the caller's last-known version.
+   * The service rejects with FAILED_PRECONDITION when the row has
+   * moved beyond this version. Unset = no check (last-write-wins,
+   * the pre-existing behaviour).
+   */
+  expectedVersion?: number | undefined;
 }
 
 export interface UpdateRescueResponse {
@@ -1043,6 +1057,7 @@ function createBaseRescue(): Rescue {
     updatedAt: '',
     plan: '',
     planExpiresAt: undefined,
+    version: undefined,
   };
 }
 
@@ -1131,6 +1146,9 @@ export const Rescue: MessageFns<Rescue> = {
     }
     if (message.planExpiresAt !== undefined) {
       writer.uint32(226).string(message.planExpiresAt);
+    }
+    if (message.version !== undefined) {
+      writer.uint32(232).uint32(message.version);
     }
     return writer;
   },
@@ -1366,6 +1384,14 @@ export const Rescue: MessageFns<Rescue> = {
           message.planExpiresAt = reader.string();
           continue;
         }
+        case 29: {
+          if (tag !== 232) {
+            break;
+          }
+
+          message.version = reader.uint32();
+          continue;
+        }
       }
       if ((tag & 7) === 4 || tag === 0) {
         break;
@@ -1465,6 +1491,7 @@ export const Rescue: MessageFns<Rescue> = {
         : isSet(object.plan_expires_at)
           ? globalThis.String(object.plan_expires_at)
           : undefined,
+      version: isSet(object.version) ? globalThis.Number(object.version) : undefined,
     };
   },
 
@@ -1554,6 +1581,9 @@ export const Rescue: MessageFns<Rescue> = {
     if (message.planExpiresAt !== undefined) {
       obj.planExpiresAt = message.planExpiresAt;
     }
+    if (message.version !== undefined) {
+      obj.version = Math.round(message.version);
+    }
     return obj;
   },
 
@@ -1590,6 +1620,7 @@ export const Rescue: MessageFns<Rescue> = {
     message.updatedAt = object.updatedAt ?? '';
     message.plan = object.plan ?? '';
     message.planExpiresAt = object.planExpiresAt ?? undefined;
+    message.version = object.version ?? undefined;
     return message;
   },
 };
@@ -2655,6 +2686,7 @@ function createBaseUpdateRescueRequest(): UpdateRescueRequest {
     contactEmail: undefined,
     contactPhone: undefined,
     settingsJson: undefined,
+    expectedVersion: undefined,
   };
 }
 
@@ -2707,6 +2739,9 @@ export const UpdateRescueRequest: MessageFns<UpdateRescueRequest> = {
     }
     if (message.settingsJson !== undefined) {
       writer.uint32(130).string(message.settingsJson);
+    }
+    if (message.expectedVersion !== undefined) {
+      writer.uint32(136).uint32(message.expectedVersion);
     }
     return writer;
   },
@@ -2846,6 +2881,14 @@ export const UpdateRescueRequest: MessageFns<UpdateRescueRequest> = {
           message.settingsJson = reader.string();
           continue;
         }
+        case 17: {
+          if (tag !== 136) {
+            break;
+          }
+
+          message.expectedVersion = reader.uint32();
+          continue;
+        }
       }
       if ((tag & 7) === 4 || tag === 0) {
         break;
@@ -2896,6 +2939,11 @@ export const UpdateRescueRequest: MessageFns<UpdateRescueRequest> = {
         ? globalThis.String(object.settingsJson)
         : isSet(object.settings_json)
           ? globalThis.String(object.settings_json)
+          : undefined,
+      expectedVersion: isSet(object.expectedVersion)
+        ? globalThis.Number(object.expectedVersion)
+        : isSet(object.expected_version)
+          ? globalThis.Number(object.expected_version)
           : undefined,
     };
   },
@@ -2950,6 +2998,9 @@ export const UpdateRescueRequest: MessageFns<UpdateRescueRequest> = {
     if (message.settingsJson !== undefined) {
       obj.settingsJson = message.settingsJson;
     }
+    if (message.expectedVersion !== undefined) {
+      obj.expectedVersion = Math.round(message.expectedVersion);
+    }
     return obj;
   },
 
@@ -2976,6 +3027,7 @@ export const UpdateRescueRequest: MessageFns<UpdateRescueRequest> = {
     message.contactEmail = object.contactEmail ?? undefined;
     message.contactPhone = object.contactPhone ?? undefined;
     message.settingsJson = object.settingsJson ?? undefined;
+    message.expectedVersion = object.expectedVersion ?? undefined;
     return message;
   },
 };

--- a/services/gateway/src/routes/auth.ts
+++ b/services/gateway/src/routes/auth.ts
@@ -538,9 +538,6 @@ export const registerAuthRoutes = async (
         const json = AuthV1.RegisterResponse.toJSON(res) as Record<string, unknown>;
         return reply.code(201).send(withApiUser(json, res.user));
       } catch (err) {
-        if (err instanceof BadRequestError) {
-          return reply.code(400).send({ error: err.message });
-        }
         return handleGrpcError(err, reply);
       }
     }
@@ -1103,12 +1100,6 @@ export const registerAuthRoutes = async (
 };
 
 // --- Helpers ---------------------------------------------------------
-
-// Thrown when a present field carries the wrong type. Caught in the /register
-// handler and mapped to a 400 — a non-string smuggled into a string proto field
-// is a client error, not a downstream INTERNAL. (The other routes now use Zod
-// schemas instead of pickString, so they no longer throw this.)
-class BadRequestError extends Error {}
 
 // Accept the canonical DB role string (`adopter`, `rescue_staff`, …)
 // OR the SCREAMING proto form (`USER_ROLE_ADOPTER`). The handler's

--- a/services/gateway/src/routes/rescues-public.test.ts
+++ b/services/gateway/src/routes/rescues-public.test.ts
@@ -1,3 +1,4 @@
+import { status as grpcStatus } from '@grpc/grpc-js';
 import Fastify, { type FastifyInstance } from 'fastify';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -38,6 +39,7 @@ const RESCUE = {
   settingsJson: '{}',
   createdAt: '2026-06-01T00:00:00.000Z',
   updatedAt: '2026-06-02T00:00:00.000Z',
+  version: 7,
 };
 
 describe('rescues public routes', () => {
@@ -222,7 +224,11 @@ describe('rescues public routes', () => {
     });
     expect(res.statusCode).toBe(200);
     expect(res.json()).toEqual({ success: true, data: policy });
-    const updateArg = mocks.update.mock.calls[0][0] as { rescueId: string; settingsJson: string };
+    const updateArg = mocks.update.mock.calls[0][0] as {
+      rescueId: string;
+      settingsJson: string;
+      expectedVersion: number;
+    };
     expect(updateArg.rescueId).toBe('rsc-1');
     expect(JSON.parse(updateArg.settingsJson)).toEqual({ theme: 'dark', adoptionPolicies: policy });
   });
@@ -235,5 +241,35 @@ describe('rescues public routes', () => {
       payload: {},
     });
     expect(res.statusCode).toBe(404);
+  });
+
+  // --- ADS-936: lost-update race on the settings read-merge-write ---
+
+  it('PUT /api/v1/rescues/:id/adoption-policies passes the just-read version as expectedVersion', async () => {
+    mocks.get.mockResolvedValueOnce({
+      rescue: { ...RESCUE, settingsJson: '{}', version: 7 },
+    });
+    mocks.update.mockResolvedValueOnce({ rescue: RESCUE });
+    await app.inject({
+      method: 'PUT',
+      url: '/api/v1/rescues/rsc-1/adoption-policies',
+      payload: { requireHomeVisit: true },
+    });
+    const updateArg = mocks.update.mock.calls[0][0] as { expectedVersion: number };
+    expect(updateArg.expectedVersion).toBe(7);
+  });
+
+  it('PUT /api/v1/rescues/:id/adoption-policies surfaces a 409 when a concurrent writer already moved the version', async () => {
+    mocks.get.mockResolvedValueOnce({ rescue: { ...RESCUE, settingsJson: '{}', version: 7 } });
+    mocks.update.mockRejectedValueOnce({
+      code: grpcStatus.FAILED_PRECONDITION,
+      details: 'rescue rsc-1 was modified concurrently (expected version 7); reload and retry',
+    });
+    const res = await app.inject({
+      method: 'PUT',
+      url: '/api/v1/rescues/rsc-1/adoption-policies',
+      payload: { requireHomeVisit: true },
+    });
+    expect(res.statusCode).toBe(409);
   });
 });

--- a/services/gateway/src/routes/rescues-public.ts
+++ b/services/gateway/src/routes/rescues-public.ts
@@ -587,6 +587,14 @@ export const registerRescuesPublicRoutes = async (
   // PUT /api/v1/rescues/:id/adoption-policies — replace the adoptionPolicies
   // key in settings, preserving the rest of the settings blob. UpdateRescue's
   // settingsJson field replaces the whole blob, so we read-merge-write.
+  //
+  // The read and the write are two separate RPCs, so a naive read-merge-write
+  // is racy: two concurrent PUTs can both read version N and the second
+  // writer silently clobbers the first's update (ADS-936). We close that
+  // window with optimistic concurrency — pass the version we just read as
+  // expectedVersion; UpdateRescue rejects with FAILED_PRECONDITION if the
+  // row moved on, which handleGrpcError maps to a 409 the SPA can retry
+  // from a fresh read.
   app.put<{ Params: { id: string } }>(
     '/api/v1/rescues/:id/adoption-policies',
     {
@@ -616,6 +624,12 @@ export const registerRescuesPublicRoutes = async (
               error: { type: 'string' },
             },
           },
+          409: {
+            type: 'object',
+            properties: {
+              error: { type: 'string' },
+            },
+          },
         },
       },
     },
@@ -628,7 +642,11 @@ export const registerRescuesPublicRoutes = async (
         const settings = parseSettings(current.rescue.settingsJson);
         const merged = { ...settings, adoptionPolicies: req.body ?? {} };
         const res = await client.update(
-          { rescueId: req.params.id, settingsJson: JSON.stringify(merged) },
+          {
+            rescueId: req.params.id,
+            settingsJson: JSON.stringify(merged),
+            expectedVersion: current.rescue.version,
+          },
           buildMetadata(req)
         );
         if (res.rescue === undefined) {

--- a/services/rescue/src/grpc/handlers.test.ts
+++ b/services/rescue/src/grpc/handlers.test.ts
@@ -315,6 +315,63 @@ describe('updateRescue', () => {
     await updateRescue(mocks.deps, STAFF, { rescueId: 'rsc-1', name: 'Pawsome 2' } as never);
     expect(msgID).toBe('rescue.updated.rsc-1:3');
   });
+
+  // --- ADS-936: optimistic concurrency guard on settings read-merge-write ---
+
+  it('adds a version guard to the WHERE clause when expectedVersion is supplied', async () => {
+    mocks.poolMock.query.mockResolvedValueOnce({ rows: [rescueRow({ version: 5 })] });
+    mocks.clientMock.query.mockResolvedValue({ rows: [rescueRow({ version: 6 })] });
+
+    await updateRescue(mocks.deps, STAFF, {
+      rescueId: 'rsc-1',
+      settingsJson: '{"adoptionPolicies":{"minAge":1}}',
+      expectedVersion: 5,
+    } as never);
+
+    const sql = mocks.clientMock.query.mock.calls[1][0] as string;
+    const params = mocks.clientMock.query.mock.calls[1][1] as unknown[];
+    expect(sql).toMatch(/AND version = \$\d+/);
+    expect(params).toContain(5);
+  });
+
+  it('FAILED_PRECONDITION when the row moved past expectedVersion (concurrent write lost the race)', async () => {
+    mocks.poolMock.query.mockResolvedValueOnce({ rows: [rescueRow({ version: 5 })] });
+    // The UPDATE's WHERE ... AND version = $expectedVersion matches nothing
+    // because another writer already bumped the version.
+    mocks.clientMock.query.mockResolvedValue({ rows: [] });
+
+    await expect(
+      updateRescue(mocks.deps, STAFF, {
+        rescueId: 'rsc-1',
+        settingsJson: '{"adoptionPolicies":{"minAge":1}}',
+        expectedVersion: 5,
+      } as never)
+    ).rejects.toMatchObject({ code: 'FAILED_PRECONDITION' });
+  });
+
+  it('does not publish rescue.updated when the version-guarded UPDATE matches no rows', async () => {
+    mocks.poolMock.query.mockResolvedValueOnce({ rows: [rescueRow({ version: 5 })] });
+    mocks.clientMock.query.mockResolvedValue({ rows: [] });
+
+    await expect(
+      updateRescue(mocks.deps, STAFF, {
+        rescueId: 'rsc-1',
+        settingsJson: '{}',
+        expectedVersion: 5,
+      } as never)
+    ).rejects.toMatchObject({ code: 'FAILED_PRECONDITION' });
+    expect(mocks.natsMock.publish).not.toHaveBeenCalled();
+  });
+
+  it('omits the version guard (last-write-wins) when expectedVersion is not supplied', async () => {
+    mocks.poolMock.query.mockResolvedValueOnce({ rows: [rescueRow({ version: 5 })] });
+    mocks.clientMock.query.mockResolvedValue({ rows: [rescueRow({ version: 6 })] });
+
+    await updateRescue(mocks.deps, STAFF, { rescueId: 'rsc-1', name: 'Pawsome 2' } as never);
+
+    const sql = mocks.clientMock.query.mock.calls[1][0] as string;
+    expect(sql).not.toMatch(/AND version/);
+  });
 });
 
 // --- verifyRescue ----------------------------------------------------

--- a/services/rescue/src/grpc/handlers.ts
+++ b/services/rescue/src/grpc/handlers.ts
@@ -159,6 +159,7 @@ function rowToProto(row: RescueRow): Rescue {
     updatedAt: row.updated_at.toISOString(),
     plan: row.plan,
     planExpiresAt: row.plan_expires_at?.toISOString(),
+    version: row.version,
   };
 }
 
@@ -467,24 +468,44 @@ export async function updateRescue(
   sets.push('updated_at = now()');
   sets.push('version = version + 1');
 
+  // Optimistic-concurrency guard: when the caller supplies expected_version,
+  // the UPDATE only matches the row still at that version. A concurrent
+  // writer that already bumped the version makes this a no-op UPDATE
+  // (0 rows), which we surface below as FAILED_PRECONDITION instead of
+  // silently clobbering their write (ADS-936).
+  let whereClause = `rescue_id = $${n}`;
+  const whereParams = [...params, req.rescueId];
+  if (req.expectedVersion !== undefined) {
+    whereParams.push(req.expectedVersion);
+    whereClause += ` AND version = $${n + 1}`;
+  }
+
   let updated: RescueRow | undefined;
   await withTransaction(deps, async ({ client, publish }) => {
     const result = await client.query<RescueRow>(
-      `UPDATE rescue.rescues SET ${sets.join(', ')} WHERE rescue_id = $${n} RETURNING ${RESCUES_SELECT}`,
-      [...params, req.rescueId]
+      `UPDATE rescue.rescues SET ${sets.join(', ')} WHERE ${whereClause} RETURNING ${RESCUES_SELECT}`,
+      whereParams
     );
     updated = result.rows[0];
-    // Deterministic idempotency key: aggregateId:version. The UPDATE just
-    // bumped version, so each committed update maps to exactly one id and
-    // a replay de-dups in JetStream instead of minting a fresh id.
-    publish({
-      type: 'rescue.updated',
-      id: `rescue.updated.${req.rescueId}:${updated?.version}`,
-      payload: { rescueId: req.rescueId },
-    });
+    if (updated) {
+      // Deterministic idempotency key: aggregateId:version. The UPDATE just
+      // bumped version, so each committed update maps to exactly one id and
+      // a replay de-dups in JetStream instead of minting a fresh id.
+      publish({
+        type: 'rescue.updated',
+        id: `rescue.updated.${req.rescueId}:${updated.version}`,
+        payload: { rescueId: req.rescueId },
+      });
+    }
   });
 
   if (!updated) {
+    if (req.expectedVersion !== undefined) {
+      throw new HandlerError(
+        'FAILED_PRECONDITION',
+        `rescue ${req.rescueId} was modified concurrently (expected version ${req.expectedVersion}); reload and retry`
+      );
+    }
     throw new HandlerError('INTERNAL', 'update returned no rows');
   }
   return { rescue: rowToProto(updated) };


### PR DESCRIPTION
## Summary

- **ADS-936 (High, Bug)**: the rescue adoption-policies PUT did a read-merge-write that silently dropped concurrent settings edits. Fixed with optimistic concurrency (matching the existing `services/applications` answers pattern): a `version` field on the `Rescue` message and `expected_version` on `UpdateRescueRequest`; `updateRescue` guards the SQL `UPDATE` with `AND version = $expectedVersion`, throws `FAILED_PRECONDITION` on a zero-row match (→ 409 at the gateway via `handleGrpcError`), and no longer publishes a phantom `rescue.updated` event on a no-op. Both new fields are optional, so callers/fixtures that don't opt in keep last-write-wins behaviour
- **ADS-940 (Low)**: removed the dead `BadRequestError` class in `services/gateway/src/routes/auth.ts` (declared and caught but never thrown) and simplified the `/register` catch to the standard `handleGrpcError` fall-through
- **ADS-938** (events routes skip Zod validation) is **already fixed on main** via PR #1208 (`events.ts` uses `events.schemas.ts` with `safeParse` on every route) — verified, no change; ticket already Done

## Changes

- `packages/proto/proto/.../rescue/v1/rescue.proto` (+ generated TS) — `version` / `expected_version` fields
- `services/rescue/src/grpc/handlers.ts` — version-guarded update, FAILED_PRECONDITION, no phantom event
- `services/gateway/src/routes/rescues-public.ts` — reads current version, passes `expectedVersion`
- `services/gateway/src/routes/auth.ts` — dead `BadRequestError` removed

## Before requesting review

- [x] Tests for new behaviour added (TDD)
- [ ] If touching `.env` requirements — not applicable
- [x] If touching a shared package (`packages/proto`) — new fields are optional; existing consumers/fixtures unaffected

## Test plan

- [x] `test:coverage` green: packages/proto 66/66, service.rescue 232/232, service.gateway 970/970; auth suite 67/67
- [x] Type-check and lint clean on all touched packages
- [x] New coverage: concurrent update with stale `expectedVersion` → FAILED_PRECONDITION/409, no event published; happy-path update still works
- [ ] **Reviewer note**: the generated proto TS was hand-patched to match the `.proto` change because `buf generate` in the agent sandbox produces unrelated formatting churn across every proto file (pre-existing environment drift — `check-generated-fresh.mjs` fails even on a clean tree here). If CI's generated-freshness check flags this, regenerate with the repo's pinned `buf` locally and force-push; the semantic change is just the two optional fields

## Screenshots / recordings

Not applicable — backend concurrency + dead-code removal.

## Related

- Linear: ADS-936, ADS-940 (fixed here) · ADS-938 (already fixed via #1208)
- Pattern reuse: optimistic concurrency mirrors the `services/applications` answers route

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q5FhHDPvEtBYRDwMAV3rtv

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q5FhHDPvEtBYRDwMAV3rtv)_