### PR TITLE
ci: audit dependencies via npm bulk advisory endpoint (pnpm audit 410 fix)

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -46,5 +46,13 @@ jobs:
 
       # ADS-387: Single workspace-level audit covers every workspace package via
       # the root pnpm-lock.yaml, replacing the previous 5-package hardcoded matrix.
+      #
+      # We can't use `pnpm audit` here: it calls npm's retired quick-audit
+      # endpoint (`/-/npm/v1/security/advisories/quick`), which now returns HTTP
+      # 410 on every request, so the step failed on every run regardless of the
+      # dependency tree. scripts/audit-bulk.mjs queries npm's supported bulk
+      # advisory endpoint against the versions in pnpm-lock.yaml instead, keeping
+      # the ADS-903 policy: all advisories go to the job summary, high/critical
+      # fail the job.
       - name: Audit all workspaces for high+ vulnerabilities
-        run: pnpm audit --audit-level high
+        run: node scripts/audit-bulk.mjs

--- a/docs/security/dependency-policy.md
+++ b/docs/security/dependency-policy.md
@@ -6,15 +6,21 @@ blocking anything.
 
 ## Blocking: `security.yml` (Dependency Audit)
 
-`pnpm audit --audit-level high` runs on every push/PR touching a workspace
+`node scripts/audit-bulk.mjs` runs on every push/PR touching a workspace
 package plus a weekly scheduled run. **`high` and `critical` severity
 vulnerabilities fail the job** — no `continue-on-error`. A red
 `security-audit` check must be resolved (patch, upgrade, or an explicit
 accepted-risk note in the PR) before merge.
 
-`low` and `moderate` findings do not fail the job — `pnpm audit`'s own exit
-code only trips at or above `--audit-level`. They're still visible in the
-job log for anyone who looks.
+`low` and `moderate` findings do not fail the job. They are still written to
+the run's job summary (`GITHUB_STEP_SUMMARY`) so they're visible on the
+workflow run page for anyone who looks.
+
+> **Why not `pnpm audit`?** npm retired the quick-audit endpoint `pnpm audit`
+> calls (it now returns HTTP 410), so the command fails on every run
+> regardless of the dependency tree. `scripts/audit-bulk.mjs` queries npm's
+> supported *bulk advisory* endpoint directly against the versions resolved in
+> `pnpm-lock.yaml` — same npm advisory data, same `high`/`critical` gate.
 
 ## Advisory: `quality.yml` (Dependency Check)
 

--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
     "jsdom": "^29.1.1",
     "lint-staged": "^17.0.8",
     "prettier": "^3.2.5",
+    "semver": "7.8.5",
     "tsx": "^4.19.2",
     "turbo": "^2.9.16",
     "typescript": "^6.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -78,6 +78,9 @@ importers:
       prettier:
         specifier: ^3.2.5
         version: 3.8.4
+      semver:
+        specifier: 7.8.5
+        version: 7.8.5
       tsx:
         specifier: ^4.19.2
         version: 4.22.4
@@ -9431,11 +9434,6 @@ packages:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
     hasBin: true
 
-  semver@7.8.4:
-    resolution: {integrity: sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==}
-    engines: {node: '>=10'}
-    hasBin: true
-
   semver@7.8.5:
     resolution: {integrity: sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==}
     engines: {node: '>=10'}
@@ -16334,7 +16332,7 @@ snapshots:
       process-warning: 5.0.0
       rfdc: 1.4.1
       secure-json-parse: 4.1.0
-      semver: 7.8.4
+      semver: 7.8.5
       toad-cache: 3.7.1
 
   fastq@1.20.1:
@@ -17099,7 +17097,7 @@ snapshots:
       lodash.isstring: 4.0.1
       lodash.once: 4.1.1
       ms: 2.1.3
-      semver: 7.8.4
+      semver: 7.8.5
 
   jspdf-autotable@5.0.8(jspdf@4.2.1):
     dependencies:
@@ -18678,8 +18676,6 @@ snapshots:
   semifies@1.0.0: {}
 
   semver@6.3.1: {}
-
-  semver@7.8.4: {}
 
   semver@7.8.5: {}
 

--- a/scripts/audit-bulk.mjs
+++ b/scripts/audit-bulk.mjs
@@ -1,0 +1,179 @@
+#!/usr/bin/env node
+// Dependency audit via npm's bulk advisory endpoint.
+//
+// Why this exists: `pnpm audit` calls npm's *quick-audit* endpoint
+// (`/-/npm/v1/security/audits/quick`), which npm retired — it now returns
+// HTTP 410 for every request, so `pnpm audit --audit-level high` fails on
+// every CI run regardless of the dependency tree. npm's guidance is to use
+// the *bulk advisory* endpoint (`/-/npm/v1/security/advisories/bulk`), which
+// this script queries directly against the versions resolved in
+// pnpm-lock.yaml.
+//
+// Behaviour preserves the ADS-903 policy:
+//   - EVERY matched advisory (all severities) is printed to the job summary
+//     and stdout — advisory visibility.
+//   - The process exits non-zero when any matched advisory is `high` or
+//     `critical` — the hard merge gate (mirrors `--audit-level high`).
+//
+// Fails closed: a registry/network error after retries exits non-zero rather
+// than letting an un-audited build pass.
+
+import { readFileSync, appendFileSync } from 'node:fs';
+
+import semver from 'semver';
+
+const BULK_ENDPOINT = 'https://registry.npmjs.org/-/npm/v1/security/advisories/bulk';
+const GATE_SEVERITIES = new Set(['high', 'critical']);
+const BATCH_SIZE = 200;
+const MAX_RETRIES = 3;
+
+// Extract name -> Set(versions) from the `packages:` section of the v9
+// lockfile. Keys look like `'@scope/name@1.2.3':` or `'name@1.2.3':`, with an
+// occasional `(peerdep@x)` suffix on the version that we strip.
+const parseLockfilePackages = (lockfile) => {
+  const byName = new Map();
+  let inPackages = false;
+  for (const rawLine of lockfile.split('\n')) {
+    if (rawLine === 'packages:') {
+      inPackages = true;
+      continue;
+    }
+    // A new top-level key (no indentation) ends the packages section.
+    if (inPackages && /^\S/.test(rawLine)) {
+      break;
+    }
+    if (!inPackages) {
+      continue;
+    }
+    const match = rawLine.match(/^ {2}'?(.+?)'?:$/);
+    if (!match) {
+      continue;
+    }
+    const key = match[1];
+    const at = key.lastIndexOf('@');
+    if (at <= 0) {
+      continue;
+    }
+    const name = key.slice(0, at);
+    const version = key.slice(at + 1).split('(')[0];
+    if (!semver.valid(version)) {
+      continue;
+    }
+    const versions = byName.get(name) ?? new Set();
+    versions.add(version);
+    byName.set(name, versions);
+  }
+  return byName;
+};
+
+const chunk = (items, size) => {
+  const out = [];
+  for (let i = 0; i < items.length; i += size) {
+    out.push(items.slice(i, i + size));
+  }
+  return out;
+};
+
+const fetchAdvisories = async (payload) => {
+  for (let attempt = 1; attempt <= MAX_RETRIES; attempt += 1) {
+    try {
+      const res = await fetch(BULK_ENDPOINT, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify(payload),
+      });
+      if (!res.ok) {
+        throw new Error(`bulk advisory endpoint responded ${res.status}`);
+      }
+      return await res.json();
+    } catch (error) {
+      if (attempt === MAX_RETRIES) {
+        throw error;
+      }
+      await new Promise((resolve) => setTimeout(resolve, attempt * 1000));
+    }
+  }
+  return {};
+};
+
+// Match each returned advisory against the versions we actually have installed
+// (the endpoint returns advisories for a package name across all versions).
+const collectFindings = (advisoriesByName, versionsByName) => {
+  const findings = [];
+  for (const [name, advisories] of Object.entries(advisoriesByName)) {
+    const installed = versionsByName.get(name);
+    if (!installed) {
+      continue;
+    }
+    for (const advisory of advisories) {
+      for (const version of installed) {
+        if (!semver.satisfies(version, advisory.vulnerable_versions, { includePrerelease: true })) {
+          continue;
+        }
+        findings.push({
+          name,
+          version,
+          severity: String(advisory.severity ?? 'unknown').toLowerCase(),
+          title: advisory.title ?? '',
+          url: advisory.url ?? '',
+        });
+      }
+    }
+  }
+  return findings;
+};
+
+const writeSummary = (findings) => {
+  const lines = [];
+  lines.push('## Dependency audit (npm bulk advisory endpoint)');
+  if (findings.length === 0) {
+    lines.push('');
+    lines.push('No advisories match the installed dependency versions.');
+  } else {
+    lines.push('');
+    lines.push('| Severity | Package | Installed | Advisory |');
+    lines.push('| --- | --- | --- | --- |');
+    const order = { critical: 0, high: 1, moderate: 2, low: 3, unknown: 4 };
+    const sorted = [...findings].sort(
+      (a, b) => (order[a.severity] ?? 5) - (order[b.severity] ?? 5)
+    );
+    for (const f of sorted) {
+      lines.push(`| ${f.severity} | \`${f.name}\` | ${f.version} | [${f.title}](${f.url}) |`);
+    }
+  }
+  const body = `${lines.join('\n')}\n`;
+  process.stdout.write(body);
+  if (process.env.GITHUB_STEP_SUMMARY) {
+    appendFileSync(process.env.GITHUB_STEP_SUMMARY, body);
+  }
+};
+
+const main = async () => {
+  const lockfile = readFileSync('pnpm-lock.yaml', 'utf8');
+  const versionsByName = parseLockfilePackages(lockfile);
+  const names = [...versionsByName.keys()];
+
+  const advisoriesByName = {};
+  for (const batch of chunk(names, BATCH_SIZE)) {
+    const payload = Object.fromEntries(batch.map((name) => [name, [...versionsByName.get(name)]]));
+    const result = await fetchAdvisories(payload);
+    Object.assign(advisoriesByName, result);
+  }
+
+  const findings = collectFindings(advisoriesByName, versionsByName);
+  writeSummary(findings);
+
+  const blocking = findings.filter((f) => GATE_SEVERITIES.has(f.severity));
+  if (blocking.length > 0) {
+    const unique = new Set(blocking.map((f) => `${f.name}@${f.version}`));
+    console.error(
+      `\n::error::${blocking.length} high/critical advisory match(es) across ${unique.size} package version(s) — see the summary above.`
+    );
+    process.exit(1);
+  }
+};
+
+main().catch((error) => {
+  console.error(`::error::dependency audit failed: ${error.message}`);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

The **Dependency Audit** gate (`security.yml`, the ADS-903 hard gate) runs `pnpm audit --audit-level high`, which calls npm's **retired** quick-audit endpoint — now `HTTP 410` on every request. The job therefore failed on **every PR, repo-wide**, regardless of the dependency tree. Confirmed locally that pnpm `10.34.3` (pinned/current) still hits the retired endpoint, so a version bump does not fix it.

This replaces the step with `scripts/audit-bulk.mjs`, which queries npm's **supported bulk advisory endpoint** (`/-/npm/v1/security/advisories/bulk`) directly against the versions resolved in `pnpm-lock.yaml`. Same npm advisory data, so the ADS-903 policy is preserved exactly:
- **every** advisory (all severities) is written to `GITHUB_STEP_SUMMARY` — advisory visibility
- **only `high`/`critical`** advisories fail the job — the hard merge gate

Fails closed: a registry/network error (after retries) exits non-zero rather than passing an un-audited build.

## Changes

- `scripts/audit-bulk.mjs` (new) — parses the lockfile's `packages:` map, batches package names to the bulk endpoint, matches installed versions against each advisory's `vulnerable_versions` with `semver`, writes the summary, and gates on high/critical
- `.github/workflows/security.yml` — runs `node scripts/audit-bulk.mjs` instead of `pnpm audit --audit-level high` (with a comment explaining the 410)
- `package.json` / `pnpm-lock.yaml` — adds `semver@7.8.5` as a root devDependency (already resolved transitively; minimal churn) for range matching
- `docs/security/dependency-policy.md` — documents the mechanism switch and why

## Test plan

- [x] **Verified live against the real dependency tree**: 1 `moderate` advisory (dompurify) → **exit 0** (advisory only, does not block)
- [x] **Verified the hard gate**: crafted `lodash@4.17.11` → `high` + `critical` matched, sorted summary printed → **exit 1** with a clear `::error::`
- [x] `node --check` on the script
- [ ] Reviewer note: this is the fix for the repo-wide Dependency Audit breakage — once merged it unblocks that check on all open PRs. A future option is to retire this script if/when pnpm ships its own bulk-endpoint migration

## Related

- Linear: ADS-903 (restores the dependency-audit hard gate broken by npm's endpoint retirement)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q5FhHDPvEtBYRDwMAV3rtv

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q5FhHDPvEtBYRDwMAV3rtv)_