### PR TITLE
feat(auth): 2FA backup-codes reveal-once enrolment + regenerate UI (ADS-914 follow-up)

### DIFF
--- a/packages/lib.auth/src/__tests__/auth-service.test.ts
+++ b/packages/lib.auth/src/__tests__/auth-service.test.ts
@@ -342,16 +342,17 @@ describe('AuthService', () => {
   });
 
   describe('twoFactorRegenerateBackupCodes', () => {
-    it('should regenerate backup codes', async () => {
+    it('should regenerate backup codes, gated on a current TOTP code', async () => {
       const mockResponse = {
-        success: true,
         backupCodes: ['new1', 'new2', 'new3'],
       };
       (apiService.post as ReturnType<typeof vi.fn>).mockResolvedValue(mockResponse);
 
-      const result = await authService.twoFactorRegenerateBackupCodes();
+      const result = await authService.twoFactorRegenerateBackupCodes('123456');
 
-      expect(apiService.post).toHaveBeenCalledWith('/api/v1/auth/2fa/backup-codes');
+      expect(apiService.post).toHaveBeenCalledWith('/api/v1/auth/2fa/backup-codes/regenerate', {
+        token: '123456',
+      });
       expect(result).toEqual(mockResponse);
     });
   });

--- a/packages/lib.auth/src/components/BackupCodesReveal.css.ts
+++ b/packages/lib.auth/src/components/BackupCodesReveal.css.ts
@@ -1,0 +1,72 @@
+import { style } from '@vanilla-extract/css';
+
+import { vars } from '@adopt-dont-shop/lib.components/theme';
+
+export const container = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: vars.spacing['4'],
+});
+
+export const heading = style({
+  margin: 0,
+  fontSize: vars.typography.size.lg,
+  fontWeight: vars.typography.weight.semibold,
+  color: vars.text.primary,
+  selectors: {
+    '&:focus': {
+      outline: 'none',
+    },
+  },
+});
+
+export const warningBox = style({
+  margin: 0,
+  padding: vars.spacing['3'],
+  background: vars.colors.warningBgSubtle,
+  border: `1px solid ${vars.colors.warningBorderSubtle}`,
+  borderRadius: vars.border.radius.base,
+  fontSize: vars.typography.size.sm,
+  color: vars.colors.warningTextEmphasis,
+});
+
+export const codesList = style({
+  display: 'grid',
+  gridTemplateColumns: 'repeat(2, 1fr)',
+  gap: vars.spacing['2'],
+  maxWidth: '320px',
+  margin: 0,
+  padding: 0,
+  listStyle: 'none',
+});
+
+export const codeItem = style({
+  padding: `${vars.spacing['2']} ${vars.spacing['2']}`,
+  background: vars.background.surface,
+  border: `1px solid ${vars.border.color.default}`,
+  borderRadius: vars.border.radius.sm,
+  fontSize: vars.typography.size.sm,
+  textAlign: 'center',
+  letterSpacing: vars.typography.letterSpacing.wide,
+});
+
+export const buttonRow = style({
+  display: 'flex',
+  gap: vars.spacing['2'],
+  flexWrap: 'wrap',
+});
+
+// Visually hidden but still available to assistive tech — used for the
+// aria-live announcements (reveal, copy status, download status) that
+// shouldn't duplicate visible copy on screen.
+export const srOnly = style({
+  position: 'absolute',
+  width: '1px',
+  height: '1px',
+  padding: 0,
+  margin: '-1px',
+  overflow: 'hidden',
+  clip: 'rect(0, 0, 0, 0)',
+  whiteSpace: 'nowrap',
+  border: '0',
+});

--- a/packages/lib.auth/src/components/BackupCodesReveal.test.tsx
+++ b/packages/lib.auth/src/components/BackupCodesReveal.test.tsx
@@ -1,0 +1,118 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+import { BackupCodesReveal } from './BackupCodesReveal';
+
+const codes = ['AAAA-1111', 'BBBB-2222', 'CCCC-3333'];
+
+describe('BackupCodesReveal', () => {
+  beforeEach(() => {
+    // jsdom does not implement URL.createObjectURL / revokeObjectURL.
+    Object.defineProperty(URL, 'createObjectURL', {
+      configurable: true,
+      value: vi.fn().mockReturnValue('blob:mock-url'),
+    });
+    Object.defineProperty(URL, 'revokeObjectURL', {
+      configurable: true,
+      value: vi.fn(),
+    });
+  });
+
+  // @testing-library/user-event's setup() replaces navigator.clipboard with
+  // its own stub, so the clipboard mock must be installed AFTER
+  // userEvent.setup() runs (not in beforeEach) or it gets clobbered.
+  const mockClipboard = (impl: ReturnType<typeof vi.fn>) => {
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText: impl },
+    });
+  };
+
+  it('displays every backup code and moves focus to the heading', () => {
+    render(<BackupCodesReveal codes={codes} onDismiss={vi.fn()} />);
+
+    codes.forEach((code) => {
+      expect(screen.getByText(code)).toBeInTheDocument();
+    });
+    expect(screen.getByRole('heading', { name: /save your backup codes/i })).toHaveFocus();
+  });
+
+  it('announces the reveal via the live region', () => {
+    render(<BackupCodesReveal codes={codes} onDismiss={vi.fn()} />);
+
+    expect(screen.getByRole('status')).toHaveTextContent(
+      '3 backup codes generated. Save them now — they will not be shown again.'
+    );
+  });
+
+  it('keeps the Done button disabled until the user confirms they saved the codes', async () => {
+    const user = userEvent.setup();
+    const onDismiss = vi.fn();
+    render(<BackupCodesReveal codes={codes} onDismiss={onDismiss} />);
+
+    const doneButton = screen.getByRole('button', { name: /done/i });
+    expect(doneButton).toBeDisabled();
+
+    await user.click(screen.getByLabelText(/i've saved these backup codes somewhere safe/i));
+    expect(doneButton).toBeEnabled();
+
+    await user.click(doneButton);
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not call onDismiss when the Done button is clicked while still disabled', async () => {
+    const user = userEvent.setup();
+    const onDismiss = vi.fn();
+    render(<BackupCodesReveal codes={codes} onDismiss={onDismiss} />);
+
+    await user.click(screen.getByRole('button', { name: /done/i }));
+    expect(onDismiss).not.toHaveBeenCalled();
+  });
+
+  it('copies every code to the clipboard, newline-separated', async () => {
+    const user = userEvent.setup();
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    mockClipboard(writeText);
+    render(<BackupCodesReveal codes={codes} onDismiss={vi.fn()} />);
+
+    await user.click(screen.getByRole('button', { name: /copy codes/i }));
+
+    expect(writeText).toHaveBeenCalledWith(codes.join('\n'));
+    expect(await screen.findByRole('button', { name: /^copied$/i })).toBeInTheDocument();
+    expect(screen.getByRole('status')).toHaveTextContent('Backup codes copied to clipboard.');
+  });
+
+  it('announces a failure when the clipboard write is rejected', async () => {
+    const user = userEvent.setup();
+    mockClipboard(vi.fn().mockRejectedValue(new Error('denied')));
+    render(<BackupCodesReveal codes={codes} onDismiss={vi.fn()} />);
+
+    await user.click(screen.getByRole('button', { name: /copy codes/i }));
+
+    expect(
+      await screen.findByText(/could not copy backup codes\. please copy them manually\./i)
+    ).toBeInTheDocument();
+  });
+
+  it('downloads the codes as a text file', async () => {
+    const user = userEvent.setup();
+    const clickSpy = vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => {});
+    render(<BackupCodesReveal codes={codes} onDismiss={vi.fn()} />);
+
+    await user.click(screen.getByRole('button', { name: /download as text/i }));
+
+    expect(URL.createObjectURL).toHaveBeenCalledWith(expect.any(Blob));
+    expect(clickSpy).toHaveBeenCalledTimes(1);
+    expect(URL.revokeObjectURL).toHaveBeenCalledWith('blob:mock-url');
+    expect(screen.getByRole('status')).toHaveTextContent('Backup codes downloaded as a text file.');
+
+    clickSpy.mockRestore();
+  });
+
+  it('accepts a custom heading for the regenerate flow', () => {
+    render(<BackupCodesReveal codes={codes} onDismiss={vi.fn()} heading="Your new backup codes" />);
+
+    expect(screen.getByRole('heading', { name: /your new backup codes/i })).toBeInTheDocument();
+  });
+});

--- a/packages/lib.auth/src/components/BackupCodesReveal.tsx
+++ b/packages/lib.auth/src/components/BackupCodesReveal.tsx
@@ -1,0 +1,124 @@
+import React, { useEffect, useId, useRef, useState } from 'react';
+import { Button, CheckboxInput } from '@adopt-dont-shop/lib.components';
+import * as styles from './BackupCodesReveal.css';
+
+export interface BackupCodesRevealProps {
+  /**
+   * The plaintext backup codes to display. These are shown exactly once —
+   * the caller must discard them from its own state once `onDismiss` fires.
+   */
+  codes: string[];
+  /**
+   * Called once the user has confirmed (via the required checkbox) that
+   * they've saved the codes. The caller is responsible for clearing `codes`
+   * from state at this point so the plaintext values aren't retained
+   * anywhere after dismissal.
+   */
+  onDismiss: () => void;
+  /**
+   * Heading shown above the codes. Defaults to the enrolment copy; callers
+   * showing a freshly-regenerated set can pass something more specific.
+   */
+  heading?: string;
+}
+
+const DOWNLOAD_FILENAME = 'adopt-dont-shop-backup-codes.txt';
+
+/**
+ * Reveal-once display for 2FA backup/recovery codes (ADS-914 follow-up).
+ *
+ * Shared by the enable-2FA flow and the regenerate-backup-codes flow in
+ * TwoFactorSettings — both show a freshly-minted, plaintext set of codes
+ * exactly once. The panel can't be dismissed until the user explicitly
+ * confirms they've saved the codes, and nothing here persists the plaintext
+ * codes beyond the caller's own transient state (no localStorage/etc).
+ */
+export const BackupCodesReveal: React.FC<BackupCodesRevealProps> = ({
+  codes,
+  onDismiss,
+  heading = 'Save your backup codes',
+}) => {
+  const [hasConfirmedSaved, setHasConfirmedSaved] = useState(false);
+  const [copyStatus, setCopyStatus] = useState<'idle' | 'copied' | 'error'>('idle');
+  const [liveMessage, setLiveMessage] = useState('');
+  const headingRef = useRef<HTMLHeadingElement>(null);
+  const headingId = useId();
+  const checkboxId = useId();
+
+  // Move focus to the heading as soon as the codes are revealed, and
+  // announce the reveal for screen reader users who aren't tracking focus.
+  useEffect(() => {
+    headingRef.current?.focus();
+    setLiveMessage(
+      `${codes.length} backup codes generated. Save them now — they will not be shown again.`
+    );
+    // Only run once per reveal (a fresh mount happens for each new set of codes).
+  }, []);
+
+  const codesText = codes.join('\n');
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(codesText);
+      setCopyStatus('copied');
+      setLiveMessage('Backup codes copied to clipboard.');
+    } catch {
+      setCopyStatus('error');
+      setLiveMessage('Could not copy backup codes. Please copy them manually.');
+    }
+  };
+
+  const handleDownload = () => {
+    const blob = new Blob([codesText], { type: 'text/plain' });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = DOWNLOAD_FILENAME;
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    URL.revokeObjectURL(url);
+    setLiveMessage('Backup codes downloaded as a text file.');
+  };
+
+  return (
+    <div className={styles.container} role="region" aria-labelledby={headingId}>
+      <h3 id={headingId} ref={headingRef} tabIndex={-1} className={styles.heading}>
+        {heading}
+      </h3>
+      <p className={styles.warningBox}>
+        These codes are shown only once. Save them somewhere safe — each code can be used a single
+        time to sign in if you lose access to your authenticator app.
+      </p>
+      <ul className={styles.codesList} aria-label="Your backup codes">
+        {codes.map((code) => (
+          <li key={code} className={styles.codeItem}>
+            <code>{code}</code>
+          </li>
+        ))}
+      </ul>
+      <div className={styles.buttonRow}>
+        <Button type="button" variant="secondary" onClick={handleCopy}>
+          {copyStatus === 'copied' ? 'Copied' : 'Copy codes'}
+        </Button>
+        <Button type="button" variant="secondary" onClick={handleDownload}>
+          Download as text
+        </Button>
+      </div>
+      <div role="status" aria-live="polite" className={styles.srOnly}>
+        {liveMessage}
+      </div>
+      <CheckboxInput
+        id={checkboxId}
+        label="I've saved these backup codes somewhere safe"
+        checked={hasConfirmedSaved}
+        onChange={(e) => setHasConfirmedSaved(e.target.checked)}
+      />
+      <Button type="button" onClick={onDismiss} disabled={!hasConfirmedSaved}>
+        Done
+      </Button>
+    </div>
+  );
+};
+
+export default BackupCodesReveal;

--- a/packages/lib.auth/src/components/TwoFactorSettings.css.ts
+++ b/packages/lib.auth/src/components/TwoFactorSettings.css.ts
@@ -101,23 +101,6 @@ export const tokenInput = style({
   },
 });
 
-export const backupCodesGrid = style({
-  display: 'grid',
-  gridTemplateColumns: 'repeat(2, 1fr)',
-  gap: vars.spacing['2'],
-  maxWidth: '320px',
-});
-
-export const backupCode = style({
-  padding: `${vars.spacing['2']} ${vars.spacing['2']}`,
-  background: vars.background.surface,
-  border: `1px solid ${vars.border.color.default}`,
-  borderRadius: vars.border.radius.sm,
-  fontSize: vars.typography.size.sm,
-  textAlign: 'center',
-  letterSpacing: vars.typography.letterSpacing.wide,
-});
-
 export const description = style({
   fontSize: vars.typography.size.sm,
   color: vars.text.secondary,
@@ -129,13 +112,4 @@ export const buttonRow = style({
   display: 'flex',
   gap: vars.spacing['2'],
   flexWrap: 'wrap',
-});
-
-export const warningBox = style({
-  padding: vars.spacing['3'],
-  background: vars.colors.warningBgSubtle,
-  border: `1px solid ${vars.colors.warningBorderSubtle}`,
-  borderRadius: vars.border.radius.base,
-  fontSize: vars.typography.size.sm,
-  color: vars.colors.warningTextEmphasis,
 });

--- a/packages/lib.auth/src/components/TwoFactorSettings.test.tsx
+++ b/packages/lib.auth/src/components/TwoFactorSettings.test.tsx
@@ -154,7 +154,23 @@ describe('TwoFactorSettings', () => {
       ).toBeInTheDocument();
     });
 
-    it('dismisses the backup codes screen once the user confirms they saved them', async () => {
+    it('shows the reveal-once panel with the enrolment heading', async () => {
+      (authService.twoFactorEnable as ReturnType<typeof vi.fn>).mockResolvedValue({
+        success: true,
+        backupCodes: ['code-a'],
+      });
+      renderSettings(buildAuthValue({ user: { ...baseUser, twoFactorEnabled: false } }));
+
+      await startSetup();
+      await userEvent.type(screen.getByPlaceholderText('000000'), '123456');
+      await userEvent.click(screen.getByRole('button', { name: /verify and enable/i }));
+
+      expect(
+        await screen.findByRole('heading', { name: /save your backup codes/i })
+      ).toBeInTheDocument();
+    });
+
+    it('keeps the backup codes panel open until the user confirms they saved them, then returns to idle', async () => {
       (authService.twoFactorEnable as ReturnType<typeof vi.fn>).mockResolvedValue({
         success: true,
         backupCodes: ['code-a'],
@@ -166,7 +182,11 @@ describe('TwoFactorSettings', () => {
       await userEvent.click(screen.getByRole('button', { name: /verify and enable/i }));
       await screen.findByText('code-a');
 
-      await userEvent.click(screen.getByRole('button', { name: /i have saved my backup codes/i }));
+      const doneButton = screen.getByRole('button', { name: /done/i });
+      expect(doneButton).toBeDisabled();
+
+      await userEvent.click(screen.getByLabelText(/i've saved these backup codes somewhere safe/i));
+      await userEvent.click(doneButton);
 
       expect(
         screen.getByRole('button', { name: /set up two-factor authentication/i })
@@ -186,17 +206,38 @@ describe('TwoFactorSettings', () => {
       expect(screen.getByRole('button', { name: /disable 2fa/i })).toBeInTheDocument();
     });
 
-    it('regenerates and displays new backup codes', async () => {
+    it('asks for a current TOTP code before regenerating, then reveals the new codes once', async () => {
       (authService.twoFactorRegenerateBackupCodes as ReturnType<typeof vi.fn>).mockResolvedValue({
-        success: true,
         backupCodes: ['new-1', 'new-2'],
       });
       renderSettings(enabledValue());
 
       await userEvent.click(screen.getByRole('button', { name: /regenerate backup codes/i }));
 
-      expect(await screen.findByText('new-1')).toBeInTheDocument();
+      // The service must not be called until a code is confirmed.
+      expect(authService.twoFactorRegenerateBackupCodes).not.toHaveBeenCalled();
+      const confirmButton = screen.getByRole('button', { name: /confirm regenerate/i });
+      expect(confirmButton).toBeDisabled();
+
+      await userEvent.type(screen.getByPlaceholderText('000000'), '654321');
+      await userEvent.click(confirmButton);
+
+      expect(authService.twoFactorRegenerateBackupCodes).toHaveBeenCalledWith('654321');
+      expect(
+        await screen.findByRole('heading', { name: /your new backup codes/i })
+      ).toBeInTheDocument();
+      expect(screen.getByText('new-1')).toBeInTheDocument();
       expect(screen.getByText('new-2')).toBeInTheDocument();
+    });
+
+    it('returns to the enabled screen when the regenerate confirmation is cancelled', async () => {
+      renderSettings(enabledValue());
+
+      await userEvent.click(screen.getByRole('button', { name: /regenerate backup codes/i }));
+      await userEvent.click(screen.getByRole('button', { name: /cancel/i }));
+
+      expect(screen.getByRole('button', { name: /regenerate backup codes/i })).toBeInTheDocument();
+      expect(authService.twoFactorRegenerateBackupCodes).not.toHaveBeenCalled();
     });
 
     it('shows an error when backup code regeneration fails', async () => {
@@ -206,6 +247,8 @@ describe('TwoFactorSettings', () => {
       renderSettings(enabledValue());
 
       await userEvent.click(screen.getByRole('button', { name: /regenerate backup codes/i }));
+      await userEvent.type(screen.getByPlaceholderText('000000'), '654321');
+      await userEvent.click(screen.getByRole('button', { name: /confirm regenerate/i }));
 
       expect(await screen.findByText('Regenerate failed')).toBeInTheDocument();
     });

--- a/packages/lib.auth/src/components/TwoFactorSettings.tsx
+++ b/packages/lib.auth/src/components/TwoFactorSettings.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { Alert, Button } from '@adopt-dont-shop/lib.components';
 import { authService } from '../services/auth-service';
 import { useAuth } from '../hooks/useAuth';
+import { BackupCodesReveal } from './BackupCodesReveal';
 import * as styles from './TwoFactorSettings.css';
 
 // --- Component Types ---
@@ -12,6 +13,9 @@ export interface TwoFactorSettingsProps {
 
 type SetupPhase = 'idle' | 'scanning' | 'verifying' | 'backup-codes';
 type DisablePhase = 'idle' | 'confirming';
+// ADS-914 follow-up: regenerating backup codes is gated on a current TOTP
+// code, same pattern as disabling 2FA.
+type RegeneratePhase = 'idle' | 'confirming';
 
 // --- Component ---
 
@@ -25,10 +29,17 @@ export const TwoFactorSettings: React.FC<TwoFactorSettingsProps> = ({ onStatusCh
   const [qrCodeDataUrl, setQrCodeDataUrl] = useState('');
   const [verifyToken, setVerifyToken] = useState('');
   const [backupCodes, setBackupCodes] = useState<string[]>([]);
+  // Distinguishes the enable-2FA reveal from the regenerate reveal so
+  // BackupCodesReveal can show the right heading for each.
+  const [backupCodesHeading, setBackupCodesHeading] = useState('Save your backup codes');
 
   // Disable state
   const [disablePhase, setDisablePhase] = useState<DisablePhase>('idle');
   const [disableToken, setDisableToken] = useState('');
+
+  // Regenerate backup codes state
+  const [regeneratePhase, setRegeneratePhase] = useState<RegeneratePhase>('idle');
+  const [regenerateToken, setRegenerateToken] = useState('');
 
   // Shared state
   const [isLoading, setIsLoading] = useState(false);
@@ -60,6 +71,7 @@ export const TwoFactorSettings: React.FC<TwoFactorSettingsProps> = ({ onStatusCh
     try {
       const response = await authService.twoFactorEnable(secret, verifyToken);
       setBackupCodes(response.backupCodes);
+      setBackupCodesHeading('Save your backup codes');
       setSetupPhase('backup-codes');
       await refreshUser();
       onStatusChange?.(true);
@@ -70,7 +82,10 @@ export const TwoFactorSettings: React.FC<TwoFactorSettingsProps> = ({ onStatusCh
     }
   };
 
-  const handleFinishSetup = () => {
+  // Dismisses the backup-codes reveal panel, whether it was shown after
+  // enrolment or after a regeneration. Clears the plaintext codes from
+  // state — nothing about them is persisted after this point.
+  const handleFinishBackupCodesReveal = () => {
     setSetupPhase('idle');
     setSecret('');
     setQrCodeDataUrl('');
@@ -99,18 +114,39 @@ export const TwoFactorSettings: React.FC<TwoFactorSettingsProps> = ({ onStatusCh
     }
   };
 
-  const handleRegenerateBackupCodes = async () => {
+  // Starts the regenerate flow — a current TOTP code is required before the
+  // server will mint a fresh set (ADS-914 follow-up).
+  const handleStartRegenerate = () => {
+    setError(null);
+    setRegeneratePhase('confirming');
+  };
+
+  const handleConfirmRegenerate = async () => {
+    if (regenerateToken.length !== 6) {
+      setError('Please enter a 6-digit code');
+      return;
+    }
+
     setIsLoading(true);
     setError(null);
     try {
-      const response = await authService.twoFactorRegenerateBackupCodes();
+      const response = await authService.twoFactorRegenerateBackupCodes(regenerateToken);
       setBackupCodes(response.backupCodes);
+      setBackupCodesHeading('Your new backup codes');
+      setRegeneratePhase('idle');
+      setRegenerateToken('');
       setSetupPhase('backup-codes');
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to regenerate backup codes');
     } finally {
       setIsLoading(false);
     }
+  };
+
+  const handleCancelRegenerate = () => {
+    setRegeneratePhase('idle');
+    setRegenerateToken('');
+    setError(null);
   };
 
   const handleCancelSetup = () => {
@@ -128,7 +164,12 @@ export const TwoFactorSettings: React.FC<TwoFactorSettingsProps> = ({ onStatusCh
   };
 
   // --- Render: 2FA Enabled State ---
-  if (isEnabled && disablePhase === 'idle' && setupPhase !== 'backup-codes') {
+  if (
+    isEnabled &&
+    disablePhase === 'idle' &&
+    regeneratePhase === 'idle' &&
+    setupPhase !== 'backup-codes'
+  ) {
     return (
       <div className={styles.container}>
         <div>
@@ -140,11 +181,49 @@ export const TwoFactorSettings: React.FC<TwoFactorSettingsProps> = ({ onStatusCh
         </p>
         {error && <Alert variant="error">{error}</Alert>}
         <div className={styles.buttonRow}>
-          <Button variant="secondary" onClick={handleRegenerateBackupCodes} disabled={isLoading}>
-            {isLoading ? 'Generating...' : 'Regenerate Backup Codes'}
+          <Button variant="secondary" onClick={handleStartRegenerate} disabled={isLoading}>
+            Regenerate Backup Codes
           </Button>
           <Button variant="secondary" onClick={() => setDisablePhase('confirming')}>
             Disable 2FA
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  // --- Render: Regenerate Backup Codes Confirmation ---
+  if (regeneratePhase === 'confirming') {
+    return (
+      <div className={styles.container}>
+        <p className={styles.description}>
+          Enter a code from your authenticator app to confirm regenerating your backup codes. Your
+          existing backup codes will stop working immediately.
+        </p>
+        {error && <Alert variant="error">{error}</Alert>}
+        <label className={styles.description} htmlFor="regenerate-backup-codes-token">
+          Verification code
+        </label>
+        <input
+          id="regenerate-backup-codes-token"
+          className={styles.tokenInput}
+          type="text"
+          inputMode="numeric"
+          maxLength={6}
+          placeholder="000000"
+          value={regenerateToken}
+          onChange={(e) => setRegenerateToken(e.target.value.replace(/\D/g, ''))}
+          autoFocus
+        />
+        <div className={styles.buttonRow}>
+          <Button
+            onClick={handleConfirmRegenerate}
+            disabled={isLoading || regenerateToken.length !== 6}
+          >
+            {isLoading ? 'Regenerating...' : 'Confirm Regenerate'}
+          </Button>
+          <Button variant="secondary" onClick={handleCancelRegenerate} disabled={isLoading}>
+            Cancel
           </Button>
         </div>
       </div>
@@ -181,7 +260,7 @@ export const TwoFactorSettings: React.FC<TwoFactorSettingsProps> = ({ onStatusCh
     );
   }
 
-  // --- Render: Backup Codes Display ---
+  // --- Render: Backup Codes Reveal (shown once after enable or regenerate) ---
   if (setupPhase === 'backup-codes') {
     return (
       <div className={styles.container}>
@@ -190,18 +269,11 @@ export const TwoFactorSettings: React.FC<TwoFactorSettingsProps> = ({ onStatusCh
             <span className={styles.statusBadge({ enabled: true })}>Enabled</span>
           </div>
         )}
-        <div className={styles.warningBox}>
-          Save these backup codes in a safe place. Each code can only be used once. If you lose
-          access to your authenticator app, you can use one of these codes to sign in.
-        </div>
-        <div className={styles.backupCodesGrid}>
-          {backupCodes.map((code) => (
-            <code className={styles.backupCode} key={code}>
-              {code}
-            </code>
-          ))}
-        </div>
-        <Button onClick={handleFinishSetup}>I have saved my backup codes</Button>
+        <BackupCodesReveal
+          codes={backupCodes}
+          heading={backupCodesHeading}
+          onDismiss={handleFinishBackupCodesReveal}
+        />
       </div>
     );
   }

--- a/packages/lib.auth/src/contexts/AuthContext.test.tsx
+++ b/packages/lib.auth/src/contexts/AuthContext.test.tsx
@@ -40,12 +40,14 @@ vi.mock('@adopt-dont-shop/lib.api', () => ({
 // C2-5: stub the toast bridge so the session-expired notification is
 // observable without dragging in sonner's real toast machinery.
 const mockToastError = vi.hoisted(() => vi.fn());
+// ADS-914 follow-up: same idea for the backup-codes-exhausted warning.
+const mockToastWarning = vi.hoisted(() => vi.fn());
 vi.mock('@adopt-dont-shop/lib.components', () => ({
-  toast: { error: mockToastError },
+  toast: { error: mockToastError, warning: mockToastWarning },
 }));
 
 // Imported AFTER vi.mock so the mocks are wired in.
-import { AuthProvider } from './AuthContext';
+import { AuthProvider, BACKUP_CODES_EXHAUSTED_MESSAGE } from './AuthContext';
 import { useAuth } from '../hooks/useAuth';
 import { apiService as mockedApiService } from '@adopt-dont-shop/lib.api';
 
@@ -669,6 +671,77 @@ describe('AuthProvider login app-type enforcement', () => {
       'auth_login_failed',
       expect.objectContaining({ email: adopterUser.email, error_message: 'Invalid credentials' })
     );
+  });
+});
+
+// ADS-914 follow-up: a login that consumes the last backup code sets
+// backupCodesExhausted on the response — the provider should prompt the
+// user to regenerate rather than let their recovery path silently run out.
+describe('AuthProvider backup codes exhausted prompt [ADS-914 follow-up]', () => {
+  beforeEach(() => {
+    mockAuthService.getCurrentUser.mockReturnValue(null);
+    mockAuthService.isAuthenticated.mockReturnValue(false);
+    mockAuthService.getProfile.mockResolvedValue(null);
+    mockAuthService.logout.mockResolvedValue(undefined);
+    mockToastWarning.mockClear();
+    window.localStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('shows a persistent warning toast when the login response signals backupCodesExhausted', async () => {
+    mockAuthService.login.mockResolvedValue({
+      ...buildAuthResponse(adopterUser),
+      backupCodesExhausted: true,
+    });
+
+    let triggerLogin: (() => Promise<void>) | undefined;
+    render(
+      <AuthProvider allowedUserTypes={ALLOWED_ADOPTER} appType="client">
+        <LoginTrigger
+          credentials={{ email: adopterUser.email, password: 'pw' }}
+          onReady={(fn) => {
+            triggerLogin = fn;
+          }}
+        />
+      </AuthProvider>
+    );
+
+    await waitFor(() => expect(triggerLogin).toBeDefined());
+
+    await act(async () => {
+      await triggerLogin?.();
+    });
+
+    expect(mockToastWarning).toHaveBeenCalledWith(BACKUP_CODES_EXHAUSTED_MESSAGE, {
+      duration: Infinity,
+    });
+  });
+
+  it('does not show the toast on an ordinary login', async () => {
+    mockAuthService.login.mockResolvedValue(buildAuthResponse(adopterUser));
+
+    let triggerLogin: (() => Promise<void>) | undefined;
+    render(
+      <AuthProvider allowedUserTypes={ALLOWED_ADOPTER} appType="client">
+        <LoginTrigger
+          credentials={{ email: adopterUser.email, password: 'pw' }}
+          onReady={(fn) => {
+            triggerLogin = fn;
+          }}
+        />
+      </AuthProvider>
+    );
+
+    await waitFor(() => expect(triggerLogin).toBeDefined());
+
+    await act(async () => {
+      await triggerLogin?.();
+    });
+
+    expect(mockToastWarning).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/lib.auth/src/contexts/AuthContext.tsx
+++ b/packages/lib.auth/src/contexts/AuthContext.tsx
@@ -6,6 +6,14 @@ import { LoginRequest, RegisterRequest, User, STORAGE_KEYS } from '../types';
 
 const SESSION_EXPIRED_MESSAGE = 'Your session has expired. Please log in again.';
 
+// ADS-914 follow-up: shown when a login just consumed the last remaining
+// backup code (AuthResponse.backupCodesExhausted). Kept visible until the
+// user dismisses it — losing self-service recovery access is worth
+// interrupting them for, and a normal auto-dismissing toast could easily
+// be missed right after signing in.
+export const BACKUP_CODES_EXHAUSTED_MESSAGE =
+  "You just used your last backup code to sign in. Regenerate backup codes in your security settings so you don't lose access to your account.";
+
 export interface AuthContextType {
   user: User | null;
   isAuthenticated: boolean;
@@ -252,6 +260,12 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({
         user_type: response.user.userType,
         email: response.user.email,
       });
+
+      // Surface the exhaustion signal now, while we have it — it's only
+      // present on this one login response, not on the persisted user.
+      if (response.backupCodesExhausted) {
+        toast.warning(BACKUP_CODES_EXHAUSTED_MESSAGE, { duration: Infinity });
+      }
 
       initializeForAuthenticatedUser(response.user);
     } catch (error) {

--- a/packages/lib.auth/src/index.ts
+++ b/packages/lib.auth/src/index.ts
@@ -36,6 +36,8 @@ export { SocialSignInButtons } from './components/SocialSignInButtons';
 export type { SocialSignInButtonsProps, SocialProvider } from './components/SocialSignInButtons';
 export { TwoFactorSettings } from './components/TwoFactorSettings';
 export type { TwoFactorSettingsProps } from './components/TwoFactorSettings';
+export { BackupCodesReveal } from './components/BackupCodesReveal';
+export type { BackupCodesRevealProps } from './components/BackupCodesReveal';
 
 // Types
 export * from './types';

--- a/packages/lib.auth/src/services/auth-service.ts
+++ b/packages/lib.auth/src/services/auth-service.ts
@@ -30,7 +30,9 @@ const AUTH_ENDPOINTS = {
   TWO_FACTOR_SETUP: '/api/v1/auth/2fa/setup',
   TWO_FACTOR_ENABLE: '/api/v1/auth/2fa/enable',
   TWO_FACTOR_DISABLE: '/api/v1/auth/2fa/disable',
-  TWO_FACTOR_BACKUP_CODES: '/api/v1/auth/2fa/backup-codes',
+  // ADS-914 follow-up: regeneration is gated on a current TOTP code — see
+  // services/gateway/src/routes/auth.ts.
+  TWO_FACTOR_BACKUP_CODES_REGENERATE: '/api/v1/auth/2fa/backup-codes/regenerate',
 } as const;
 
 // The login flow signals "password OK, now I need your TOTP code" by
@@ -288,10 +290,14 @@ export class AuthService {
   }
 
   /**
-   * Regenerate backup codes
+   * Regenerate backup codes. Gated on a current TOTP code so a stolen
+   * session alone can't mint a fresh recovery path (ADS-914 follow-up).
    */
-  async twoFactorRegenerateBackupCodes(): Promise<TwoFactorBackupCodesResponse> {
-    return apiService.post<TwoFactorBackupCodesResponse>(AUTH_ENDPOINTS.TWO_FACTOR_BACKUP_CODES);
+  async twoFactorRegenerateBackupCodes(token: string): Promise<TwoFactorBackupCodesResponse> {
+    return apiService.post<TwoFactorBackupCodesResponse>(
+      AUTH_ENDPOINTS.TWO_FACTOR_BACKUP_CODES_REGENERATE,
+      { token }
+    );
   }
 
   /**

--- a/packages/lib.auth/src/types/auth.ts
+++ b/packages/lib.auth/src/types/auth.ts
@@ -167,8 +167,11 @@ export interface TwoFactorDisableResponse {
   message: string;
 }
 
+// ADS-914 follow-up: the gateway's regenerate response carries only the
+// fresh codes (see services/gateway/src/routes/auth.ts POST
+// /api/v1/auth/2fa/backup-codes/regenerate) — there's no `success` field on
+// the wire.
 export interface TwoFactorBackupCodesResponse {
-  success: boolean;
   backupCodes: string[];
 }
 

--- a/packages/lib.auth/src/types/auth.ts
+++ b/packages/lib.auth/src/types/auth.ts
@@ -223,6 +223,11 @@ export interface AuthResponse {
   // user to verify their email (and can resend it). auth-service turns this
   // into the EMAIL_VERIFICATION_REQUIRED_MESSAGE error the LoginForm prompts on.
   emailVerificationRequired?: boolean;
+  // ADS-914 follow-up: set when this login just consumed the LAST remaining
+  // backup code (see services/auth/src/grpc/handlers.ts). The client should
+  // prompt the user to regenerate backup codes before they lose their
+  // self-service recovery path entirely.
+  backupCodesExhausted?: boolean;
 }
 
 export interface ChangePasswordRequest {


### PR DESCRIPTION
## Summary

Adds the frontend for the 2FA backup codes whose backend/gateway shipped in #1217. The API returned the codes ready for a UI but nothing surfaced them — and the frontend was still calling the **old, ungated** `/2fa/backup-codes` route with no token (a latent bug this fixes). All in `packages/lib.auth`; no app code needed changes (`TwoFactorSettings` and `AuthContext` are shared across all three apps).

## What's built (3 commits)

1. **`BackupCodesReveal`** (new shared component, exported from `index.ts`) — reveal-once panel with copy-to-clipboard, download-as-`.txt`, and a required **"I've saved these"** checkbox gating the Done button. Focus moves to the heading on mount; an `aria-live="polite"` region announces the reveal/copy/download for screen readers; nothing is persisted after dismiss
2. **TOTP-gated regeneration** — `auth-service.ts`'s `twoFactorRegenerateBackupCodes` now posts to `/api/v1/auth/2fa/backup-codes/regenerate` with a `token` (was hitting the old ungated path). `TwoFactorSettings` gains a confirm step (mirrors the disable-2FA pattern) then reveals the fresh set via `BackupCodesReveal`; the enable-2FA screen uses the same component instead of the old always-dismissible grid
3. **Exhaustion prompt** — `AuthContext.login()` fires a persistent (`duration: Infinity`) `toast.warning` when a login consumes the last backup code, so it survives the post-login navigation

## Before requesting review

- [x] Tests for new behaviour added (TDD, RTL)
- [x] Accessibility: focus management + `aria-live`, keyboard-navigable reveal panel (per the accessibility skill)
- [x] Shared `lib.auth` change — verified no downstream app breakage (all three apps type-check)

## Test plan

- [x] `lib.auth test:coverage`: 141 tests / 12 files pass; coverage 89.72% stmts / 76.49% branch (above 85/72 thresholds); `BackupCodesReveal.tsx` 100% on all metrics
- [x] `app.admin` / `app.client` / `app.rescue` type-check clean
- [x] Type-check + lint clean on lib.auth (2 pre-existing unrelated warnings left untouched)
- [ ] Reviewer: exercise enrolment reveal + regenerate + exhaustion toast in a running app

## Related

- Linear: ADS-914 (completes the backup-codes UI; backend shipped in #1217)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q5FhHDPvEtBYRDwMAV3rtv

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q5FhHDPvEtBYRDwMAV3rtv)_