### PR TITLE
fix(seed): guard all service seed scripts against running in production

### DIFF
--- a/services/applications/src/db/seed.test.ts
+++ b/services/applications/src/db/seed.test.ts
@@ -1,7 +1,33 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { seedApplications, type QueryFn } from './seed.js';
+import { assertNotProduction, seedApplications, type QueryFn } from './seed.js';
 import { SEED_APPLICATIONS } from './seed-data.js';
+
+describe('production guard', () => {
+  afterEach(() => vi.unstubAllEnvs());
+
+  it('throws when NODE_ENV is production and ALLOW_PROD_SEED is not set', () => {
+    vi.stubEnv('NODE_ENV', 'production');
+    vi.stubEnv('ALLOW_PROD_SEED', '');
+
+    expect(() => assertNotProduction()).toThrowError(
+      'Refusing to run db:seed in production. Set ALLOW_PROD_SEED=true to override.'
+    );
+  });
+
+  it('permits seeding when NODE_ENV is production and ALLOW_PROD_SEED=true', () => {
+    vi.stubEnv('NODE_ENV', 'production');
+    vi.stubEnv('ALLOW_PROD_SEED', 'true');
+
+    expect(() => assertNotProduction()).not.toThrow();
+  });
+
+  it('permits seeding in non-production environments', () => {
+    vi.stubEnv('NODE_ENV', 'development');
+
+    expect(() => assertNotProduction()).not.toThrow();
+  });
+});
 
 function recordingQuery(): { query: QueryFn; calls: Array<{ text: string; values: unknown[] }> } {
   const calls: Array<{ text: string; values: unknown[] }> = [];

--- a/services/applications/src/db/seed.ts
+++ b/services/applications/src/db/seed.ts
@@ -55,7 +55,14 @@ const appParams = (a: SeedApplication): readonly unknown[] => [
   a.status,
 ];
 
+export const assertNotProduction = (): void => {
+  if (process.env.NODE_ENV === 'production' && process.env.ALLOW_PROD_SEED !== 'true') {
+    throw new Error('Refusing to run db:seed in production. Set ALLOW_PROD_SEED=true to override.');
+  }
+};
+
 const main = async (): Promise<void> => {
+  assertNotProduction();
   const logger = createLogger({ serviceName: 'service.applications.seed' });
   const config = loadConfig();
   const pool = createDbClient({ connectionString: config.databaseUrl, schema: config.schema });

--- a/services/auth/src/db/seed.test.ts
+++ b/services/auth/src/db/seed.test.ts
@@ -1,7 +1,33 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { seedUsers, type QueryFn } from './seed.js';
+import { assertNotProduction, seedUsers, type QueryFn } from './seed.js';
 import { SEED_PASSWORD, SEED_USERS } from './seed-data.js';
+
+describe('production guard', () => {
+  afterEach(() => vi.unstubAllEnvs());
+
+  it('throws when NODE_ENV is production and ALLOW_PROD_SEED is not set', () => {
+    vi.stubEnv('NODE_ENV', 'production');
+    vi.stubEnv('ALLOW_PROD_SEED', '');
+
+    expect(() => assertNotProduction()).toThrowError(
+      'Refusing to run db:seed in production. Set ALLOW_PROD_SEED=true to override.'
+    );
+  });
+
+  it('permits seeding when NODE_ENV is production and ALLOW_PROD_SEED=true', () => {
+    vi.stubEnv('NODE_ENV', 'production');
+    vi.stubEnv('ALLOW_PROD_SEED', 'true');
+
+    expect(() => assertNotProduction()).not.toThrow();
+  });
+
+  it('permits seeding in non-production environments', () => {
+    vi.stubEnv('NODE_ENV', 'development');
+
+    expect(() => assertNotProduction()).not.toThrow();
+  });
+});
 
 // A recording query stub — the seed is pure aside from the injected
 // query/hash, so we can assert the SQL + params it would run without a

--- a/services/auth/src/db/seed.ts
+++ b/services/auth/src/db/seed.ts
@@ -74,7 +74,14 @@ const paramsFor = (user: SeedUser, passwordHash: string): readonly unknown[] => 
   user.userType,
 ];
 
+export const assertNotProduction = (): void => {
+  if (process.env.NODE_ENV === 'production' && process.env.ALLOW_PROD_SEED !== 'true') {
+    throw new Error('Refusing to run db:seed in production. Set ALLOW_PROD_SEED=true to override.');
+  }
+};
+
 const main = async (): Promise<void> => {
+  assertNotProduction();
   const logger = createLogger({ serviceName: 'service.auth.seed' });
   const config = loadConfig();
   const pool = createDbClient({ connectionString: config.databaseUrl, schema: config.schema });

--- a/services/chat/src/db/seed.test.ts
+++ b/services/chat/src/db/seed.test.ts
@@ -1,7 +1,33 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { seedChats, type QueryFn } from './seed.js';
+import { assertNotProduction, seedChats, type QueryFn } from './seed.js';
 import { SEED_CHATS } from './seed-data.js';
+
+describe('production guard', () => {
+  afterEach(() => vi.unstubAllEnvs());
+
+  it('throws when NODE_ENV is production and ALLOW_PROD_SEED is not set', () => {
+    vi.stubEnv('NODE_ENV', 'production');
+    vi.stubEnv('ALLOW_PROD_SEED', '');
+
+    expect(() => assertNotProduction()).toThrowError(
+      'Refusing to run db:seed in production. Set ALLOW_PROD_SEED=true to override.'
+    );
+  });
+
+  it('permits seeding when NODE_ENV is production and ALLOW_PROD_SEED=true', () => {
+    vi.stubEnv('NODE_ENV', 'production');
+    vi.stubEnv('ALLOW_PROD_SEED', 'true');
+
+    expect(() => assertNotProduction()).not.toThrow();
+  });
+
+  it('permits seeding in non-production environments', () => {
+    vi.stubEnv('NODE_ENV', 'development');
+
+    expect(() => assertNotProduction()).not.toThrow();
+  });
+});
 
 function recordingQuery(): { query: QueryFn; calls: Array<{ text: string; values: unknown[] }> } {
   const calls: Array<{ text: string; values: unknown[] }> = [];

--- a/services/chat/src/db/seed.ts
+++ b/services/chat/src/db/seed.ts
@@ -58,7 +58,14 @@ export const seedChats = async (deps: SeedDeps): Promise<string[]> => {
   return seeded;
 };
 
+export const assertNotProduction = (): void => {
+  if (process.env.NODE_ENV === 'production' && process.env.ALLOW_PROD_SEED !== 'true') {
+    throw new Error('Refusing to run db:seed in production. Set ALLOW_PROD_SEED=true to override.');
+  }
+};
+
 const main = async (): Promise<void> => {
+  assertNotProduction();
   const logger = createLogger({ serviceName: 'service.chat.seed' });
   const config = loadConfig();
   const pool = createDbClient({ connectionString: config.databaseUrl, schema: config.schema });

--- a/services/pets/src/db/seed.test.ts
+++ b/services/pets/src/db/seed.test.ts
@@ -1,7 +1,33 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { seedFavorites, seedPets, type QueryFn } from './seed.js';
+import { assertNotProduction, seedFavorites, seedPets, type QueryFn } from './seed.js';
 import { SEED_FAVORITES, SEED_PETS } from './seed-data.js';
+
+describe('production guard', () => {
+  afterEach(() => vi.unstubAllEnvs());
+
+  it('throws when NODE_ENV is production and ALLOW_PROD_SEED is not set', () => {
+    vi.stubEnv('NODE_ENV', 'production');
+    vi.stubEnv('ALLOW_PROD_SEED', '');
+
+    expect(() => assertNotProduction()).toThrowError(
+      'Refusing to run db:seed in production. Set ALLOW_PROD_SEED=true to override.'
+    );
+  });
+
+  it('permits seeding when NODE_ENV is production and ALLOW_PROD_SEED=true', () => {
+    vi.stubEnv('NODE_ENV', 'production');
+    vi.stubEnv('ALLOW_PROD_SEED', 'true');
+
+    expect(() => assertNotProduction()).not.toThrow();
+  });
+
+  it('permits seeding in non-production environments', () => {
+    vi.stubEnv('NODE_ENV', 'development');
+
+    expect(() => assertNotProduction()).not.toThrow();
+  });
+});
 
 function recordingQuery(): { query: QueryFn; calls: Array<{ text: string; values: unknown[] }> } {
   const calls: Array<{ text: string; values: unknown[] }> = [];

--- a/services/pets/src/db/seed.ts
+++ b/services/pets/src/db/seed.ts
@@ -85,7 +85,14 @@ const petParams = (p: SeedPet): readonly unknown[] => [
   PAWS_MANAGER_ID,
 ];
 
+export const assertNotProduction = (): void => {
+  if (process.env.NODE_ENV === 'production' && process.env.ALLOW_PROD_SEED !== 'true') {
+    throw new Error('Refusing to run db:seed in production. Set ALLOW_PROD_SEED=true to override.');
+  }
+};
+
 const main = async (): Promise<void> => {
+  assertNotProduction();
   const logger = createLogger({ serviceName: 'service.pets.seed' });
   const config = loadConfig();
   const pool = createDbClient({ connectionString: config.databaseUrl, schema: config.schema });

--- a/services/rescue/src/db/seed.test.ts
+++ b/services/rescue/src/db/seed.test.ts
@@ -1,7 +1,33 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { seedRescues, type QueryFn } from './seed.js';
+import { assertNotProduction, seedRescues, type QueryFn } from './seed.js';
 import { SEED_RESCUES, SEED_STAFF } from './seed-data.js';
+
+describe('production guard', () => {
+  afterEach(() => vi.unstubAllEnvs());
+
+  it('throws when NODE_ENV is production and ALLOW_PROD_SEED is not set', () => {
+    vi.stubEnv('NODE_ENV', 'production');
+    vi.stubEnv('ALLOW_PROD_SEED', '');
+
+    expect(() => assertNotProduction()).toThrowError(
+      'Refusing to run db:seed in production. Set ALLOW_PROD_SEED=true to override.'
+    );
+  });
+
+  it('permits seeding when NODE_ENV is production and ALLOW_PROD_SEED=true', () => {
+    vi.stubEnv('NODE_ENV', 'production');
+    vi.stubEnv('ALLOW_PROD_SEED', 'true');
+
+    expect(() => assertNotProduction()).not.toThrow();
+  });
+
+  it('permits seeding in non-production environments', () => {
+    vi.stubEnv('NODE_ENV', 'development');
+
+    expect(() => assertNotProduction()).not.toThrow();
+  });
+});
 
 function recordingQuery(): { query: QueryFn; calls: Array<{ text: string; values: unknown[] }> } {
   const calls: Array<{ text: string; values: unknown[] }> = [];

--- a/services/rescue/src/db/seed.ts
+++ b/services/rescue/src/db/seed.ts
@@ -92,7 +92,14 @@ const staffParams = (s: SeedStaff): readonly unknown[] => [
   s.title,
 ];
 
+export const assertNotProduction = (): void => {
+  if (process.env.NODE_ENV === 'production' && process.env.ALLOW_PROD_SEED !== 'true') {
+    throw new Error('Refusing to run db:seed in production. Set ALLOW_PROD_SEED=true to override.');
+  }
+};
+
 const main = async (): Promise<void> => {
+  assertNotProduction();
   const logger = createLogger({ serviceName: 'service.rescue.seed' });
   const config = loadConfig();
   const pool = createDbClient({ connectionString: config.databaseUrl, schema: config.schema });


### PR DESCRIPTION
## Summary

- Adds a production guard (`assertNotProduction`) to all five service seed entry points: `auth`, `applications`, `chat`, `pets`, and `rescue`
- Running `pnpm db:seed` with `NODE_ENV=production` now exits non-zero with a clear error message instead of overwriting live rows with well-known dev credentials (`DevPassword123!` / fixed UUIDs)
- An emergency escape hatch `ALLOW_PROD_SEED=true` is available for intentional production re-seeds

## Changes

- `services/{auth,applications,chat,pets,rescue}/src/db/seed.ts` — export `assertNotProduction()` (throws if `NODE_ENV=production` and `ALLOW_PROD_SEED !== 'true'`); `main()` calls it before opening the DB pool
- `services/{auth,applications,chat,pets,rescue}/src/db/seed.test.ts` — three guard tests each: rejects in prod, permits with `ALLOW_PROD_SEED=true`, permits in non-prod

## Before requesting review

- [x] Tests for new behaviour added (TDD)
- [x] No `.env` changes required

## Test plan

- [x] Existing tests pass (`pnpm test` on all 5 services — 38 seed tests, all green)
- [x] New behaviour is covered by tests (3 guard tests per service × 5 = 15 new tests)
- [x] No TypeScript errors
- [x] Lint passes (pre-commit hook ran clean)

## Related

Closes [ADS-959](https://linear.app/ideasquared/issue/ADS-959/security-servicesauthsrcdbseedts-has-no-node_env-guard-seeds-well)

---
_Generated by [Claude Code](https://claude.ai/code/session_01ETqBFAS6RHPkjy7kmKRiBQ)_