### PR TITLE
feat(auth): migrate token storage from localStorage to httpOnly cookies (ADS-919)

### DIFF
--- a/apps/client/src/services/libraryServices.ts
+++ b/apps/client/src/services/libraryServices.ts
@@ -58,7 +58,10 @@ export const authService = new AuthService();
 export const apiService = globalApiService;
 export const api = globalApiService;
 
-// ✅ Configure chatService with authentication headers and Socket.IO URL.
+// ✅ Configure chatService with the Socket.IO URL. ADS-919: no Authorization
+// header is built here anymore — auth rides along automatically on both the
+// WS handshake and chatService's REST calls via the HttpOnly accessToken
+// cookie (credentials: 'include'), so there's no JS-readable token to read.
 // Socket.IO can't use a relative/empty URL (it would default to window.location.origin,
 // which is the Vite dev server on port 3000). The docker-compose dev config sets
 // VITE_WS_BASE_URL specifically for this; in prod, fall back to the REST base URL
@@ -67,12 +70,6 @@ const wsBaseUrl = (import.meta.env.VITE_WS_BASE_URL as string | undefined) || ba
 export const chatService = new ChatService({
   ...serviceConfig,
   socketUrl: wsBaseUrl,
-  headers: {
-    Authorization: () => {
-      const token = authService.getToken();
-      return token ? `Bearer ${token}` : '';
-    },
-  },
   // Share the global apiService's CSRF token cache so chatService's
   // mutating requests (send message, mark-as-read, reactions, etc.) pass
   // the double-submit-cookie check in the backend middleware.

--- a/apps/rescue/src/pages/Dashboard.tsx
+++ b/apps/rescue/src/pages/Dashboard.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { Card, Container, Heading, Text } from '@adopt-dont-shop/lib.components';
-import { useAuth, STORAGE_KEYS } from '@adopt-dont-shop/lib.auth';
+import { useAuth, authService, STORAGE_KEYS } from '@adopt-dont-shop/lib.auth';
 import { useDashboardData } from '../hooks';
 import { UnreadMessagesPanel } from '../components/dashboard/UnreadMessagesPanel';
 import { DashboardSkeleton } from '../components/skeletons';
@@ -43,11 +43,14 @@ const Dashboard: React.FC = () => {
               </button>
               <button
                 onClick={() => {
-                  // Clear only auth-related keys rather than all localStorage,
-                  // to avoid wiping unrelated user preferences (theme, etc.).
+                  // Clear only auth-related client state rather than all
+                  // localStorage, to avoid wiping unrelated user preferences
+                  // (theme, etc.). The access/refresh tokens themselves are
+                  // HttpOnly cookies and can't be cleared from here — this
+                  // drops the JS-visible session marker + cached user/CSRF
+                  // state so a stale session doesn't keep rendering.
                   localStorage.removeItem(STORAGE_KEYS.USER);
-                  localStorage.removeItem(STORAGE_KEYS.AUTH_TOKEN);
-                  localStorage.removeItem(STORAGE_KEYS.ACCESS_TOKEN);
+                  authService.clearTokens();
                   apiService.clearCsrfToken();
                   window.location.reload();
                 }}

--- a/apps/rescue/src/services/libraryServices.ts
+++ b/apps/rescue/src/services/libraryServices.ts
@@ -41,26 +41,19 @@ export const applicationService = new ApplicationsService(globalApiService, serv
 export const petService = new PetsService(globalApiService);
 export const rescueService = new RescueService(globalApiService, serviceConfig);
 
-// AuthService uses the pre-configured global apiService. Must be declared
-// before chatService so the chat Authorization resolver can reference it.
+// AuthService uses the pre-configured global apiService.
 export const authService = new AuthService();
 
-// ✅ Configure chatService with Socket.IO URL and authentication headers.
-// Uses the canonical authService.getToken() abstraction to stay in sync with
-// how the rest of the app reads auth tokens. Reading localStorage directly
-// caused silent Socket.IO auth failures when the token shape/location changed.
+// ✅ Configure chatService with the Socket.IO URL. ADS-919: no Authorization
+// header is built here anymore — auth rides along automatically on both the
+// WS handshake and chatService's REST calls via the HttpOnly accessToken
+// cookie (credentials: 'include'), so there's no JS-readable token to read.
 // Socket.IO can't use a relative/empty URL — it would default to the Vite dev
 // server origin. VITE_WS_BASE_URL points directly at the backend.
 const wsBaseUrl = (import.meta.env.VITE_WS_BASE_URL as string | undefined) || baseUrl || undefined;
 export const chatService = new ChatService({
   ...serviceConfig,
   socketUrl: wsBaseUrl,
-  headers: {
-    Authorization: () => {
-      const token = authService.getToken();
-      return token ? `Bearer ${token}` : '';
-    },
-  },
   // Share the global apiService's CSRF token cache so chatService's
   // mutating requests pass the backend CSRF middleware.
   csrfToken: () => globalApiService.getCsrfToken(),

--- a/packages/lib.auth/src/__tests__/auth-service.test.ts
+++ b/packages/lib.auth/src/__tests__/auth-service.test.ts
@@ -40,17 +40,17 @@ describe('AuthService', () => {
     updatedAt: '2023-01-01T00:00:00Z',
   };
 
-  // Gateway login/refresh return a Bearer token pair in the JSON body.
-  const mockTokens = {
-    accessToken: 'access.jwt',
-    refreshToken: 'refresh.jwt',
-    accessExpiresAt: '2026-01-01T01:00:00Z',
-    refreshExpiresAt: '2026-02-01T00:00:00Z',
-  };
+  // ADS-919: the gateway sets the access + refresh token pair as HttpOnly
+  // cookies — the JSON body no longer carries them.
   const mockAuthResponse: AuthResponse = {
     user: mockUser,
-    tokens: mockTokens,
     permissions: ['pets.read'],
+  };
+
+  // Clears the `hasSession` cookie between tests so isAuthenticated() tests
+  // aren't polluted by a previous test's cookie write.
+  const clearSessionCookie = () => {
+    document.cookie = 'hasSession=; Max-Age=0; path=/';
   };
 
   beforeEach(() => {
@@ -63,22 +63,15 @@ describe('AuthService', () => {
     mockLocalStorage.getItem.mockReset();
     mockLocalStorage.setItem.mockClear();
     mockLocalStorage.removeItem.mockClear();
+    clearSessionCookie();
   });
 
-  describe('initialization', () => {
-    it('should configure API service with getAuthToken callback on construction', () => {
-      vi.clearAllMocks();
-
-      new AuthService();
-
-      expect(apiService.updateConfig).toHaveBeenCalledWith({
-        getAuthToken: expect.any(Function),
-      });
-    });
+  afterEach(() => {
+    clearSessionCookie();
   });
 
   describe('login', () => {
-    it('should login, store the user and the Bearer token pair', async () => {
+    it('should log in, store only the user profile, and never touch a token storage key', async () => {
       const credentials: LoginRequest = {
         email: 'test@example.com',
         password: 'password123',
@@ -93,15 +86,9 @@ describe('AuthService', () => {
         STORAGE_KEYS.USER,
         JSON.stringify(mockUser)
       );
-      // Access + refresh tokens persisted so requests carry a Bearer header.
-      expect(mockLocalStorage.setItem).toHaveBeenCalledWith(
-        STORAGE_KEYS.ACCESS_TOKEN,
-        mockTokens.accessToken
-      );
-      expect(mockLocalStorage.setItem).toHaveBeenCalledWith(
-        STORAGE_KEYS.REFRESH_TOKEN,
-        mockTokens.refreshToken
-      );
+      // Only ever ONE localStorage write (the user profile) — the token
+      // pair rides home as HttpOnly cookies, never written here.
+      expect(mockLocalStorage.setItem).toHaveBeenCalledTimes(1);
       expect(result).toEqual(mockAuthResponse);
     });
 
@@ -144,42 +131,29 @@ describe('AuthService', () => {
   });
 
   describe('logout', () => {
-    it('should revoke the stored refresh token and clear the session', async () => {
-      mockLocalStorage.getItem.mockImplementation((key: string) =>
-        key === STORAGE_KEYS.REFRESH_TOKEN ? 'refresh.jwt' : null
-      );
+    it('posts an empty body (the refresh token rides in its HttpOnly cookie) and clears the session', async () => {
       (apiService.post as ReturnType<typeof vi.fn>).mockResolvedValue({});
-
-      await authService.logout();
-
-      expect(apiService.post).toHaveBeenCalledWith('/api/v1/auth/logout', {
-        refreshToken: 'refresh.jwt',
-      });
-      // User + both tokens removed from localStorage.
-      expect(mockLocalStorage.removeItem).toHaveBeenCalledWith(STORAGE_KEYS.USER);
-      expect(mockLocalStorage.removeItem).toHaveBeenCalledWith(STORAGE_KEYS.ACCESS_TOKEN);
-      expect(mockLocalStorage.removeItem).toHaveBeenCalledWith(STORAGE_KEYS.REFRESH_TOKEN);
-    });
-
-    it('should post an empty body when no refresh token is stored', async () => {
-      mockLocalStorage.getItem.mockReturnValue(null);
-      (apiService.post as ReturnType<typeof vi.fn>).mockResolvedValue({});
+      document.cookie = 'hasSession=1';
 
       await authService.logout();
 
       expect(apiService.post).toHaveBeenCalledWith('/api/v1/auth/logout', {});
+      // User profile removed from localStorage; the session marker cookie
+      // cleared client-side (the real cookies are cleared server-side).
+      expect(mockLocalStorage.removeItem).toHaveBeenCalledWith(STORAGE_KEYS.USER);
+      expect(document.cookie).not.toContain('hasSession=1');
     });
 
     it('should clear storage even if API call fails', async () => {
       const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
-      mockLocalStorage.getItem.mockReturnValue(null);
       (apiService.post as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('Network error'));
+      document.cookie = 'hasSession=1';
 
       await authService.logout();
 
       expect(consoleSpy).toHaveBeenCalledWith('Logout API call failed:', expect.any(Error));
       expect(mockLocalStorage.removeItem).toHaveBeenCalledWith(STORAGE_KEYS.USER);
-      expect(mockLocalStorage.removeItem).toHaveBeenCalledWith(STORAGE_KEYS.ACCESS_TOKEN);
+      expect(document.cookie).not.toContain('hasSession=1');
 
       consoleSpy.mockRestore();
     });
@@ -235,109 +209,49 @@ describe('AuthService', () => {
   });
 
   describe('isAuthenticated', () => {
-    it('should return true when both user data and an access token exist', () => {
-      mockLocalStorage.getItem.mockImplementation((key: string) => {
-        if (key === STORAGE_KEYS.USER) return JSON.stringify(mockUser);
-        if (key === STORAGE_KEYS.ACCESS_TOKEN) return 'access.jwt';
-        return null;
-      });
+    it('returns true when both a stored user and the hasSession marker cookie are present', () => {
+      mockLocalStorage.getItem.mockReturnValue(JSON.stringify(mockUser));
+      document.cookie = 'hasSession=1';
 
       expect(authService.isAuthenticated()).toBe(true);
     });
 
-    it('should return false when an access token is present but no user', () => {
-      mockLocalStorage.getItem.mockImplementation((key: string) =>
-        key === STORAGE_KEYS.ACCESS_TOKEN ? 'access.jwt' : null
-      );
-
-      expect(authService.isAuthenticated()).toBe(false);
-    });
-
-    it('should return false when a user is present but no access token', () => {
-      mockLocalStorage.getItem.mockImplementation((key: string) =>
-        key === STORAGE_KEYS.USER ? JSON.stringify(mockUser) : null
-      );
-
-      expect(authService.isAuthenticated()).toBe(false);
-    });
-  });
-
-  describe('getToken', () => {
-    it('should return the stored access token', () => {
-      mockLocalStorage.getItem.mockImplementation((key: string) =>
-        key === STORAGE_KEYS.ACCESS_TOKEN ? 'access.jwt' : null
-      );
-
-      expect(authService.getToken()).toBe('access.jwt');
-      expect(mockLocalStorage.getItem).toHaveBeenCalledWith(STORAGE_KEYS.ACCESS_TOKEN);
-    });
-
-    it('should return null when no access token is stored', () => {
+    it('returns false when the session cookie is present but no user is stored', () => {
       mockLocalStorage.getItem.mockReturnValue(null);
+      document.cookie = 'hasSession=1';
 
-      expect(authService.getToken()).toBeNull();
-    });
-  });
-
-  describe('setToken', () => {
-    it('should store the access token when given a value', () => {
-      authService.setToken('access.jwt');
-
-      expect(mockLocalStorage.setItem).toHaveBeenCalledWith(
-        STORAGE_KEYS.ACCESS_TOKEN,
-        'access.jwt'
-      );
+      expect(authService.isAuthenticated()).toBe(false);
     });
 
-    it('should remove the access token when given a falsy value', () => {
-      authService.setToken(null);
+    it('returns false when a user is stored but the session cookie is absent', () => {
+      mockLocalStorage.getItem.mockReturnValue(JSON.stringify(mockUser));
 
-      expect(mockLocalStorage.removeItem).toHaveBeenCalledWith(STORAGE_KEYS.ACCESS_TOKEN);
+      expect(authService.isAuthenticated()).toBe(false);
     });
-  });
 
-  describe('clearTokens', () => {
-    it('should remove both the access and refresh tokens', () => {
+    it('returns false once the session cookie has been cleared, even with a stale stored user', () => {
+      mockLocalStorage.getItem.mockReturnValue(JSON.stringify(mockUser));
+      document.cookie = 'hasSession=1';
+      expect(authService.isAuthenticated()).toBe(true);
+
       authService.clearTokens();
 
-      expect(mockLocalStorage.removeItem).toHaveBeenCalledWith(STORAGE_KEYS.ACCESS_TOKEN);
-      expect(mockLocalStorage.removeItem).toHaveBeenCalledWith(STORAGE_KEYS.REFRESH_TOKEN);
+      expect(authService.isAuthenticated()).toBe(false);
     });
   });
 
   describe('refreshToken', () => {
-    it('should send the stored refresh token, persist the rotated pair, and return the new access token', async () => {
-      mockLocalStorage.getItem.mockImplementation((key: string) =>
-        key === STORAGE_KEYS.REFRESH_TOKEN ? 'refresh.jwt' : null
-      );
-      const refreshResponse = {
-        tokens: {
-          accessToken: 'new.access.jwt',
-          refreshToken: 'new.refresh.jwt',
-          accessExpiresAt: '2026-01-01T02:00:00Z',
-          refreshExpiresAt: '2026-02-01T00:00:00Z',
-        },
-      };
-      (apiService.post as ReturnType<typeof vi.fn>).mockResolvedValue(refreshResponse);
+    it('posts an empty body (the refresh token rides in its HttpOnly cookie) and resolves on success', async () => {
+      (apiService.post as ReturnType<typeof vi.fn>).mockResolvedValue({ success: true });
 
-      const newToken = await authService.refreshToken();
+      await expect(authService.refreshToken()).resolves.toBeUndefined();
 
-      expect(apiService.post).toHaveBeenCalledWith('/api/v1/auth/refresh-token', {
-        refreshToken: 'refresh.jwt',
-      });
-      expect(mockLocalStorage.setItem).toHaveBeenCalledWith(
-        STORAGE_KEYS.ACCESS_TOKEN,
-        'new.access.jwt'
-      );
-      expect(mockLocalStorage.setItem).toHaveBeenCalledWith(
-        STORAGE_KEYS.REFRESH_TOKEN,
-        'new.refresh.jwt'
-      );
-      expect(newToken).toBe('new.access.jwt');
+      expect(apiService.post).toHaveBeenCalledWith('/api/v1/auth/refresh-token', {});
+      // Nothing to persist — the rotated pair rides home as cookies.
+      expect(mockLocalStorage.setItem).not.toHaveBeenCalled();
     });
 
     it('should propagate error if refresh API call fails', async () => {
-      mockLocalStorage.getItem.mockReturnValue(null);
       (apiService.post as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('Unauthorized'));
 
       await expect(authService.refreshToken()).rejects.toThrow('Unauthorized');

--- a/packages/lib.auth/src/contexts/AuthContext.test.tsx
+++ b/packages/lib.auth/src/contexts/AuthContext.test.tsx
@@ -2,7 +2,7 @@ import { act, render, waitFor } from '@testing-library/react';
 import React from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { STORAGE_KEYS, type AuthResponse, type LoginRequest, type User } from '../types';
+import { type AuthResponse, type LoginRequest, type User } from '../types';
 
 // Module-level mock state lets each test stub out auth-service behaviour
 // before mounting AuthProvider. Using vi.hoisted because vi.mock factories
@@ -326,14 +326,10 @@ describe('AuthProvider onLogout callback', () => {
     expect(mockedApiService.clearCsrfToken).toHaveBeenCalled();
   });
 
-  it('clears the dev mock tokens (stored under the __dev_* keys) on logout', async () => {
+  it('clears the dev_user marker key on logout (ADS-919: no mock token to clean up)', async () => {
     vi.stubEnv('DEV', true);
     const devUser = { userId: 'dev-1', email: 'dev@example.com' };
     window.localStorage.setItem('dev_user', JSON.stringify(devUser));
-    // The setters write the mock token under STORAGE_KEYS.* — cleanup must
-    // read/remove the SAME keys, not the bare 'accessToken'/'authToken'.
-    window.localStorage.setItem(STORAGE_KEYS.ACCESS_TOKEN, 'dev-token-dev-1-123');
-    window.localStorage.setItem(STORAGE_KEYS.AUTH_TOKEN, 'dev-token-dev-1-123');
 
     let triggerLogout: (() => Promise<void>) | undefined;
     render(
@@ -354,8 +350,7 @@ describe('AuthProvider onLogout callback', () => {
       await triggerLogout?.();
     });
 
-    expect(window.localStorage.getItem(STORAGE_KEYS.ACCESS_TOKEN)).toBeNull();
-    expect(window.localStorage.getItem(STORAGE_KEYS.AUTH_TOKEN)).toBeNull();
+    expect(window.localStorage.getItem('dev_user')).toBeNull();
   });
 
   it('invokes onLogout even when the backend logout call fails', async () => {

--- a/packages/lib.auth/src/contexts/AuthContext.tsx
+++ b/packages/lib.auth/src/contexts/AuthContext.tsx
@@ -100,15 +100,11 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({
           if (devUser) {
             const parsedUser = JSON.parse(devUser);
 
-            // Ensure dev user has a mock token (namespaced to avoid
-            // colliding with prod cleanup paths that watch STORAGE_KEYS).
-            const existingToken = localStorage.getItem(STORAGE_KEYS.ACCESS_TOKEN);
-            if (!existingToken || !existingToken.startsWith('dev-token-')) {
-              const mockToken = `dev-token-${parsedUser.userId}-${Date.now()}`;
-              localStorage.setItem(STORAGE_KEYS.ACCESS_TOKEN, mockToken);
-              localStorage.setItem(STORAGE_KEYS.AUTH_TOKEN, mockToken);
-            }
-
+            // ADS-919: dev-mock auth state is driven entirely by the
+            // presence of the `dev_user` key — there's no longer a mock
+            // access token to mint. Real sessions authenticate via HttpOnly
+            // cookies the gateway sets, which nothing in this dev path can
+            // (or needs to) forge.
             setUser(parsedUser);
             initializeForAuthenticatedUser(parsedUser);
             setIsLoading(false);
@@ -188,18 +184,16 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({
   // Cross-tab logout sync: when another tab removes the persisted user
   // record (logout, account deletion), drop local auth state here too
   // so this tab doesn't keep rendering the authenticated UI until its
-  // next API call fails with 401. Only react to the user/token keys —
-  // unrelated storage writes (theme, feature flags, etc.) must not
-  // trigger a logout. We don't navigate from here; route-level guards
-  // pick up the user === null transition.
+  // next API call fails with 401. Only react to the user key — unrelated
+  // storage writes (theme, feature flags, etc.) must not trigger a logout.
+  // We don't navigate from here; route-level guards pick up the
+  // user === null transition.
+  //
+  // ADS-919: there's no longer a token storage key to watch — the tokens
+  // live in HttpOnly cookies, which don't fire `storage` events at all.
   useEffect(() => {
     const onStorageEvent = (e: StorageEvent) => {
-      const isUserKey = e.key === STORAGE_KEYS.USER;
-      const isTokenKey = e.key === STORAGE_KEYS.AUTH_TOKEN || e.key === STORAGE_KEYS.ACCESS_TOKEN;
-      if (!isUserKey && !isTokenKey) {
-        return;
-      }
-      if (e.newValue !== null) {
+      if (e.key !== STORAGE_KEYS.USER || e.newValue !== null) {
         return;
       }
       authService.clearTokens();
@@ -335,12 +329,6 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({
       // Clear dev user data in development mode
       if (import.meta.env?.DEV) {
         localStorage.removeItem('dev_user');
-        // Clear mock tokens for dev users
-        const token = localStorage.getItem(STORAGE_KEYS.ACCESS_TOKEN);
-        if (token?.startsWith('dev-token-')) {
-          localStorage.removeItem(STORAGE_KEYS.ACCESS_TOKEN);
-          localStorage.removeItem(STORAGE_KEYS.AUTH_TOKEN);
-        }
       }
     } catch (error) {
       if (import.meta.env?.DEV) {
@@ -358,12 +346,6 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({
       setUser(null);
       if (import.meta.env?.DEV) {
         localStorage.removeItem('dev_user');
-        // Clear mock tokens for dev users
-        const token = localStorage.getItem(STORAGE_KEYS.ACCESS_TOKEN);
-        if (token?.startsWith('dev-token-')) {
-          localStorage.removeItem(STORAGE_KEYS.ACCESS_TOKEN);
-          localStorage.removeItem(STORAGE_KEYS.AUTH_TOKEN);
-        }
       }
     } finally {
       // Clear the per-session CSRF token cache so the next signed-in
@@ -391,14 +373,11 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({
     }
 
     // In development mode, handle dev users differently
-    if (import.meta.env?.DEV) {
-      const token = localStorage.getItem(STORAGE_KEYS.ACCESS_TOKEN);
-      if (token?.startsWith('dev-token-')) {
-        const updatedUser = { ...user, ...profileData };
-        setUser(updatedUser);
-        localStorage.setItem('dev_user', JSON.stringify(updatedUser));
-        return;
-      }
+    if (import.meta.env?.DEV && localStorage.getItem('dev_user')) {
+      const updatedUser = { ...user, ...profileData };
+      setUser(updatedUser);
+      localStorage.setItem('dev_user', JSON.stringify(updatedUser));
+      return;
     }
 
     const updatedUser = await authService.updateProfile(profileData);
@@ -440,13 +419,9 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({
     if (import.meta.env?.DEV) {
       setUser(devUser);
       // Store dev user in localStorage for persistence across refreshes.
-      // Tokens use the __dev_* namespace so prod cleanup code (which
-      // watches STORAGE_KEYS.AUTH_TOKEN / STORAGE_KEYS.ACCESS_TOKEN)
-      // handles them correctly without touching real prod entries.
+      // ADS-919: no mock token to mint — dev auth state is driven entirely
+      // by the presence of this key (see initializeAuth/refreshUser above).
       localStorage.setItem('dev_user', JSON.stringify(devUser));
-      const mockToken = `dev-token-${devUser.userId}-${Date.now()}`;
-      localStorage.setItem(STORAGE_KEYS.ACCESS_TOKEN, mockToken);
-      localStorage.setItem(STORAGE_KEYS.AUTH_TOKEN, mockToken);
     }
   };
 

--- a/packages/lib.auth/src/services/auth-service.ts
+++ b/packages/lib.auth/src/services/auth-service.ts
@@ -6,7 +6,6 @@ import {
   User,
   ChangePasswordRequest,
   RefreshTokenResponse,
-  TokenPair,
   TwoFactorSetupResponse,
   TwoFactorEnableResponse,
   TwoFactorDisableResponse,
@@ -14,6 +13,7 @@ import {
   STORAGE_KEYS,
   StoredUserSchema,
 } from '../types';
+import { clearSessionCookie, hasSessionCookie } from './session-cookie';
 
 // ✅ INDUSTRY STANDARD: Centralized API path constants
 const AUTH_ENDPOINTS = {
@@ -46,22 +46,17 @@ export const EMAIL_VERIFICATION_REQUIRED_MESSAGE = 'Email verification required'
 /**
  * AuthService - Authentication and user management service
  *
- * Phase 11 follow-up: the Fastify gateway replaced the deleted monolith's
- * httpOnly-cookie + CSRF model with Bearer tokens. Login / refresh return
- * `{ user, tokens: { accessToken, refreshToken } }` in the JSON body; the
- * access token is stored here and attached to every authenticated request
- * as `Authorization: Bearer <token>` via lib.api's `getAuthToken` hook
- * (wired in the constructor). The refresh token is replayed to
- * `/auth/refresh-token` to rotate the pair.
+ * ADS-919: the access + refresh tokens live in HttpOnly cookies the gateway
+ * sets on login/refresh and clears on logout (see
+ * services/gateway/src/middleware/auth-cookies.ts) — this class never reads
+ * or writes them, and lib.api attaches no `Authorization` header (no
+ * `getAuthToken` is wired below). `credentials: 'include'` (already set by
+ * lib.api) carries the cookies on every request automatically. The only
+ * things persisted client-side are the non-sensitive user profile
+ * (STORAGE_KEYS.USER) and a JS-readable `hasSession` marker cookie the
+ * gateway sets alongside the HttpOnly ones — see isAuthenticated() below.
  */
 export class AuthService {
-  constructor() {
-    // Configure the API service to get auth tokens from this service
-    apiService.updateConfig({
-      getAuthToken: () => this.getToken(),
-    });
-  }
-
   /**
    * Login user with credentials
    */
@@ -83,11 +78,10 @@ export class AuthService {
       throw new Error(EMAIL_VERIFICATION_REQUIRED_MESSAGE);
     }
 
-    // Persist the user + the Bearer token pair the gateway returned in the
-    // body. getToken() then feeds the access token to lib.api so subsequent
-    // requests are authenticated.
+    // The gateway set the access + refresh token pair as HttpOnly cookies on
+    // this response (never in the body) — only the user profile is
+    // persisted client-side.
     this.setUser(response.user);
-    this.setTokens(response.tokens);
 
     return response;
   }
@@ -110,11 +104,12 @@ export class AuthService {
    * Logout user and clear all stored data
    */
   async logout(): Promise<void> {
-    // The gateway revokes the supplied refresh token (idempotent — an
-    // already-revoked/expired token still returns OK).
-    const refreshToken = localStorage.getItem(STORAGE_KEYS.REFRESH_TOKEN);
+    // The refresh token rides along as an HttpOnly cookie — the gateway
+    // reads it server-side to revoke the session (idempotent — an
+    // already-revoked/expired token still returns OK) and clears all three
+    // auth cookies on the response.
     try {
-      await apiService.post(AUTH_ENDPOINTS.LOGOUT, refreshToken ? { refreshToken } : {});
+      await apiService.post(AUTH_ENDPOINTS.LOGOUT, {});
     } catch (error) {
       console.error('Logout API call failed:', error);
     } finally {
@@ -157,26 +152,24 @@ export class AuthService {
   }
 
   /**
-   * Check if user is authenticated. Both the stored user record and the
-   * access token must be present — the user drives UI gating while the
-   * token is what actually authenticates API calls.
+   * Check if a session is present. Both the stored user record and the
+   * gateway's non-secret `hasSession` marker cookie must be present — the
+   * user drives UI gating, while the cookie reflects whether the gateway
+   * currently considers this browser logged in (set on login/refresh,
+   * cleared on logout). Neither the real access nor refresh token is ever
+   * JS-readable, so this is the closest synchronous equivalent.
    */
   isAuthenticated(): boolean {
-    return !!this.getCurrentUser() && !!this.getToken();
+    return !!this.getCurrentUser() && hasSessionCookie();
   }
 
   /**
-   * Refresh the access token. Sends the stored refresh token to the gateway,
-   * persists the rotated pair, and returns the new access token.
+   * Refresh the access token. The refresh token rides along as an HttpOnly
+   * cookie — the gateway reads it server-side and rotates the cookie pair
+   * on success. Nothing to persist client-side.
    */
-  async refreshToken(): Promise<string> {
-    const stored = localStorage.getItem(STORAGE_KEYS.REFRESH_TOKEN);
-    const response = await apiService.post<RefreshTokenResponse>(
-      AUTH_ENDPOINTS.REFRESH,
-      stored ? { refreshToken: stored } : {}
-    );
-    this.setTokens(response.tokens);
-    return response.tokens.accessToken;
+  async refreshToken(): Promise<void> {
+    await apiService.post<RefreshTokenResponse>(AUTH_ENDPOINTS.REFRESH, {});
   }
 
   /**
@@ -324,44 +317,19 @@ export class AuthService {
   }
 
   /**
-   * Returns the stored access token (or null). lib.api calls this via the
-   * `getAuthToken` hook to attach `Authorization: Bearer <token>`; the
-   * Socket.IO clients read it the same way.
-   */
-  getToken(): string | null {
-    return localStorage.getItem(STORAGE_KEYS.ACCESS_TOKEN);
-  }
-
-  /**
-   * Store (or clear) the access token. Passing a falsy value removes it.
-   */
-  setToken(token: string | null | undefined): void {
-    if (token) {
-      localStorage.setItem(STORAGE_KEYS.ACCESS_TOKEN, token);
-      return;
-    }
-    localStorage.removeItem(STORAGE_KEYS.ACCESS_TOKEN);
-  }
-
-  /**
-   * Clears the stored Bearer token pair. Called on logout (after the gateway
-   * revokes the refresh token) and when a session is found to be invalid.
+   * Clears the JS-visible session marker. Called on logout (after the
+   * gateway revokes the refresh token) and when a session is found to be
+   * invalid (401) — flips isAuthenticated() to false immediately without
+   * waiting on a network round trip. The real HttpOnly access/refresh
+   * cookies can only be cleared server-side (Set-Cookie on /auth/logout).
    */
   clearTokens(): void {
-    localStorage.removeItem(STORAGE_KEYS.ACCESS_TOKEN);
-    localStorage.removeItem(STORAGE_KEYS.REFRESH_TOKEN);
+    clearSessionCookie();
   }
 
   // Private helper methods
   private setUser(user: User): void {
     localStorage.setItem(STORAGE_KEYS.USER, JSON.stringify(user));
-  }
-
-  private setTokens(tokens: TokenPair): void {
-    localStorage.setItem(STORAGE_KEYS.ACCESS_TOKEN, tokens.accessToken);
-    if (tokens.refreshToken) {
-      localStorage.setItem(STORAGE_KEYS.REFRESH_TOKEN, tokens.refreshToken);
-    }
   }
 
   private clearStorage(): void {

--- a/packages/lib.auth/src/services/session-cookie.test.ts
+++ b/packages/lib.auth/src/services/session-cookie.test.ts
@@ -1,0 +1,45 @@
+import { clearSessionCookie, hasSessionCookie } from './session-cookie';
+
+describe('hasSessionCookie', () => {
+  afterEach(() => {
+    // Expire anything the test set so state doesn't leak between cases.
+    document.cookie = 'hasSession=; Max-Age=0; path=/';
+    document.cookie = 'otherCookie=; Max-Age=0; path=/';
+  });
+
+  it('returns false when no cookies are set', () => {
+    expect(hasSessionCookie()).toBe(false);
+  });
+
+  it('returns false when only unrelated cookies are present', () => {
+    document.cookie = 'otherCookie=abc';
+    expect(hasSessionCookie()).toBe(false);
+  });
+
+  it('returns true when the hasSession marker cookie is present', () => {
+    document.cookie = 'hasSession=1';
+    expect(hasSessionCookie()).toBe(true);
+  });
+
+  it('finds the marker cookie among several cookies', () => {
+    document.cookie = 'otherCookie=abc';
+    document.cookie = 'hasSession=1';
+    expect(hasSessionCookie()).toBe(true);
+  });
+});
+
+describe('clearSessionCookie', () => {
+  it('removes the session marker cookie', () => {
+    document.cookie = 'hasSession=1';
+    expect(hasSessionCookie()).toBe(true);
+
+    clearSessionCookie();
+
+    expect(hasSessionCookie()).toBe(false);
+  });
+
+  it('is a no-op when the cookie was never set', () => {
+    expect(() => clearSessionCookie()).not.toThrow();
+    expect(hasSessionCookie()).toBe(false);
+  });
+});

--- a/packages/lib.auth/src/services/session-cookie.ts
+++ b/packages/lib.auth/src/services/session-cookie.ts
@@ -1,0 +1,32 @@
+// ADS-919: the gateway sets a small, non-HttpOnly `hasSession` cookie
+// alongside the real HttpOnly access/refresh token cookies on login/refresh
+// (see services/gateway/src/middleware/auth-cookies.ts), and clears it on
+// logout. It carries no secret — just a presence flag — so
+// AuthService.isAuthenticated() can answer "is someone logged in"
+// synchronously, without a network round trip and without ever touching
+// the real tokens (which JS can't read at all).
+
+const SESSION_COOKIE_NAME = 'hasSession';
+
+/** True when the gateway's non-HttpOnly session marker cookie is present. */
+export const hasSessionCookie = (): boolean => {
+  if (typeof document === 'undefined') {
+    return false;
+  }
+  return document.cookie
+    .split(';')
+    .some((entry) => entry.trim().startsWith(`${SESSION_COOKIE_NAME}=`));
+};
+
+/**
+ * Clears the JS-visible session marker so isAuthenticated() flips to false
+ * immediately (e.g. after a 401, or on logout) without waiting on a network
+ * round trip. The real HttpOnly access/refresh cookies can only be cleared
+ * server-side (Set-Cookie on /auth/logout).
+ */
+export const clearSessionCookie = (): void => {
+  if (typeof document === 'undefined') {
+    return;
+  }
+  document.cookie = `${SESSION_COOKIE_NAME}=; Max-Age=0; path=/`;
+};

--- a/packages/lib.auth/src/types/auth.ts
+++ b/packages/lib.auth/src/types/auth.ts
@@ -184,27 +184,30 @@ export interface RegisterRequest {
 }
 
 /**
- * Token pair returned by the gateway in the JSON body.
+ * Token pair the gateway issues on login/refresh.
  *
- * Phase 11 follow-up: the Fastify gateway replaced the monolith's
- * httpOnly-cookie + CSRF model with Bearer tokens carried in the response
- * body (see services/gateway/src/routes/auth.ts and the `TokenPair` proto
- * message in packages/proto). The access token is attached to subsequent
- * requests as `Authorization: Bearer <token>` via lib.api's `getAuthToken`
- * hook; the refresh token is replayed to `/auth/refresh-token`.
+ * ADS-919: the gateway sets these as HttpOnly cookies (see
+ * services/gateway/src/middleware/auth-cookies.ts) — it no longer returns
+ * them in the JSON response body, so this type describes the gateway's
+ * internal `TokenPair` proto message shape, not anything the SPA reads.
+ * Kept here only because `AuthResponse.tokens` is typed against it for
+ * backward-compat call sites that may still narrow on it; AuthService
+ * itself never reads `response.tokens`.
  */
 export interface TokenPair {
   accessToken: string;
   refreshToken: string;
-  // RFC 3339 expiry timestamps (optional — present on the gateway contract,
-  // but the SPA only needs the token strings to authenticate).
+  // RFC 3339 expiry timestamps.
   accessExpiresAt?: string;
   refreshExpiresAt?: string;
 }
 
 export interface AuthResponse {
   user: User;
-  tokens: TokenPair;
+  // ADS-919: no longer present on the wire — the token pair rides home as
+  // HttpOnly cookies instead (see TokenPair's doc comment). Optional so the
+  // type still reflects what the gateway actually sends.
+  tokens?: TokenPair;
   // Flattened permission snapshot at login time (gateway LoginResponse).
   permissions?: string[];
   // Set when the password was correct but the account has 2FA enabled and
@@ -228,8 +231,11 @@ export interface RefreshTokenRequest {
   refreshToken?: string;
 }
 
+// ADS-919: the gateway's refresh-token response no longer carries the
+// rotated token pair — it's set as HttpOnly cookies instead. The body is
+// just an acknowledgement.
 export interface RefreshTokenResponse {
-  tokens: TokenPair;
+  success: boolean;
 }
 
 export interface PasswordResetRequest {
@@ -264,11 +270,15 @@ export interface TokenData {
   expiresIn: number;
 }
 
-// Storage keys constants
+// Storage keys constants.
+//
+// ADS-919: the access + refresh tokens are no longer persisted here (or
+// anywhere JS-readable) — they live in HttpOnly cookies the gateway sets
+// (see services/gateway/src/middleware/auth-cookies.ts) and
+// AuthService.isAuthenticated() reads a non-secret session-presence marker
+// cookie instead (see services/session-cookie.ts). Only the non-sensitive
+// user profile is kept in localStorage.
 export const STORAGE_KEYS = {
-  AUTH_TOKEN: '__dev_authToken',
-  ACCESS_TOKEN: '__dev_accessToken',
-  REFRESH_TOKEN: '__dev_refreshToken',
   USER: 'user',
 } as const;
 

--- a/services/gateway/src/middleware/auth-cookies.test.ts
+++ b/services/gateway/src/middleware/auth-cookies.test.ts
@@ -1,0 +1,130 @@
+import cookie from '@fastify/cookie';
+import Fastify, { type FastifyInstance } from 'fastify';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  ACCESS_TOKEN_COOKIE_NAME,
+  REFRESH_TOKEN_COOKIE_NAME,
+  SESSION_COOKIE_NAME,
+  clearAuthCookies,
+  extractAccessTokenFromCookie,
+  extractRefreshTokenFromCookie,
+  setAuthCookies,
+} from './auth-cookies.js';
+
+async function makeApp(): Promise<FastifyInstance> {
+  const app = Fastify({ logger: false });
+  await app.register(cookie);
+  app.post('/set', async (req, reply) => {
+    setAuthCookies(req, reply, { accessToken: 'a.jwt', refreshToken: 'r.jwt' });
+    return reply.send({ ok: true });
+  });
+  app.post('/clear', async (req, reply) => {
+    clearAuthCookies(req, reply);
+    return reply.send({ ok: true });
+  });
+  app.get('/read', async req => ({
+    access: extractAccessTokenFromCookie(req) ?? null,
+    refresh: extractRefreshTokenFromCookie(req) ?? null,
+  }));
+  return app;
+}
+
+describe('setAuthCookies', () => {
+  let app: FastifyInstance;
+
+  beforeEach(async () => {
+    app = await makeApp();
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  it('sets the access token cookie as HttpOnly at Path=/', async () => {
+    const res = await app.inject({ method: 'POST', url: '/set' });
+    const setCookie = res.cookies.find(c => c.name === ACCESS_TOKEN_COOKIE_NAME);
+
+    expect(setCookie).toBeDefined();
+    expect(setCookie?.value).toBe('a.jwt');
+    expect(setCookie?.httpOnly).toBe(true);
+    expect(setCookie?.path).toBe('/');
+    expect(setCookie?.sameSite).toBe('Lax');
+  });
+
+  it('sets the refresh token cookie as HttpOnly, scoped to /api/v1/auth', async () => {
+    const res = await app.inject({ method: 'POST', url: '/set' });
+    const setCookie = res.cookies.find(c => c.name === REFRESH_TOKEN_COOKIE_NAME);
+
+    expect(setCookie).toBeDefined();
+    expect(setCookie?.value).toBe('r.jwt');
+    expect(setCookie?.httpOnly).toBe(true);
+    expect(setCookie?.path).toBe('/api/v1/auth');
+  });
+
+  it('sets a non-HttpOnly session marker cookie carrying no token value', async () => {
+    const res = await app.inject({ method: 'POST', url: '/set' });
+    const setCookie = res.cookies.find(c => c.name === SESSION_COOKIE_NAME);
+
+    expect(setCookie).toBeDefined();
+    expect(setCookie?.httpOnly).toBeFalsy();
+    expect(setCookie?.value).toBe('1');
+  });
+
+  it('does not mark cookies Secure over plain HTTP (inject default protocol)', async () => {
+    const res = await app.inject({ method: 'POST', url: '/set' });
+    const setCookie = res.cookies.find(c => c.name === ACCESS_TOKEN_COOKIE_NAME);
+    expect(setCookie?.secure).toBeFalsy();
+  });
+});
+
+describe('clearAuthCookies', () => {
+  let app: FastifyInstance;
+
+  beforeEach(async () => {
+    app = await makeApp();
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  it('expires all three cookies at matching paths', async () => {
+    const res = await app.inject({ method: 'POST', url: '/clear' });
+    const byName = Object.fromEntries(res.cookies.map(c => [c.name, c]));
+
+    expect(byName[ACCESS_TOKEN_COOKIE_NAME]?.path).toBe('/');
+    expect(byName[REFRESH_TOKEN_COOKIE_NAME]?.path).toBe('/api/v1/auth');
+    expect(byName[SESSION_COOKIE_NAME]?.path).toBe('/');
+    // @fastify/cookie's clearCookie sets Max-Age=0 / an epoch Expires.
+    for (const name of [ACCESS_TOKEN_COOKIE_NAME, REFRESH_TOKEN_COOKIE_NAME, SESSION_COOKIE_NAME]) {
+      expect(byName[name]?.value).toBe('');
+    }
+  });
+});
+
+describe('extractAccessTokenFromCookie / extractRefreshTokenFromCookie', () => {
+  let app: FastifyInstance;
+
+  beforeEach(async () => {
+    app = await makeApp();
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  it('reads both cookies off the request', async () => {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/read',
+      headers: { cookie: `${ACCESS_TOKEN_COOKIE_NAME}=a.jwt; ${REFRESH_TOKEN_COOKIE_NAME}=r.jwt` },
+    });
+    expect(res.json()).toEqual({ access: 'a.jwt', refresh: 'r.jwt' });
+  });
+
+  it('returns undefined (null in the JSON probe) when neither cookie is present', async () => {
+    const res = await app.inject({ method: 'GET', url: '/read' });
+    expect(res.json()).toEqual({ access: null, refresh: null });
+  });
+});

--- a/services/gateway/src/middleware/auth-cookies.ts
+++ b/services/gateway/src/middleware/auth-cookies.ts
@@ -1,0 +1,103 @@
+// httpOnly access/refresh token cookies (ADS-919 Phase 1+).
+//
+// Replaces the Bearer-token-in-JSON-body model: routes/auth.ts sets the
+// token pair as Set-Cookie headers on login/refresh-token and clears them
+// on logout, instead of returning them in the response body. Neither
+// cookie is JS-readable — the SPA never sees the raw tokens, so an XSS on
+// any of the three apps can no longer exfiltrate them via
+// `localStorage`/`document.cookie`.
+//
+// authenticate.ts reads ACCESS_TOKEN_COOKIE_NAME as a fallback to the
+// Authorization header. middleware/csrf.ts checks for its presence to
+// decide whether a state-changing request is "authenticated" (and
+// therefore must carry a valid CSRF token). ws/socket-server.ts already
+// reads the same cookie name off the raw handshake Cookie header — this
+// module is the REST-side counterpart, kept in sync by using the same
+// literal name.
+//
+// A fourth, non-HttpOnly `hasSession` cookie rides alongside the two
+// HttpOnly ones so the SPA (lib.auth's AuthService.isAuthenticated()) can
+// synchronously answer "is someone logged in" without a network round trip
+// and without ever exposing the real tokens — it carries no secret, just a
+// presence flag.
+//
+// TTLs mirror services/auth/src/grpc/token-issuer.ts's ACCESS_TTL_SECONDS /
+// REFRESH_TTL_SECONDS (15 minutes / 30 days, both fixed constants there
+// too). Not imported directly — the gateway and service.auth don't share
+// that module — so keep these in sync by hand if either changes.
+
+import type { FastifyReply, FastifyRequest } from 'fastify';
+
+export const ACCESS_TOKEN_COOKIE_NAME = 'accessToken';
+export const REFRESH_TOKEN_COOKIE_NAME = 'refreshToken';
+export const SESSION_COOKIE_NAME = 'hasSession';
+
+const ACCESS_TOKEN_MAX_AGE_SECONDS = 15 * 60;
+const REFRESH_TOKEN_MAX_AGE_SECONDS = 30 * 24 * 60 * 60;
+
+// Scoped to the auth surface so a compromised non-auth endpoint (an XSS
+// gadget hitting the wrong route, a vulnerable proxy rule, etc.) can't read
+// the refresh token off the request even if it could somehow reach cookies
+// server-side. The access-token cookie stays at Path=/ — every route needs
+// it for authentication.
+const REFRESH_TOKEN_COOKIE_PATH = '/api/v1/auth';
+
+export type AuthTokenPair = {
+  accessToken: string;
+  refreshToken: string;
+};
+
+// Only Secure over an actual HTTPS request — dev/test run over plain HTTP,
+// and a Secure cookie is silently dropped by the browser there. Same check
+// routes/csrf.ts already uses for the CSRF cookie.
+const isSecureRequest = (req: FastifyRequest): boolean => req.protocol === 'https';
+
+/** Sets the httpOnly access/refresh cookies + the JS-readable session marker. */
+export const setAuthCookies = (
+  req: FastifyRequest,
+  reply: FastifyReply,
+  tokens: AuthTokenPair
+): void => {
+  const secure = isSecureRequest(req);
+
+  reply.setCookie(ACCESS_TOKEN_COOKIE_NAME, tokens.accessToken, {
+    path: '/',
+    httpOnly: true,
+    sameSite: 'lax',
+    secure,
+    maxAge: ACCESS_TOKEN_MAX_AGE_SECONDS,
+  });
+  reply.setCookie(REFRESH_TOKEN_COOKIE_NAME, tokens.refreshToken, {
+    path: REFRESH_TOKEN_COOKIE_PATH,
+    httpOnly: true,
+    sameSite: 'lax',
+    secure,
+    maxAge: REFRESH_TOKEN_MAX_AGE_SECONDS,
+  });
+  reply.setCookie(SESSION_COOKIE_NAME, '1', {
+    path: '/',
+    httpOnly: false,
+    sameSite: 'lax',
+    secure,
+    maxAge: REFRESH_TOKEN_MAX_AGE_SECONDS,
+  });
+};
+
+/** Clears all three auth cookies — called on logout regardless of upstream outcome. */
+export const clearAuthCookies = (req: FastifyRequest, reply: FastifyReply): void => {
+  const secure = isSecureRequest(req);
+
+  reply.clearCookie(ACCESS_TOKEN_COOKIE_NAME, { path: '/', secure, sameSite: 'lax' });
+  reply.clearCookie(REFRESH_TOKEN_COOKIE_NAME, {
+    path: REFRESH_TOKEN_COOKIE_PATH,
+    secure,
+    sameSite: 'lax',
+  });
+  reply.clearCookie(SESSION_COOKIE_NAME, { path: '/', secure, sameSite: 'lax' });
+};
+
+export const extractAccessTokenFromCookie = (req: FastifyRequest): string | undefined =>
+  req.cookies?.[ACCESS_TOKEN_COOKIE_NAME];
+
+export const extractRefreshTokenFromCookie = (req: FastifyRequest): string | undefined =>
+  req.cookies?.[REFRESH_TOKEN_COOKIE_NAME];

--- a/services/gateway/src/middleware/authenticate.test.ts
+++ b/services/gateway/src/middleware/authenticate.test.ts
@@ -1,3 +1,4 @@
+import cookie from '@fastify/cookie';
 import Fastify, { type FastifyInstance } from 'fastify';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -24,12 +25,15 @@ type ValidatedHeaders = {
   'x-rescue-id'?: string;
 };
 
-function makeApp(
+async function makeApp(
   authClient: AuthClient,
   principalSigningKey?: string,
   rescueClient?: RescueClient
 ): Promise<FastifyInstance> {
   const app = Fastify({ logger: false });
+  // Cookie parsing (ADS-919) — the middleware falls back to the
+  // `accessToken` cookie when no Authorization header is present.
+  await app.register(cookie);
   // Echo endpoint that returns the headers the middleware left on
   // the request. Anything spoofable that survives is a failure.
   app.get('/api/echo', async req => {
@@ -45,12 +49,13 @@ function makeApp(
   app.get('/health/simple', async () => ({ ok: true }));
   app.post('/api/v1/auth/login', async () => ({ logged: 'in' }));
   app.post('/api/v1/auth/refresh-token', async () => ({ refreshed: true }));
-  return registerAuthenticate(app, {
+  await registerAuthenticate(app, {
     authClient,
     logger: quietLogger,
     principalSigningKey,
     rescueClient,
-  }).then(() => app);
+  });
+  return app;
 }
 
 // Minimal RescueClient stub — the enrichment only ever calls
@@ -143,6 +148,72 @@ describe('registerAuthenticate — header spoofing', () => {
     expect(body.roles).toBe('rescue_staff,admin');
     expect(body.permissions).toBe('pets.read,pets.update');
     expect(body.rescueId).toBe('rsc-1');
+  });
+});
+
+describe('registerAuthenticate — accessToken cookie fallback (ADS-919)', () => {
+  let app: FastifyInstance;
+  let validateMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(async () => {
+    const m = makeAuthClient();
+    validateMock = m.validateMock;
+    app = await makeApp(m.client);
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  it('authenticates via the httpOnly accessToken cookie when no Authorization header is present', async () => {
+    validateMock.mockResolvedValueOnce(VALIDATED_RES);
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/echo',
+      headers: { cookie: 'accessToken=cookie.jwt' },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(validateMock).toHaveBeenCalledWith({ accessToken: 'cookie.jwt' }, expect.anything());
+    const body = res.json() as { userId: string | null };
+    expect(body.userId).toBe('usr-1');
+  });
+
+  it('prefers the Authorization header over the accessToken cookie when both are present', async () => {
+    validateMock.mockResolvedValueOnce(VALIDATED_RES);
+
+    await app.inject({
+      method: 'GET',
+      url: '/api/echo',
+      headers: {
+        authorization: 'Bearer header.jwt',
+        cookie: 'accessToken=cookie.jwt',
+      },
+    });
+
+    expect(validateMock).toHaveBeenCalledWith({ accessToken: 'header.jwt' }, expect.anything());
+  });
+
+  it('401s a protected path with an invalid accessToken cookie', async () => {
+    validateMock.mockRejectedValueOnce(Object.assign(new Error('bad token'), { code: 16 }));
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/echo',
+      headers: { cookie: 'accessToken=expired.jwt' },
+    });
+
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('passes through with no principal when neither an Authorization header nor a cookie is present', async () => {
+    const res = await app.inject({ method: 'GET', url: '/api/echo' });
+
+    expect(res.statusCode).toBe(200);
+    expect(validateMock).not.toHaveBeenCalled();
+    const body = res.json() as { userId: string | null };
+    expect(body.userId).toBeNull();
   });
 });
 

--- a/services/gateway/src/middleware/authenticate.ts
+++ b/services/gateway/src/middleware/authenticate.ts
@@ -8,8 +8,11 @@
 //      NEVER let a client forge those, so we delete them unconditionally
 //      before potentially restamping with the validated principal.
 //
-//   2. **Best-effort token validation.** When an `Authorization:
-//      Bearer <token>` header is present, call
+//   2. **Best-effort token validation.** The access token is read from
+//      an `Authorization: Bearer <token>` header if present, otherwise
+//      from the httpOnly `accessToken` cookie the gateway sets on
+//      login/refresh (ADS-919) — the header wins so a non-browser API
+//      caller can still authenticate explicitly. Either way, call
 //      `service.auth.ValidateToken`. On success, stamp the principal
 //      onto the request headers so downstream code (routes/notifications,
 //      catch-all proxy) forwards them as gRPC/HTTP metadata. On failure
@@ -36,6 +39,8 @@ import { signPrincipalToken } from '@adopt-dont-shop/service-bootstrap';
 
 import type { AuthClient } from '../grpc-clients/auth-client.js';
 import type { RescueClient } from '../grpc-clients/rescue-client.js';
+
+import { extractAccessTokenFromCookie } from './auth-cookies.js';
 
 export type AuthMiddlewareOptions = {
   authClient: AuthClient;
@@ -150,7 +155,7 @@ export const registerAuthenticate = async (
       delete (req.headers as Record<string, unknown>)[key];
     }
 
-    const token = extractBearerToken(req);
+    const token = extractBearerToken(req) ?? extractAccessTokenFromCookie(req);
 
     // No token + public path → pass through. No token + non-public
     // path → still pass through (the downstream handler / catch-all

--- a/services/gateway/src/middleware/csrf.test.ts
+++ b/services/gateway/src/middleware/csrf.test.ts
@@ -110,6 +110,66 @@ describe('CSRF protection — opportunistic double-submit enforcement (ADS-919 P
   );
 });
 
+// ADS-919: once auth rides along on cookies, the CSRF check must not depend
+// on the browser having already fetched the CSRF cookie — an authenticated
+// (accessToken-cookie-carrying) request has to be protected outright.
+describe('CSRF protection — enforced when an accessToken session cookie is present (ADS-919)', () => {
+  let app: FastifyInstance;
+
+  beforeEach(async () => {
+    app = await makeApp();
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  it('rejects a state-changing request that carries an accessToken cookie but no CSRF cookie/header', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/v1/things',
+      headers: { cookie: 'accessToken=session.jwt' },
+    });
+    expect(res.statusCode).toBe(403);
+    expect(res.json()).toEqual({ error: 'invalid csrf token' });
+  });
+
+  it('rejects when the accessToken cookie is present and the CSRF header is missing', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/v1/things',
+      headers: { cookie: 'accessToken=session.jwt; csrfToken=matching-token-123' },
+    });
+    expect(res.statusCode).toBe(403);
+  });
+
+  it('accepts an authenticated mutation when the CSRF header matches the cookie', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/v1/things',
+      headers: {
+        cookie: 'accessToken=session.jwt; csrfToken=matching-token-123',
+        'x-csrf-token': 'matching-token-123',
+      },
+    });
+    expect(res.statusCode).toBe(200);
+  });
+
+  it('does not enforce GET requests even with an accessToken cookie present', async () => {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/v1/things',
+      headers: { cookie: 'accessToken=session.jwt' },
+    });
+    expect(res.statusCode).toBe(200);
+  });
+
+  it('leaves an unauthenticated mutation (no accessToken, no csrfToken cookie) unenforced', async () => {
+    const res = await app.inject({ method: 'POST', url: '/api/v1/things' });
+    expect(res.statusCode).toBe(200);
+  });
+});
+
 describe('verifyCsrfToken', () => {
   let app: FastifyInstance;
 

--- a/services/gateway/src/middleware/csrf.ts
+++ b/services/gateway/src/middleware/csrf.ts
@@ -1,4 +1,4 @@
-// CSRF double-submit-cookie primitive (ADS-919 Phase 0).
+// CSRF double-submit-cookie primitive (ADS-919).
 //
 // Pattern: GET /api/v1/csrf-token (routes/csrf.ts) mints a random token,
 // sets it as a non-HttpOnly `csrfToken` cookie, and returns the same value
@@ -7,22 +7,28 @@
 // header on every state-changing (POST/PUT/PATCH/DELETE) request — this
 // file is the server-side half: comparing the header against the cookie.
 //
-// Enforcement scope (deliberately narrow for Phase 0 — see
-// docs/security/ADS-919-token-storage-plan.md): the hook below only
-// rejects a state-changing request when a `csrfToken` cookie IS present.
-// Nothing in the codebase sets that cookie except the new route this hook
-// ships alongside, so every existing route/test that never calls GET
-// /api/v1/csrf-token first is unaffected. Once a client HAS fetched the
-// cookie (every real SPA mutation does, via the interceptor above), a
-// missing or mismatched x-csrf-token header on a subsequent mutation 403s.
-// Widening enforcement to reject requests with no cookie at all is a
-// follow-up once the frontend fetch is verified working end-to-end in
-// every environment — see the plan doc's Phase 0 rollout note.
+// Enforcement scope (widened from Phase 0 — see
+// docs/security/ADS-919-token-storage-plan.md): a state-changing request
+// is enforced (must carry a valid double-submit header) whenever the
+// browser is opted into EITHER cookie flow:
+//   - it already fetched the CSRF cookie (the original Phase 0 rule), OR
+//   - it carries the httpOnly `accessToken` session cookie (ADS-919
+//     Phase 1+) — now that auth rides along on cookies automatically,
+//     every authenticated mutation must be protected, not just the ones
+//     that happen to have called GET /api/v1/csrf-token first.
+// A request with NEITHER cookie (no session, hasn't opted into CSRF) is
+// unauthenticated by definition — login, register, forgot-password, and
+// any request that carries a Bearer token instead of relying on cookies —
+// and is left unenforced here, same as Phase 0. The SPA always fetches the
+// CSRF cookie before its first mutation (see the interceptor above), so in
+// practice every real browser request is covered either way.
 
 import { timingSafeEqual } from 'node:crypto';
 
 import type { FastifyInstance, FastifyRequest } from 'fastify';
 import type { Logger } from 'winston';
+
+import { ACCESS_TOKEN_COOKIE_NAME } from './auth-cookies.js';
 
 export const CSRF_COOKIE_NAME = 'csrfToken';
 export const CSRF_HEADER_NAME = 'x-csrf-token';
@@ -59,10 +65,12 @@ export const registerCsrfProtection = (app: FastifyInstance, opts: CsrfProtectio
     if (!STATE_CHANGING_METHODS.has(req.method)) {
       return;
     }
-    const cookieToken = req.cookies?.[CSRF_COOKIE_NAME];
-    if (!cookieToken) {
-      // Client hasn't opted into the double-submit flow yet (or this
-      // route predates it). Not enforced — see module comment.
+    const hasCsrfCookie = Boolean(req.cookies?.[CSRF_COOKIE_NAME]);
+    const hasSessionCookie = Boolean(req.cookies?.[ACCESS_TOKEN_COOKIE_NAME]);
+    if (!hasCsrfCookie && !hasSessionCookie) {
+      // Unauthenticated request that also hasn't opted into the
+      // double-submit flow (or this route predates it). Not enforced —
+      // see module comment.
       return;
     }
     if (!verifyCsrfToken(req)) {

--- a/services/gateway/src/routes/auth.test.ts
+++ b/services/gateway/src/routes/auth.test.ts
@@ -1,4 +1,5 @@
 import { status as grpcStatus } from '@grpc/grpc-js';
+import cookie from '@fastify/cookie';
 import Fastify, { type FastifyInstance } from 'fastify';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -101,6 +102,7 @@ function makeClient(): {
 
 async function makeApp(client: AuthClient): Promise<FastifyInstance> {
   const app = Fastify({ logger: false });
+  await app.register(cookie);
   await registerAuthRoutes(app, { client });
   return app;
 }
@@ -152,20 +154,58 @@ describe('POST /api/v1/auth/login', () => {
     expect(res.statusCode).toBe(200);
     const body = res.json() as {
       user: { email: string; userType: string; status: string };
-      tokens: { accessToken: string };
+      tokens?: { accessToken: string };
     };
     expect(body.user.email).toBe('alex@example.com');
     // The SPA speaks the canonical DB strings, not the SCREAMING proto enum
     // names — the gateway must normalise these in the body (auth contract).
     expect(body.user.userType).toBe('adopter');
     expect(body.user.status).toBe('active');
-    expect(body.tokens.accessToken).toBe('a.jwt');
+    // ADS-919: the token pair is never returned in the JSON body — only as
+    // httpOnly cookies (asserted below) — so an XSS reading the fetch
+    // response can't exfiltrate it.
+    expect(body.tokens).toBeUndefined();
 
     const [req] = loginMock.mock.calls[0];
     expect(req.email).toBe('alex@example.com');
     expect(req.password).toBe('hunter2');
     expect(req.userAgent).toBe('vitest');
     expect(req.ipAddress).toBeDefined();
+  });
+
+  it('sets the access + refresh token pair as httpOnly cookies plus a JS-readable session marker (ADS-919)', async () => {
+    loginMock.mockResolvedValueOnce(LOGIN_RES);
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/v1/auth/login',
+      payload: { email: 'alex@example.com', password: 'hunter2' },
+    });
+
+    expect(res.statusCode).toBe(200);
+    const byName = Object.fromEntries(res.cookies.map(c => [c.name, c]));
+
+    expect(byName.accessToken?.value).toBe('a.jwt');
+    expect(byName.accessToken?.httpOnly).toBe(true);
+    expect(byName.accessToken?.path).toBe('/');
+
+    expect(byName.refreshToken?.value).toBe('r.jwt');
+    expect(byName.refreshToken?.httpOnly).toBe(true);
+    expect(byName.refreshToken?.path).toBe('/api/v1/auth');
+
+    expect(byName.hasSession?.value).toBe('1');
+    expect(byName.hasSession?.httpOnly).toBeFalsy();
+  });
+
+  it('does not set auth cookies when 2FA is required (no tokens minted yet)', async () => {
+    loginMock.mockResolvedValueOnce({ twoFactorRequired: true, permissions: [] });
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/v1/auth/login',
+      payload: { email: 'alex@example.com', password: 'hunter2' },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.cookies.find(c => c.name === 'accessToken')).toBeUndefined();
   });
 
   it('maps UNAUTHENTICATED → 401', async () => {
@@ -232,10 +272,58 @@ describe('POST /api/v1/auth/logout', () => {
     expect(req.refreshToken).toBe('r.jwt');
     expect(metadata.get('x-user-id')[0]).toBe('usr-1');
   });
+
+  it('prefers the refreshToken cookie over the body field (ADS-919)', async () => {
+    logoutMock.mockResolvedValueOnce({ revoked: true });
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/v1/auth/logout',
+      headers: { cookie: 'refreshToken=cookie.jwt' },
+      payload: { refreshToken: 'body.jwt' },
+    });
+
+    expect(res.statusCode).toBe(200);
+    const [req] = logoutMock.mock.calls[0];
+    expect(req.refreshToken).toBe('cookie.jwt');
+  });
+
+  it('clears all three auth cookies on a successful logout (ADS-919)', async () => {
+    logoutMock.mockResolvedValueOnce({ revoked: true });
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/v1/auth/logout',
+      headers: { cookie: 'accessToken=a.jwt; refreshToken=r.jwt; hasSession=1' },
+      payload: {},
+    });
+
+    const byName = Object.fromEntries(res.cookies.map(c => [c.name, c]));
+    expect(byName.accessToken?.value).toBe('');
+    expect(byName.refreshToken?.value).toBe('');
+    expect(byName.hasSession?.value).toBe('');
+  });
+
+  it('still clears auth cookies when the upstream revoke call fails (ADS-919)', async () => {
+    logoutMock.mockRejectedValueOnce(
+      Object.assign(new Error('invalid refresh token'), { code: grpcStatus.INVALID_ARGUMENT })
+    );
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/v1/auth/logout',
+      headers: { cookie: 'accessToken=a.jwt; refreshToken=r.jwt; hasSession=1' },
+      payload: {},
+    });
+
+    expect(res.statusCode).toBe(400);
+    const byName = Object.fromEntries(res.cookies.map(c => [c.name, c]));
+    expect(byName.accessToken?.value).toBe('');
+  });
 });
 
 describe('POST /api/v1/auth/refresh-token', () => {
-  it('forwards the refreshToken and returns the rotated TokenPair', async () => {
+  it('forwards the refreshToken and rotates the cookie pair (ADS-919)', async () => {
     const { client, refreshMock } = makeClient();
     const app = await makeApp(client);
     try {
@@ -256,8 +344,38 @@ describe('POST /api/v1/auth/refresh-token', () => {
       });
 
       expect(res.statusCode).toBe(200);
-      const body = res.json() as { tokens: { accessToken: string } };
-      expect(body.tokens.accessToken).toBe('a2.jwt');
+      // No token pair in the body — only the rotated cookies.
+      expect(res.json()).toEqual({ success: true });
+      const byName = Object.fromEntries(res.cookies.map(c => [c.name, c]));
+      expect(byName.accessToken?.value).toBe('a2.jwt');
+      expect(byName.refreshToken?.value).toBe('r2.jwt');
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('prefers the refreshToken cookie over the body field (ADS-919)', async () => {
+    const { client, refreshMock } = makeClient();
+    const app = await makeApp(client);
+    try {
+      refreshMock.mockResolvedValueOnce({
+        tokens: {
+          accessToken: 'a2.jwt',
+          refreshToken: 'r2.jwt',
+          accessExpiresAt: '2026-06-05T19:00:00Z',
+          refreshExpiresAt: '2026-07-05T19:00:00Z',
+        },
+      });
+
+      await app.inject({
+        method: 'POST',
+        url: '/api/v1/auth/refresh-token',
+        headers: { cookie: 'refreshToken=cookie.jwt' },
+        payload: { refreshToken: 'body.jwt' },
+      });
+
+      const [req] = refreshMock.mock.calls[0];
+      expect(req.refreshToken).toBe('cookie.jwt');
     } finally {
       await app.close();
     }
@@ -1285,6 +1403,7 @@ describe('auth rate limiting — per-email login cap (ADS-916)', () => {
     const m = makeClient();
     m.loginMock.mockResolvedValue(LOGIN_RES);
     const app = Fastify({ logger: false, trustProxy: true });
+    await app.register(cookie);
     const loginEmailRateLimiter = createEmailRateLimiter({ max: 5, windowMs: 5 * 60_000 });
     // The per-IP @fastify/rate-limit plugin is intentionally NOT registered
     // here — only the per-email preHandler can produce a 429, proving the
@@ -1316,6 +1435,7 @@ describe('auth rate limiting — per-email login cap (ADS-916)', () => {
     const m = makeClient();
     m.loginMock.mockResolvedValue(LOGIN_RES);
     const app = Fastify({ logger: false, trustProxy: true });
+    await app.register(cookie);
     const loginEmailRateLimiter = createEmailRateLimiter({ max: 1, windowMs: 5 * 60_000 });
     await registerAuthRoutes(app, { client: m.client, loginEmailRateLimiter });
     try {
@@ -1347,6 +1467,7 @@ describe('auth rate limiting — per-email login cap (ADS-916)', () => {
     m.loginMock.mockResolvedValue(LOGIN_RES);
     const onLoginEmailRateLimitTrip = vi.fn();
     const app = Fastify({ logger: false, trustProxy: true });
+    await app.register(cookie);
     const loginEmailRateLimiter = createEmailRateLimiter({ max: 1, windowMs: 60_000 });
     await registerAuthRoutes(app, {
       client: m.client,

--- a/services/gateway/src/routes/auth.ts
+++ b/services/gateway/src/routes/auth.ts
@@ -19,6 +19,13 @@
 // principal — Logout, GetMe, AssignRole. Login + RefreshToken don't
 // need them (they mint a fresh principal); the middleware passes
 // requests with no Authorization header through to the route.
+//
+// ADS-919: Login and RefreshToken set the access + refresh token pair as
+// httpOnly cookies (see ../middleware/auth-cookies.ts) instead of
+// returning them in the JSON body — the SPA never sees the raw tokens.
+// Logout and RefreshToken read the refresh token from its httpOnly cookie
+// (falling back to the request body for non-browser callers), and Logout
+// clears all three auth cookies regardless of the upstream RPC outcome.
 
 import type { FastifyInstance, FastifyReply, FastifyRequest, RouteShorthandOptions } from 'fastify';
 
@@ -33,6 +40,11 @@ import {
 import type { AuthClient } from '../grpc-clients/auth-client.js';
 import { buildMetadata } from '../middleware/metadata.js';
 import { handleGrpcError } from '../middleware/grpc-error.js';
+import {
+  clearAuthCookies,
+  extractRefreshTokenFromCookie,
+  setAuthCookies,
+} from '../middleware/auth-cookies.js';
 
 import { normalizeEmail, type EmailRateLimiter } from './email-rate-limiter.js';
 import { rolesToApi, withApiUser } from './auth-user-json.js';
@@ -212,15 +224,6 @@ export const registerAuthRoutes = async (
           200: {
             type: 'object',
             properties: {
-              tokens: {
-                type: 'object',
-                properties: {
-                  accessToken: { type: 'string' },
-                  refreshToken: { type: 'string' },
-                  accessExpiresAt: { type: 'string' },
-                  refreshExpiresAt: { type: 'string' },
-                },
-              },
               user: {
                 type: 'object',
                 properties: {
@@ -261,8 +264,18 @@ export const registerAuthRoutes = async (
 
       try {
         const res = await client.login(grpcReq, buildMetadata(req));
-        const json = AuthV1.LoginResponse.toJSON(res) as Record<string, unknown>;
-        return reply.send(withApiUser(json, res.user));
+        // ADS-919: the token pair rides home as httpOnly cookies, never in
+        // the JSON body — an XSS that can read the fetch response could
+        // otherwise exfiltrate it even with HttpOnly cookies also set.
+        if (res.tokens) {
+          setAuthCookies(req, reply, res.tokens);
+        }
+        const json = AuthV1.LoginResponse.toJSON(res) as Record<string, unknown> & {
+          tokens?: unknown;
+        };
+        const { tokens, ...jsonWithoutTokens } = json;
+        void tokens;
+        return reply.send(withApiUser(jsonWithoutTokens, res.user));
       } catch (err) {
         return handleGrpcError(err, reply);
       }
@@ -301,12 +314,20 @@ export const registerAuthRoutes = async (
     },
     async (req, reply) => {
       const body = (req.body ?? {}) as LogoutBody;
-      const grpcReq: LogoutRequest = { refreshToken: body.refreshToken ?? '' };
+      // ADS-919: the refresh token normally rides in its httpOnly cookie;
+      // the body field stays as a fallback for non-browser callers.
+      const refreshToken = extractRefreshTokenFromCookie(req) ?? body.refreshToken ?? '';
+      const grpcReq: LogoutRequest = { refreshToken };
 
+      // Cookies are cleared on EITHER outcome — logout must always look
+      // like a logout client-side, even if the upstream revoke call fails
+      // (e.g. the refresh token was already expired/revoked).
       try {
         const res = await client.logout(grpcReq, buildMetadata(req));
+        clearAuthCookies(req, reply);
         return reply.send(AuthV1.LogoutResponse.toJSON(res));
       } catch (err) {
+        clearAuthCookies(req, reply);
         return handleGrpcError(err, reply);
       }
     }
@@ -329,15 +350,7 @@ export const registerAuthRoutes = async (
           200: {
             type: 'object',
             properties: {
-              tokens: {
-                type: 'object',
-                properties: {
-                  accessToken: { type: 'string' },
-                  refreshToken: { type: 'string' },
-                  accessExpiresAt: { type: 'string' },
-                  refreshExpiresAt: { type: 'string' },
-                },
-              },
+              success: { type: 'boolean' },
             },
           },
           400: {
@@ -352,11 +365,18 @@ export const registerAuthRoutes = async (
     },
     async (req, reply) => {
       const body = (req.body ?? {}) as RefreshTokenBody;
-      const grpcReq: RefreshTokenRequest = { refreshToken: body.refreshToken ?? '' };
+      // ADS-919: the refresh token normally rides in its httpOnly cookie;
+      // the body field stays as a fallback for non-browser callers.
+      const refreshToken = extractRefreshTokenFromCookie(req) ?? body.refreshToken ?? '';
+      const grpcReq: RefreshTokenRequest = { refreshToken };
 
       try {
         const res = await client.refreshToken(grpcReq, buildMetadata(req));
-        return reply.send(AuthV1.RefreshTokenResponse.toJSON(res));
+        // The rotated pair rides home as httpOnly cookies, never in the body.
+        if (res.tokens) {
+          setAuthCookies(req, reply, res.tokens);
+        }
+        return reply.send({ success: true });
       } catch (err) {
         return handleGrpcError(err, reply);
       }

--- a/services/gateway/src/ws/socket-server.test.ts
+++ b/services/gateway/src/ws/socket-server.test.ts
@@ -255,6 +255,71 @@ describe('attachSocketServer — handshake authentication', () => {
     expect(connected).toBe(true);
     expect(registry.socketsFor('usr-dev')).toHaveLength(1);
   });
+
+  // ADS-919: the web frontend no longer sends handshake.auth.token — the
+  // httpOnly accessToken cookie rides along on the upgrade request instead,
+  // and this fallback (previously unreachable — nothing ever set the
+  // cookie) is now the real path browser clients use.
+  it('authenticates via the accessToken httpOnly cookie when handshake.auth carries no token', async () => {
+    const validateMock = vi.fn().mockResolvedValue(VALID_RES);
+    const { url, registry } = await startServer({
+      logger: quietLogger(),
+      authClient: makeAuthClient(validateMock),
+    });
+
+    const client = ioClient(url, {
+      path: '/socket.io',
+      transports: ['websocket'],
+      reconnection: false,
+      extraHeaders: { Cookie: 'accessToken=cookie.jwt' },
+    });
+    clients.push(client);
+    const connected = await awaitConnectOutcome(client);
+
+    expect(connected).toBe(true);
+    expect(validateMock).toHaveBeenCalledWith({ accessToken: 'cookie.jwt' }, expect.anything());
+    expect(registry.socketsFor('usr-from-principal')).toHaveLength(1);
+  });
+
+  it('prefers handshake.auth.token over the accessToken cookie when both are present', async () => {
+    const validateMock = vi.fn().mockResolvedValue(VALID_RES);
+    const { url } = await startServer({
+      logger: quietLogger(),
+      authClient: makeAuthClient(validateMock),
+    });
+
+    const client = ioClient(url, {
+      path: '/socket.io',
+      transports: ['websocket'],
+      reconnection: false,
+      auth: { token: 'auth.jwt' },
+      extraHeaders: { Cookie: 'accessToken=cookie.jwt' },
+    });
+    clients.push(client);
+    await awaitConnectOutcome(client);
+
+    expect(validateMock).toHaveBeenCalledWith({ accessToken: 'auth.jwt' }, expect.anything());
+  });
+
+  it('rejects a handshake whose accessToken cookie the auth service rejects', async () => {
+    const validateMock = vi.fn().mockRejectedValue(new Error('invalid token'));
+    const { url, registry } = await startServer({
+      logger: quietLogger(),
+      authClient: makeAuthClient(validateMock),
+    });
+
+    const client = ioClient(url, {
+      path: '/socket.io',
+      transports: ['websocket'],
+      reconnection: false,
+      extraHeaders: { Cookie: 'accessToken=bad.jwt' },
+    });
+    clients.push(client);
+    const connected = await awaitConnectOutcome(client);
+
+    expect(connected).toBe(false);
+    expect(registry.size()).toBe(0);
+  });
 });
 
 describe('attachSocketServer — origin allowlist (ADS-843)', () => {


### PR DESCRIPTION
## Summary

Completes ADS-919 in one PR — JWT access + refresh tokens move out of `localStorage` (any XSS = persistent account takeover) into httpOnly cookies. Builds on the merged Phase 0 CSRF route (#1215) and follows `docs/security/ADS-919-token-storage-plan.md`.

## Gateway (`services/gateway`)

- **`middleware/auth-cookies.ts` (new)**: sets `accessToken` / `refreshToken` as `HttpOnly; Secure; SameSite=Lax` (refresh scoped to `Path=/api/v1/auth`), plus a **non-HttpOnly `hasSession` marker** (`"1"`, no secret) so the SPA can cheaply tell "logged in" without JS-readable tokens. `clearAuthCookies` clears all three
- **`routes/auth.ts`**: login/refresh set cookies and **strip `tokens` from the JSON body entirely** — leaving them in the response would let any XSS reading the fetch result exfiltrate them regardless of HttpOnly. Logout/refresh read the refresh token from its cookie (body fallback kept for non-browser callers); logout clears cookies on success *and* failure paths
- **`middleware/authenticate.ts`**: falls back to the `accessToken` cookie when there's no `Authorization` header (header still wins)
- **`middleware/csrf.ts`**: enforcement **widened** — a state-changing request is now checked whenever it carries the `accessToken` session cookie (Phase 0 only enforced when the CSRF cookie was already present). Unauthenticated login/register unaffected
- **`ws/socket-server.ts`**: no code change — it already read the `accessToken` cookie as a fallback (previously dead code, now the primary path and covered by new tests)

## `packages/lib.auth`

- **`services/session-cookie.ts` (new)**: synchronous non-secret `hasSessionCookie()` / `clearSessionCookie()`
- **`auth-service.ts`**: `login`/`logout`/`refreshToken` no longer touch token storage; `isAuthenticated()` = `!!getCurrentUser() && hasSessionCookie()`; `getToken`/`setToken`/`setTokens` removed (no remaining callers); `clearTokens()` clears the marker cookie
- **`types/auth.ts`**: `STORAGE_KEYS` reduced to `{ USER }` — the `__dev_*` access/refresh/auth keys are gone; `AuthResponse.tokens` optional
- **`AuthContext.tsx`**: dev-mock path no longer mints a fake token; cross-tab logout sync watches only the `USER` key

## `packages/lib.api`

No change needed — its `getAuthToken` extension point already no-ops when unconfigured, and lib.auth no longer wires it. Verified against its existing suite.

## Apps

- `apps/rescue` + `apps/client` `libraryServices.ts`: dropped the `Authorization` header block from the chat WS handshake (the WS server reads the cookie; REST already sends `credentials: 'include'`)
- `apps/rescue/.../Dashboard.tsx`: "Clear Auth & Restart" calls `authService.clearTokens()` instead of removing deleted keys
- `apps/admin`: no changes needed

## ⚠️ Deployer caveat (expected, not a bug)

Existing logged-in users' `localStorage` tokens are simply ignored post-deploy — nothing reads them anymore. Without a `hasSession` cookie, `isAuthenticated()` returns `false` on next load, so **all current users are forced to re-login once** at rollout. No server-side action required.

## Test plan

- [x] `test:coverage` green (exit 0) on every touched package: gateway 75 files/1019 tests, lib.auth 11/127, lib.api 6/90 (unchanged), app.rescue/app.client/app.admin full runs
- [x] New behaviour covered: login sets httpOnly cookies; authed request works via cookie with no `Authorization` header; logout clears cookies; refresh rotates; state-changing request without a valid CSRF token is rejected; `isAuthenticated()` tracks the marker cookie; WS handshake authenticates via cookie
- [x] `turbo build` succeeds; grepped built `dist/` bundles for `__dev_access`/`__dev_refresh`/`__dev_authToken` → zero matches (removed keys don't ship)
- [x] Type-check + lint clean across all touched packages
- [ ] **Deferred**: full-stack E2E Playwright specs (injected-`<script>` exfiltration attempt, live CSRF-403) — need the docker stack this sandbox can't run; the equivalent guarantees are asserted at the gateway-route level (cookie attributes + "tokens never in response body"). Worth adding in a follow-up once run against the stack

## Related

- Linear: ADS-919 (full migration; Phase 0 CSRF shipped in #1215)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q5FhHDPvEtBYRDwMAV3rtv

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q5FhHDPvEtBYRDwMAV3rtv)_