### PR TITLE
fix(auth): make 2FA backup code consumption atomic (ADS-975)

### DIFF
--- a/services/auth/src/grpc/backup-codes.test.ts
+++ b/services/auth/src/grpc/backup-codes.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import {
   consumeBackupCode,
+  findMatchingBackupCodeHash,
   generateBackupCodes,
   hashBackupCodes,
   normalizeBackupCode,
@@ -43,6 +44,58 @@ describe('hashBackupCodes', () => {
     const codes = ['abcd-efgh-ijkl-mnop'];
     const hashes = await hashBackupCodes(testHasher, codes);
     expect(hashes).toEqual(['hashed:ABCDEFGHIJKLMNOP']);
+  });
+});
+
+describe('findMatchingBackupCodeHash', () => {
+  it('returns the stored hash that matches the candidate code', async () => {
+    const codes = generateBackupCodes(3);
+    const hashes = await hashBackupCodes(testHasher, codes);
+
+    const result = await findMatchingBackupCodeHash(testHasher, hashes, codes[1]);
+
+    expect(result).toBe(hashes[1]);
+  });
+
+  it('accepts the code with or without hyphens', async () => {
+    const codes = generateBackupCodes(1);
+    const hashes = await hashBackupCodes(testHasher, codes);
+
+    const result = await findMatchingBackupCodeHash(
+      testHasher,
+      hashes,
+      codes[0].replace(/-/g, '').toLowerCase()
+    );
+
+    expect(result).toBe(hashes[0]);
+  });
+
+  it('returns null when no hash matches', async () => {
+    const codes = generateBackupCodes(2);
+    const hashes = await hashBackupCodes(testHasher, codes);
+
+    expect(await findMatchingBackupCodeHash(testHasher, hashes, 'ZZZZ-ZZZZ-ZZZZ-ZZZZ')).toBeNull();
+  });
+
+  it('returns null when storedHashes is null or empty', async () => {
+    expect(await findMatchingBackupCodeHash(testHasher, null, 'ABCD-EFGH-IJKL-MNOP')).toBeNull();
+    expect(await findMatchingBackupCodeHash(testHasher, [], 'ABCD-EFGH-IJKL-MNOP')).toBeNull();
+  });
+
+  it('returns null when the candidate is empty', async () => {
+    const codes = generateBackupCodes(1);
+    const hashes = await hashBackupCodes(testHasher, codes);
+    expect(await findMatchingBackupCodeHash(testHasher, hashes, '')).toBeNull();
+  });
+
+  it('does not modify the stored hash list', async () => {
+    const codes = generateBackupCodes(2);
+    const hashes = await hashBackupCodes(testHasher, codes);
+    const hashesSnapshot = [...hashes];
+
+    await findMatchingBackupCodeHash(testHasher, hashes, codes[0]);
+
+    expect(hashes).toEqual(hashesSnapshot);
   });
 });
 

--- a/services/auth/src/grpc/backup-codes.ts
+++ b/services/auth/src/grpc/backup-codes.ts
@@ -50,6 +50,24 @@ export type BackupCodeConsumeResult = {
   remaining: string[];
 };
 
+// Returns the stored bcrypt hash that matches the candidate, or null if none
+// matches. Does not modify the hash list — callers use the returned hash as the
+// predicate in an atomic conditional SQL UPDATE (ADS-975).
+export async function findMatchingBackupCodeHash(
+  hasher: PasswordHasher,
+  storedHashes: readonly string[] | null,
+  candidate: string
+): Promise<string | null> {
+  const hashes = storedHashes ?? [];
+  const normalized = normalizeBackupCode(candidate);
+  if (!normalized || hashes.length === 0) return null;
+
+  for (const hash of hashes) {
+    if (await hasher.compare(normalized, hash)) return hash;
+  }
+  return null;
+}
+
 export async function consumeBackupCode(
   hasher: PasswordHasher,
   storedHashes: readonly string[] | null,

--- a/services/auth/src/grpc/handlers.test.ts
+++ b/services/auth/src/grpc/handlers.test.ts
@@ -529,8 +529,8 @@ describe('login', () => {
     mocks.issuerMock.mint.mockResolvedValueOnce(mintedFixture());
     mocks.clientMock.query.mockResolvedValue({ rows: [] });
     mocks.poolMock.query
-      // The backup_codes UPDATE removing the consumed hash.
-      .mockResolvedValueOnce({ rows: [] })
+      // Atomic conditional array_remove UPDATE — RETURNING the remaining hashes.
+      .mockResolvedValueOnce({ rows: [{ remaining: ['hash-a'] }], rowCount: 1 })
       .mockResolvedValueOnce({ rows: [{ user_type: 'adopter' }] })
       .mockResolvedValueOnce({ rows: [] })
       .mockResolvedValueOnce({ rows: [{ name: 'pets.read' }] });
@@ -541,10 +541,10 @@ describe('login', () => {
     expect(res.tokens?.accessToken).toBe('access.jwt.token');
     expect(res.backupCodesExhausted).toBe(false);
     const updateCall = mocks.poolMock.query.mock.calls.find(c =>
-      (c[0] as string).includes('backup_codes = $2')
+      (c[0] as string).includes('array_remove')
     );
-    // Only the matched hash ("hash-b") was removed — "hash-a" survives.
-    expect(updateCall?.[1]).toEqual(['usr-adopter', ['hash-a']]);
+    // The matched hash ("hash-b") is passed as the conditional predicate — not the remaining list.
+    expect(updateCall?.[1]).toEqual(['usr-adopter', 'hash-b']);
   });
 
   it('signals backupCodesExhausted when the LAST backup code is consumed', async () => {
@@ -563,7 +563,8 @@ describe('login', () => {
     mocks.issuerMock.mint.mockResolvedValueOnce(mintedFixture());
     mocks.clientMock.query.mockResolvedValue({ rows: [] });
     mocks.poolMock.query
-      .mockResolvedValueOnce({ rows: [] })
+      // RETURNING shows empty remaining array — all codes spent.
+      .mockResolvedValueOnce({ rows: [{ remaining: [] }], rowCount: 1 })
       .mockResolvedValueOnce({ rows: [{ user_type: 'adopter' }] })
       .mockResolvedValueOnce({ rows: [] })
       .mockResolvedValueOnce({ rows: [{ name: 'pets.read' }] });
@@ -571,6 +572,73 @@ describe('login', () => {
     const res = await login(mocks.deps, null, { ...BASE_LOGIN_REQ, backupCode: 'AAAA-BBBB' });
 
     expect(res.backupCodesExhausted).toBe(true);
+  });
+
+  it('rejects when the DB UPDATE predicate fails — concurrent login already consumed the code (ADS-975)', async () => {
+    mocks.poolMock.query.mockResolvedValueOnce({
+      rows: [
+        userRowFixture({
+          two_factor_enabled: true,
+          two_factor_secret: encryptTotpSecret(ENCRYPTION_KEY, generateSecret()),
+          backup_codes: ['hash-only'],
+        }),
+      ],
+    });
+    mocks.hasherMock.compare
+      .mockResolvedValueOnce(true) // password check
+      .mockResolvedValueOnce(true); // backup code matches client-side
+    // The DB UPDATE finds the hash already removed (rowCount 0) — concurrent login won the race.
+    mocks.poolMock.query.mockResolvedValueOnce({ rows: [], rowCount: 0 });
+
+    await expect(
+      login(mocks.deps, null, { ...BASE_LOGIN_REQ, backupCode: 'AAAA-BBBB' })
+    ).rejects.toMatchObject({ code: 'UNAUTHENTICATED' });
+    expect(mocks.issuerMock.mint).not.toHaveBeenCalled();
+  });
+
+  it('concurrent logins with the same backup code: exactly one succeeds, the other is rejected (ADS-975)', async () => {
+    const twoFactorSecret = encryptTotpSecret(ENCRYPTION_KEY, generateSecret());
+    const userRow = userRowFixture({
+      two_factor_enabled: true,
+      two_factor_secret: twoFactorSecret,
+      backup_codes: ['hash-only'],
+    });
+
+    // Both logins SELECT the same stale user row (before either UPDATE commits).
+    mocks.poolMock.query
+      .mockResolvedValueOnce({ rows: [userRow] })
+      .mockResolvedValueOnce({ rows: [userRow] });
+
+    mocks.hasherMock.compare
+      .mockResolvedValueOnce(true) // login A: password check
+      .mockResolvedValueOnce(true) // login B: password check
+      .mockResolvedValueOnce(true) // login A: backup code vs hash-only — match
+      .mockResolvedValueOnce(true); // login B: backup code vs hash-only — match (stale read)
+
+    mocks.issuerMock.mint.mockResolvedValueOnce(mintedFixture());
+    mocks.clientMock.query.mockResolvedValue({ rows: [] });
+
+    mocks.poolMock.query
+      .mockResolvedValueOnce({ rows: [{ remaining: [] }], rowCount: 1 }) // A wins the DB race
+      .mockResolvedValueOnce({ rows: [], rowCount: 0 }) // B loses — hash already removed
+      // loadPrincipal for the successful login only
+      .mockResolvedValueOnce({ rows: [{ user_type: 'adopter' }] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [{ name: 'pets.read' }] });
+
+    const [resA, resB] = await Promise.allSettled([
+      login(mocks.deps, null, { ...BASE_LOGIN_REQ, backupCode: 'AAAA-BBBB' }),
+      login(mocks.deps, null, { ...BASE_LOGIN_REQ, backupCode: 'AAAA-BBBB' }),
+    ]);
+
+    const successes = [resA, resB].filter(r => r.status === 'fulfilled');
+    const failures = [resA, resB].filter(r => r.status === 'rejected');
+    expect(successes).toHaveLength(1);
+    expect(failures).toHaveLength(1);
+    expect((failures[0] as PromiseRejectedResult).reason).toMatchObject({
+      code: 'UNAUTHENTICATED',
+    });
+    expect(mocks.issuerMock.mint).toHaveBeenCalledTimes(1);
   });
 
   it('rejects an unrecognised backup code with UNAUTHENTICATED (no token minted)', async () => {

--- a/services/auth/src/grpc/handlers.ts
+++ b/services/auth/src/grpc/handlers.ts
@@ -52,7 +52,7 @@ import {
   type UserRoleDb,
   type UserStatusDb,
 } from './enum-map.js';
-import { consumeBackupCode } from './backup-codes.js';
+import { findMatchingBackupCodeHash } from './backup-codes.js';
 import { createAuthMetrics } from './auth-metrics.js';
 import { verifyAndConsumeTotp } from './totp-verification.js';
 
@@ -388,15 +388,28 @@ async function verifySecondFactor(
   req: LoginRequest
 ): Promise<SecondFactorOutcome> {
   if (req.backupCode) {
-    const result = await consumeBackupCode(deps.passwordHasher, user.backup_codes, req.backupCode);
-    if (!result.ok) {
+    const matchedHash = await findMatchingBackupCodeHash(
+      deps.passwordHasher,
+      user.backup_codes,
+      req.backupCode
+    );
+    if (!matchedHash) {
       return { ok: false, backupCodesExhausted: false };
     }
-    await deps.pool.query(
-      `UPDATE auth.users SET backup_codes = $2, updated_at = now() WHERE user_id = $1`,
-      [user.user_id, result.remaining]
+    // Atomic conditional removal: only removes the hash if it is still present.
+    // If a concurrent login consumed the same hash first, rowCount is 0 and we
+    // treat it as a failed attempt — the code was already spent (ADS-975).
+    const res = await deps.pool.query<{ remaining: string[] }>(
+      `UPDATE auth.users
+          SET backup_codes = array_remove(backup_codes, $2), updated_at = now()
+        WHERE user_id = $1 AND $2 = ANY(backup_codes)
+        RETURNING backup_codes AS remaining`,
+      [user.user_id, matchedHash]
     );
-    return { ok: true, backupCodesExhausted: result.remaining.length === 0 };
+    if (res.rowCount === 0) {
+      return { ok: false, backupCodesExhausted: false };
+    }
+    return { ok: true, backupCodesExhausted: res.rows[0].remaining.length === 0 };
   }
 
   const ok = await verifyAndConsumeTotp(


### PR DESCRIPTION
## Summary

- Fixes a race condition where two concurrent logins presenting the same 2FA backup code could both succeed, violating the single-use guarantee
- Replaces the non-atomic read→compare→overwrite with a single conditional SQL `UPDATE ... WHERE $2 = ANY(backup_codes) RETURNING backup_codes AS remaining` — if the hash is already gone, `rowCount` is 0 and the second caller is rejected as `UNAUTHENTICATED`
- Adds `findMatchingBackupCodeHash` to `backup-codes.ts` as the pure lookup step before the DB-gated removal

## Changes

- `services/auth/src/grpc/backup-codes.ts` — new exported `findMatchingBackupCodeHash` (returns the stored hash that bcrypt-matches a candidate, without modifying the array)
- `services/auth/src/grpc/handlers.ts` — `verifySecondFactor` backup-code branch rewritten to use the atomic conditional UPDATE; import switched from `consumeBackupCode` to `findMatchingBackupCodeHash`
- `services/auth/src/grpc/backup-codes.test.ts` — unit tests for `findMatchingBackupCodeHash`
- `services/auth/src/grpc/handlers.test.ts` — updated existing backup-code tests to match new SQL shape (matched hash as `$2`, `RETURNING` result); added race-lost test and `Promise.allSettled` concurrent-login test

## Before requesting review

- [ ] Ran `pnpm ci:local:quick` locally (or installed the pre-push hook — see CONTRIBUTING.md)
- [x] Tests for new behaviour added (TDD)
- [ ] If touching `.env` requirements, updated `.env.example`'s REQUIRED block
- [ ] If touching a `lib.*`, considered consumer impact across `app.*` and `service.backend`

## Test plan

- [x] Existing tests pass (`pnpm test` — 77/77 in affected files, 357/357 overall)
- [x] New behaviour is covered by tests
  - `findMatchingBackupCodeHash` — 6 unit tests (match, hyphen-normalisation, no-match, null/empty storedHashes, empty candidate, immutability)
  - Race-lost path: single login where UPDATE returns `rowCount: 0` → `UNAUTHENTICATED`
  - Concurrent race: `Promise.allSettled([loginA, loginB])` with same code → exactly 1 success, 1 `UNAUTHENTICATED`, `mint` called once
- [ ] Tested manually (describe how)
- [ ] No TypeScript errors (`pnpm type-check`) — pre-existing `lib.types` not-built errors only; no new errors in changed files
- [ ] Lint passes (`pnpm lint`)

## Related

Fixes [ADS-975](https://linear.app/ideasquared/issue/ADS-975/2fa-backup-codes-consume-then-update-is-not-atomic-same-code-accepted)

---
_Generated by [Claude Code](https://claude.ai/code/session_011MbTxHsfX3wTMGreNZmDTf)_