### PR TITLE
test(e2e): httpOnly-cookie auth specs — token exfiltration + CSRF-403 (ADS-919 follow-up)

### DIFF
--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -102,6 +102,16 @@ const UNPARKED: Record<'client' | 'rescue' | 'admin', string[]> = {
     '**/api-auth-contract.spec.ts',
     '**/logout-flow.spec.ts',
     '**/rate-limit-application-submission.spec.ts',
+    // ADS-919 follow-up: the two full-stack specs the acceptance criteria
+    // called for (httpOnly-cookie token storage + CSRF double-submit
+    // enforcement), deferred when #1218/#1215 shipped the backend/frontend
+    // halves. Both drive a real browser session against the live gateway —
+    // cookie-auth-token-exfiltration proves the access/refresh tokens are
+    // unreachable from in-page JS after a real login and survive a reload;
+    // csrf-enforcement proves a state-changing request needs a valid
+    // x-csrf-token header once the session cookie is present.
+    '**/cookie-auth-token-exfiltration.spec.ts',
+    '**/csrf-enforcement.spec.ts',
     // ADS-801 (Batch C / ADS-868): profile-update-persistence was re-parked
     // because authService.updateProfile called PUT /api/v1/auth/me, a route
     // that does not exist in the gateway (the real route is

--- a/e2e/tests/client/cookie-auth-token-exfiltration.spec.ts
+++ b/e2e/tests/client/cookie-auth-token-exfiltration.spec.ts
@@ -1,0 +1,94 @@
+import { test, expect } from '../../fixtures';
+import { loginViaUI } from '../../helpers/auth';
+import { ROLES } from '../../fixtures/roles';
+
+/**
+ * ADS-919 acceptance criteria (deferred full-stack spec, shipped in
+ * #1218 + #1215). The gateway now sets the access/refresh token pair as
+ * HttpOnly cookies on login (services/gateway/src/middleware/auth-cookies.ts)
+ * instead of returning them in the JSON body or letting the SPA persist them
+ * to localStorage (the pre-cookie AuthService's `__dev_*` keys were removed
+ * in #1219). Only a non-HttpOnly `hasSession` presence marker is
+ * JS-readable — see packages/lib.auth/src/services/session-cookie.ts.
+ *
+ * This spec proves the token pair is genuinely unreachable from in-page
+ * JavaScript — the exact threat model an XSS payload would exploit — and
+ * that the session still survives a full page reload despite that.
+ */
+test.describe('httpOnly cookie auth — token exfiltration guard (ADS-919)', () => {
+  // Start from a clean, unauthenticated context so every assertion below
+  // follows directly from a real login performed inside this test, not from
+  // the pre-authenticated storageState the rest of the client project uses.
+  test.use({ storageState: { cookies: [], origins: [] } });
+
+  test('an injected page script cannot recover the access/refresh tokens after login, and a reload keeps the session @smoke', async ({
+    page,
+  }) => {
+    const { email, password } = ROLES.adopter;
+    await loginViaUI(page, email, password);
+
+    // --- 1. The cookies exist and are flagged HttpOnly -------------------
+    // Playwright's BrowserContext.cookies() reads the cookie jar out of
+    // band (via CDP) — the same channel any automation/devtools tooling
+    // uses, NOT a page script. Asserting the flag directly (rather than
+    // only inferring it from document.cookie below) means a regression
+    // that drops HttpOnly fails loudly even if this particular page
+    // happens not to read it back.
+    const cookies = await page.context().cookies();
+    const accessTokenCookie = cookies.find(c => c.name === 'accessToken');
+    const refreshTokenCookie = cookies.find(c => c.name === 'refreshToken');
+    const sessionMarkerCookie = cookies.find(c => c.name === 'hasSession');
+
+    expect(accessTokenCookie, 'accessToken cookie must be set after login').toBeTruthy();
+    expect(refreshTokenCookie, 'refreshToken cookie must be set after login').toBeTruthy();
+    expect(accessTokenCookie?.httpOnly).toBe(true);
+    expect(refreshTokenCookie?.httpOnly).toBe(true);
+
+    // The session marker is DELIBERATELY JS-readable (it carries no secret)
+    // so the SPA can answer "am I logged in" synchronously — assert it
+    // exists and is NOT HttpOnly, the inverse of the two real tokens.
+    expect(sessionMarkerCookie, 'hasSession marker cookie must be set after login').toBeTruthy();
+    expect(sessionMarkerCookie?.httpOnly).toBe(false);
+
+    // --- 2. Simulate an injected reader running inside the page ----------
+    // This is the actual attack an XSS payload would run: read everything
+    // JS has access to and try to find the tokens.
+    const pageVisible = await page.evaluate(() => ({
+      cookie: document.cookie,
+      localStorage: JSON.stringify(window.localStorage),
+      sessionStorage: JSON.stringify(window.sessionStorage),
+    }));
+
+    expect(pageVisible.cookie).not.toContain('accessToken=');
+    expect(pageVisible.cookie).not.toContain('refreshToken=');
+
+    // The strongest form of the assertion: the real token VALUES must not
+    // be recoverable anywhere JS can read, not just absent under their
+    // expected cookie/key names (a leak under a renamed key would still
+    // show up here).
+    expect(pageVisible.cookie).not.toContain(accessTokenCookie!.value);
+    expect(pageVisible.cookie).not.toContain(refreshTokenCookie!.value);
+    expect(pageVisible.localStorage).not.toContain(accessTokenCookie!.value);
+    expect(pageVisible.localStorage).not.toContain(refreshTokenCookie!.value);
+    expect(pageVisible.sessionStorage).not.toContain(accessTokenCookie!.value);
+    expect(pageVisible.sessionStorage).not.toContain(refreshTokenCookie!.value);
+
+    // ADS-919 cleanup (#1219): the pre-cookie AuthService's plaintext
+    // localStorage keys are gone entirely, not just emptied.
+    expect(pageVisible.localStorage).not.toMatch(/__dev_(auth|access|refresh)Token/);
+
+    // --- 3. A reload keeps the session with no JS-visible token ----------
+    // The session is carried purely by the HttpOnly cookies attached
+    // automatically on navigation — there is no token round-trip through
+    // JS-visible storage to "restore" on boot.
+    await page.reload({ waitUntil: 'domcontentloaded' });
+    await page.goto('/profile', { waitUntil: 'domcontentloaded', timeout: 60_000 });
+    await expect(page.getByRole('heading', { level: 1, name: /my profile/i })).toBeVisible({
+      timeout: 15_000,
+    });
+
+    const cookieAfterReload = await page.evaluate(() => document.cookie);
+    expect(cookieAfterReload).not.toContain('accessToken=');
+    expect(cookieAfterReload).not.toContain('refreshToken=');
+  });
+});

--- a/e2e/tests/client/csrf-enforcement.spec.ts
+++ b/e2e/tests/client/csrf-enforcement.spec.ts
@@ -1,0 +1,66 @@
+import { test, expect } from '../../fixtures';
+import { URLS } from '../../playwright.config';
+
+/**
+ * ADS-919 acceptance criteria (deferred full-stack spec, shipped in
+ * #1215 + #1218). Once a browser holds the httpOnly `accessToken` session
+ * cookie, every state-changing request must also carry a valid
+ * `x-csrf-token` header that matches the non-HttpOnly `csrfToken`
+ * double-submit cookie (services/gateway/src/middleware/csrf.ts) — the
+ * session cookie riding along automatically (SameSite=Lax + same-site
+ * requests) is NOT sufficient on its own, otherwise a cross-site
+ * form/fetch could ride the logged-in user's session. See
+ * services/gateway/src/routes/csrf.ts for the token-issuing route and
+ * packages/lib.api/src/services/api-service.ts for the client-side half
+ * that fetches + attaches the header automatically on every mutating call.
+ *
+ * Logout is used as the representative authenticated mutation: it's a real
+ * POST the SPA issues (AuthService.logout()), is naturally a one-shot
+ * action (no cleanup / no risk of colliding with another spec's seeded
+ * fixtures), and each test gets its own fresh browser context so logging
+ * out here doesn't affect any other test's session.
+ */
+test.describe('CSRF double-submit enforcement (ADS-919)', () => {
+  test('an authenticated mutation is rejected without a valid CSRF token, and succeeds with one @smoke', async ({
+    page,
+  }) => {
+    const logoutUrl = `${URLS.api}/api/v1/auth/logout`;
+
+    // `page.request` shares this browsing context's cookie jar, so the
+    // httpOnly accessToken cookie from the project's authenticated
+    // storageState rides along automatically on every call below — exactly
+    // how the SPA's own fetches behave (`credentials: 'include'`).
+
+    // 1. No x-csrf-token header at all -> rejected before the route even
+    // runs (middleware/csrf.ts's onRequest hook). The session cookie alone
+    // is not sufficient.
+    const missingHeaderRes = await page.request.post(logoutUrl);
+    expect(missingHeaderRes.status()).toBe(403);
+
+    // 2. A header present but not matching the csrfToken cookie -> also
+    // rejected.
+    const mismatchedRes = await page.request.post(logoutUrl, {
+      headers: { 'x-csrf-token': 'not-the-real-token' },
+    });
+    expect(mismatchedRes.status()).toBe(403);
+
+    // Neither rejected attempt logged the user out — the session must
+    // still be alive before we prove the valid-token path below.
+    const meRes = await page.request.get(`${URLS.api}/api/v1/auth/me`);
+    expect(meRes.ok()).toBe(true);
+
+    // 3. Fetch the real double-submit token the way the SPA's request
+    // interceptor does (GET /api/v1/csrf-token sets the csrfToken cookie
+    // and returns the same value in the body), then retry with a matching
+    // x-csrf-token header.
+    const csrfRes = await page.request.get(`${URLS.api}/api/v1/csrf-token`);
+    expect(csrfRes.ok()).toBe(true);
+    const { csrfToken } = (await csrfRes.json()) as { csrfToken: string };
+    expect(csrfToken).toBeTruthy();
+
+    const validRes = await page.request.post(logoutUrl, {
+      headers: { 'x-csrf-token': csrfToken },
+    });
+    expect(validRes.ok()).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Adds the two full-stack E2E specs the ADS-919 acceptance criteria called for but that were deferred from #1218 (they need the running docker stack).

- `e2e/tests/client/cookie-auth-token-exfiltration.spec.ts` — after a real UI login: asserts `accessToken`/`refreshToken` cookies exist and are **`httpOnly: true`** (read via Playwright's CDP cookie channel, distinct from what page JS sees); asserts `hasSession` exists and is `httpOnly: false`; simulates an injected reader via `page.evaluate` over `document.cookie`/`localStorage`/`sessionStorage` and asserts neither the cookie names nor the raw token values are recoverable; asserts no legacy `__dev_*` localStorage keys; reloads + navigates to `/profile` and asserts the session survived with still no JS-visible token
- `e2e/tests/client/csrf-enforcement.spec.ts` — via the pre-authenticated `page.request` (shares the cookie jar): `POST /api/v1/auth/logout` with no `x-csrf-token` → **403**, mismatched header → **403**, session still alive (`GET /auth/me` ok), then `GET /api/v1/csrf-token` + retry with the matching header → **success**. Logout chosen as a representative mutation because it's one-shot and can't collide with other specs' seeded fixtures under `fullyParallel`
- Both registered in `UNPARKED.client` in `playwright.config.ts` (otherwise the client project's `testMatch` allowlist silently skips them) and `@smoke`-tagged

## ⚠️ Reviewer finding worth acting on separately

The existing e2e fixtures (`fixtures/api.ts`, `helpers/auth.ts`, specs like `api-auth-contract.spec.ts`, `gateway-login.spec.ts`, `logout-flow.spec.ts`) still assume the **pre-ADS-919 Bearer-token model** ("no CSRF, tokens in the login JSON body"). That's now stale — the gateway strips `tokens` from the login response and sets httpOnly cookies — so `apiAs()`/`loginViaApi()` (Bearer minting) is broken against the post-#1218 gateway. **These new specs deliberately avoid that path** (real UI login + `page.request` cookie jar). Updating the stale fixtures is out of scope here but should be its own follow-up.

## Test plan

- [x] `tsc --noEmit` on the e2e workspace — clean
- [x] `eslint` on both new files — clean; pre-commit hook (prettier + turbo lint) passed (no `--no-verify`)
- [ ] **Playwright not run in-sandbox** (no docker stack). Reviewer must validate behaviourally:
  ```
  pnpm docker:dev:detach && pnpm db:seed && pnpm test:e2e:install
  cd e2e && pnpm test -- tests/client/cookie-auth-token-exfiltration.spec.ts tests/client/csrf-enforcement.spec.ts --project=client
  ```
  (or `pnpm test:e2e:smoke` once the stack is up — both are `@smoke`-tagged)

## Related

- Linear: ADS-919 (the deferred E2E specs; full migration shipped in #1218)
- Follow-up: refresh the stale pre-ADS-919 e2e auth fixtures

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q5FhHDPvEtBYRDwMAV3rtv

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q5FhHDPvEtBYRDwMAV3rtv)_