### PR TITLE
fix(lib.auth): purge legacy plaintext token keys from localStorage (ADS-919)

### DIFF
--- a/packages/lib.auth/src/__tests__/auth-service.test.ts
+++ b/packages/lib.auth/src/__tests__/auth-service.test.ts
@@ -1,4 +1,4 @@
-import { AuthService } from '../services/auth-service';
+import { AuthService, purgeLegacyTokenStorage } from '../services/auth-service';
 import { apiService } from '@adopt-dont-shop/lib.api';
 import { AuthResponse, LoginRequest, RegisterRequest, User, STORAGE_KEYS } from '../types';
 
@@ -561,6 +561,24 @@ describe('AuthService', () => {
 
       await expect(authService.deleteAccount('wrong')).rejects.toThrow('Incorrect password');
       expect(mockLocalStorage.removeItem).not.toHaveBeenCalled();
+    });
+  });
+
+  // ADS-919 follow-up: legacy plaintext token keys from the pre-cookie era are
+  // actively purged from localStorage, not just ignored.
+  describe('purgeLegacyTokenStorage', () => {
+    it('removes the legacy __dev_* token keys', () => {
+      purgeLegacyTokenStorage();
+
+      expect(mockLocalStorage.removeItem).toHaveBeenCalledWith('__dev_authToken');
+      expect(mockLocalStorage.removeItem).toHaveBeenCalledWith('__dev_accessToken');
+      expect(mockLocalStorage.removeItem).toHaveBeenCalledWith('__dev_refreshToken');
+    });
+
+    it('does not touch the stored user profile', () => {
+      purgeLegacyTokenStorage();
+
+      expect(mockLocalStorage.removeItem).not.toHaveBeenCalledWith(STORAGE_KEYS.USER);
     });
   });
 });

--- a/packages/lib.auth/src/services/auth-service.ts
+++ b/packages/lib.auth/src/services/auth-service.ts
@@ -337,5 +337,30 @@ export class AuthService {
   }
 }
 
+// ADS-919 follow-up: one-time purge of the legacy plaintext token keys the
+// pre-cookie AuthService wrote to localStorage (`__dev_authToken` /
+// `__dev_accessToken` / `__dev_refreshToken`). After the httpOnly-cookie
+// migration nothing reads them, but a token pair lingering in a user's
+// localStorage is a residual exfiltration artifact, so we actively remove
+// them on first load post-deploy rather than leaving them as dead weight.
+// Idempotent and safe when the keys are absent or localStorage is unavailable
+// (SSR / non-browser test envs).
+const LEGACY_TOKEN_STORAGE_KEYS = [
+  '__dev_authToken',
+  '__dev_accessToken',
+  '__dev_refreshToken',
+] as const;
+
+export const purgeLegacyTokenStorage = (): void => {
+  if (typeof localStorage === 'undefined') {
+    return;
+  }
+  for (const key of LEGACY_TOKEN_STORAGE_KEYS) {
+    localStorage.removeItem(key);
+  }
+};
+
+purgeLegacyTokenStorage();
+
 // Export singleton instance
 export const authService = new AuthService();


### PR DESCRIPTION
## Summary

Closes the one loose end from the ADS-919 cookie migration (#1218): it stopped *reading* the old `__dev_authToken` / `__dev_accessToken` / `__dev_refreshToken` localStorage keys, but pre-existing values were left sitting in users' browsers. This actively removes them once on module load, satisfying the ADS-919 acceptance criterion "clear localStorage on first post-deploy load" so a stolen token pair can't linger as a residual exfiltration artifact.

## Changes

- `packages/lib.auth/src/services/auth-service.ts` — new exported `purgeLegacyTokenStorage()` that removes the three legacy keys; called once at module load (before the `authService` singleton is constructed). Idempotent; no-ops when the keys are absent or `localStorage` is unavailable (SSR/non-browser)
- `packages/lib.auth/src/__tests__/auth-service.test.ts` — tests that the legacy keys are removed and the `USER` profile key is untouched

## Test plan

- [x] `lib.auth test:coverage`: 129 tests pass (+2), thresholds green (stmts 89.08 / branch 76.04 / funcs 89.16)
- [x] Type-check clean; lint 0 errors (2 pre-existing unrelated warnings)
- [x] New coverage: purge removes `__dev_authToken`/`__dev_accessToken`/`__dev_refreshToken`; does not touch `STORAGE_KEYS.USER`

## Related

- Linear: ADS-919 (final cleanup — full migration shipped in #1218)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q5FhHDPvEtBYRDwMAV3rtv

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q5FhHDPvEtBYRDwMAV3rtv)_