### PR TITLE
fix(security): edge hardening — strict SPA CSP, socket.io rate limit, fail-closed CORS (ADS-958/962/967)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,9 +73,10 @@ jobs:
       - name: Verify prod/staging base images are digest-pinned
         run: node scripts/check-docker-pinning.mjs
 
-      # ADS-847: the nginx CSP baked into Dockerfile.app must not contain
-      # 'unsafe-inline' in style-src now that styled-components is gone.
-      - name: Verify CSP style-src has no unsafe-inline
+      # ADS-847/ADS-958: no CSP in the repo's nginx configs may carry
+      # 'unsafe-inline'/'unsafe-eval', and every prod SPA vhost at the edge
+      # must declare its own CSP.
+      - name: Verify CSP headers
         run: node scripts/check-csp-headers.mjs
 
   # ============================================================================

--- a/apps/admin/nginx.conf
+++ b/apps/admin/nginx.conf
@@ -42,7 +42,7 @@ server {
     add_header X-Content-Type-Options "nosniff" always;
     add_header X-XSS-Protection "1; mode=block" always;
     add_header Referrer-Policy "strict-origin-when-cross-origin" always;
-    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self' ws: wss:;" always;
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self' ws: wss:;" always;
     # HSTS: served on HTTP too — browsers ignore it on plaintext connections
     # but cache it after the first HTTPS hit. preload requires the apex
     # domain to be added to the HSTS preload list separately (ADS-353).

--- a/apps/client/nginx.conf
+++ b/apps/client/nginx.conf
@@ -42,7 +42,7 @@ server {
     add_header X-Content-Type-Options "nosniff" always;
     add_header X-XSS-Protection "1; mode=block" always;
     add_header Referrer-Policy "strict-origin-when-cross-origin" always;
-    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self' ws: wss:;" always;
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self' ws: wss:;" always;
     add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload" always;
     add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=()" always;
 }

--- a/apps/rescue/nginx.conf
+++ b/apps/rescue/nginx.conf
@@ -42,7 +42,7 @@ server {
     add_header X-Content-Type-Options "nosniff" always;
     add_header X-XSS-Protection "1; mode=block" always;
     add_header Referrer-Policy "strict-origin-when-cross-origin" always;
-    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self' ws: wss:;" always;
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self' ws: wss:;" always;
     add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload" always;
     add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=()" always;
 }

--- a/deploy/gateway/nginx.conf
+++ b/deploy/gateway/nginx.conf
@@ -38,6 +38,11 @@ http {
     # Rate limiting
     limit_req_zone $binary_remote_addr zone=api:10m rate=10r/s;
     limit_req_zone $binary_remote_addr zone=login:10m rate=5r/m;
+    # ADS-962: Socket.IO handshakes are one-shot (not a steady request stream
+    # like /api/), so a modest rate with a small burst absorbs page-load
+    # reconnect storms without giving an unauthenticated flood room to hammer
+    # service.auth's ValidateToken RPC.
+    limit_req_zone $binary_remote_addr zone=socketio:10m rate=2r/s;
 
     # ADS-915: this file is the PUBLIC edge — it terminates connections
     # directly from the internet, so it is the trust boundary for
@@ -142,6 +147,7 @@ http {
         add_header Referrer-Policy "strict-origin-when-cross-origin" always;
         add_header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload" always;
         add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=()" always;
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self' data: https:; connect-src 'self' https://api.adoptdontshop.com wss://api.adoptdontshop.com; frame-ancestors 'none'; object-src 'none'; base-uri 'self'; form-action 'self'" always;
 
         include /etc/nginx/snippets/uploads-prod.conf;
 
@@ -166,6 +172,7 @@ http {
         }
 
         location /socket.io/ {
+            limit_req zone=socketio burst=10 nodelay;
             proxy_pass http://prod_backend;
             proxy_http_version 1.1;
             proxy_set_header Upgrade $http_upgrade;
@@ -213,6 +220,7 @@ http {
         }
 
         location /socket.io/ {
+            limit_req zone=socketio burst=10 nodelay;
             proxy_pass http://prod_backend;
             proxy_http_version 1.1;
             proxy_set_header Upgrade $http_upgrade;
@@ -261,6 +269,7 @@ http {
         add_header Referrer-Policy "strict-origin-when-cross-origin" always;
         add_header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload" always;
         add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=()" always;
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self' data: https:; connect-src 'self' https://api.adoptdontshop.com wss://api.adoptdontshop.com; frame-ancestors 'none'; object-src 'none'; base-uri 'self'; form-action 'self'" always;
 
         include /etc/nginx/snippets/uploads-prod.conf;
 
@@ -284,6 +293,7 @@ http {
         }
 
         location /socket.io/ {
+            limit_req zone=socketio burst=10 nodelay;
             proxy_pass http://prod_backend;
             proxy_http_version 1.1;
             proxy_set_header Upgrade $http_upgrade;
@@ -320,6 +330,7 @@ http {
         add_header Referrer-Policy "strict-origin-when-cross-origin" always;
         add_header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload" always;
         add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=()" always;
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self' data: https:; connect-src 'self' https://api.adoptdontshop.com wss://api.adoptdontshop.com; frame-ancestors 'none'; object-src 'none'; base-uri 'self'; form-action 'self'" always;
 
         include /etc/nginx/snippets/uploads-prod.conf;
 
@@ -343,6 +354,7 @@ http {
         }
 
         location /socket.io/ {
+            limit_req zone=socketio burst=10 nodelay;
             proxy_pass http://prod_backend;
             proxy_http_version 1.1;
             proxy_set_header Upgrade $http_upgrade;
@@ -403,6 +415,7 @@ http {
         }
 
         location /socket.io/ {
+            limit_req zone=socketio burst=10 nodelay;
             proxy_pass http://staging_backend;
             proxy_http_version 1.1;
             proxy_set_header Upgrade $http_upgrade;
@@ -450,6 +463,7 @@ http {
         }
 
         location /socket.io/ {
+            limit_req zone=socketio burst=10 nodelay;
             proxy_pass http://staging_backend;
             proxy_http_version 1.1;
             proxy_set_header Upgrade $http_upgrade;
@@ -522,6 +536,7 @@ http {
         }
 
         location /socket.io/ {
+            limit_req zone=socketio burst=10 nodelay;
             proxy_pass http://staging_backend;
             proxy_http_version 1.1;
             proxy_set_header Upgrade $http_upgrade;
@@ -582,6 +597,7 @@ http {
         }
 
         location /socket.io/ {
+            limit_req zone=socketio burst=10 nodelay;
             proxy_pass http://staging_backend;
             proxy_http_version 1.1;
             proxy_set_header Upgrade $http_upgrade;

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -50,6 +50,11 @@ http {
     # Rate limiting
     limit_req_zone $binary_remote_addr zone=api:10m rate=10r/s;
     limit_req_zone $binary_remote_addr zone=login:10m rate=5r/m;
+    # ADS-962: Socket.IO handshakes are one-shot (not a steady request stream
+    # like /api/), so a modest rate with a small burst absorbs page-load
+    # reconnect storms without giving an unauthenticated flood room to hammer
+    # service.auth's ValidateToken RPC.
+    limit_req_zone $binary_remote_addr zone=socketio:10m rate=2r/s;
 
     # WebSocket upgrade map
     map $http_upgrade $connection_upgrade {
@@ -233,6 +238,7 @@ http {
 
         # WebSocket support
         location /socket.io/ {
+            limit_req zone=socketio burst=10 nodelay;
             proxy_pass http://backend;
             proxy_http_version 1.1;
             proxy_set_header Upgrade $http_upgrade;

--- a/nginx/nginx.prod.conf
+++ b/nginx/nginx.prod.conf
@@ -61,6 +61,11 @@ http {
 
     limit_req_zone $binary_remote_addr zone=api:10m rate=10r/s;
     limit_req_zone $binary_remote_addr zone=login:10m rate=5r/m;
+    # ADS-962: Socket.IO handshakes are one-shot (not a steady request stream
+    # like /api/), so a modest rate with a small burst absorbs page-load
+    # reconnect storms without giving an unauthenticated flood room to hammer
+    # service.auth's ValidateToken RPC.
+    limit_req_zone $binary_remote_addr zone=socketio:10m rate=2r/s;
 
     map $http_upgrade $connection_upgrade {
         default upgrade;
@@ -236,6 +241,7 @@ http {
         }
 
         location /socket.io/ {
+            limit_req zone=socketio burst=10 nodelay;
             proxy_pass http://backend;
             proxy_http_version 1.1;
             proxy_set_header Upgrade $http_upgrade;

--- a/scripts/check-csp-headers.mjs
+++ b/scripts/check-csp-headers.mjs
@@ -1,11 +1,19 @@
 #!/usr/bin/env node
 /**
- * CSP regression guard (ADS-847).
+ * CSP regression guard (ADS-847, extended by ADS-958).
  *
- * Asserts that the nginx security-headers.conf baked into Dockerfile.app does
- * not contain `unsafe-inline` in style-src. The codebase migrated from
- * styled-components (which required unsafe-inline) to vanilla-extract; this
- * check prevents backsliding.
+ * Three checks:
+ *  1. The nginx security-headers.conf baked into Dockerfile.app does not
+ *     contain `unsafe-inline` in style-src. The codebase migrated from
+ *     styled-components (which required unsafe-inline) to vanilla-extract;
+ *     this check prevents backsliding.
+ *  2. No Content-Security-Policy header anywhere in the repo's nginx configs
+ *     (Dockerfile.app, deploy/gateway/nginx.conf, nginx/nginx.conf,
+ *     nginx/nginx.prod.conf, apps/*\/nginx.conf) contains `unsafe-inline` or
+ *     `unsafe-eval` in script-src.
+ *  3. Every production SPA vhost in deploy/gateway/nginx.conf (the main
+ *     client, admin, and rescue server blocks) declares a
+ *     Content-Security-Policy header.
  *
  * Run via `node scripts/check-csp-headers.mjs` or wired into ci.yml.
  */
@@ -15,40 +23,111 @@ import { fileURLToPath } from 'url';
 
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
 
-const dockerfile = readFileSync(join(ROOT, 'Dockerfile.app'), 'utf8');
+// Extract every Content-Security-Policy header value from a config's text.
+const extractPolicies = text => {
+  const cspPattern = /add_header Content-Security-Policy "([^"]+)"/g;
+  const policies = [];
+  let match;
+  while ((match = cspPattern.exec(text)) !== null) {
+    policies.push(match[1]);
+  }
+  return policies;
+};
 
-// Extract every Content-Security-Policy header value from the Dockerfile.
-const cspPattern = /add_header Content-Security-Policy "([^"]+)"/g;
-const policies = [];
-let match;
-while ((match = cspPattern.exec(dockerfile)) !== null) {
-  policies.push(match[1]);
-}
+// Every nginx-ish config in the repo that carries a Content-Security-Policy
+// header, read once and reused by both the style-src and script-src checks.
+const cspSources = [
+  { label: 'Dockerfile.app', path: 'Dockerfile.app' },
+  { label: 'deploy/gateway/nginx.conf', path: 'deploy/gateway/nginx.conf' },
+  { label: 'nginx/nginx.conf', path: 'nginx/nginx.conf' },
+  { label: 'nginx/nginx.prod.conf', path: 'nginx/nginx.prod.conf' },
+  { label: 'apps/client/nginx.conf', path: 'apps/client/nginx.conf' },
+  { label: 'apps/admin/nginx.conf', path: 'apps/admin/nginx.conf' },
+  { label: 'apps/rescue/nginx.conf', path: 'apps/rescue/nginx.conf' },
+].map(source => {
+  const text = readFileSync(join(ROOT, source.path), 'utf8');
+  return { ...source, text, policies: extractPolicies(text) };
+});
 
-if (policies.length === 0) {
+const dockerfileSource = cspSources.find(s => s.path === 'Dockerfile.app');
+
+if (dockerfileSource.policies.length === 0) {
   console.error('ERROR: No Content-Security-Policy header found in Dockerfile.app');
   process.exit(1);
 }
 
 const failures = [];
-for (const policy of policies) {
-  // Check style-src specifically — unsafe-inline there lets CSS injection bypass CSP.
+
+// Check 1 (ADS-847): style-src in Dockerfile.app must not carry unsafe-inline.
+for (const policy of dockerfileSource.policies) {
   const styleSrcMatch = policy.match(/style-src\s+([^;]+)/);
   if (!styleSrcMatch) continue;
-  const styleSrc = styleSrcMatch[1];
-  if (styleSrc.includes("'unsafe-inline'")) {
-    failures.push(`style-src contains 'unsafe-inline': ${policy}`);
+  if (styleSrcMatch[1].includes("'unsafe-inline'")) {
+    failures.push(`Dockerfile.app: style-src contains 'unsafe-inline': ${policy}`);
+  }
+}
+
+// Check 2 (ADS-958): no CSP anywhere may allow unsafe-inline/unsafe-eval in
+// script-src. The codebase migrated to vanilla-extract (CSS) and ships no
+// inline <script> tags, so script-src 'self' is sufficient everywhere.
+for (const source of cspSources) {
+  for (const policy of source.policies) {
+    const scriptSrcMatch = policy.match(/script-src\s+([^;]+)/);
+    if (!scriptSrcMatch) continue;
+    const scriptSrc = scriptSrcMatch[1];
+    if (scriptSrc.includes("'unsafe-inline'") || scriptSrc.includes("'unsafe-eval'")) {
+      failures.push(`${source.label}: script-src contains unsafe-inline/unsafe-eval: ${policy}`);
+    }
+  }
+}
+
+// Check 3 (ADS-958): every prod SPA vhost in deploy/gateway/nginx.conf must
+// declare its own CSP header (nginx does not inherit add_header from a
+// sibling server block).
+const gatewayNginxConf = cspSources.find(s => s.path === 'deploy/gateway/nginx.conf').text;
+// Split on top-level `    server {` block boundaries so each chunk is one vhost.
+const serverBlocks = gatewayNginxConf.split(/\n(?=    server \{)/);
+
+const PROD_SPA_HOSTNAMES = [
+  'adoptdontshop.com',
+  'admin.adoptdontshop.com',
+  'rescue.adoptdontshop.com',
+];
+
+for (const hostname of PROD_SPA_HOSTNAMES) {
+  const block = serverBlocks.find(b => {
+    const match = b.match(/server_name\s+([^;]+);/);
+    if (!match) return false;
+    // Exclude the staging vhosts (e.g. staging-admin.adoptdontshop.com) —
+    // they don't literally equal the prod hostname.
+    const names = match[1].trim().split(/\s+/);
+    return names.includes(hostname);
+  });
+  if (!block) {
+    failures.push(
+      `deploy/gateway/nginx.conf: no server block found for prod SPA host "${hostname}"`
+    );
+    continue;
+  }
+  if (!/add_header Content-Security-Policy "/.test(block)) {
+    failures.push(
+      `deploy/gateway/nginx.conf: prod SPA host "${hostname}" has no Content-Security-Policy header`
+    );
   }
 }
 
 if (failures.length > 0) {
-  console.error('CSP regression detected in Dockerfile.app:');
+  console.error('CSP regression detected:');
   for (const f of failures) console.error(`  ${f}`);
   console.error(
-    "\nThe codebase uses vanilla-extract for styling; 'unsafe-inline' in style-src is not needed.",
-    '\nRemove it from the Content-Security-Policy in Dockerfile.app. [ADS-847]',
+    '\nThe codebase uses vanilla-extract for styling and ships no inline <script> tags —',
+    "\n'unsafe-inline'/'unsafe-eval' are not needed in style-src or script-src, and every",
+    '\nprod SPA vhost at the edge must declare its own CSP. [ADS-847, ADS-958]'
   );
   process.exit(1);
 }
 
-console.log(`✓ CSP style-src is clean (${policies.length} polic${policies.length === 1 ? 'y' : 'ies'} checked)`);
+const totalPolicies = cspSources.reduce((sum, source) => sum + source.policies.length, 0);
+console.log(
+  `✓ CSP headers are clean (${totalPolicies} polic${totalPolicies === 1 ? 'y' : 'ies'} checked, ${PROD_SPA_HOSTNAMES.length} prod SPA vhosts verified)`
+);

--- a/services/gateway/src/config.test.ts
+++ b/services/gateway/src/config.test.ts
@@ -17,6 +17,9 @@ describe('loadConfig', () => {
       GATEWAY_HOST: '127.0.0.1',
       NODE_ENV: 'production',
       NATS_URL: 'nats://nats.internal:4222',
+      // ADS-967: production fails closed without CORS_ORIGIN — irrelevant to
+      // what this test asserts, so set it to isolate the behaviour under test.
+      CORS_ORIGIN: 'https://app.example.com',
     });
 
     expect(config.port).toBe(4321);
@@ -182,7 +185,11 @@ describe('loadConfig — test-token-peek seam (ADS-871)', () => {
   });
 
   it('does not throw in production when the flag is off', () => {
-    expect(() => loadConfig({ NODE_ENV: 'production' })).not.toThrow();
+    // ADS-967: production also requires CORS_ORIGIN — set it here so this
+    // test isolates the test-token-peek behaviour it actually asserts.
+    expect(() =>
+      loadConfig({ NODE_ENV: 'production', CORS_ORIGIN: 'https://app.example.com' })
+    ).not.toThrow();
   });
 });
 
@@ -217,5 +224,35 @@ describe('loadConfig — CORS origins (ADS-809)', () => {
   it('falls back to defaults when CORS_ORIGIN is an empty string', () => {
     const config = loadConfig({ CORS_ORIGIN: '' });
     expect(config.cors.origins).toContain('http://localhost:3000');
+  });
+});
+
+describe('loadConfig — CORS fail-closed in production/staging (ADS-967)', () => {
+  it('refuses to boot under NODE_ENV=production when CORS_ORIGIN is unset', () => {
+    expect(() => loadConfig({ NODE_ENV: 'production' })).toThrow(/CORS_ORIGIN must be set/);
+  });
+
+  it('refuses to boot under NODE_ENV=production when CORS_ORIGIN is an empty string', () => {
+    expect(() => loadConfig({ NODE_ENV: 'production', CORS_ORIGIN: '' })).toThrow(
+      /CORS_ORIGIN must be set/
+    );
+  });
+
+  it('refuses to boot under NODE_ENV=staging when CORS_ORIGIN is unset', () => {
+    expect(() => loadConfig({ NODE_ENV: 'staging' })).toThrow(/CORS_ORIGIN must be set/);
+  });
+
+  it('boots fine under NODE_ENV=production when CORS_ORIGIN is set', () => {
+    const config = loadConfig({
+      NODE_ENV: 'production',
+      CORS_ORIGIN: 'https://adoptdontshop.com',
+    });
+    expect(config.cors.origins).toEqual(['https://adoptdontshop.com']);
+  });
+
+  it('still falls back to localhost dev origins outside production/staging', () => {
+    expect(() => loadConfig({ NODE_ENV: 'development' })).not.toThrow();
+    expect(() => loadConfig({ NODE_ENV: 'test' })).not.toThrow();
+    expect(() => loadConfig({})).not.toThrow();
   });
 });

--- a/services/gateway/src/config.ts
+++ b/services/gateway/src/config.ts
@@ -147,11 +147,12 @@ export const loadConfig = (env: NodeJS.ProcessEnv = process.env): GatewayConfig 
   if (Number.isNaN(port) || port <= 0) {
     throw new Error(`GATEWAY_PORT must be a positive integer, got "${portRaw}"`);
   }
+  const environment = env.NODE_ENV?.trim() || 'development';
 
   return {
     port,
     host: env.GATEWAY_HOST?.trim() || DEFAULT_HOST,
-    environment: env.NODE_ENV?.trim() || 'development',
+    environment,
     natsUrl: env.NATS_URL?.trim() || DEFAULT_NATS_URL,
     notificationsGrpcUrl: env.NOTIFICATIONS_GRPC_URL?.trim() || DEFAULT_NOTIFICATIONS_GRPC_URL,
     authGrpcUrl: env.AUTH_GRPC_URL?.trim() || DEFAULT_AUTH_GRPC_URL,
@@ -173,7 +174,7 @@ export const loadConfig = (env: NodeJS.ProcessEnv = process.env): GatewayConfig 
     },
     principalSigningKey: readOptionalSecret('PRINCIPAL_SIGNING_KEY', env, 32),
     testTokenPeek: buildTestTokenPeekConfig(env),
-    cors: buildCorsConfig(env),
+    cors: buildCorsConfig(env, environment),
     rateLimit: buildRateLimitConfig(env),
   };
 };
@@ -181,15 +182,20 @@ export const loadConfig = (env: NodeJS.ProcessEnv = process.env): GatewayConfig 
 // Build the CORS config block. CORS_ORIGIN is a comma-separated list
 // of allowed origins (e.g. "http://localhost:3000,http://localhost:3001").
 // Defaults to localhost dev origins when unset so local dev works without
-// extra config; production must set this explicitly.
-function buildCorsConfig(env: NodeJS.ProcessEnv): GatewayConfig['cors'] {
+// extra config. production/staging FAIL CLOSED instead: booting with the
+// localhost allowlist + credentials:true (see server.ts) would let any
+// page on *.localhost issue credentialed cross-origin requests against a
+// real prod/staging deploy (ADS-967).
+function buildCorsConfig(env: NodeJS.ProcessEnv, environment: string): GatewayConfig['cors'] {
   const raw = env.CORS_ORIGIN?.trim() || '';
-  const origins = raw
-    ? raw
-        .split(',')
-        .map(o => o.trim())
-        .filter(Boolean)
-    : [
+  if (!raw) {
+    if (environment === 'production' || environment === 'staging') {
+      throw new Error(
+        `CORS_ORIGIN must be set when NODE_ENV=${environment} — refusing to fall back to the localhost dev allowlist`
+      );
+    }
+    return {
+      origins: [
         'http://localhost:3000',
         'http://localhost:3001',
         'http://localhost:3002',
@@ -197,7 +203,13 @@ function buildCorsConfig(env: NodeJS.ProcessEnv): GatewayConfig['cors'] {
         'http://admin.localhost',
         'http://rescue.localhost',
         'http://api.localhost',
-      ];
+      ],
+    };
+  }
+  const origins = raw
+    .split(',')
+    .map(o => o.trim())
+    .filter(Boolean);
   return { origins };
 }
 

--- a/services/gateway/src/server.ts
+++ b/services/gateway/src/server.ts
@@ -235,7 +235,11 @@ export const createServer = async (opts: CreateServerOptions): Promise<FastifyIn
 
   // CORS — explicit allowed-origins list from config. nginx also handles
   // CORS at the edge; this layer protects direct-gateway scenarios
-  // (internal load balancer, debug runs without nginx, etc.).
+  // (internal load balancer, debug runs without nginx, etc.). loadConfig
+  // fails closed in production/staging when CORS_ORIGIN is unset (ADS-967),
+  // so logging the effective allowlist here lets operators confirm at
+  // boot that it isn't the localhost dev fallback.
+  logger.info('cors allowlist configured', { origins: config.cors?.origins ?? [] });
   await server.register(cors, {
     origin: config.cors?.origins ?? [],
     credentials: true,


### PR DESCRIPTION
<!-- Before opening: make sure you've read [CONTRIBUTING.md](../CONTRIBUTING.md) and that all CI checks pass. -->

## Summary

- **ADS-958**: prod SPA vhosts (`adoptdontshop.com`, `admin.*`, `rescue.*`) in `deploy/gateway/nginx.conf` now send their own strict `Content-Security-Policy`, and `script-src` no longer allows `'unsafe-inline'`/`'unsafe-eval'` anywhere in the repo's nginx configs.
- **ADS-962**: every `/socket.io/` location across the edge and per-stack nginx configs now rate-limits the handshake, closing an unauthenticated DoS vector against `service.auth`'s `ValidateToken`.
- **ADS-967**: the gateway's `loadConfig` now fails closed — it refuses to boot in `production`/`staging` when `CORS_ORIGIN` is unset, instead of silently falling back to the localhost dev allowlist with `credentials: true`.

## Changes

- `apps/{client,admin,rescue}/nginx.conf` — drop `'unsafe-inline'`/`'unsafe-eval'` from `script-src` (vanilla-extract needs neither; verified no inline `<script>` in any `index.html`).
- `deploy/gateway/nginx.conf` — add `Content-Security-Policy` to the three prod SPA vhosts (`script-src 'self'`, `connect-src` pinned to `api.adoptdontshop.com`); add a dedicated `socketio` `limit_req` zone (2r/s, burst 10) and apply it to all 8 `/socket.io/` locations (4 prod + 4 staging).
- `nginx/nginx.conf`, `nginx/nginx.prod.conf` — same `socketio` rate-limit zone + `limit_req` applied to their `/socket.io/` locations, for consistency with the edge config.
- `scripts/check-csp-headers.mjs` (wired into `ci.yml`) — extended to assert every prod SPA vhost in `deploy/gateway/nginx.conf` declares a CSP, and that no CSP anywhere in the repo (`Dockerfile.app`, all three nginx configs, `apps/*/nginx.conf`) allows `unsafe-inline`/`unsafe-eval` in `script-src`.
- `services/gateway/src/config.ts` — `buildCorsConfig` throws at boot when `environment` is `production`/`staging` and `CORS_ORIGIN` is empty/unset; dev/test fallback to the localhost allowlist is unchanged.
- `services/gateway/src/server.ts` — logs the effective CORS allowlist at boot.
- `services/gateway/src/config.test.ts` — new tests for the fail-closed guard; two pre-existing tests that incidentally used `NODE_ENV=production` without `CORS_ORIGIN` now set it so they isolate the behaviour they actually assert.

## Notes / things I did not change

- `apps/{client,admin,rescue}/nginx.conf` are **not** wired into any Dockerfile or compose file — the actual prod SPA container image (`Dockerfile.app`) bakes its own nginx config via a heredoc, which already had a clean `script-src` (no `unsafe-inline`/`unsafe-eval`, from ADS-847). I updated the `apps/*/nginx.conf` files anyway per the ticket/comment's explicit instruction, and `check-csp-headers.mjs` now guards them too, but flagging this discrepancy since fixing them has no effect on what's actually deployed today.
- ADS-967's ticket "Proposed Fix" also suggested trimming the bare `http://localhost` entry from the dev fallback list; I left the dev fallback list unchanged per this task's explicit scope ("keeping the localhost default for dev") — only the fail-closed guard and boot log were added.
- ADS-962's ticket additionally asks for gateway-side (`socket-server.ts`) protection: a per-IP handshake counter in `io.use(...)`, a Redis-backed limiter, and a `gateway_ws_handshake_rejects_total` Prometheus counter. That's a meaningfully larger change to the WS auth path and is not included here — this PR covers the nginx-level rate limiting only (which the ticket's progress-check comment identifies as the still-open gap). Flagging as a follow-up if the gateway-side defence-in-depth layer is wanted too.
- The ticket's AC for ADS-958 also mentions "a CI smoke test in the deploy pipeline asserts the header is present on all three prod hosts" via live `curl -I` — out of scope here (no live deploy to curl in CI); the static `check-csp-headers.mjs` guard covers the same regression at the config level instead.

## Before requesting review

- [x] Ran gateway tests/lint/type-check locally (`pnpm exec turbo test lint type-check --filter=@adopt-dont-shop/service.gateway`)
- [x] Tests for new behaviour added (TDD) — `config.test.ts`
- [ ] If touching `.env` requirements, updated `.env.example`'s REQUIRED block — N/A, `CORS_ORIGIN` was already documented as required in prod
- [ ] If touching a `lib.*`, considered consumer impact across `app.*` and `service.backend` — N/A

## Test plan

- [x] `pnpm exec turbo test lint type-check --filter=@adopt-dont-shop/service.gateway` — 75 files / 1024 tests pass, lint clean, type-check clean
- [x] `node scripts/check-csp-headers.mjs` — passes; manually verified it fails when a prod SPA CSP is removed (then restored)
- [x] New behaviour covered by tests (ADS-967 fail-closed guard)
- [ ] Tested manually against a running nginx (`nginx -t` unavailable in this environment — no container)
- [x] No TypeScript errors
- [x] Lint passes

## Related

ADS-958, ADS-962, ADS-967

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_015F6J4DXQ1Amyth4dwD5Q8P)_