### PR TITLE
fix(auth): unverified-account login acts as password oracle (ADS-964)

### DIFF
--- a/services/auth/src/grpc/handlers.test.ts
+++ b/services/auth/src/grpc/handlers.test.ts
@@ -681,24 +681,70 @@ describe('login', () => {
 
   // --- Email-verification enforcement --------------------------------
 
-  it('blocks login (no tokens) when the email is not verified', async () => {
+  // ADS-964: a correct password on an unverified account must be treated
+  // identically to a wrong password so the response cannot act as a
+  // password-check oracle. The fix increments login_attempts (same DB path
+  // as the wrong-password branch) and returns the same UNAUTHENTICATED error.
+
+  it('rejects with UNAUTHENTICATED (not emailVerificationRequired) on correct password + unverified account', async () => {
     mocks.poolMock.query.mockResolvedValueOnce({
       rows: [userRowFixture({ email_verified: false })],
     });
     mocks.hasherMock.compare.mockResolvedValueOnce(true);
+    mocks.clientMock.query.mockResolvedValue({ rows: [] });
 
-    const res = await login(mocks.deps, null, BASE_LOGIN_REQ);
-
-    expect(res.emailVerificationRequired).toBe(true);
-    expect(res.tokens).toBeUndefined();
-    expect(res.user).toBeUndefined();
-    // No token was minted — the login is not complete until the email is verified.
+    await expect(login(mocks.deps, null, BASE_LOGIN_REQ)).rejects.toMatchObject({
+      code: 'UNAUTHENTICATED',
+      message: 'invalid credentials',
+    });
     expect(mocks.issuerMock.mint).not.toHaveBeenCalled();
   });
 
-  it('gates email verification BEFORE the second factor', async () => {
-    // An unverified account with 2FA on is still blocked on verification
-    // first — we never reach the TOTP check, so no code is requested.
+  it('increments login_attempts on correct password + unverified account (same as wrong password)', async () => {
+    mocks.poolMock.query.mockResolvedValueOnce({
+      rows: [userRowFixture({ email_verified: false })],
+    });
+    mocks.hasherMock.compare.mockResolvedValueOnce(true);
+    mocks.clientMock.query.mockResolvedValue({ rows: [] });
+
+    await expect(login(mocks.deps, null, BASE_LOGIN_REQ)).rejects.toMatchObject({
+      code: 'UNAUTHENTICATED',
+    });
+
+    const bumpCall = mocks.clientMock.query.mock.calls
+      .map(c => c[0] as string)
+      .find(sql => /login_attempts = login_attempts \+ 1/.test(sql));
+    expect(bumpCall).toBeDefined();
+  });
+
+  it('publishes a denied audit event on correct password + unverified account', async () => {
+    mocks.poolMock.query.mockResolvedValueOnce({
+      rows: [userRowFixture({ email_verified: false })],
+    });
+    mocks.hasherMock.compare.mockResolvedValueOnce(true);
+    mocks.clientMock.query.mockResolvedValue({ rows: [] });
+
+    await expect(login(mocks.deps, null, BASE_LOGIN_REQ)).rejects.toMatchObject({
+      code: 'UNAUTHENTICATED',
+    });
+
+    expect(mocks.natsMock.publish.mock.calls[0][0]).toBe('auth.actionTaken');
+    const envelope = JSON.parse(
+      new TextDecoder().decode(mocks.natsMock.publish.mock.calls[0][1] as Uint8Array)
+    );
+    expect(envelope.payload).toMatchObject({
+      action: 'login',
+      outcome: 'denied',
+      actorUserId: 'usr-adopter',
+      actorEmailSnapshot: 'alex@example.com',
+    });
+  });
+
+  it('gates email verification BEFORE the second factor — still returns UNAUTHENTICATED', async () => {
+    // An unverified account with 2FA on hits the unverified gate first.
+    // We never reach the TOTP check, and the response is UNAUTHENTICATED —
+    // not twoFactorRequired — so the attacker cannot learn whether 2FA is
+    // enabled on an unverified account whose password they just guessed.
     const secret = generateSecret();
     mocks.poolMock.query.mockResolvedValueOnce({
       rows: [
@@ -710,11 +756,11 @@ describe('login', () => {
       ],
     });
     mocks.hasherMock.compare.mockResolvedValueOnce(true);
+    mocks.clientMock.query.mockResolvedValue({ rows: [] });
 
-    const res = await login(mocks.deps, null, BASE_LOGIN_REQ);
-
-    expect(res.emailVerificationRequired).toBe(true);
-    expect(res.twoFactorRequired).toBe(false);
+    await expect(login(mocks.deps, null, BASE_LOGIN_REQ)).rejects.toMatchObject({
+      code: 'UNAUTHENTICATED',
+    });
     expect(mocks.issuerMock.mint).not.toHaveBeenCalled();
   });
 

--- a/services/auth/src/grpc/handlers.ts
+++ b/services/auth/src/grpc/handlers.ts
@@ -541,19 +541,53 @@ export async function login(
     throw new HandlerError('UNAUTHENTICATED', 'invalid credentials');
   }
 
-  // Email verification gate. The password is correct, but an account whose
-  // email has not been verified cannot log in. We answer with
-  // email_verification_required (no tokens minted) so the client can prompt
-  // the user to verify — and resend the verification email — before
-  // re-attempting login.
+  // Email verification gate. A correct password on an unverified account must
+  // NOT reveal that the password was right — doing so turns the response into
+  // a password-check oracle (ADS-964). We increment login_attempts exactly as
+  // the wrong-password path does and throw the same UNAUTHENTICATED shape so
+  // the two cases are indistinguishable to the caller. The user must trigger a
+  // "resend verification email" flow separately; the client should surface that
+  // option alongside any invalid-credentials error.
   if (!user.email_verified) {
+    await withTransaction(deps, async ({ client, publish }) => {
+      await client.query(
+        `UPDATE auth.users
+            SET login_attempts = login_attempts + 1,
+                locked_until = CASE
+                  WHEN login_attempts + 1 >= $2
+                  THEN now() + make_interval(
+                    secs => LEAST(
+                      $3::double precision * power(2, login_attempts + 1 - $2),
+                      $4::double precision
+                    )
+                  )
+                  ELSE locked_until
+                END,
+                updated_at = now()
+          WHERE user_id = $1`,
+        [user.user_id, LOGIN_LOCK_THRESHOLD, LOGIN_LOCK_BASE_SECONDS, LOGIN_LOCK_MAX_SECONDS]
+      );
+      publish({
+        type: 'auth.actionTaken',
+        id: `auth.actionTaken.${randomUUID()}`,
+        payload: {
+          eventId: randomUUID(),
+          service: 'service.auth',
+          subject: 'auth.actionTaken',
+          aggregateType: 'user',
+          aggregateId: user.user_id,
+          actorUserId: user.user_id,
+          actorEmailSnapshot: user.email,
+          action: 'login',
+          outcome: 'denied',
+          occurredAt: new Date().toISOString(),
+          ipAddress: req.ipAddress,
+          userAgent: req.userAgent,
+        },
+      });
+    });
     loginCounter.inc({ outcome: 'email_unverified' });
-    return {
-      permissions: [],
-      twoFactorRequired: false,
-      emailVerificationRequired: true,
-      backupCodesExhausted: false,
-    };
+    throw new HandlerError('UNAUTHENTICATED', 'invalid credentials');
   }
 
   // Second factor. The password is correct; if the account has 2FA on we


### PR DESCRIPTION
## Summary

- Fixes a security vulnerability where a correct password on an unverified account returned `emailVerificationRequired: true` — distinguishable from a wrong-password response, making it a silent password-check oracle with no lockout.
- Unverified-account login attempts now run the same `login_attempts` increment and soft-lock path as wrong passwords, and throw `UNAUTHENTICATED('invalid credentials')` so both responses are identical to the caller.
- Audit events (`auth.actionTaken` with `outcome: 'denied'`) are published for these attempts, matching the wrong-password audit trail.

## Changes

- `services/auth/src/grpc/handlers.ts` — replaced the unverified-email early return with the same `withTransaction` block used by the wrong-password path (counter increment + audit publish), then throws `UNAUTHENTICATED`.
- `services/auth/src/grpc/handlers.test.ts` — replaced the two existing email-verification tests and added three new focused tests: UNAUTHENTICATED shape, `login_attempts` increment, and denied audit event publication.

## Before requesting review

- [x] Tests for new behaviour added (TDD)
- [x] No `.env` requirements touched
- [x] No `lib.*` touched

## Test plan

- [x] Existing tests pass (`pnpm test` — 359 tests, 22 suites; 2 pre-existing suite failures unrelated to this change)
- [x] New behaviour is covered by tests (3 new tests asserting UNAUTHENTICATED, attempt counter increment, and audit event)
- [x] No TypeScript errors (lint-staged ran cleanly on commit)
- [x] Lint passes (Turbo lint ran on commit via lint-staged)

## Screenshots / recordings

N/A — backend-only security fix, no UI changes.

## Related

Closes [ADS-964](https://linear.app/ideasquared/issue/ADS-964/security-login-on-unverified-account-is-a-password-oracle-correct)

---
_Generated by [Claude Code](https://claude.ai/code/session_01W8z8iAC2enHiwRiBT3Eypt)_