### PR TITLE
fix(auth): close 2FA account-lockout primitive — store pending secret server-side (ADS-963)

### DIFF
--- a/packages/proto/proto/adopt_dont_shop/auth/v1/auth.proto
+++ b/packages/proto/proto/adopt_dont_shop/auth/v1/auth.proto
@@ -616,16 +616,20 @@ message ChangePasswordResponse {
 message SetupTwoFactorRequest {}
 
 message SetupTwoFactorResponse {
-  // Base32 TOTP secret the client shows (and re-submits to EnableTwoFactor).
+  // Base32 TOTP secret the client shows to the user (for QR / manual entry).
+  // The server now persists this server-side; the client does NOT re-submit it
+  // to EnableTwoFactor (ADS-963).
   string secret = 1;
   // otpauth:// provisioning URI for QR rendering.
   string otpauth_url = 2;
 }
 
 message EnableTwoFactorRequest {
-  // The secret returned by SetupTwoFactor and the current TOTP code that
-  // proves the user scanned it correctly.
-  string secret = 1;
+  // DEPRECATED (ADS-963): this field is ignored by the server. The server
+  // reads the pending secret it stored during SetupTwoFactor instead of
+  // trusting a client-supplied value. Kept for wire compatibility.
+  string secret = 1 [deprecated = true];
+  // The current TOTP code proving the user has their authenticator app set up.
   string token = 2;
 }
 

--- a/packages/proto/src/generated/proto/adopt_dont_shop/auth/v1/auth.ts
+++ b/packages/proto/src/generated/proto/adopt_dont_shop/auth/v1/auth.ts
@@ -649,7 +649,7 @@ export interface ChangePasswordResponse {
 export interface SetupTwoFactorRequest {}
 
 export interface SetupTwoFactorResponse {
-  /** Base32 TOTP secret the client shows (and re-submits to EnableTwoFactor). */
+  /** Base32 TOTP secret the client shows to the user for QR / manual entry. */
   secret: string;
   /** otpauth:// provisioning URI for QR rendering. */
   otpauthUrl: string;
@@ -657,10 +657,12 @@ export interface SetupTwoFactorResponse {
 
 export interface EnableTwoFactorRequest {
   /**
-   * The secret returned by SetupTwoFactor and the current TOTP code that
-   * proves the user scanned it correctly.
+   * @deprecated Ignored by the server (ADS-963). The server reads the pending
+   * secret stored during SetupTwoFactor instead of trusting a client-supplied
+   * value. Kept for wire compatibility only.
    */
-  secret: string;
+  secret?: string | undefined;
+  /** The current TOTP code proving the user has their authenticator app set up. */
   token: string;
 }
 
@@ -4444,12 +4446,12 @@ export const SetupTwoFactorResponse: MessageFns<SetupTwoFactorResponse> = {
 };
 
 function createBaseEnableTwoFactorRequest(): EnableTwoFactorRequest {
-  return { secret: '', token: '' };
+  return { token: '' };
 }
 
 export const EnableTwoFactorRequest: MessageFns<EnableTwoFactorRequest> = {
   encode(message: EnableTwoFactorRequest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    if (message.secret !== '') {
+    if (message.secret !== undefined && message.secret !== '') {
       writer.uint32(10).string(message.secret);
     }
     if (message.token !== '') {
@@ -4492,14 +4494,14 @@ export const EnableTwoFactorRequest: MessageFns<EnableTwoFactorRequest> = {
 
   fromJSON(object: any): EnableTwoFactorRequest {
     return {
-      secret: isSet(object.secret) ? globalThis.String(object.secret) : '',
+      secret: isSet(object.secret) ? globalThis.String(object.secret) : undefined,
       token: isSet(object.token) ? globalThis.String(object.token) : '',
     };
   },
 
   toJSON(message: EnableTwoFactorRequest): unknown {
     const obj: any = {};
-    if (message.secret !== '') {
+    if (message.secret !== undefined && message.secret !== '') {
       obj.secret = message.secret;
     }
     if (message.token !== '') {
@@ -4517,7 +4519,7 @@ export const EnableTwoFactorRequest: MessageFns<EnableTwoFactorRequest> = {
     object: I
   ): EnableTwoFactorRequest {
     const message = createBaseEnableTwoFactorRequest();
-    message.secret = object.secret ?? '';
+    message.secret = object.secret ?? undefined;
     message.token = object.token ?? '';
     return message;
   },

--- a/services/auth/src/grpc/account-handlers.test.ts
+++ b/services/auth/src/grpc/account-handlers.test.ts
@@ -416,7 +416,7 @@ describe('resetPassword', () => {
     expect(params[1]).toMatch(/^[0-9a-f]{64}$/);
   });
 
-  it('revokes all of the user’s refresh tokens (sessions) on reset', async () => {
+  it("revokes all of the user's refresh tokens (sessions) on reset", async () => {
     mocks.hasherMock.hash.mockResolvedValueOnce('hash');
     mocks.clientScript([userRowFixture()]);
     await resetPassword(mocks.deps, null, { resetToken: 'tok', newPassword: 'longenough' });
@@ -425,6 +425,19 @@ describe('resetPassword', () => {
     );
     expect(revoke).toBeDefined();
     expect(revoke?.[1]).toContain('usr-1');
+  });
+
+  it('clears 2FA state on reset — a password reset is a compromise-recovery flow (ADS-963)', async () => {
+    mocks.hasherMock.hash.mockResolvedValueOnce('hash');
+    mocks.clientScript([userRowFixture()]);
+    await resetPassword(mocks.deps, null, { resetToken: 'tok', newPassword: 'longenough' });
+    const sql = realQueries(mocks.clientMock.query)[0][0] as string;
+    expect(sql).toContain('two_factor_secret = NULL');
+    expect(sql).toContain('two_factor_enabled = false');
+    expect(sql).toContain('two_factor_last_step = NULL');
+    expect(sql).toContain('two_factor_secret_pending = NULL');
+    expect(sql).toContain('two_factor_pending_expires_at = NULL');
+    expect(sql).toContain('backup_codes = NULL');
   });
 });
 
@@ -527,7 +540,7 @@ describe('changePassword', () => {
     );
   });
 
-  it('revokes all of the user’s refresh tokens (sessions) on change', async () => {
+  it("revokes all of the user's refresh tokens (sessions) on change", async () => {
     mocks.poolMock.query.mockResolvedValueOnce({ rows: [{ password: 'existing-hash' }] });
     mocks.hasherMock.compare.mockResolvedValueOnce(true);
     mocks.hasherMock.hash.mockResolvedValueOnce('new-hash');

--- a/services/auth/src/grpc/account-handlers.ts
+++ b/services/auth/src/grpc/account-handlers.ts
@@ -418,6 +418,12 @@ export async function resetPassword(
           locked_until = NULL,
           login_attempts = 0,
           tokens_valid_from = now(),
+          two_factor_secret = NULL,
+          two_factor_enabled = false,
+          two_factor_last_step = NULL,
+          two_factor_secret_pending = NULL,
+          two_factor_pending_expires_at = NULL,
+          backup_codes = NULL,
           updated_at = now()
       WHERE reset_token_hash = $2
         AND (reset_token_expiration IS NULL OR reset_token_expiration > now())

--- a/services/auth/src/grpc/two-factor-handlers.test.ts
+++ b/services/auth/src/grpc/two-factor-handlers.test.ts
@@ -28,9 +28,6 @@ const ENCRYPTION_KEY = 'a'.repeat(64);
 function makeMocks() {
   const pool = { query: vi.fn() };
   pool.query.mockResolvedValue({ rows: [], rowCount: 0 });
-  // Real bcryptjs compare/hash — cheap enough at test scale (10 codes) and
-  // lets the backup-code assertions exercise the real hash/compare pair
-  // instead of a stub that can't tell a match from a miss.
   const passwordHasher = {
     hash: (value: string) => Promise.resolve(`hashed:${value}`),
     compare: (value: string, hash: string) => Promise.resolve(hash === `hashed:${value}`),
@@ -55,20 +52,32 @@ describe('setupTwoFactor', () => {
     mocks = makeMocks();
   });
 
-  it('returns a secret + otpauth URL for a user without 2FA', async () => {
-    mocks.poolMock.query.mockResolvedValueOnce({
-      rows: [{ email: 'a@b.com', two_factor_enabled: false, two_factor_secret: null }],
-    });
+  it('returns a secret + otpauth URL and persists an encrypted pending secret', async () => {
+    mocks.poolMock.query
+      // SELECT
+      .mockResolvedValueOnce({ rows: [{ email: 'a@b.com', two_factor_enabled: false }] })
+      // UPDATE (persist pending secret)
+      .mockResolvedValueOnce({ rows: [], rowCount: 1 });
+
     const res = await setupTwoFactor(mocks.deps, PRINCIPAL, {});
+
     expect(res.secret).toMatch(/^[A-Z2-7]+$/); // base32
     expect(res.otpauthUrl).toContain('otpauth://totp/');
-    // A code generated from the returned secret is a valid 6-digit TOTP.
     expect(generateSync({ secret: res.secret })).toMatch(/^\d{6}$/);
+
+    // Second call is the UPDATE that stores the pending secret.
+    expect(mocks.poolMock.query).toHaveBeenCalledTimes(2);
+    const [updateSql, updateParams] = mocks.poolMock.query.mock.calls[1] as [string, unknown[]];
+    expect(updateSql).toMatch(/two_factor_secret_pending/);
+    expect(updateSql).toMatch(/two_factor_pending_expires_at/);
+    // The stored value is encrypted — NOT the plaintext secret.
+    expect(updateParams[0]).not.toBe(res.secret);
+    expect(decryptTotpSecret(ENCRYPTION_KEY, updateParams[0] as string)).toBe(res.secret);
   });
 
-  it('rejects when 2FA is already enabled (400 already enabled)', async () => {
+  it('rejects when 2FA is already enabled', async () => {
     mocks.poolMock.query.mockResolvedValueOnce({
-      rows: [{ email: 'a@b.com', two_factor_enabled: true, two_factor_secret: 'X' }],
+      rows: [{ email: 'a@b.com', two_factor_enabled: true }],
     });
     await expect(setupTwoFactor(mocks.deps, PRINCIPAL, {})).rejects.toMatchObject({
       code: 'INVALID_ARGUMENT',
@@ -89,58 +98,169 @@ describe('enableTwoFactor', () => {
     mocks = makeMocks();
   });
 
-  it('persists the ENCRYPTED secret + flips the flag when the code verifies', async () => {
+  function makePendingRow(secret: string, expiredMinutesAgo?: number) {
+    const encrypted = encryptTotpSecret(ENCRYPTION_KEY, secret);
+    const expires = new Date(
+      Date.now() + (expiredMinutesAgo !== undefined ? -expiredMinutesAgo : 9) * 60_000
+    );
+    return {
+      two_factor_enabled: false,
+      two_factor_secret_pending: encrypted,
+      two_factor_pending_expires_at: expires,
+    };
+  }
+
+  it('enables 2FA when the token verifies against the server-stored pending secret', async () => {
     const secret = generateSecret();
     const token = generateSync({ secret });
-    mocks.poolMock.query.mockResolvedValueOnce({ rows: [], rowCount: 1 });
-    const res = await enableTwoFactor(mocks.deps, PRINCIPAL, { secret, token });
+
+    mocks.poolMock.query
+      // SELECT pending secret
+      .mockResolvedValueOnce({ rows: [makePendingRow(secret)], rowCount: 1 })
+      // UPDATE promote pending→active
+      .mockResolvedValueOnce({ rows: [], rowCount: 1 });
+
+    const res = await enableTwoFactor(mocks.deps, PRINCIPAL, { token });
+
     expect(res.enabled).toBe(true);
-    const [sql, params] = mocks.poolMock.query.mock.calls[0] as [string, unknown[]];
-    expect(sql).toMatch(/two_factor_enabled = true/);
-    expect(sql).toMatch(/two_factor_enabled = false/); // the guard
-    // The secret is encrypted at rest (ADS-914a) — never write the plaintext.
-    expect(params[0]).not.toBe(secret);
-    expect(decryptTotpSecret(ENCRYPTION_KEY, params[0] as string)).toBe(secret);
+
+    const [updateSql] = mocks.poolMock.query.mock.calls[1] as [string, unknown[]];
+    expect(updateSql).toMatch(/two_factor_secret = two_factor_secret_pending/);
+    expect(updateSql).toMatch(/two_factor_enabled = true/);
+    expect(updateSql).toMatch(/two_factor_secret_pending = NULL/);
+  });
+
+  it('ignores req.secret entirely — attacker-supplied secret does not enable 2FA', async () => {
+    // Attack scenario from ADS-963: attacker has a token but no server-stored pending secret.
+    // They supply their own secret + a valid TOTP for it. Must be rejected.
+    const attackerSecret = generateSecret();
+    const attackerToken = generateSync({ secret: attackerSecret });
+
+    mocks.poolMock.query.mockResolvedValueOnce({
+      rows: [
+        {
+          two_factor_enabled: false,
+          two_factor_secret_pending: null,
+          two_factor_pending_expires_at: null,
+        },
+      ],
+      rowCount: 1,
+    });
+
+    await expect(
+      enableTwoFactor(mocks.deps, PRINCIPAL, { secret: attackerSecret, token: attackerToken })
+    ).rejects.toMatchObject({
+      code: 'INVALID_ARGUMENT',
+      message: expect.stringMatching(/setup.*required|setup first/i),
+    });
+
+    // No UPDATE must have run.
+    expect(mocks.poolMock.query).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects when no prior setupTwoFactor ran (no pending secret in DB)', async () => {
+    mocks.poolMock.query.mockResolvedValueOnce({
+      rows: [
+        {
+          two_factor_enabled: false,
+          two_factor_secret_pending: null,
+          two_factor_pending_expires_at: null,
+        },
+      ],
+      rowCount: 1,
+    });
+    await expect(enableTwoFactor(mocks.deps, PRINCIPAL, { token: '123456' })).rejects.toMatchObject(
+      {
+        code: 'INVALID_ARGUMENT',
+        message: expect.stringMatching(/setup.*required|setup first/i),
+      }
+    );
+  });
+
+  it('rejects an expired pending secret', async () => {
+    const secret = generateSecret();
+    const token = generateSync({ secret });
+
+    mocks.poolMock.query.mockResolvedValueOnce({
+      rows: [makePendingRow(secret, 1)], // expired 1 minute ago
+      rowCount: 1,
+    });
+
+    await expect(enableTwoFactor(mocks.deps, PRINCIPAL, { token })).rejects.toMatchObject({
+      code: 'INVALID_ARGUMENT',
+      message: expect.stringMatching(/expired/i),
+    });
+    expect(mocks.poolMock.query).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects an invalid TOTP code without writing', async () => {
+    const secret = generateSecret();
+
+    mocks.poolMock.query.mockResolvedValueOnce({ rows: [makePendingRow(secret)], rowCount: 1 });
+
+    await expect(enableTwoFactor(mocks.deps, PRINCIPAL, { token: '000000' })).rejects.toMatchObject(
+      { code: 'INVALID_ARGUMENT' }
+    );
+    expect(mocks.poolMock.query).toHaveBeenCalledTimes(1);
+  });
+
+  it('surfaces a no-op UPDATE (already enabled race) as 400', async () => {
+    const secret = generateSecret();
+    const token = generateSync({ secret });
+
+    mocks.poolMock.query
+      .mockResolvedValueOnce({ rows: [makePendingRow(secret)], rowCount: 1 })
+      .mockResolvedValueOnce({ rows: [], rowCount: 0 }); // UPDATE matched 0 rows
+
+    await expect(enableTwoFactor(mocks.deps, PRINCIPAL, { token })).rejects.toMatchObject({
+      code: 'INVALID_ARGUMENT',
+    });
   });
 
   it('returns 10 unique backup codes and stores only their hashes (ADS-914b)', async () => {
     const secret = generateSecret();
     const token = generateSync({ secret });
-    mocks.poolMock.query.mockResolvedValueOnce({ rows: [], rowCount: 1 });
-    const res = await enableTwoFactor(mocks.deps, PRINCIPAL, { secret, token });
+
+    mocks.poolMock.query
+      .mockResolvedValueOnce({ rows: [makePendingRow(secret)], rowCount: 1 })
+      .mockResolvedValueOnce({ rows: [], rowCount: 1 });
+
+    const res = await enableTwoFactor(mocks.deps, PRINCIPAL, { token });
 
     expect(res.backupCodes).toHaveLength(10);
     expect(new Set(res.backupCodes).size).toBe(10);
-    // Human-friendly hyphenated format.
     for (const code of res.backupCodes) {
       expect(code).toMatch(/^[A-Z2-7]{4}(-[A-Z2-7]{4}){3}$/);
     }
 
-    const [sql, params] = mocks.poolMock.query.mock.calls[0] as [string, unknown[]];
-    expect(sql).toMatch(/backup_codes = \$2/);
-    const storedHashes = params[1] as string[];
+    const [, updateParams] = mocks.poolMock.query.mock.calls[1] as [string, unknown[]];
+    const storedHashes = updateParams[0] as string[];
     expect(storedHashes).toHaveLength(10);
-    // Never the plaintext codes.
     for (const [i, code] of res.backupCodes.entries()) {
       expect(storedHashes[i]).not.toBe(code);
       expect(storedHashes[i]).toBe(`hashed:${normalizeBackupCode(code)}`);
     }
   });
 
-  it('rejects an invalid code without writing', async () => {
-    const secret = generateSecret();
-    await expect(
-      enableTwoFactor(mocks.deps, PRINCIPAL, { secret, token: '000000' })
-    ).rejects.toMatchObject({ code: 'INVALID_ARGUMENT' });
-    expect(mocks.poolMock.query).not.toHaveBeenCalled();
+  it('rejects when 2FA is already enabled', async () => {
+    mocks.poolMock.query.mockResolvedValueOnce({
+      rows: [
+        {
+          two_factor_enabled: true,
+          two_factor_secret_pending: null,
+          two_factor_pending_expires_at: null,
+        },
+      ],
+      rowCount: 1,
+    });
+    await expect(enableTwoFactor(mocks.deps, PRINCIPAL, { token: '123456' })).rejects.toMatchObject(
+      { code: 'INVALID_ARGUMENT', message: expect.stringMatching(/already enabled/) }
+    );
   });
 
-  it('surfaces a no-op UPDATE (already enabled) as 400', async () => {
-    const secret = generateSecret();
-    const token = generateSync({ secret });
-    mocks.poolMock.query.mockResolvedValueOnce({ rows: [], rowCount: 0 });
-    await expect(enableTwoFactor(mocks.deps, PRINCIPAL, { secret, token })).rejects.toMatchObject({
-      code: 'INVALID_ARGUMENT',
+  it('requires authentication', async () => {
+    await expect(enableTwoFactor(mocks.deps, null, { token: '123456' })).rejects.toMatchObject({
+      code: 'UNAUTHENTICATED',
     });
   });
 });
@@ -151,7 +271,7 @@ describe('disableTwoFactor', () => {
     mocks = makeMocks();
   });
 
-  it('clears the secret + flag when the code verifies', async () => {
+  it('clears the secret, flag, and pending columns when the code verifies', async () => {
     const secret = generateSecret();
     const token = generateSync({ secret });
     const encryptedSecret = encryptTotpSecret(ENCRYPTION_KEY, secret);
@@ -172,6 +292,8 @@ describe('disableTwoFactor', () => {
     expect(res.disabled).toBe(true);
     const [sql] = mocks.poolMock.query.mock.calls[2] as [string];
     expect(sql).toMatch(/two_factor_secret = NULL/);
+    expect(sql).toMatch(/two_factor_secret_pending = NULL/);
+    expect(sql).toMatch(/two_factor_pending_expires_at = NULL/);
   });
 
   it('rejects when 2FA is not enabled', async () => {

--- a/services/auth/src/grpc/two-factor-handlers.ts
+++ b/services/auth/src/grpc/two-factor-handlers.ts
@@ -4,13 +4,14 @@
 // management here).
 //
 // Flow:
-//   1. Setup mints a fresh base32 secret + otpauth URI. The secret is
-//      NOT persisted yet — the client holds it and proves possession on
-//      Enable, so a never-confirmed secret never lands in the DB.
-//   2. Enable verifies a current TOTP code against that secret, then
-//      stores it, mints 10 backup/recovery codes (ADS-914b), and flips
-//      two_factor_enabled on. The plaintext codes are returned exactly
-//      once — only their hashes are persisted.
+//   1. Setup mints a fresh base32 secret, stores it encrypted in
+//      two_factor_secret_pending (10-minute TTL), and returns it to the
+//      client so they can show it as a QR code / manual entry. The pending
+//      secret is server-side only from this point (ADS-963).
+//   2. Enable reads the pending secret from the DB (NOT req.secret), verifies
+//      the TOTP code against it, promotes the pending secret to two_factor_secret,
+//      mints 10 backup/recovery codes, and flips two_factor_enabled on. The
+//      plaintext codes are returned exactly once — only their hashes are persisted.
 //   3. Disable verifies a current code against the STORED secret, then
 //      clears it (and the backup codes, via GDPR erase / re-enable).
 //   4. RegenerateBackupCodes verifies a current code and mints a fresh
@@ -36,16 +37,19 @@ import type {
 
 import { generateBackupCodes, hashBackupCodes } from './backup-codes.js';
 import { HandlerError, type HandlerDeps } from './handlers.js';
-import { encryptTotpSecret } from './totp-crypto.js';
+import { decryptTotpSecret, encryptTotpSecret } from './totp-crypto.js';
 import { verifyAndConsumeTotp } from './totp-verification.js';
 
 const TOTP_ISSUER = 'Adopt Dont Shop';
+const PENDING_SECRET_TTL_MINUTES = 10;
 
 type TwoFactorRow = {
   email: string;
   two_factor_enabled: boolean;
   two_factor_secret: string | null;
   two_factor_last_step: number | null;
+  two_factor_secret_pending: string | null;
+  two_factor_pending_expires_at: Date | null;
 };
 
 const requirePrincipal = (principal: Principal | null): Principal => {
@@ -61,8 +65,8 @@ export async function setupTwoFactor(
   _req: SetupTwoFactorRequest
 ): Promise<SetupTwoFactorResponse> {
   const me = requirePrincipal(principal);
-  const res = await deps.pool.query<TwoFactorRow>(
-    `SELECT email, two_factor_enabled, two_factor_secret
+  const res = await deps.pool.query<Pick<TwoFactorRow, 'email' | 'two_factor_enabled'>>(
+    `SELECT email, two_factor_enabled
        FROM auth.users WHERE user_id = $1 AND deleted_at IS NULL`,
     [me.userId]
   );
@@ -76,6 +80,22 @@ export async function setupTwoFactor(
 
   const secret = generateSecret();
   const otpauthUrl = generateURI({ secret, label: row.email, issuer: TOTP_ISSUER });
+
+  // Persist the pending secret (AES-256-GCM encrypted) with a short TTL so
+  // enableTwoFactor can verify against it without trusting the client.
+  await deps.pool.query(
+    `UPDATE auth.users
+        SET two_factor_secret_pending = $1,
+            two_factor_pending_expires_at = now() + $2::interval,
+            updated_at = now()
+      WHERE user_id = $3 AND deleted_at IS NULL`,
+    [
+      encryptTotpSecret(deps.encryptionKey, secret),
+      `${PENDING_SECRET_TTL_MINUTES} minutes`,
+      me.userId,
+    ]
+  );
+
   return { secret, otpauthUrl };
 }
 
@@ -85,14 +105,43 @@ export async function enableTwoFactor(
   req: EnableTwoFactorRequest
 ): Promise<EnableTwoFactorResponse> {
   const me = requirePrincipal(principal);
-  if (!req.secret) {
-    throw new HandlerError('INVALID_ARGUMENT', 'secret is required');
-  }
   if (!req.token) {
     throw new HandlerError('INVALID_ARGUMENT', 'token is required');
   }
-  // The code proves the user actually scanned the secret we minted.
-  if (!verifySync({ token: req.token, secret: req.secret }).valid) {
+
+  // Read the server-stored pending secret — never trust req.secret (ADS-963).
+  const res = await deps.pool.query<
+    Pick<
+      TwoFactorRow,
+      'two_factor_enabled' | 'two_factor_secret_pending' | 'two_factor_pending_expires_at'
+    >
+  >(
+    `SELECT two_factor_enabled, two_factor_secret_pending, two_factor_pending_expires_at
+       FROM auth.users WHERE user_id = $1 AND deleted_at IS NULL`,
+    [me.userId]
+  );
+  const row = res.rows[0];
+  if (!row) {
+    throw new HandlerError('NOT_FOUND', 'user not found');
+  }
+  if (row.two_factor_enabled) {
+    throw new HandlerError('INVALID_ARGUMENT', 'two-factor authentication is already enabled');
+  }
+  if (!row.two_factor_secret_pending || !row.two_factor_pending_expires_at) {
+    throw new HandlerError(
+      'INVALID_ARGUMENT',
+      'two-factor setup is required before enabling; call setup first'
+    );
+  }
+  if (new Date(row.two_factor_pending_expires_at) <= new Date()) {
+    throw new HandlerError(
+      'INVALID_ARGUMENT',
+      'two-factor setup has expired; please start setup again'
+    );
+  }
+
+  const pendingSecret = decryptTotpSecret(deps.encryptionKey, row.two_factor_secret_pending);
+  if (!verifySync({ token: req.token, secret: pendingSecret }).valid) {
     throw new HandlerError('INVALID_ARGUMENT', 'invalid two-factor code');
   }
 
@@ -103,19 +152,25 @@ export async function enableTwoFactor(
   const backupCodes = generateBackupCodes();
   const backupCodeHashes = await hashBackupCodes(deps.passwordHasher, backupCodes);
 
-  // Guard on two_factor_enabled = false so a concurrent enable can't be
-  // overwritten and a re-enable surfaces as the "already enabled" 400.
-  // The secret is encrypted at rest (ADS-914a) — only the ciphertext is
-  // ever written to the DB. Backup codes are stored as bcrypt hashes only;
-  // the plaintext codes are returned to the caller exactly once below.
-  const res = await deps.pool.query(
+  // Promote the pending secret atomically. The WHERE clause re-checks both
+  // two_factor_enabled = false and the pending expiry so a concurrent enable
+  // or an expired setup can't slip through between the SELECT and this UPDATE.
+  const updateRes = await deps.pool.query(
     `UPDATE auth.users
-        SET two_factor_secret = $1, two_factor_enabled = true, two_factor_last_step = NULL,
-            backup_codes = $2, updated_at = now()
-      WHERE user_id = $3 AND deleted_at IS NULL AND two_factor_enabled = false`,
-    [encryptTotpSecret(deps.encryptionKey, req.secret), backupCodeHashes, me.userId]
+        SET two_factor_secret = two_factor_secret_pending,
+            two_factor_enabled = true,
+            two_factor_last_step = NULL,
+            two_factor_secret_pending = NULL,
+            two_factor_pending_expires_at = NULL,
+            backup_codes = $1,
+            updated_at = now()
+      WHERE user_id = $2 AND deleted_at IS NULL
+        AND two_factor_enabled = false
+        AND two_factor_secret_pending IS NOT NULL
+        AND two_factor_pending_expires_at > now()`,
+    [backupCodeHashes, me.userId]
   );
-  if (res.rowCount === 0) {
+  if (updateRes.rowCount === 0) {
     throw new HandlerError('INVALID_ARGUMENT', 'two-factor authentication is already enabled');
   }
   return { enabled: true, backupCodes };
@@ -161,7 +216,8 @@ export async function disableTwoFactor(
   await deps.pool.query(
     `UPDATE auth.users
         SET two_factor_secret = NULL, two_factor_enabled = false, two_factor_last_step = NULL,
-            backup_codes = NULL, updated_at = now()
+            backup_codes = NULL, two_factor_secret_pending = NULL, two_factor_pending_expires_at = NULL,
+            updated_at = now()
       WHERE user_id = $1`,
     [me.userId]
   );

--- a/services/auth/src/migrations/028_add_two_factor_pending.ts
+++ b/services/auth/src/migrations/028_add_two_factor_pending.ts
@@ -1,0 +1,22 @@
+import type { MigrationBuilder } from 'node-pg-migrate';
+
+// ADS-963: Fix 2FA enable() trusting client-supplied secret.
+//
+// Previously, setupTwoFactor minted a secret and returned it to the client
+// without persisting it. enableTwoFactor then accepted req.secret from the
+// caller and verified a TOTP code against *that* secret — meaning an attacker
+// with a temporary access token could supply their own secret, lock the victim
+// out with a permanent second factor, and survive a password reset.
+//
+// Fix: store the setup secret server-side with a short TTL. enableTwoFactor
+// reads from the DB instead of trusting the client.
+export const up = async (pgm: MigrationBuilder): Promise<void> => {
+  pgm.addColumns('users', {
+    two_factor_secret_pending: { type: 'text' },
+    two_factor_pending_expires_at: { type: 'timestamptz' },
+  });
+};
+
+export const down = async (pgm: MigrationBuilder): Promise<void> => {
+  pgm.dropColumns('users', ['two_factor_secret_pending', 'two_factor_pending_expires_at']);
+};


### PR DESCRIPTION
## Summary

- Fixes a security vulnerability where `enableTwoFactor` trusted `req.secret` supplied by the caller, allowing an attacker with a temporary access token to enrol their own TOTP secret and permanently lock the victim out — surviving even a password reset.
- `setupTwoFactor` now persists the generated secret (AES-256-GCM encrypted) in a new `two_factor_secret_pending` column with a 10-minute TTL; `enableTwoFactor` reads from the DB instead of accepting a client-supplied secret.
- `resetPassword` now clears all 2FA state (stored secret, enabled flag, backup codes, and pending columns) since a password reset is a compromise-recovery flow.

## Changes

- `services/auth/src/migrations/028_add_two_factor_pending.ts` — new migration adding `two_factor_secret_pending` and `two_factor_pending_expires_at` columns to `auth.users`
- `services/auth/src/grpc/two-factor-handlers.ts` — `setupTwoFactor` persists pending secret; `enableTwoFactor` reads from DB (ignores `req.secret`); `disableTwoFactor` clears pending columns on success
- `services/auth/src/grpc/account-handlers.ts` — `resetPassword` clears all 2FA columns
- `packages/proto/proto/adopt_dont_shop/auth/v1/auth.proto` — marks `EnableTwoFactorRequest.secret` as `[deprecated = true]`; updates comments
- `packages/proto/src/generated/proto/adopt_dont_shop/auth/v1/auth.ts` — `EnableTwoFactorRequest.secret` made optional (`secret?: string | undefined`) for wire compatibility

## Before requesting review

- [x] Tests for new behaviour added (TDD)
- [x] If touching `.env` requirements, updated `.env.example`'s REQUIRED block — n/a
- [x] If touching a `lib.*`, considered consumer impact — n/a (proto change is backward-compatible)

## Test plan

- [x] Existing tests pass (`pnpm test`) — 363 passing, 2 pre-existing failures unrelated to this change
- [x] New behaviour is covered by tests
  - Attack scenario: `enableTwoFactor` with attacker-supplied `req.secret` and no server-side pending secret → rejected
  - No pending secret in DB → rejected
  - Expired pending secret → rejected
  - `setupTwoFactor` asserts it writes an encrypted pending secret to DB
  - `resetPassword` asserts all 2FA columns are cleared
  - `disableTwoFactor` asserts pending columns are cleared in the UPDATE
- [x] No TypeScript errors — lint-staged passed on commit
- [x] Lint passes — lint-staged passed on commit

## Related

- Linear: https://linear.app/ideasquared/issue/ADS-963/security-2fa-enable-trusts-client-supplied-secret-post-compromise

---
_Generated by [Claude Code](https://claude.ai/code/session_012Asa8qjpD81YpAxp18QxKB)_