### PR TITLE
feat(gateway): CSRF token issuance + validation route — ADS-919 Phase 0

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1965,6 +1965,9 @@ importers:
       '@adopt-dont-shop/storage':
         specifier: workspace:*
         version: link:../../packages/storage
+      '@fastify/cookie':
+        specifier: ^11.1.1
+        version: 11.1.1
       '@fastify/cors':
         specifier: ^11.2.0
         version: 11.2.0
@@ -3375,6 +3378,9 @@ packages:
 
   '@fastify/busboy@3.2.0':
     resolution: {integrity: sha512-m9FVDXU3GT2ITSe0UaMA5rU3QkfC/UXtCU8y0gSN/GugTqtVldOBWIB5V6V3sbmenVZUIpU6f+mPEO2+m5iTaA==}
+
+  '@fastify/cookie@11.1.1':
+    resolution: {integrity: sha512-sJ0NXzGVYjUB4OynPZRsIcQ1mKSP4rW45xLCN0aelRq5Vl37xVVbz5kJ6Y0a9m2T0mCUjYCuvlUA9QlTafrZWw==}
 
   '@fastify/cors@11.2.0':
     resolution: {integrity: sha512-LbLHBuSAdGdSFZYTLVA3+Ch2t+sA6nq3Ejc6XLAKiQ6ViS2qFnvicpj0htsx03FyYeLs04HfRNBsz/a8SvbcUw==}
@@ -6735,6 +6741,10 @@ packages:
     resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
     engines: {node: '>=18'}
 
+  cookie@2.0.1:
+    resolution: {integrity: sha512-yuToqVvRrj6pfDXREyQAAv8SkAEk/8GS3jQRTiUMm66TVtBYmqQeoEjL2Lmq8Rpo6271vH76InTChTitEAm65w==}
+    engines: {node: '>=22'}
+
   core-js-compat@3.49.0:
     resolution: {integrity: sha512-VQXt1jr9cBz03b331DFDCCP90b3fanciLkgiOoy8SBHy06gNf+vQ1A3WFLqG7I8TipYIKeYK9wxd0tUrvHcOZA==}
 
@@ -7387,6 +7397,9 @@ packages:
 
   fastify-plugin@5.1.0:
     resolution: {integrity: sha512-FAIDA8eovSt5qcDgcBvDuX/v0Cjz0ohGhENZ/wpc3y+oZCY2afZ9Baqql3g/lC+OHRnciQol4ww7tuthOb9idw==}
+
+  fastify-plugin@6.0.0:
+    resolution: {integrity: sha512-fZOty7z3O7vOliF6d8bHE3wiEh1KcNnKEQensSgTk9C1DvN6nRLS++XVd86v33Hw/8u9Un8A1zDrQ8ujcQDHEg==}
 
   fastify@5.8.5:
     resolution: {integrity: sha512-Yqptv59pQzPgQUSIm87hMqHJmdkb1+GPxdE6vW6FRyVE9G86mt7rOghitiU4JHRaTyDUk9pfeKmDeu70lAwM4Q==}
@@ -11851,6 +11864,11 @@ snapshots:
 
   '@fastify/busboy@3.2.0': {}
 
+  '@fastify/cookie@11.1.1':
+    dependencies:
+      cookie: 2.0.1
+      fastify-plugin: 6.0.0
+
   '@fastify/cors@11.2.0':
     dependencies:
       fastify-plugin: 5.1.0
@@ -15454,6 +15472,8 @@ snapshots:
 
   cookie@1.1.1: {}
 
+  cookie@2.0.1: {}
+
   core-js-compat@3.49.0:
     dependencies:
       browserslist: 4.28.4
@@ -16296,6 +16316,8 @@ snapshots:
       strnum: 2.4.1
 
   fastify-plugin@5.1.0: {}
+
+  fastify-plugin@6.0.0: {}
 
   fastify@5.8.5:
     dependencies:

--- a/services/gateway/package.json
+++ b/services/gateway/package.json
@@ -43,6 +43,7 @@
     "@adopt-dont-shop/proto": "workspace:*",
     "@adopt-dont-shop/service-bootstrap": "workspace:*",
     "@adopt-dont-shop/storage": "workspace:*",
+    "@fastify/cookie": "^11.1.1",
     "@fastify/cors": "^11.2.0",
     "@fastify/helmet": "^13.0.2",
     "@fastify/multipart": "^10.0.0",

--- a/services/gateway/src/middleware/csrf.test.ts
+++ b/services/gateway/src/middleware/csrf.test.ts
@@ -1,0 +1,148 @@
+import cookie from '@fastify/cookie';
+import Fastify, { type FastifyInstance } from 'fastify';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { CSRF_COOKIE_NAME, registerCsrfProtection, verifyCsrfToken } from './csrf.js';
+
+const quietLogger = {
+  info: () => undefined,
+  error: () => undefined,
+  warn: () => undefined,
+  debug: () => undefined,
+  silly: () => undefined,
+} as unknown as Parameters<typeof registerCsrfProtection>[1]['logger'];
+
+async function makeApp(): Promise<FastifyInstance> {
+  const app = Fastify({ logger: false });
+  await app.register(cookie);
+  registerCsrfProtection(app, { logger: quietLogger });
+  app.get('/api/v1/things', async () => ({ ok: true }));
+  app.post('/api/v1/things', async () => ({ created: true }));
+  app.put('/api/v1/things', async () => ({ updated: true }));
+  app.patch('/api/v1/things', async () => ({ patched: true }));
+  app.delete('/api/v1/things', async () => ({ deleted: true }));
+  return app;
+}
+
+describe('CSRF protection — opportunistic double-submit enforcement (ADS-919 Phase 0)', () => {
+  let app: FastifyInstance;
+
+  beforeEach(async () => {
+    app = await makeApp();
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  it('does not enforce GET requests even with a mismatched cookie/header', async () => {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/v1/things',
+      headers: { cookie: `${CSRF_COOKIE_NAME}=abc` },
+    });
+    expect(res.statusCode).toBe(200);
+  });
+
+  it('lets a state-changing request through when NO csrfToken cookie is present', async () => {
+    // This is the "not enforced yet" bucket per the module comment —
+    // every existing route/test in the gateway never sets this cookie,
+    // so this behaviour keeps them working unmodified.
+    const res = await app.inject({ method: 'POST', url: '/api/v1/things' });
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual({ created: true });
+  });
+
+  it('accepts a state-changing request when the header matches the cookie', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/v1/things',
+      headers: {
+        cookie: `${CSRF_COOKIE_NAME}=matching-token-123`,
+        'x-csrf-token': 'matching-token-123',
+      },
+    });
+    expect(res.statusCode).toBe(200);
+  });
+
+  it('rejects with 403 when the cookie is present but the header is missing', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/v1/things',
+      headers: { cookie: `${CSRF_COOKIE_NAME}=matching-token-123` },
+    });
+    expect(res.statusCode).toBe(403);
+    expect(res.json()).toEqual({ error: 'invalid csrf token' });
+  });
+
+  it('rejects with 403 when the cookie and header values do not match', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/v1/things',
+      headers: {
+        cookie: `${CSRF_COOKIE_NAME}=matching-token-123`,
+        'x-csrf-token': 'a-different-token',
+      },
+    });
+    expect(res.statusCode).toBe(403);
+  });
+
+  it.each(['PUT', 'PATCH', 'DELETE'] as const)(
+    'enforces %s the same way as POST once the cookie is present',
+    async method => {
+      const rejected = await app.inject({
+        method,
+        url: '/api/v1/things',
+        headers: { cookie: `${CSRF_COOKIE_NAME}=matching-token-123` },
+      });
+      expect(rejected.statusCode).toBe(403);
+
+      const accepted = await app.inject({
+        method,
+        url: '/api/v1/things',
+        headers: {
+          cookie: `${CSRF_COOKIE_NAME}=matching-token-123`,
+          'x-csrf-token': 'matching-token-123',
+        },
+      });
+      expect(accepted.statusCode).toBe(200);
+    }
+  );
+});
+
+describe('verifyCsrfToken', () => {
+  let app: FastifyInstance;
+
+  beforeEach(async () => {
+    app = Fastify({ logger: false });
+    await app.register(cookie);
+    app.get('/check', async req => ({ valid: verifyCsrfToken(req) }));
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  it('returns false when neither cookie nor header is present', async () => {
+    const res = await app.inject({ method: 'GET', url: '/check' });
+    expect(res.json()).toEqual({ valid: false });
+  });
+
+  it('returns false when the header is empty', async () => {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/check',
+      headers: { cookie: `${CSRF_COOKIE_NAME}=abc`, 'x-csrf-token': '' },
+    });
+    expect(res.json()).toEqual({ valid: false });
+  });
+
+  it('returns true when cookie and header match exactly', async () => {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/check',
+      headers: { cookie: `${CSRF_COOKIE_NAME}=exact-match`, 'x-csrf-token': 'exact-match' },
+    });
+    expect(res.json()).toEqual({ valid: true });
+  });
+});

--- a/services/gateway/src/middleware/csrf.ts
+++ b/services/gateway/src/middleware/csrf.ts
@@ -1,0 +1,76 @@
+// CSRF double-submit-cookie primitive (ADS-919 Phase 0).
+//
+// Pattern: GET /api/v1/csrf-token (routes/csrf.ts) mints a random token,
+// sets it as a non-HttpOnly `csrfToken` cookie, and returns the same value
+// in the JSON body. `packages/lib.api/src/services/api-service.ts` already
+// fetches that route and attaches the returned value as the `x-csrf-token`
+// header on every state-changing (POST/PUT/PATCH/DELETE) request — this
+// file is the server-side half: comparing the header against the cookie.
+//
+// Enforcement scope (deliberately narrow for Phase 0 — see
+// docs/security/ADS-919-token-storage-plan.md): the hook below only
+// rejects a state-changing request when a `csrfToken` cookie IS present.
+// Nothing in the codebase sets that cookie except the new route this hook
+// ships alongside, so every existing route/test that never calls GET
+// /api/v1/csrf-token first is unaffected. Once a client HAS fetched the
+// cookie (every real SPA mutation does, via the interceptor above), a
+// missing or mismatched x-csrf-token header on a subsequent mutation 403s.
+// Widening enforcement to reject requests with no cookie at all is a
+// follow-up once the frontend fetch is verified working end-to-end in
+// every environment — see the plan doc's Phase 0 rollout note.
+
+import { timingSafeEqual } from 'node:crypto';
+
+import type { FastifyInstance, FastifyRequest } from 'fastify';
+import type { Logger } from 'winston';
+
+export const CSRF_COOKIE_NAME = 'csrfToken';
+export const CSRF_HEADER_NAME = 'x-csrf-token';
+
+const STATE_CHANGING_METHODS = new Set(['POST', 'PUT', 'PATCH', 'DELETE']);
+
+// Constant-time comparison of the double-submit cookie against the
+// x-csrf-token header. Exported so it can be unit tested directly without
+// spinning up a full route.
+export const verifyCsrfToken = (req: FastifyRequest): boolean => {
+  const cookieToken = req.cookies?.[CSRF_COOKIE_NAME];
+  const headerToken = req.headers[CSRF_HEADER_NAME];
+  if (!cookieToken || typeof headerToken !== 'string' || headerToken.length === 0) {
+    return false;
+  }
+  const cookieBuf = Buffer.from(cookieToken);
+  const headerBuf = Buffer.from(headerToken);
+  if (cookieBuf.length !== headerBuf.length) {
+    return false;
+  }
+  return timingSafeEqual(cookieBuf, headerBuf);
+};
+
+export type CsrfProtectionOptions = {
+  logger: Logger;
+};
+
+// Registers the onRequest hook that enforces the double-submit check on
+// every route — see the module comment above for exactly what's enforced
+// vs. issued-only. Requires @fastify/cookie to already be registered on
+// `app` (for `req.cookies` / `reply.setCookie`).
+export const registerCsrfProtection = (app: FastifyInstance, opts: CsrfProtectionOptions): void => {
+  app.addHook('onRequest', async (req, reply) => {
+    if (!STATE_CHANGING_METHODS.has(req.method)) {
+      return;
+    }
+    const cookieToken = req.cookies?.[CSRF_COOKIE_NAME];
+    if (!cookieToken) {
+      // Client hasn't opted into the double-submit flow yet (or this
+      // route predates it). Not enforced — see module comment.
+      return;
+    }
+    if (!verifyCsrfToken(req)) {
+      opts.logger.warn('rejecting request: missing/invalid CSRF token', {
+        method: req.method,
+        url: req.url,
+      });
+      return reply.code(403).send({ error: 'invalid csrf token' });
+    }
+  });
+};

--- a/services/gateway/src/routes/csrf.test.ts
+++ b/services/gateway/src/routes/csrf.test.ts
@@ -1,0 +1,54 @@
+import cookie from '@fastify/cookie';
+import Fastify, { type FastifyInstance } from 'fastify';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { registerCsrfRoutes } from './csrf.js';
+
+describe('GET /api/v1/csrf-token — issues the double-submit CSRF cookie', () => {
+  let app: FastifyInstance;
+
+  beforeEach(async () => {
+    app = Fastify({ logger: false });
+    await app.register(cookie);
+    await registerCsrfRoutes(app);
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  it('returns a csrfToken in the JSON body', async () => {
+    const res = await app.inject({ method: 'GET', url: '/api/v1/csrf-token' });
+    expect(res.statusCode).toBe(200);
+    const body = res.json() as { csrfToken: string };
+    expect(typeof body.csrfToken).toBe('string');
+    expect(body.csrfToken.length).toBeGreaterThan(0);
+  });
+
+  it('sets a non-HttpOnly, SameSite=Lax csrfToken cookie matching the body value', async () => {
+    const res = await app.inject({ method: 'GET', url: '/api/v1/csrf-token' });
+    const body = res.json() as { csrfToken: string };
+
+    const setCookieHeader = res.cookies.find(c => c.name === 'csrfToken');
+    expect(setCookieHeader).toBeDefined();
+    expect(setCookieHeader?.value).toBe(body.csrfToken);
+    expect(setCookieHeader?.httpOnly).toBeFalsy();
+    expect(setCookieHeader?.sameSite).toBe('Lax');
+    expect(setCookieHeader?.path).toBe('/');
+  });
+
+  it('mints a different token on each call', async () => {
+    const first = (await app.inject({ method: 'GET', url: '/api/v1/csrf-token' })).json() as {
+      csrfToken: string;
+    };
+    const second = (await app.inject({ method: 'GET', url: '/api/v1/csrf-token' })).json() as {
+      csrfToken: string;
+    };
+    expect(first.csrfToken).not.toBe(second.csrfToken);
+  });
+
+  it('does not require an Authorization header (public route)', async () => {
+    const res = await app.inject({ method: 'GET', url: '/api/v1/csrf-token' });
+    expect(res.statusCode).toBe(200);
+  });
+});

--- a/services/gateway/src/routes/csrf.ts
+++ b/services/gateway/src/routes/csrf.ts
@@ -1,0 +1,54 @@
+// GET /api/v1/csrf-token — issues the double-submit CSRF cookie (ADS-919
+// Phase 0). See middleware/csrf.ts for the validation half and its module
+// comment for exactly what's enforced today.
+//
+// Public route — no Authorization required. The SPA's request interceptor
+// (packages/lib.api/src/services/api-service.ts) fetches this before ANY
+// state-changing request, including unauthenticated ones like login and
+// register, so this must stay reachable without a token.
+
+import { randomBytes } from 'node:crypto';
+
+import type { FastifyInstance } from 'fastify';
+
+import { CSRF_COOKIE_NAME } from '../middleware/csrf.js';
+
+const CSRF_TOKEN_BYTES = 32;
+// How long the double-submit cookie stays valid before a client has to
+// re-fetch it. Not tied to access-token TTL — this is a per-tab CSRF
+// nonce, not a credential. 4 hours comfortably covers a working session
+// without forcing frequent re-fetches, while still rotating regularly.
+const CSRF_COOKIE_MAX_AGE_SECONDS = 60 * 60 * 4;
+
+export const registerCsrfRoutes = async (app: FastifyInstance): Promise<void> => {
+  app.get(
+    '/api/v1/csrf-token',
+    {
+      schema: {
+        tags: ['csrf'],
+        summary: 'Issue a CSRF token (double-submit cookie pattern)',
+        security: [],
+        response: {
+          200: {
+            type: 'object',
+            properties: { csrfToken: { type: 'string' } },
+            required: ['csrfToken'],
+          },
+        },
+      },
+    },
+    async (req, reply) => {
+      const token = randomBytes(CSRF_TOKEN_BYTES).toString('hex');
+
+      reply.setCookie(CSRF_COOKIE_NAME, token, {
+        path: '/',
+        httpOnly: false, // must be JS-readable for the double-submit pattern
+        sameSite: 'lax',
+        secure: req.protocol === 'https',
+        maxAge: CSRF_COOKIE_MAX_AGE_SECONDS,
+      });
+
+      return reply.send({ csrfToken: token });
+    }
+  );
+};

--- a/services/gateway/src/server.ts
+++ b/services/gateway/src/server.ts
@@ -29,6 +29,7 @@ import {
   registerMetrics,
   registerRequestId,
 } from '@adopt-dont-shop/observability';
+import cookie from '@fastify/cookie';
 import cors from '@fastify/cors';
 import helmet from '@fastify/helmet';
 import rateLimit from '@fastify/rate-limit';
@@ -48,6 +49,7 @@ import type { NotificationsClient } from './grpc-clients/notifications-client.js
 import type { PetsClient } from './grpc-clients/pets-client.js';
 import type { RescueClient } from './grpc-clients/rescue-client.js';
 import { registerAuthenticate } from './middleware/authenticate.js';
+import { registerCsrfProtection } from './middleware/csrf.js';
 import { createEmailRateLimiter } from './routes/email-rate-limiter.js';
 import { registerApplicationDocumentsRoutes } from './routes/application-documents.js';
 import { registerAnalyticsRoutes } from './routes/analytics.js';
@@ -59,6 +61,7 @@ import { registerAuthRoutes } from './routes/auth.js';
 import { registerChatRoutes } from './routes/chat.js';
 import { registerCmsRoutes } from './routes/cms.js';
 import { registerConfigRoutes } from './routes/config.js';
+import { registerCsrfRoutes } from './routes/csrf.js';
 import { registerDashboardRoutes } from './routes/dashboard.js';
 import { registerDevicesRoutes } from './routes/devices.js';
 import { registerBroadcastRoutes } from './routes/broadcast.js';
@@ -239,6 +242,14 @@ export const createServer = async (opts: CreateServerOptions): Promise<FastifyIn
     methods: ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'],
   });
 
+  // Cookie support (ADS-919 Phase 0). No signing secret — the CSRF
+  // double-submit cookie doesn't need one (its security comes from
+  // same-origin JS being the only thing that can read a non-HttpOnly
+  // cookie AND set a custom header in the same request), and nothing
+  // else sets cookies yet. A later phase that adds HttpOnly auth cookies
+  // can register signed cookies with a secret at that point.
+  await server.register(cookie);
+
   // Request-id middleware runs FIRST so the id is on req for every
   // hook after it (including the metrics onResponse hook + the
   // authenticate hook, which forwards it on downstream gRPC metadata).
@@ -417,6 +428,18 @@ export const createServer = async (opts: CreateServerOptions): Promise<FastifyIn
       }
     });
   }
+
+  // CSRF double-submit-cookie protection (ADS-919 Phase 0). Registered
+  // unconditionally (no gRPC client dependency) and safe to add globally:
+  // see middleware/csrf.ts's module comment for the enforcement scope —
+  // it only rejects a state-changing request that already carries the
+  // csrfToken cookie, so no existing route or test that doesn't fetch
+  // GET /api/v1/csrf-token first is affected.
+  registerCsrfProtection(server, { logger });
+
+  // GET /api/v1/csrf-token — issues the double-submit cookie. Public,
+  // gateway-folded (no upstream service), same shape as /api/v1/config.
+  await registerCsrfRoutes(server);
 
   // Service-specific routes register at /api/v1/<domain> BEFORE the
   // unmatched-route 404 handler — Fastify's first-registered-wins prefix


### PR DESCRIPTION
## Summary

Implements Phase 0 of the ADS-919 token-storage plan (`docs/security/ADS-919-token-storage-plan.md`): the real CSRF-token route that was the missing prerequisite. The SPA's `lib.api` already calls `GET /api/v1/csrf-token` and attaches `x-csrf-token` on mutations, but no such route existed (it 404'd, silently swallowed) — this makes that plumbing real, without touching token storage or auth cookies (later phases).

## What's implemented

- **Route** `GET /api/v1/csrf-token` (`services/gateway/src/routes/csrf.ts`): mints a 32-byte hex token, sets it as a non-HttpOnly `SameSite=Lax` `csrfToken` cookie (4h), and returns `{ csrfToken }` — matching exactly what `lib.api`'s `fetchCsrfToken()` expects (`credentials: 'include'` already set client-side). No auth required (login/register are unauthenticated POSTs that still need the header)
- **Validation** (`services/gateway/src/middleware/csrf.ts`): `verifyCsrfToken` does a constant-time (`timingSafeEqual`) double-submit comparison of the `csrfToken` cookie vs the `x-csrf-token` header; `registerCsrfProtection()` installs a global `onRequest` hook for POST/PUT/PATCH/DELETE
- **Dependency**: `@fastify/cookie@^11.1.1`, registered unsigned (double-submit needs no signing secret; a later phase adding HttpOnly auth cookies can add one)

## Enforcement scope — deliberately narrow (won't break existing routes)

- Request with **no** `csrfToken` cookie → passes through unchecked. That's every existing route and test today, since nothing else sets that cookie yet
- Request **with** the cookie (i.e. the client already fetched a token, which the SPA interceptor does before every mutation) → header must match or 403 `{ error: 'invalid csrf token' }`

Tightening this to reject *all* cookieless mutations is a Phase 0 follow-up, once the frontend fetch is confirmed working in every environment.

## Test plan

- [x] `service.gateway test:coverage`: 990/990 pass (verified end-to-end through real `createServer()` — token fetch works; mutation with no cookie passes; cookie-without-header 403s; matching cookie+header passes)
- [x] New tests: `middleware/csrf.test.ts` (methods, missing cookie/header, mismatch), `routes/csrf.test.ts` (body shape, cookie attrs, freshness, no-auth)
- [x] Type-check and lint clean

## Related

- Linear: ADS-919 (Phase 0 of the phased migration; token-storage/auth-cookie phases still to come)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q5FhHDPvEtBYRDwMAV3rtv

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q5FhHDPvEtBYRDwMAV3rtv)_