### PR TITLE
feat(auth): encrypt TOTP secrets at rest + TOTP replay protection (ADS-914)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -519,6 +519,7 @@ jobs:
           GHCR_TOKEN: ${{ secrets.GHCR_TOKEN }}
           SECRET_JWT_SECRET: ${{ secrets.JWT_SECRET }}
           SECRET_JWT_REFRESH_SECRET: ${{ secrets.JWT_REFRESH_SECRET }}
+          SECRET_ENCRYPTION_KEY: ${{ secrets.ENCRYPTION_KEY }}
           SECRET_UPLOAD_SIGNING_SECRET: ${{ secrets.UPLOAD_SIGNING_SECRET }}
           SECRET_DB_PASSWORD: ${{ secrets.DB_PASSWORD }}
           SECRET_PRINCIPAL_SIGNING_KEY: ${{ secrets.PRINCIPAL_SIGNING_KEY }}
@@ -531,7 +532,7 @@ jobs:
           username: deploy
           key: ${{ secrets.HETZNER_SSH_KEY }}
           fingerprint: ${{ secrets.HETZNER_HOST_FINGERPRINT }}
-          envs: GHCR_TOKEN,SECRET_JWT_SECRET,SECRET_JWT_REFRESH_SECRET,SECRET_UPLOAD_SIGNING_SECRET,SECRET_DB_PASSWORD,SECRET_PRINCIPAL_SIGNING_KEY,TAG_OVERRIDES
+          envs: GHCR_TOKEN,SECRET_JWT_SECRET,SECRET_JWT_REFRESH_SECRET,SECRET_ENCRYPTION_KEY,SECRET_UPLOAD_SIGNING_SECRET,SECRET_DB_PASSWORD,SECRET_PRINCIPAL_SIGNING_KEY,TAG_OVERRIDES
           script: |
             set -euo pipefail
             ENV="${{ github.event.inputs.environment }}"
@@ -623,6 +624,7 @@ jobs:
             printf '%s' "$REDIS_PW"                             > secrets/redis_password
             printf '%s' "$SECRET_JWT_SECRET"                    > secrets/jwt_secret
             printf '%s' "$SECRET_JWT_REFRESH_SECRET"            > secrets/jwt_refresh_secret
+            printf '%s' "$SECRET_ENCRYPTION_KEY"                > secrets/encryption_key
             printf '%s' "$SECRET_UPLOAD_SIGNING_SECRET"         > secrets/upload_signing_secret
             printf '%s' "$SECRET_PRINCIPAL_SIGNING_KEY"         > secrets/principal_signing_key
             printf '%s' "$SECRET_DB_PASSWORD"                   > secrets/db_password

--- a/.github/workflows/rollback.yml
+++ b/.github/workflows/rollback.yml
@@ -59,6 +59,7 @@ jobs:
           ROLLBACK_ENV: ${{ github.event.inputs.environment }}
           SECRET_JWT_SECRET: ${{ secrets.JWT_SECRET }}
           SECRET_JWT_REFRESH_SECRET: ${{ secrets.JWT_REFRESH_SECRET }}
+          SECRET_ENCRYPTION_KEY: ${{ secrets.ENCRYPTION_KEY }}
           SECRET_UPLOAD_SIGNING_SECRET: ${{ secrets.UPLOAD_SIGNING_SECRET }}
           SECRET_DB_PASSWORD: ${{ secrets.DB_PASSWORD }}
           SECRET_PRINCIPAL_SIGNING_KEY: ${{ secrets.PRINCIPAL_SIGNING_KEY }}
@@ -68,7 +69,7 @@ jobs:
           username: deploy
           key: ${{ secrets.HETZNER_SSH_KEY }}
           fingerprint: ${{ secrets.HETZNER_HOST_FINGERPRINT }}
-          envs: GHCR_TOKEN,ROLLBACK_SHA,ROLLBACK_ENV,SECRET_JWT_SECRET,SECRET_JWT_REFRESH_SECRET,SECRET_UPLOAD_SIGNING_SECRET,SECRET_DB_PASSWORD,SECRET_PRINCIPAL_SIGNING_KEY
+          envs: GHCR_TOKEN,ROLLBACK_SHA,ROLLBACK_ENV,SECRET_JWT_SECRET,SECRET_JWT_REFRESH_SECRET,SECRET_ENCRYPTION_KEY,SECRET_UPLOAD_SIGNING_SECRET,SECRET_DB_PASSWORD,SECRET_PRINCIPAL_SIGNING_KEY
           script: |
             set -euo pipefail
             # Validate SHA before use to prevent shell injection.
@@ -124,6 +125,7 @@ jobs:
             printf '%s' "$REDIS_PW"                             > secrets/redis_password
             printf '%s' "$SECRET_JWT_SECRET"                    > secrets/jwt_secret
             printf '%s' "$SECRET_JWT_REFRESH_SECRET"            > secrets/jwt_refresh_secret
+            printf '%s' "$SECRET_ENCRYPTION_KEY"                > secrets/encryption_key
             printf '%s' "$SECRET_UPLOAD_SIGNING_SECRET"         > secrets/upload_signing_secret
             printf '%s' "$SECRET_PRINCIPAL_SIGNING_KEY"         > secrets/principal_signing_key
             printf '%s' "$SECRET_DB_PASSWORD"                   > secrets/db_password

--- a/.github/workflows/schema-equivalence.yml
+++ b/.github/workflows/schema-equivalence.yml
@@ -54,6 +54,11 @@ jobs:
       # path; dummy values are fine — migrations never read them.
       JWT_SECRET: ci-dummy-jwt-secret-not-used-by-migrations
       JWT_REFRESH_SECRET: ci-dummy-jwt-refresh-secret-not-used-by-migrations
+      # ADS-914: loadConfig() now also requires ENCRYPTION_KEY (TOTP secret
+      # encryption). A fresh CI DB has no rows to re-wrap, so the dummy 64-hex
+      # key is never used — it only satisfies config validation on the migrate
+      # path.
+      ENCRYPTION_KEY: '0000000000000000000000000000000000000000000000000000000000000000'
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -240,12 +240,16 @@ services:
       <<: *service-env
       JWT_SECRET_FILE: /run/secrets/jwt_secret
       JWT_REFRESH_SECRET_FILE: /run/secrets/jwt_refresh_secret
-    # Auth needs the JWT signing secrets on top of the common DB/Redis ones.
+      # ADS-914: AES-256-GCM key for encrypting TOTP 2FA secrets at rest.
+      ENCRYPTION_KEY_FILE: /run/secrets/encryption_key
+    # Auth needs the JWT signing secrets + the TOTP encryption key on top of
+    # the common DB/Redis ones.
     secrets:
       - database_url
       - redis_url
       - jwt_secret
       - jwt_refresh_secret
+      - encryption_key
       - principal_signing_key
     expose:
       - "5002"
@@ -616,6 +620,8 @@ secrets:
     file: ./secrets/jwt_secret
   jwt_refresh_secret:
     file: ./secrets/jwt_refresh_secret
+  encryption_key:
+    file: ./secrets/encryption_key
   upload_signing_secret:
     file: ./secrets/upload_signing_secret
   principal_signing_key:

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -219,12 +219,16 @@ services:
       <<: *service-env
       JWT_SECRET_FILE: /run/secrets/jwt_secret
       JWT_REFRESH_SECRET_FILE: /run/secrets/jwt_refresh_secret
-    # Auth needs the JWT signing secrets on top of the common DB/Redis ones.
+      # ADS-914: AES-256-GCM key for encrypting TOTP 2FA secrets at rest.
+      ENCRYPTION_KEY_FILE: /run/secrets/encryption_key
+    # Auth needs the JWT signing secrets + the TOTP encryption key on top of
+    # the common DB/Redis ones.
     secrets:
       - database_url
       - redis_url
       - jwt_secret
       - jwt_refresh_secret
+      - encryption_key
       - principal_signing_key
     expose:
       - "5002"
@@ -486,6 +490,8 @@ secrets:
     file: ./secrets/jwt_secret
   jwt_refresh_secret:
     file: ./secrets/jwt_refresh_secret
+  encryption_key:
+    file: ./secrets/encryption_key
   upload_signing_secret:
     file: ./secrets/upload_signing_secret
   principal_signing_key:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -463,6 +463,8 @@ services:
       <<: *ms-env
       JWT_SECRET: '${JWT_SECRET:?Error: JWT_SECRET required}'
       JWT_REFRESH_SECRET: '${JWT_REFRESH_SECRET:?Error: JWT_REFRESH_SECRET required}'
+      # ADS-914: AES-256-GCM key for encrypting TOTP 2FA secrets at rest.
+      ENCRYPTION_KEY: '${ENCRYPTION_KEY:?Error: ENCRYPTION_KEY required}'
     ports:
       - '127.0.0.1:5002:5002'
     depends_on: *ms-deps

--- a/secrets/README.md
+++ b/secrets/README.md
@@ -18,6 +18,7 @@ before `docker compose up -d`; the deploy workflow
 | `redis_url`                   | every domain service            | `redis://:pass@redis:6379`                                     |
 | `jwt_secret`                  | `service-auth`                  | access-token signing secret                                    |
 | `jwt_refresh_secret`          | `service-auth`                  | refresh-token signing secret                                   |
+| `encryption_key`              | `service-auth`                  | AES-256-GCM key (64 hex chars / 32 bytes) for TOTP 2FA secrets at rest (ADS-914) |
 | `upload_signing_secret`       | `service-gateway`               | HMAC secret for `/uploads-signed` URLs                         |
 | `principal_signing_key`       | `service-gateway` + every domain service | HMAC key for the signed `x-principal-token` gRPC metadata (ADS-800) |
 | `db_password`                 | `database` container (staging + production) | Postgres superuser password (read via `POSTGRES_PASSWORD_FILE`) |

--- a/services/auth/src/config.test.ts
+++ b/services/auth/src/config.test.ts
@@ -5,11 +5,14 @@ import { loadConfig } from './config.js';
 // Signing secrets must be >= 32 bytes (enforced at boot).
 const VALID_ACCESS_SECRET = 'access-signing-secret-at-least-32-bytes';
 const VALID_REFRESH_SECRET = 'refresh-signing-secret-at-least-32-bytes';
+// ENCRYPTION_KEY must be exactly 64 hex chars (32 bytes) — AES-256-GCM key.
+const VALID_ENCRYPTION_KEY = 'a'.repeat(64);
 
 const REQUIRED = {
   DATABASE_URL: 'postgres://test:test@localhost:5432/test',
   JWT_SECRET: VALID_ACCESS_SECRET,
   JWT_REFRESH_SECRET: VALID_REFRESH_SECRET,
+  ENCRYPTION_KEY: VALID_ENCRYPTION_KEY,
 };
 
 describe('loadConfig', () => {
@@ -24,6 +27,7 @@ describe('loadConfig', () => {
     expect(config.natsUrl).toBe('nats://nats:4222');
     expect(config.jwtSecret).toBe(REQUIRED.JWT_SECRET);
     expect(config.jwtRefreshSecret).toBe(REQUIRED.JWT_REFRESH_SECRET);
+    expect(config.encryptionKey).toBe(REQUIRED.ENCRYPTION_KEY);
   });
 
   it('honours all env overrides when set', () => {
@@ -37,6 +41,7 @@ describe('loadConfig', () => {
       NATS_URL: 'nats://nats.internal:4222',
       JWT_SECRET: VALID_ACCESS_SECRET,
       JWT_REFRESH_SECRET: VALID_REFRESH_SECRET,
+      ENCRYPTION_KEY: VALID_ENCRYPTION_KEY,
     });
 
     expect(config.port).toBe(5500);
@@ -48,6 +53,7 @@ describe('loadConfig', () => {
     expect(config.natsUrl).toBe('nats://nats.internal:4222');
     expect(config.jwtSecret).toBe(VALID_ACCESS_SECRET);
     expect(config.jwtRefreshSecret).toBe(VALID_REFRESH_SECRET);
+    expect(config.encryptionKey).toBe(VALID_ENCRYPTION_KEY);
   });
 
   it('rejects a non-numeric AUTH_PORT', () => {
@@ -97,6 +103,25 @@ describe('loadConfig', () => {
         JWT_REFRESH_SECRET: VALID_REFRESH_SECRET,
       })
     ).toThrow(/JWT_SECRET must be at least 32 bytes/);
+  });
+
+  it('rejects an unset ENCRYPTION_KEY — auth refuses to boot without a TOTP-secret encryption key', () => {
+    expect(() =>
+      loadConfig({
+        DATABASE_URL: REQUIRED.DATABASE_URL,
+        JWT_SECRET: VALID_ACCESS_SECRET,
+        JWT_REFRESH_SECRET: VALID_REFRESH_SECRET,
+      })
+    ).toThrow(/ENCRYPTION_KEY is required/);
+  });
+
+  it('rejects an ENCRYPTION_KEY that is not 64 hex chars', () => {
+    expect(() =>
+      loadConfig({
+        ...REQUIRED,
+        ENCRYPTION_KEY: 'not-hex',
+      })
+    ).toThrow(/ENCRYPTION_KEY does not match the required format/);
   });
 
   it('trims surrounding whitespace from string env values', () => {

--- a/services/auth/src/config.ts
+++ b/services/auth/src/config.ts
@@ -1,4 +1,4 @@
-import { parsePort, requireSecret } from '@adopt-dont-shop/config-secrets';
+import { parsePort, requireHexSecret, requireSecret } from '@adopt-dont-shop/config-secrets';
 
 export type AuthConfig = {
   // HTTP port for the boot-readiness surface (/health/simple). Distinct
@@ -29,6 +29,9 @@ export type AuthConfig = {
   // JWT signing secret for refresh tokens. Distinct from jwtSecret so
   // a leaked access-token secret doesn't compromise refresh either.
   jwtRefreshSecret: string;
+  // AES-256-GCM key (64 hex chars / 32 bytes) used to encrypt TOTP secrets
+  // at rest (ADS-914a) — a DB read alone must not yield usable 2FA secrets.
+  encryptionKey: string;
 };
 
 const DEFAULT_PORT = 5002;
@@ -53,6 +56,9 @@ export const loadConfig = (env: NodeJS.ProcessEnv = process.env): AuthConfig => 
     'refresh-token signing secret',
     { minBytes: 32 }
   );
+  const encryptionKey = requireHexSecret('ENCRYPTION_KEY', env, {
+    description: 'AES-256-GCM key for encrypting TOTP secrets at rest',
+  });
 
   return {
     port,
@@ -64,5 +70,6 @@ export const loadConfig = (env: NodeJS.ProcessEnv = process.env): AuthConfig => 
     natsUrl: env.NATS_URL?.trim() || DEFAULT_NATS_URL,
     jwtSecret,
     jwtRefreshSecret,
+    encryptionKey,
   };
 };

--- a/services/auth/src/gdpr/erase.ts
+++ b/services/auth/src/gdpr/erase.ts
@@ -34,6 +34,7 @@ export async function eraseAuth(
             address_line_2 = NULL,
             postal_code = NULL,
             two_factor_secret = NULL,
+            two_factor_last_step = NULL,
             backup_codes = NULL,
             reset_token_hash = NULL,
             reset_token_expiration = NULL,

--- a/services/auth/src/grpc/handlers.test.ts
+++ b/services/auth/src/grpc/handlers.test.ts
@@ -19,8 +19,11 @@ import {
   type HandlerDeps,
   type MintedTokens,
 } from './handlers.js';
+import { encryptTotpSecret } from './totp-crypto.js';
 
 // --- Fixtures --------------------------------------------------------
+
+const ENCRYPTION_KEY = 'a'.repeat(64);
 
 const ADOPTER_PRINCIPAL: Principal = {
   userId: 'usr-adopter' as UserId,
@@ -50,6 +53,8 @@ function userRowFixture(overrides: Record<string, unknown> = {}) {
     email_verified: true,
     phone_verified: false,
     two_factor_enabled: false,
+    two_factor_secret: null,
+    two_factor_last_step: null,
     status: 'active',
     user_type: 'adopter',
     profile_image_url: null,
@@ -112,6 +117,7 @@ function makeMocks() {
     nats: nats as unknown as NatsConnection,
     passwordHasher,
     tokenIssuer,
+    encryptionKey: ENCRYPTION_KEY,
   };
   return {
     deps,
@@ -401,7 +407,12 @@ describe('login', () => {
   it('asks for the second factor (no tokens) when 2FA is on and no code is given', async () => {
     const secret = generateSecret();
     mocks.poolMock.query.mockResolvedValueOnce({
-      rows: [userRowFixture({ two_factor_enabled: true, two_factor_secret: secret })],
+      rows: [
+        userRowFixture({
+          two_factor_enabled: true,
+          two_factor_secret: encryptTotpSecret(ENCRYPTION_KEY, secret),
+        }),
+      ],
     });
     mocks.hasherMock.compare.mockResolvedValueOnce(true);
 
@@ -417,7 +428,12 @@ describe('login', () => {
   it('rejects a wrong 2FA code with UNAUTHENTICATED', async () => {
     const secret = generateSecret();
     mocks.poolMock.query.mockResolvedValueOnce({
-      rows: [userRowFixture({ two_factor_enabled: true, two_factor_secret: secret })],
+      rows: [
+        userRowFixture({
+          two_factor_enabled: true,
+          two_factor_secret: encryptTotpSecret(ENCRYPTION_KEY, secret),
+        }),
+      ],
     });
     mocks.hasherMock.compare.mockResolvedValueOnce(true);
 
@@ -437,12 +453,19 @@ describe('login', () => {
     const secret = generateSecret();
     const code = generateSync({ secret });
     mocks.poolMock.query.mockResolvedValueOnce({
-      rows: [userRowFixture({ two_factor_enabled: true, two_factor_secret: secret })],
+      rows: [
+        userRowFixture({
+          two_factor_enabled: true,
+          two_factor_secret: encryptTotpSecret(ENCRYPTION_KEY, secret),
+        }),
+      ],
     });
     mocks.hasherMock.compare.mockResolvedValueOnce(true);
     mocks.issuerMock.mint.mockResolvedValueOnce(mintedFixture());
     mocks.clientMock.query.mockResolvedValue({ rows: [] });
     mocks.poolMock.query
+      // Replay-guard UPDATE (two_factor_last_step) fired by verifyAndConsumeTotp.
+      .mockResolvedValueOnce({ rows: [] })
       .mockResolvedValueOnce({ rows: [{ user_type: 'adopter' }] })
       .mockResolvedValueOnce({ rows: [] })
       .mockResolvedValueOnce({ rows: [{ name: 'pets.read' }] });
@@ -452,6 +475,39 @@ describe('login', () => {
     expect(res.twoFactorRequired).toBe(false);
     expect(res.tokens?.accessToken).toBe('access.jwt.token');
     expect(mocks.issuerMock.mint).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects a replayed 2FA code on a second login attempt (ADS-914c)', async () => {
+    // Pin the clock so the code's time step and the "already accepted"
+    // step below can't drift apart at a 30s window boundary (flake guard).
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-01-01T00:00:00Z'));
+    try {
+      const secret = generateSecret();
+      const code = generateSync({ secret });
+      const encryptedSecret = encryptTotpSecret(ENCRYPTION_KEY, secret);
+      const timeStep = Math.floor(Date.now() / 1000 / 30);
+
+      mocks.poolMock.query.mockResolvedValueOnce({
+        rows: [
+          userRowFixture({
+            two_factor_enabled: true,
+            two_factor_secret: encryptedSecret,
+            // Simulate the code having already been accepted at the current
+            // time step (e.g. by an attacker who captured it first).
+            two_factor_last_step: timeStep,
+          }),
+        ],
+      });
+      mocks.hasherMock.compare.mockResolvedValueOnce(true);
+
+      await expect(
+        login(mocks.deps, null, { ...BASE_LOGIN_REQ, twoFactorToken: code })
+      ).rejects.toMatchObject({ code: 'UNAUTHENTICATED' });
+      expect(mocks.issuerMock.mint).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   // --- Email-verification enforcement --------------------------------
@@ -480,7 +536,7 @@ describe('login', () => {
         userRowFixture({
           email_verified: false,
           two_factor_enabled: true,
-          two_factor_secret: secret,
+          two_factor_secret: encryptTotpSecret(ENCRYPTION_KEY, secret),
         }),
       ],
     });

--- a/services/auth/src/grpc/handlers.ts
+++ b/services/auth/src/grpc/handlers.ts
@@ -22,8 +22,6 @@
 
 import { createHash, randomUUID } from 'node:crypto';
 
-import { verifySync } from 'otplib';
-
 import { requirePermission, type Principal } from '@adopt-dont-shop/authz';
 import { withTransaction, type WithTransactionDeps } from '@adopt-dont-shop/events';
 import type { Permission, UserId, UserRole } from '@adopt-dont-shop/lib.types';
@@ -55,6 +53,7 @@ import {
   type UserStatusDb,
 } from './enum-map.js';
 import { createAuthMetrics } from './auth-metrics.js';
+import { verifyAndConsumeTotp } from './totp-verification.js';
 
 // --- Errors ----------------------------------------------------------
 
@@ -125,6 +124,9 @@ export type MintedTokens = {
 export type HandlerDeps = WithTransactionDeps & {
   passwordHasher: PasswordHasher;
   tokenIssuer: TokenIssuer;
+  // AES-256-GCM key (hex) for encrypting/decrypting TOTP secrets at rest
+  // (ADS-914a). See ./totp-crypto.ts and ./totp-verification.ts.
+  encryptionKey: string;
 };
 
 // --- Row types -------------------------------------------------------
@@ -139,6 +141,9 @@ export type UserRow = {
   phone_verified: boolean;
   two_factor_enabled: boolean;
   two_factor_secret: string | null;
+  // Last accepted TOTP RFC 6238 time step (ADS-914c replay guard). Null
+  // until the first successful 2FA verification.
+  two_factor_last_step: number | null;
   status: UserStatusDb;
   user_type: UserRoleDb;
   profile_image_url: string | null;
@@ -310,10 +315,6 @@ function rolesToProto(roles: UserRole[]): AuthV1.UserRole[] {
 // to spend an equivalent amount of CPU when the email is unknown, so login
 // latency doesn't reveal whether an account exists.
 const DUMMY_PASSWORD_HASH = '$2a$12$0000000000000000000000000000000000000000000000000000u';
-
-// Verify a TOTP code against a stored base32 secret. Wraps otplib's
-// VerifyResult ({ valid, ... }) down to a boolean.
-const verifyTotp = (token: string, secret: string): boolean => verifySync({ token, secret }).valid;
 
 // Progressive login throttle. Rather than a hard lockout (which lets an
 // attacker deny a victim access by deliberately failing logins), failed
@@ -504,7 +505,16 @@ export async function login(
     if (!req.twoFactorToken) {
       return { permissions: [], twoFactorRequired: true, emailVerificationRequired: false };
     }
-    if (!user.two_factor_secret || !verifyTotp(req.twoFactorToken, user.two_factor_secret)) {
+    const twoFactorOk = await verifyAndConsumeTotp(
+      deps,
+      {
+        userId: user.user_id,
+        encryptedSecret: user.two_factor_secret,
+        lastStep: user.two_factor_last_step,
+      },
+      req.twoFactorToken
+    );
+    if (!twoFactorOk) {
       loginCounter.inc({ outcome: 'invalid_credentials' });
       await publishLoginActionTaken(deps, {
         outcome: 'denied',

--- a/services/auth/src/grpc/server.test.ts
+++ b/services/auth/src/grpc/server.test.ts
@@ -27,6 +27,7 @@ const config: AuthConfig = {
   natsUrl: 'nats://localhost:4222',
   jwtSecret: 'access-secret',
   jwtRefreshSecret: 'refresh-secret',
+  encryptionKey: 'a'.repeat(64),
 };
 
 const pool = {} as unknown as Pool;

--- a/services/auth/src/grpc/server.ts
+++ b/services/auth/src/grpc/server.ts
@@ -92,7 +92,13 @@ export type { RunningGrpcServer };
 
 export const createGrpcServer = (opts: CreateGrpcServerOptions): Server => {
   const { config, pool, nats, passwordHasher, tokenIssuer, logger } = opts;
-  const deps: HandlerDeps = { pool, nats, passwordHasher, tokenIssuer };
+  const deps: HandlerDeps = {
+    pool,
+    nats,
+    passwordHasher,
+    tokenIssuer,
+    encryptionKey: config.encryptionKey,
+  };
   const server = new Server();
 
   server.addService(AuthV1.AuthServiceService, {

--- a/services/auth/src/grpc/totp-crypto.test.ts
+++ b/services/auth/src/grpc/totp-crypto.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+
+import { decryptTotpSecret, encryptTotpSecret } from './totp-crypto.js';
+
+const KEY_A = 'a'.repeat(64);
+const KEY_B = 'b'.repeat(64);
+
+describe('encryptTotpSecret / decryptTotpSecret', () => {
+  it('round-trips a TOTP secret through encrypt then decrypt', () => {
+    const secret = 'JBSWY3DPEHPK3PXP';
+    const encrypted = encryptTotpSecret(KEY_A, secret);
+    expect(decryptTotpSecret(KEY_A, encrypted)).toBe(secret);
+  });
+
+  it('never stores the plaintext secret in the encrypted output', () => {
+    const secret = 'JBSWY3DPEHPK3PXP';
+    const encrypted = encryptTotpSecret(KEY_A, secret);
+    expect(encrypted).not.toContain(secret);
+  });
+
+  it('produces a different ciphertext each time (random IV)', () => {
+    const secret = 'JBSWY3DPEHPK3PXP';
+    const first = encryptTotpSecret(KEY_A, secret);
+    const second = encryptTotpSecret(KEY_A, secret);
+    expect(first).not.toBe(second);
+    expect(decryptTotpSecret(KEY_A, first)).toBe(secret);
+    expect(decryptTotpSecret(KEY_A, second)).toBe(secret);
+  });
+
+  it('fails to decrypt with the wrong key', () => {
+    const encrypted = encryptTotpSecret(KEY_A, 'JBSWY3DPEHPK3PXP');
+    expect(() => decryptTotpSecret(KEY_B, encrypted)).toThrow();
+  });
+
+  it('fails to decrypt tampered ciphertext', () => {
+    const encrypted = encryptTotpSecret(KEY_A, 'JBSWY3DPEHPK3PXP');
+    const raw = Buffer.from(encrypted, 'base64');
+    raw[raw.length - 1] = raw[raw.length - 1] ^ 0xff;
+    expect(() => decryptTotpSecret(KEY_A, raw.toString('base64'))).toThrow();
+  });
+
+  it('fails to decrypt a malformed (too-short) value', () => {
+    expect(() => decryptTotpSecret(KEY_A, Buffer.from('short').toString('base64'))).toThrow(
+      /malformed/
+    );
+  });
+});

--- a/services/auth/src/grpc/totp-crypto.ts
+++ b/services/auth/src/grpc/totp-crypto.ts
@@ -1,0 +1,46 @@
+// AES-256-GCM helpers for encrypting TOTP secrets at rest (ADS-914a).
+//
+// `two_factor_secret` used to be written and read verbatim — a single DB
+// read yielded a permanent, offline 2FA bypass for every enrolled user.
+// Encrypt/decrypt with the service's ENCRYPTION_KEY (config.encryptionKey,
+// 64 hex chars / 32 bytes) so a DB compromise alone isn't enough.
+//
+// Encoding: base64(iv[12] || authTag[16] || ciphertext). IV is random per
+// call (GCM requires a unique IV per encryption under the same key); the
+// auth tag detects tampering/corruption on decrypt.
+
+import { createCipheriv, createDecipheriv, randomBytes } from 'node:crypto';
+
+const ALGORITHM = 'aes-256-gcm';
+const IV_LENGTH = 12;
+const AUTH_TAG_LENGTH = 16;
+
+function keyFromHex(encryptionKeyHex: string): Buffer {
+  return Buffer.from(encryptionKeyHex, 'hex');
+}
+
+export function encryptTotpSecret(encryptionKeyHex: string, plaintext: string): string {
+  const key = keyFromHex(encryptionKeyHex);
+  const iv = randomBytes(IV_LENGTH);
+  const cipher = createCipheriv(ALGORITHM, key, iv);
+  const ciphertext = Buffer.concat([cipher.update(plaintext, 'utf8'), cipher.final()]);
+  const authTag = cipher.getAuthTag();
+  return Buffer.concat([iv, authTag, ciphertext]).toString('base64');
+}
+
+// Throws if `encoded` is malformed or fails GCM auth-tag verification
+// (tampered/corrupted ciphertext, or wrong key).
+export function decryptTotpSecret(encryptionKeyHex: string, encoded: string): string {
+  const key = keyFromHex(encryptionKeyHex);
+  const raw = Buffer.from(encoded, 'base64');
+  if (raw.length <= IV_LENGTH + AUTH_TAG_LENGTH) {
+    throw new Error('encrypted TOTP secret is malformed');
+  }
+  const iv = raw.subarray(0, IV_LENGTH);
+  const authTag = raw.subarray(IV_LENGTH, IV_LENGTH + AUTH_TAG_LENGTH);
+  const ciphertext = raw.subarray(IV_LENGTH + AUTH_TAG_LENGTH);
+  const decipher = createDecipheriv(ALGORITHM, key, iv);
+  decipher.setAuthTag(authTag);
+  const plaintext = Buffer.concat([decipher.update(ciphertext), decipher.final()]);
+  return plaintext.toString('utf8');
+}

--- a/services/auth/src/grpc/totp-verification.test.ts
+++ b/services/auth/src/grpc/totp-verification.test.ts
@@ -1,0 +1,96 @@
+import { generateSecret, generateSync } from 'otplib';
+import { describe, expect, it, vi } from 'vitest';
+
+import { encryptTotpSecret } from './totp-crypto.js';
+import { verifyAndConsumeTotp } from './totp-verification.js';
+
+const KEY = 'a'.repeat(64);
+
+function makeDeps() {
+  const query = vi.fn().mockResolvedValue(undefined);
+  return { deps: { pool: { query }, encryptionKey: KEY }, query };
+}
+
+describe('verifyAndConsumeTotp', () => {
+  it('returns false when no secret is enrolled', async () => {
+    const { deps, query } = makeDeps();
+    const ok = await verifyAndConsumeTotp(
+      deps,
+      { userId: 'u1', encryptedSecret: null, lastStep: null },
+      '123456'
+    );
+    expect(ok).toBe(false);
+    expect(query).not.toHaveBeenCalled();
+  });
+
+  it('accepts a valid code and persists the matched time step', async () => {
+    const { deps, query } = makeDeps();
+    const secret = generateSecret();
+    const token = generateSync({ secret });
+    const encryptedSecret = encryptTotpSecret(KEY, secret);
+
+    const ok = await verifyAndConsumeTotp(
+      deps,
+      { userId: 'u1', encryptedSecret, lastStep: null },
+      token
+    );
+
+    expect(ok).toBe(true);
+    expect(query).toHaveBeenCalledWith(
+      expect.stringMatching(/UPDATE auth\.users SET two_factor_last_step/),
+      ['u1', expect.any(Number)]
+    );
+  });
+
+  it('rejects an incorrect code', async () => {
+    const { deps, query } = makeDeps();
+    const secret = generateSecret();
+    const encryptedSecret = encryptTotpSecret(KEY, secret);
+
+    const ok = await verifyAndConsumeTotp(
+      deps,
+      { userId: 'u1', encryptedSecret, lastStep: null },
+      '000000'
+    );
+
+    expect(ok).toBe(false);
+    expect(query).not.toHaveBeenCalled();
+  });
+
+  it('rejects replay of a code already accepted at or before the last step (ADS-914c)', async () => {
+    const { deps, query } = makeDeps();
+    const secret = generateSecret();
+    const token = generateSync({ secret });
+    const encryptedSecret = encryptTotpSecret(KEY, secret);
+
+    const first = await verifyAndConsumeTotp(
+      deps,
+      { userId: 'u1', encryptedSecret, lastStep: null },
+      token
+    );
+    expect(first).toBe(true);
+
+    const lastStep = query.mock.calls[0]?.[1]?.[1] as number;
+    query.mockClear();
+
+    // Same code, same time step — must be rejected as a replay.
+    const second = await verifyAndConsumeTotp(
+      deps,
+      { userId: 'u1', encryptedSecret, lastStep },
+      token
+    );
+    expect(second).toBe(false);
+    expect(query).not.toHaveBeenCalled();
+  });
+
+  it('fails closed (returns false) when the stored ciphertext cannot be decrypted', async () => {
+    const { deps, query } = makeDeps();
+    const ok = await verifyAndConsumeTotp(
+      deps,
+      { userId: 'u1', encryptedSecret: 'not-valid-ciphertext', lastStep: null },
+      '123456'
+    );
+    expect(ok).toBe(false);
+    expect(query).not.toHaveBeenCalled();
+  });
+});

--- a/services/auth/src/grpc/totp-verification.ts
+++ b/services/auth/src/grpc/totp-verification.ts
@@ -1,0 +1,73 @@
+// Shared TOTP verification for the encrypted-at-rest secret, with replay
+// protection (ADS-914a/c). Used by both Login's 2FA check (handlers.ts)
+// and disableTwoFactor (two-factor-handlers.ts) — anywhere a code is
+// checked against the STORED secret, as opposed to setup/enable's
+// not-yet-persisted secret.
+//
+// Replay protection: otplib's `afterTimeStep` rejects any code whose
+// RFC 6238 time step is <= the last accepted step, so a code observed
+// once (screenshare, shoulder-surf, AiTM phishing proxy) can't be reused
+// even within its still-valid 30s window. We persist the matched time
+// step on every successful verification.
+
+import type { Pool } from 'pg';
+
+import { verifySync } from 'otplib';
+
+import { decryptTotpSecret } from './totp-crypto.js';
+
+// RFC 6238 defaults otplib uses: 30-second period, t0 = 0. The accepted
+// time step for a given epoch is therefore floor(epoch / TOTP_PERIOD).
+const TOTP_PERIOD_SECONDS = 30;
+
+export type TotpVerificationDeps = {
+  pool: Pick<Pool, 'query'>;
+  encryptionKey: string;
+};
+
+export type TotpVerificationInput = {
+  userId: string;
+  // The at-rest (encrypted) secret, or null if 2FA was never enrolled.
+  encryptedSecret: string | null;
+  // The last TOTP time step accepted for this user, or null if none yet.
+  lastStep: number | null;
+};
+
+export async function verifyAndConsumeTotp(
+  deps: TotpVerificationDeps,
+  input: TotpVerificationInput,
+  token: string
+): Promise<boolean> {
+  if (!input.encryptedSecret) {
+    return false;
+  }
+
+  let secret: string;
+  try {
+    secret = decryptTotpSecret(deps.encryptionKey, input.encryptedSecret);
+  } catch {
+    // Corrupted/foreign ciphertext must not crash the request — fail
+    // closed as an invalid code, same as a wrong 6-digit guess.
+    return false;
+  }
+
+  // Pin the epoch so the accepted step we persist matches the epoch the
+  // verification used (no window-boundary race between verify and compute).
+  const epoch = Math.floor(Date.now() / 1000);
+  const result = verifySync({
+    token,
+    secret,
+    epoch,
+    afterTimeStep: input.lastStep ?? undefined,
+  });
+  if (!result.valid) {
+    return false;
+  }
+
+  const step = Math.floor(epoch / TOTP_PERIOD_SECONDS);
+  await deps.pool.query(
+    `UPDATE auth.users SET two_factor_last_step = $2, updated_at = now() WHERE user_id = $1`,
+    [input.userId, step]
+  );
+  return true;
+}

--- a/services/auth/src/grpc/two-factor-handlers.test.ts
+++ b/services/auth/src/grpc/two-factor-handlers.test.ts
@@ -8,6 +8,7 @@ import type { Principal } from '@adopt-dont-shop/authz';
 import type { UserId } from '@adopt-dont-shop/lib.types';
 
 import type { HandlerDeps } from './handlers.js';
+import { decryptTotpSecret, encryptTotpSecret } from './totp-crypto.js';
 import { disableTwoFactor, enableTwoFactor, setupTwoFactor } from './two-factor-handlers.js';
 
 const PRINCIPAL: Principal = {
@@ -16,12 +17,15 @@ const PRINCIPAL: Principal = {
   permissions: [],
 };
 
+const ENCRYPTION_KEY = 'a'.repeat(64);
+
 function makeMocks() {
   const pool = { query: vi.fn() };
   pool.query.mockResolvedValue({ rows: [], rowCount: 0 });
   const deps: HandlerDeps = {
     pool: pool as unknown as Pool,
     nats: {} as unknown as NatsConnection,
+    encryptionKey: ENCRYPTION_KEY,
   };
   return { deps, poolMock: pool };
 }
@@ -66,7 +70,7 @@ describe('enableTwoFactor', () => {
     mocks = makeMocks();
   });
 
-  it('persists the secret + flips the flag when the code verifies', async () => {
+  it('persists the ENCRYPTED secret + flips the flag when the code verifies', async () => {
     const secret = generateSecret();
     const token = generateSync({ secret });
     mocks.poolMock.query.mockResolvedValueOnce({ rows: [], rowCount: 1 });
@@ -75,7 +79,9 @@ describe('enableTwoFactor', () => {
     const [sql, params] = mocks.poolMock.query.mock.calls[0] as [string, unknown[]];
     expect(sql).toMatch(/two_factor_enabled = true/);
     expect(sql).toMatch(/two_factor_enabled = false/); // the guard
-    expect(params[0]).toBe(secret);
+    // The secret is encrypted at rest (ADS-914a) — never write the plaintext.
+    expect(params[0]).not.toBe(secret);
+    expect(decryptTotpSecret(ENCRYPTION_KEY, params[0] as string)).toBe(secret);
   });
 
   it('rejects an invalid code without writing', async () => {
@@ -105,18 +111,29 @@ describe('disableTwoFactor', () => {
   it('clears the secret + flag when the code verifies', async () => {
     const secret = generateSecret();
     const token = generateSync({ secret });
+    const encryptedSecret = encryptTotpSecret(ENCRYPTION_KEY, secret);
     mocks.poolMock.query
-      .mockResolvedValueOnce({ rows: [{ two_factor_enabled: true, two_factor_secret: secret }] })
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            two_factor_enabled: true,
+            two_factor_secret: encryptedSecret,
+            two_factor_last_step: null,
+          },
+        ],
+      })
+      // Replay-guard UPDATE (two_factor_last_step) fired by verifyAndConsumeTotp.
+      .mockResolvedValueOnce({ rows: [] })
       .mockResolvedValueOnce({ rows: [], rowCount: 1 });
     const res = await disableTwoFactor(mocks.deps, PRINCIPAL, { token });
     expect(res.disabled).toBe(true);
-    const [sql] = mocks.poolMock.query.mock.calls[1] as [string];
+    const [sql] = mocks.poolMock.query.mock.calls[2] as [string];
     expect(sql).toMatch(/two_factor_secret = NULL/);
   });
 
   it('rejects when 2FA is not enabled', async () => {
     mocks.poolMock.query.mockResolvedValueOnce({
-      rows: [{ two_factor_enabled: false, two_factor_secret: null }],
+      rows: [{ two_factor_enabled: false, two_factor_secret: null, two_factor_last_step: null }],
     });
     await expect(
       disableTwoFactor(mocks.deps, PRINCIPAL, { token: '123456' })
@@ -125,13 +142,46 @@ describe('disableTwoFactor', () => {
 
   it('rejects a wrong code (does not clear the secret)', async () => {
     const secret = generateSecret();
+    const encryptedSecret = encryptTotpSecret(ENCRYPTION_KEY, secret);
     mocks.poolMock.query.mockResolvedValueOnce({
-      rows: [{ two_factor_enabled: true, two_factor_secret: secret }],
+      rows: [
+        {
+          two_factor_enabled: true,
+          two_factor_secret: encryptedSecret,
+          two_factor_last_step: null,
+        },
+      ],
     });
     await expect(
       disableTwoFactor(mocks.deps, PRINCIPAL, { token: '000000' })
     ).rejects.toMatchObject({ code: 'INVALID_ARGUMENT' });
-    // Only the SELECT ran — no clearing UPDATE.
+    // Only the SELECT ran — no replay-guard update, no clearing UPDATE.
     expect(mocks.poolMock.query).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects a replayed code that was already accepted (ADS-914c)', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-01-01T00:00:00Z'));
+    try {
+      const secret = generateSecret();
+      const token = generateSync({ secret });
+      const encryptedSecret = encryptTotpSecret(ENCRYPTION_KEY, secret);
+      const timeStep = Math.floor(Date.now() / 1000 / 30);
+      mocks.poolMock.query.mockResolvedValueOnce({
+        rows: [
+          {
+            two_factor_enabled: true,
+            two_factor_secret: encryptedSecret,
+            two_factor_last_step: timeStep,
+          },
+        ],
+      });
+      await expect(disableTwoFactor(mocks.deps, PRINCIPAL, { token })).rejects.toMatchObject({
+        code: 'INVALID_ARGUMENT',
+      });
+      expect(mocks.poolMock.query).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/services/auth/src/grpc/two-factor-handlers.ts
+++ b/services/auth/src/grpc/two-factor-handlers.ts
@@ -27,6 +27,8 @@ import type {
 } from '@adopt-dont-shop/proto';
 
 import { HandlerError, type HandlerDeps } from './handlers.js';
+import { encryptTotpSecret } from './totp-crypto.js';
+import { verifyAndConsumeTotp } from './totp-verification.js';
 
 const TOTP_ISSUER = 'Adopt Dont Shop';
 
@@ -34,6 +36,7 @@ type TwoFactorRow = {
   email: string;
   two_factor_enabled: boolean;
   two_factor_secret: string | null;
+  two_factor_last_step: number | null;
 };
 
 const requirePrincipal = (principal: Principal | null): Principal => {
@@ -86,11 +89,14 @@ export async function enableTwoFactor(
 
   // Guard on two_factor_enabled = false so a concurrent enable can't be
   // overwritten and a re-enable surfaces as the "already enabled" 400.
+  // The secret is encrypted at rest (ADS-914a) — only the ciphertext is
+  // ever written to the DB.
   const res = await deps.pool.query(
     `UPDATE auth.users
-        SET two_factor_secret = $1, two_factor_enabled = true, updated_at = now()
+        SET two_factor_secret = $1, two_factor_enabled = true, two_factor_last_step = NULL,
+            updated_at = now()
       WHERE user_id = $2 AND deleted_at IS NULL AND two_factor_enabled = false`,
-    [req.secret, me.userId]
+    [encryptTotpSecret(deps.encryptionKey, req.secret), me.userId]
   );
   if (res.rowCount === 0) {
     throw new HandlerError('INVALID_ARGUMENT', 'two-factor authentication is already enabled');
@@ -108,8 +114,10 @@ export async function disableTwoFactor(
     throw new HandlerError('INVALID_ARGUMENT', 'token is required');
   }
 
-  const res = await deps.pool.query<Pick<TwoFactorRow, 'two_factor_enabled' | 'two_factor_secret'>>(
-    `SELECT two_factor_enabled, two_factor_secret
+  const res = await deps.pool.query<
+    Pick<TwoFactorRow, 'two_factor_enabled' | 'two_factor_secret' | 'two_factor_last_step'>
+  >(
+    `SELECT two_factor_enabled, two_factor_secret, two_factor_last_step
        FROM auth.users WHERE user_id = $1 AND deleted_at IS NULL`,
     [me.userId]
   );
@@ -120,13 +128,23 @@ export async function disableTwoFactor(
   if (!row.two_factor_enabled || !row.two_factor_secret) {
     throw new HandlerError('INVALID_ARGUMENT', 'two-factor authentication is not enabled');
   }
-  if (!verifySync({ token: req.token, secret: row.two_factor_secret }).valid) {
+  const ok = await verifyAndConsumeTotp(
+    deps,
+    {
+      userId: me.userId,
+      encryptedSecret: row.two_factor_secret,
+      lastStep: row.two_factor_last_step,
+    },
+    req.token
+  );
+  if (!ok) {
     throw new HandlerError('INVALID_ARGUMENT', 'invalid two-factor code');
   }
 
   await deps.pool.query(
     `UPDATE auth.users
-        SET two_factor_secret = NULL, two_factor_enabled = false, updated_at = now()
+        SET two_factor_secret = NULL, two_factor_enabled = false, two_factor_last_step = NULL,
+            updated_at = now()
       WHERE user_id = $1`,
     [me.userId]
   );

--- a/services/auth/src/migrations/027_encrypt_totp_secrets.test.ts
+++ b/services/auth/src/migrations/027_encrypt_totp_secrets.test.ts
@@ -1,0 +1,86 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { decryptTotpSecret } from '../grpc/totp-crypto.js';
+
+import { down, up } from './027_encrypt_totp_secrets.js';
+
+const ENCRYPTION_KEY = 'a'.repeat(64);
+
+type SelectRow = { user_id: string; two_factor_secret: string };
+
+function makePgm(rows: SelectRow[]) {
+  const updates: Array<{ sql: string; params: unknown[] }> = [];
+  const pgm = {
+    addColumns: vi.fn(),
+    dropColumns: vi.fn(),
+    db: {
+      select: vi.fn().mockResolvedValue(rows),
+      query: vi.fn((sql: string, params: unknown[]) => {
+        updates.push({ sql, params });
+        return Promise.resolve();
+      }),
+    },
+  };
+  return { pgm, updates };
+}
+
+describe('027_encrypt_totp_secrets', () => {
+  const originalKey = process.env.ENCRYPTION_KEY;
+
+  beforeEach(() => {
+    process.env.ENCRYPTION_KEY = ENCRYPTION_KEY;
+  });
+
+  afterEach(() => {
+    process.env.ENCRYPTION_KEY = originalKey;
+    vi.restoreAllMocks();
+  });
+
+  it('adds the two_factor_last_step column and re-wraps existing plaintext secrets', async () => {
+    const { pgm, updates } = makePgm([{ user_id: 'u1', two_factor_secret: 'JBSWY3DPEHPK3PXP' }]);
+
+    await up(pgm as any);
+
+    expect(pgm.addColumns).toHaveBeenCalledWith('users', {
+      two_factor_last_step: { type: 'integer' },
+    });
+    expect(updates).toHaveLength(1);
+    const [{ params }] = updates;
+    // The written value is ciphertext, not the plaintext secret, and
+    // round-trips back to the original.
+    expect(params[0]).not.toBe('JBSWY3DPEHPK3PXP');
+    expect(decryptTotpSecret(ENCRYPTION_KEY, params[0] as string)).toBe('JBSWY3DPEHPK3PXP');
+    expect(params[1]).toBe('u1');
+  });
+
+  it('is a no-op on the row set when no secrets are enrolled', async () => {
+    const { pgm, updates } = makePgm([]);
+
+    await up(pgm as any);
+
+    expect(updates).toHaveLength(0);
+  });
+
+  it('logs a warning and continues when a single row fails to encrypt', async () => {
+    const { pgm, updates } = makePgm([{ user_id: 'u1', two_factor_secret: 'GOOD' }]);
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    // Force the second write to be reached by making the key invalid mid-run
+    // is awkward; instead make db.query throw for the first row so the catch
+    // path runs, then assert we surfaced a warning rather than aborting.
+    pgm.db.query.mockRejectedValueOnce(new Error('boom'));
+
+    await up(pgm as any);
+
+    expect(warn).toHaveBeenCalled();
+    // The write was attempted (and failed) but up() did not throw.
+    expect(updates).toHaveLength(0);
+  });
+
+  it('down drops the two_factor_last_step column', async () => {
+    const { pgm } = makePgm([]);
+
+    await down(pgm as any);
+
+    expect(pgm.dropColumns).toHaveBeenCalledWith('users', ['two_factor_last_step']);
+  });
+});

--- a/services/auth/src/migrations/027_encrypt_totp_secrets.ts
+++ b/services/auth/src/migrations/027_encrypt_totp_secrets.ts
@@ -1,0 +1,65 @@
+import type { MigrationBuilder } from 'node-pg-migrate';
+
+import { requireHexSecret } from '@adopt-dont-shop/config-secrets';
+
+import { encryptTotpSecret } from '../grpc/totp-crypto.js';
+
+// ADS-914: TOTP 2FA hardening.
+//
+// (a) `two_factor_secret` was written and read verbatim — a single DB read
+// gave permanent, offline 2FA bypass for every enrolled user (the same
+// class of risk 024/025 already fixed for reset/verification/refresh
+// tokens, there by hashing). TOTP secrets must round-trip (the server
+// needs the plaintext back to compute codes), so they're encrypted with
+// AES-256-GCM under ENCRYPTION_KEY instead — see grpc/totp-crypto.ts.
+// This migration re-wraps every existing plaintext secret in place; from
+// this point the column holds ciphertext only, matching the runtime
+// encrypt-on-enable / decrypt-on-verify code path (grpc/two-factor-handlers.ts,
+// grpc/totp-verification.ts).
+//
+// (c) TOTP codes could be replayed within their validity window (observed
+// once via screenshare/shoulder-surf/AiTM phishing, then reused). Adds
+// `two_factor_last_step` so verifyAndConsumeTotp can reject any code whose
+// RFC 6238 time step is <= the last accepted one.
+//
+// (b) Backup codes are a separate, larger self-service-recovery feature
+// (generation, hashing, storage, redemption UI) and are deliberately out
+// of scope for this migration — tracked as a follow-up.
+export const up = async (pgm: MigrationBuilder): Promise<void> => {
+  pgm.addColumns('users', {
+    two_factor_last_step: { type: 'integer' },
+  });
+
+  const encryptionKey = requireHexSecret('ENCRYPTION_KEY', process.env, {
+    description: 'AES-256-GCM key for encrypting TOTP secrets at rest',
+  });
+
+  const rows = (await pgm.db.select(
+    `SELECT user_id, two_factor_secret FROM auth.users WHERE two_factor_secret IS NOT NULL`
+  )) as Array<{ user_id: string; two_factor_secret: string }>;
+
+  for (const row of rows) {
+    try {
+      const encrypted = encryptTotpSecret(encryptionKey, row.two_factor_secret);
+      await pgm.db.query(`UPDATE auth.users SET two_factor_secret = $1 WHERE user_id = $2`, [
+        encrypted,
+        row.user_id,
+      ]);
+    } catch (err) {
+      // A single malformed row must not abort the whole rollout. The
+      // affected user simply falls back to the existing admin-mediated
+      // disableTwoFactor / re-enrolment flow.
+      console.warn(
+        `[027_encrypt_totp_secrets] failed to encrypt two_factor_secret for user_id=${row.user_id}`,
+        err
+      );
+    }
+  }
+};
+
+export const down = async (pgm: MigrationBuilder): Promise<void> => {
+  pgm.dropColumns('users', ['two_factor_last_step']);
+  // Deliberately not reversing the encryption — decrypting back to
+  // plaintext on downgrade would be a worse security posture than leaving
+  // already-encrypted rows encrypted (same stance as 024/025).
+};

--- a/services/auth/src/migrations/migrations.test.ts
+++ b/services/auth/src/migrations/migrations.test.ts
@@ -47,6 +47,7 @@ describe('auth migrations', () => {
     '006_create_refresh_tokens.ts',
     '007_create_revoked_tokens.ts',
     '015_add_tokens_valid_from.ts',
+    '027_encrypt_totp_secrets.ts',
   ])('%s exports `up` and `down` functions', async filename => {
     const mod = (await import(`./${filename}`)) as {
       up: unknown;


### PR DESCRIPTION
## Summary

- **ADS-914 (Medium, partial)** — two of the ticket's three 2FA weaknesses fixed:
  - **(a) TOTP secrets encrypted at rest**: new `grpc/totp-crypto.ts` (AES-256-GCM, random IV per write, `base64(iv‖tag‖ciphertext)`) under an `ENCRYPTION_KEY` config. `enableTwoFactor` writes ciphertext; login and `disableTwoFactor` decrypt on demand and fail closed on undecryptable rows. Migration `027_encrypt_totp_secrets.ts` re-wraps existing plaintext rows in place
  - **(c) TOTP replay prevention**: new `grpc/totp-verification.ts` pins the epoch and persists the accepted RFC 6238 timestep in a new `users.two_factor_last_step` column, so a code can't be reused within its validity window; GDPR erase clears the column
  - **(b) Backup codes — DEFERRED** to its own ticket: self-service recovery (generation, hashing, single-use redemption at login, regenerate-on-empty, plus reveal-once enrolment UI across all three apps) spans the proto surface and frontends — not a contained backend change. Enrolment/recovery behaviour is unchanged
- **ADS-913 (High)** — refresh-token reuse → family revocation is **already fixed on main** via PR #1204 (`91cd9d7`): both reuse-detection paths revoke the whole `family_id`, stamp `tokens_valid_from`, publish `auth.tokenReuseDetected`, and bump the reuse counters, with regression tests. Verified, no change

## ⚠️ Deploy prerequisite

This makes **`ENCRYPTION_KEY` a required secret for service.auth** (64 hex chars). It's wired through dev/staging/prod compose and the deploy + rollback workflows as a file-mounted Docker secret (matching the jwt-secret pattern), and CI already generates it — **but a live deploy must have the secret materialised before service.auth will boot.** Migration `027` re-wraps existing plaintext TOTP rows on run.

## Changes

- `services/auth/src/grpc/totp-crypto.ts`, `totp-verification.ts` (new) + tests
- `services/auth/src/grpc/handlers.ts` — enable/login/disable use encrypt/decrypt + replay guard
- `services/auth/src/migrations/027_encrypt_totp_secrets.ts` (new) + test; `two_factor_last_step` column
- `services/auth` config — `ENCRYPTION_KEY` (`requireHexSecret`, 64 hex)
- `docker-compose.{dev,staging,prod}.yml`, `deploy.yml`, `rollback.yml`, `secrets/README.md` — wire the secret

## Before requesting review

- [x] Tests for new behaviour added (TDD)
- [x] If touching `.env` requirements — `ENCRYPTION_KEY` wired through compose/workflows/secrets README; CI generates it
- [x] If touching a shared package — n/a (service.auth-local)

## Test plan

- [x] `service.auth test:coverage`: 347 tests / 23 files green, thresholds satisfied; new files have dedicated tests (`totp-crypto.test.ts`, `totp-verification.test.ts`, `027_encrypt_totp_secrets.test.ts`)
- [x] Type-check and lint clean (one pre-existing warning in untouched `auth-metrics.ts`)
- [x] All compose + workflow YAML validated
- [ ] Reviewer note: migration `027` warns-and-continues per row if a secret can't be re-wrapped — check the run logs on first deploy

## Screenshots / recordings

Not applicable — backend auth hardening.

## Related

- Linear: ADS-914 (partial — backup codes deferred) · ADS-913 (already fixed via #1204)
- Follow-up: backup codes need their own ticket (backend + enrolment UI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q5FhHDPvEtBYRDwMAV3rtv

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q5FhHDPvEtBYRDwMAV3rtv)_