### PR TITLE
fix(security): auth hardening — 2FA confirm replay, login state leak, invitation rate limit (ADS-976/966/961)

### DIFF
--- a/services/auth/src/grpc/auth-metrics.test.ts
+++ b/services/auth/src/grpc/auth-metrics.test.ts
@@ -152,9 +152,11 @@ describe('auth_logins_total counter', () => {
     expect(await readCounter('auth_logins_total', { outcome: 'invalid_credentials' })).toBe(1);
   });
 
-  it('increments account_locked when locked_until is in the future', async () => {
+  it('increments account_locked when locked_until is in the future and the password is correct', async () => {
     const locked_until = new Date(Date.now() + 60_000);
     mocks.poolMock.query.mockResolvedValueOnce({ rows: [userRowFixture({ locked_until })] });
+    // Account state (ADS-966) is only revealed once the password checks out.
+    mocks.hasherMock.compare.mockResolvedValue(true);
 
     await expect(
       login(mocks.deps, null, { email: 'test@example.com', password: 'pw' })
@@ -163,8 +165,9 @@ describe('auth_logins_total counter', () => {
     expect(await readCounter('auth_logins_total', { outcome: 'account_locked' })).toBe(1);
   });
 
-  it('increments account_suspended for a suspended account', async () => {
+  it('increments account_suspended for a suspended account with a correct password', async () => {
     mocks.poolMock.query.mockResolvedValueOnce({ rows: [userRowFixture({ status: 'suspended' })] });
+    mocks.hasherMock.compare.mockResolvedValue(true);
 
     await expect(
       login(mocks.deps, null, { email: 'test@example.com', password: 'pw' })

--- a/services/auth/src/grpc/handlers.test.ts
+++ b/services/auth/src/grpc/handlers.test.ts
@@ -206,12 +206,21 @@ describe('login', () => {
     );
   });
 
-  it('returns PERMISSION_DENIED when account is locked', async () => {
+  // --- Account-state disclosure (ADS-966) -----------------------------
+  //
+  // Locked/suspended/deactivated state must only be revealed AFTER the
+  // submitted password is verified correct. A wrong password against any
+  // of these accounts must be indistinguishable from a wrong password
+  // against a normal or unknown account.
+
+  it('returns PERMISSION_DENIED when account is locked AND the password is correct', async () => {
     mocks.poolMock.query.mockResolvedValueOnce({
       rows: [userRowFixture({ locked_until: new Date(Date.now() + 60_000) })],
     });
+    mocks.hasherMock.compare.mockResolvedValueOnce(true);
     await expect(login(mocks.deps, null, BASE_LOGIN_REQ)).rejects.toMatchObject({
       code: 'PERMISSION_DENIED',
+      message: 'account is temporarily locked',
     });
 
     expect(mocks.natsMock.publish.mock.calls[0][0]).toBe('auth.actionTaken');
@@ -226,12 +235,14 @@ describe('login', () => {
     });
   });
 
-  it('returns PERMISSION_DENIED when account is suspended', async () => {
+  it('returns PERMISSION_DENIED when account is suspended AND the password is correct', async () => {
     mocks.poolMock.query.mockResolvedValueOnce({
       rows: [userRowFixture({ status: 'suspended' })],
     });
+    mocks.hasherMock.compare.mockResolvedValueOnce(true);
     await expect(login(mocks.deps, null, BASE_LOGIN_REQ)).rejects.toMatchObject({
       code: 'PERMISSION_DENIED',
+      message: 'account is suspended',
     });
 
     expect(mocks.natsMock.publish.mock.calls[0][0]).toBe('auth.actionTaken');
@@ -244,6 +255,69 @@ describe('login', () => {
       actorUserId: 'usr-adopter',
       actorEmailSnapshot: BASE_LOGIN_REQ.email,
     });
+  });
+
+  it('returns UNAUTHENTICATED "invalid credentials" (not PERMISSION_DENIED) when a locked account gets a wrong password', async () => {
+    mocks.poolMock.query.mockResolvedValueOnce({
+      rows: [userRowFixture({ locked_until: new Date(Date.now() + 60_000) })],
+    });
+    mocks.hasherMock.compare.mockResolvedValueOnce(false);
+    mocks.clientMock.query.mockResolvedValue({ rows: [] });
+    await expect(login(mocks.deps, null, BASE_LOGIN_REQ)).rejects.toMatchObject({
+      code: 'UNAUTHENTICATED',
+      message: 'invalid credentials',
+    });
+  });
+
+  it('returns UNAUTHENTICATED "invalid credentials" (not PERMISSION_DENIED) when a suspended account gets a wrong password', async () => {
+    mocks.poolMock.query.mockResolvedValueOnce({
+      rows: [userRowFixture({ status: 'suspended' })],
+    });
+    mocks.hasherMock.compare.mockResolvedValueOnce(false);
+    mocks.clientMock.query.mockResolvedValue({ rows: [] });
+    await expect(login(mocks.deps, null, BASE_LOGIN_REQ)).rejects.toMatchObject({
+      code: 'UNAUTHENTICATED',
+      message: 'invalid credentials',
+    });
+  });
+
+  it('returns UNAUTHENTICATED "invalid credentials" (not PERMISSION_DENIED) when a deactivated account gets a wrong password', async () => {
+    mocks.poolMock.query.mockResolvedValueOnce({
+      rows: [userRowFixture({ status: 'deactivated' })],
+    });
+    mocks.hasherMock.compare.mockResolvedValueOnce(false);
+    mocks.clientMock.query.mockResolvedValue({ rows: [] });
+    await expect(login(mocks.deps, null, BASE_LOGIN_REQ)).rejects.toMatchObject({
+      code: 'UNAUTHENTICATED',
+      message: 'invalid credentials',
+    });
+  });
+
+  it('the four wrong-password branches (unknown/locked/suspended/deactivated) return an identical error', async () => {
+    const scenarios: Array<{ name: string; rows: unknown[] }> = [
+      { name: 'unknown', rows: [] },
+      { name: 'locked', rows: [userRowFixture({ locked_until: new Date(Date.now() + 60_000) })] },
+      { name: 'suspended', rows: [userRowFixture({ status: 'suspended' })] },
+      { name: 'deactivated', rows: [userRowFixture({ status: 'deactivated' })] },
+    ];
+
+    const errors: unknown[] = [];
+    for (const scenario of scenarios) {
+      const m = makeMocks();
+      m.poolMock.query.mockResolvedValueOnce({ rows: scenario.rows });
+      m.hasherMock.compare.mockResolvedValueOnce(false);
+      m.clientMock.query.mockResolvedValue({ rows: [] });
+      try {
+        await login(m.deps, null, BASE_LOGIN_REQ);
+        throw new Error(`expected login to reject for scenario ${scenario.name}`);
+      } catch (err) {
+        errors.push(err);
+      }
+    }
+
+    for (const err of errors) {
+      expect(err).toMatchObject({ code: 'UNAUTHENTICATED', message: 'invalid credentials' });
+    }
   });
 
   it('returns UNAUTHENTICATED on wrong password and increments login_attempts', async () => {

--- a/services/auth/src/grpc/handlers.ts
+++ b/services/auth/src/grpc/handlers.ts
@@ -466,33 +466,12 @@ export async function login(
   }
   const user = userRes.rows[0];
 
-  // Block locked accounts BEFORE comparing the password — even a
-  // correct password shouldn't reveal the account is back online.
-  if (user.locked_until && user.locked_until > new Date()) {
-    loginCounter.inc({ outcome: 'account_locked' });
-    await publishLoginActionTaken(deps, {
-      outcome: 'denied',
-      aggregateId: user.user_id,
-      actorUserId: user.user_id,
-      actorEmailSnapshot: user.email,
-      ipAddress: req.ipAddress,
-      userAgent: req.userAgent,
-    });
-    throw new HandlerError('PERMISSION_DENIED', 'account is temporarily locked');
-  }
-  if (user.status === 'suspended' || user.status === 'deactivated') {
-    loginCounter.inc({ outcome: 'account_suspended' });
-    await publishLoginActionTaken(deps, {
-      outcome: 'denied',
-      aggregateId: user.user_id,
-      actorUserId: user.user_id,
-      actorEmailSnapshot: user.email,
-      ipAddress: req.ipAddress,
-      userAgent: req.userAgent,
-    });
-    throw new HandlerError('PERMISSION_DENIED', `account is ${user.status}`);
-  }
-
+  // Compare the password BEFORE revealing anything about account state
+  // (ADS-966) — checking locked/suspended/deactivated first turned those
+  // branches into an email-enumeration oracle, since any password (even a
+  // wrong one) reached them. A wrong password now falls straight through
+  // to the generic invalid-credentials branch below regardless of the
+  // account's state.
   const ok = await deps.passwordHasher.compare(req.password, user.password);
   if (!ok) {
     // Count the failure and, once past the threshold, apply a short
@@ -539,6 +518,35 @@ export async function login(
     });
     loginCounter.inc({ outcome: 'invalid_credentials' });
     throw new HandlerError('UNAUTHENTICATED', 'invalid credentials');
+  }
+
+  // The password is correct — only now is it safe to reveal account state
+  // (ADS-966). A locked/suspended/deactivated account still can't log in,
+  // but the distinct message is reserved for someone who has already
+  // proven they know the password.
+  if (user.locked_until && user.locked_until > new Date()) {
+    loginCounter.inc({ outcome: 'account_locked' });
+    await publishLoginActionTaken(deps, {
+      outcome: 'denied',
+      aggregateId: user.user_id,
+      actorUserId: user.user_id,
+      actorEmailSnapshot: user.email,
+      ipAddress: req.ipAddress,
+      userAgent: req.userAgent,
+    });
+    throw new HandlerError('PERMISSION_DENIED', 'account is temporarily locked');
+  }
+  if (user.status === 'suspended' || user.status === 'deactivated') {
+    loginCounter.inc({ outcome: 'account_suspended' });
+    await publishLoginActionTaken(deps, {
+      outcome: 'denied',
+      aggregateId: user.user_id,
+      actorUserId: user.user_id,
+      actorEmailSnapshot: user.email,
+      ipAddress: req.ipAddress,
+      userAgent: req.userAgent,
+    });
+    throw new HandlerError('PERMISSION_DENIED', `account is ${user.status}`);
   }
 
   // Email verification gate. A correct password on an unverified account must

--- a/services/auth/src/grpc/totp-verification.ts
+++ b/services/auth/src/grpc/totp-verification.ts
@@ -18,7 +18,10 @@ import { decryptTotpSecret } from './totp-crypto.js';
 
 // RFC 6238 defaults otplib uses: 30-second period, t0 = 0. The accepted
 // time step for a given epoch is therefore floor(epoch / TOTP_PERIOD).
-const TOTP_PERIOD_SECONDS = 30;
+// Exported so two-factor-handlers.ts can compute the same step when it
+// verifies a code directly against a not-yet-persisted secret (enrolment)
+// instead of going through verifyAndConsumeTotp (ADS-976).
+export const TOTP_PERIOD_SECONDS = 30;
 
 export type TotpVerificationDeps = {
   pool: Pick<Pool, 'query'>;

--- a/services/auth/src/grpc/two-factor-handlers.test.ts
+++ b/services/auth/src/grpc/two-factor-handlers.test.ts
@@ -8,7 +8,7 @@ import type { Principal } from '@adopt-dont-shop/authz';
 import type { UserId } from '@adopt-dont-shop/lib.types';
 
 import { normalizeBackupCode } from './backup-codes.js';
-import type { HandlerDeps } from './handlers.js';
+import { login, type HandlerDeps } from './handlers.js';
 import { decryptTotpSecret, encryptTotpSecret } from './totp-crypto.js';
 import {
   disableTwoFactor,
@@ -130,6 +130,28 @@ describe('enableTwoFactor', () => {
     expect(updateSql).toMatch(/two_factor_secret_pending = NULL/);
   });
 
+  it('persists the accepted confirmation step (not NULL) so the code cannot be replayed on Login (ADS-976)', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-01-01T00:00:00Z'));
+    try {
+      const secret = generateSecret();
+      const token = generateSync({ secret });
+
+      mocks.poolMock.query
+        .mockResolvedValueOnce({ rows: [makePendingRow(secret)], rowCount: 1 })
+        .mockResolvedValueOnce({ rows: [], rowCount: 1 });
+
+      await enableTwoFactor(mocks.deps, PRINCIPAL, { token });
+
+      const [updateSql, updateParams] = mocks.poolMock.query.mock.calls[1] as [string, unknown[]];
+      expect(updateSql).not.toMatch(/two_factor_last_step = NULL/);
+      expect(updateSql).toMatch(/two_factor_last_step = \$1/);
+      expect(updateParams[0]).toBe(Math.floor(Date.now() / 1000 / 30));
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('ignores req.secret entirely — attacker-supplied secret does not enable 2FA', async () => {
     // Attack scenario from ADS-963: attacker has a token but no server-stored pending secret.
     // They supply their own secret + a valid TOTP for it. Must be rejected.
@@ -234,7 +256,7 @@ describe('enableTwoFactor', () => {
     }
 
     const [, updateParams] = mocks.poolMock.query.mock.calls[1] as [string, unknown[]];
-    const storedHashes = updateParams[0] as string[];
+    const storedHashes = updateParams[1] as string[];
     expect(storedHashes).toHaveLength(10);
     for (const [i, code] of res.backupCodes.entries()) {
       expect(storedHashes[i]).not.toBe(code);
@@ -262,6 +284,101 @@ describe('enableTwoFactor', () => {
     await expect(enableTwoFactor(mocks.deps, null, { token: '123456' })).rejects.toMatchObject({
       code: 'UNAUTHENTICATED',
     });
+  });
+});
+
+// ADS-976: reproduces the reported replay attack end-to-end — the exact
+// 6-digit code used to confirm enrolment must not also be accepted by
+// Login within the same 30s window, because verifyAndConsumeTotp's
+// afterTimeStep replay guard is keyed on the persisted two_factor_last_step.
+describe('enableTwoFactor confirmation-code replay (ADS-976)', () => {
+  it('rejects an immediate Login that replays the code used to confirm enrolment', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-01-01T00:00:00Z'));
+    try {
+      const secret = generateSecret();
+      const token = generateSync({ secret });
+      const enableMocks = makeMocks();
+
+      const encrypted = encryptTotpSecret(ENCRYPTION_KEY, secret);
+      enableMocks.poolMock.query
+        // SELECT pending secret
+        .mockResolvedValueOnce({
+          rows: [
+            {
+              two_factor_enabled: false,
+              two_factor_secret_pending: encrypted,
+              two_factor_pending_expires_at: new Date(Date.now() + 9 * 60_000),
+            },
+          ],
+          rowCount: 1,
+        })
+        // UPDATE promote pending→active
+        .mockResolvedValueOnce({ rows: [], rowCount: 1 });
+
+      await enableTwoFactor(enableMocks.deps, PRINCIPAL, { token });
+
+      const [, updateParams] = enableMocks.poolMock.query.mock.calls[1] as [string, unknown[]];
+      const persistedStep = updateParams[0] as number;
+
+      // Login as if the very next call, within the same 30s window, supplies
+      // the identical code — using the step just persisted by enableTwoFactor.
+      const client = { query: vi.fn().mockResolvedValue({ rows: [] }), release: vi.fn() };
+      const natsPublish = vi.fn();
+      const loginPool = {
+        connect: vi.fn().mockResolvedValue(client),
+        query: vi.fn().mockResolvedValueOnce({
+          rows: [
+            {
+              user_id: 'usr-1',
+              email: 'alex@example.com',
+              password: 'hashed:hunter2',
+              first_name: null,
+              last_name: null,
+              email_verified: true,
+              phone_verified: false,
+              two_factor_enabled: true,
+              two_factor_secret: encrypted,
+              two_factor_last_step: persistedStep,
+              backup_codes: null,
+              status: 'active',
+              user_type: 'adopter',
+              profile_image_url: null,
+              bio: null,
+              timezone: null,
+              language: null,
+              country: null,
+              city: null,
+              last_login_at: null,
+              locked_until: null,
+              login_attempts: 0,
+              created_at: new Date('2026-01-01T00:00:00Z'),
+              updated_at: new Date('2026-01-01T00:00:00Z'),
+            },
+          ],
+        }),
+      };
+      const loginDeps: HandlerDeps = {
+        pool: loginPool as unknown as HandlerDeps['pool'],
+        nats: {
+          publish: natsPublish,
+          jetstream: () => ({ publish: natsPublish }),
+        } as unknown as HandlerDeps['nats'],
+        passwordHasher: enableMocks.deps.passwordHasher,
+        tokenIssuer: enableMocks.deps.tokenIssuer,
+        encryptionKey: ENCRYPTION_KEY,
+      };
+
+      await expect(
+        login(loginDeps, null, {
+          email: 'alex@example.com',
+          password: 'hunter2',
+          twoFactorToken: token,
+        })
+      ).rejects.toMatchObject({ code: 'UNAUTHENTICATED' });
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });
 
@@ -420,5 +537,39 @@ describe('regenerateBackupCodes', () => {
     await expect(
       regenerateBackupCodes(mocks.deps, null, { token: '123456' })
     ).rejects.toMatchObject({ code: 'UNAUTHENTICATED' });
+  });
+
+  // ADS-976 AC: "RegenerateBackupCodes behaves the same way (its own TOTP
+  // code is not replayable on the next Login)." Unlike enableTwoFactor,
+  // this handler already verifies via verifyAndConsumeTotp (see the
+  // "mints a fresh set" test above — call 2 is its replay-guard UPDATE),
+  // which persists the accepted step. This test documents that the guard
+  // is live: a code already accepted at the current step is rejected here
+  // too, same as disableTwoFactor / Login.
+  it('rejects a replayed code that was already accepted (ADS-914c/976)', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-01-01T00:00:00Z'));
+    try {
+      const secret = generateSecret();
+      const token = generateSync({ secret });
+      const encryptedSecret = encryptTotpSecret(ENCRYPTION_KEY, secret);
+      const timeStep = Math.floor(Date.now() / 1000 / 30);
+      mocks.poolMock.query.mockResolvedValueOnce({
+        rows: [
+          {
+            two_factor_enabled: true,
+            two_factor_secret: encryptedSecret,
+            two_factor_last_step: timeStep,
+          },
+        ],
+      });
+      await expect(regenerateBackupCodes(mocks.deps, PRINCIPAL, { token })).rejects.toMatchObject({
+        code: 'INVALID_ARGUMENT',
+      });
+      // Only the SELECT ran — no replay-guard update, no regeneration.
+      expect(mocks.poolMock.query).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/services/auth/src/grpc/two-factor-handlers.ts
+++ b/services/auth/src/grpc/two-factor-handlers.ts
@@ -38,7 +38,7 @@ import type {
 import { generateBackupCodes, hashBackupCodes } from './backup-codes.js';
 import { HandlerError, type HandlerDeps } from './handlers.js';
 import { decryptTotpSecret, encryptTotpSecret } from './totp-crypto.js';
-import { verifyAndConsumeTotp } from './totp-verification.js';
+import { TOTP_PERIOD_SECONDS, verifyAndConsumeTotp } from './totp-verification.js';
 
 const TOTP_ISSUER = 'Adopt Dont Shop';
 const PENDING_SECRET_TTL_MINUTES = 10;
@@ -141,9 +141,18 @@ export async function enableTwoFactor(
   }
 
   const pendingSecret = decryptTotpSecret(deps.encryptionKey, row.two_factor_secret_pending);
-  if (!verifySync({ token: req.token, secret: pendingSecret }).valid) {
+  // Pin the epoch so the accepted step we persist below matches the epoch
+  // verifySync used (no window-boundary race between verify and compute) —
+  // mirrors totp-verification.ts's verifyAndConsumeTotp.
+  const epoch = Math.floor(Date.now() / 1000);
+  if (!verifySync({ token: req.token, secret: pendingSecret, epoch }).valid) {
     throw new HandlerError('INVALID_ARGUMENT', 'invalid two-factor code');
   }
+  // The confirmation code just accepted proves possession of the
+  // authenticator, exactly like a code checked via verifyAndConsumeTotp —
+  // persist its time step so it can't also be replayed on the very next
+  // Login within the same 30s window (ADS-976).
+  const acceptedStep = Math.floor(epoch / TOTP_PERIOD_SECONDS);
 
   // Mint the backup/recovery codes (ADS-914b) now, before the write, so a
   // failed UPDATE (already-enabled race) doesn't leave us having hashed
@@ -159,16 +168,16 @@ export async function enableTwoFactor(
     `UPDATE auth.users
         SET two_factor_secret = two_factor_secret_pending,
             two_factor_enabled = true,
-            two_factor_last_step = NULL,
+            two_factor_last_step = $1,
             two_factor_secret_pending = NULL,
             two_factor_pending_expires_at = NULL,
-            backup_codes = $1,
+            backup_codes = $2,
             updated_at = now()
-      WHERE user_id = $2 AND deleted_at IS NULL
+      WHERE user_id = $3 AND deleted_at IS NULL
         AND two_factor_enabled = false
         AND two_factor_secret_pending IS NOT NULL
         AND two_factor_pending_expires_at > now()`,
-    [backupCodeHashes, me.userId]
+    [acceptedStep, backupCodeHashes, me.userId]
   );
   if (updateRes.rowCount === 0) {
     throw new HandlerError('INVALID_ARGUMENT', 'two-factor authentication is already enabled');

--- a/services/gateway/src/routes/invitation-accept.test.ts
+++ b/services/gateway/src/routes/invitation-accept.test.ts
@@ -5,6 +5,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { AuthClient } from '../grpc-clients/auth-client.js';
 import type { RescueClient } from '../grpc-clients/rescue-client.js';
 
+import { createEmailRateLimiter } from './email-rate-limiter.js';
 import { registerInvitationAcceptRoutes } from './invitation-accept.js';
 
 function makeClients() {
@@ -34,10 +35,11 @@ function makeClients() {
 
 async function makeApp(
   authClient: AuthClient,
-  rescueClient: RescueClient
+  rescueClient: RescueClient,
+  extraOpts: Partial<Parameters<typeof registerInvitationAcceptRoutes>[1]> = {}
 ): Promise<FastifyInstance> {
-  const app = Fastify({ logger: false });
-  await registerInvitationAcceptRoutes(app, { authClient, rescueClient });
+  const app = Fastify({ logger: false, trustProxy: true });
+  await registerInvitationAcceptRoutes(app, { authClient, rescueClient, ...extraOpts });
   return app;
 }
 
@@ -181,5 +183,156 @@ describe('POST /api/v1/invitations/accept', () => {
     });
 
     expect(res.statusCode).toBe(404);
+  });
+});
+
+// ADS-961: the route provisions an auth user + attaches rescue-staff
+// membership from nothing but a bearer token, so a brute-forced token is a
+// full account-hijack primitive. Both a per-IP cap (route config.rateLimit)
+// and a per-token cap (preHandler, same shape as the login per-email
+// limiter in auth.ts/email-rate-limiter.ts) must hold.
+describe('POST /api/v1/invitations/accept rate limiting (ADS-961)', () => {
+  const successMocks = (m: ReturnType<typeof makeClients>) => {
+    m.getInvitationByTokenMock.mockResolvedValue({
+      invitation: { email: 'invitee@example.com', rescueId: 'rsc-1' },
+    });
+    m.provisionInvitedUserMock.mockResolvedValue({ user: { userId: 'usr-new' } });
+    m.acceptInvitationMock.mockResolvedValue({ staffMember: { userId: 'usr-new' } });
+  };
+
+  it('throttles a per-IP flood (more than 10/min/IP returns 429)', async () => {
+    const m = makeClients();
+    successMocks(m);
+    const app = Fastify({ logger: false, trustProxy: true });
+    const { default: rateLimit } = await import('@fastify/rate-limit');
+    await app.register(rateLimit, {
+      global: true,
+      max: 100,
+      timeWindow: '1 minute',
+      keyGenerator: req => req.ip,
+    });
+    await registerInvitationAcceptRoutes(app, {
+      authClient: m.authClient,
+      rescueClient: m.rescueClient,
+    });
+    try {
+      const sameIp = { 'x-forwarded-for': '9.9.9.9' };
+      const statuses: number[] = [];
+      // Vary the token each call so it's unambiguously the per-IP cap firing.
+      for (let i = 0; i < 11; i += 1) {
+        const res = await app.inject({
+          method: 'POST',
+          url: '/api/v1/invitations/accept',
+          headers: sameIp,
+          payload: { ...VALID_BODY, token: `tok-${i}` },
+        });
+        statuses.push(res.statusCode);
+      }
+      // 10 within the per-IP cap pass; the 11th from the same IP is 429.
+      expect(statuses.slice(0, 10)).toEqual(new Array(10).fill(201));
+      expect(statuses[10]).toBe(429);
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('throttles a per-TOKEN flood spread across many IPs (more than 5/5min returns 429)', async () => {
+    const m = makeClients();
+    successMocks(m);
+    const tokenRateLimiter = createEmailRateLimiter({ max: 5, windowMs: 5 * 60_000 });
+    const app = await makeApp(m.authClient, m.rescueClient, { tokenRateLimiter });
+    try {
+      const hit = (ip: string) =>
+        app.inject({
+          method: 'POST',
+          url: '/api/v1/invitations/accept',
+          headers: { 'x-forwarded-for': ip },
+          payload: { ...VALID_BODY, token: 'shared-guessed-token' },
+        });
+
+      const statuses: number[] = [];
+      for (let i = 0; i < 6; i += 1) {
+        statuses.push((await hit(`1.1.1.${i}`)).statusCode);
+      }
+
+      // First 5 (the cap) pass; the 6th — same token, different IP — is 429.
+      expect(statuses.slice(0, 5)).toEqual(new Array(5).fill(201));
+      expect(statuses[5]).toBe(429);
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('does not throttle a DIFFERENT token once one trips the per-token cap', async () => {
+    const m = makeClients();
+    successMocks(m);
+    const tokenRateLimiter = createEmailRateLimiter({ max: 1, windowMs: 5 * 60_000 });
+    const app = await makeApp(m.authClient, m.rescueClient, { tokenRateLimiter });
+    try {
+      await app.inject({
+        method: 'POST',
+        url: '/api/v1/invitations/accept',
+        payload: { ...VALID_BODY, token: 'token-a' },
+      });
+      const tripped = await app.inject({
+        method: 'POST',
+        url: '/api/v1/invitations/accept',
+        payload: { ...VALID_BODY, token: 'token-a' },
+      });
+      const other = await app.inject({
+        method: 'POST',
+        url: '/api/v1/invitations/accept',
+        payload: { ...VALID_BODY, token: 'token-b' },
+      });
+
+      expect(tripped.statusCode).toBe(429);
+      expect(other.statusCode).toBe(201);
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('calls onTokenRateLimitTrip when the per-token cap trips', async () => {
+    const m = makeClients();
+    successMocks(m);
+    const onTokenRateLimitTrip = vi.fn();
+    const tokenRateLimiter = createEmailRateLimiter({ max: 1, windowMs: 60_000 });
+    const app = await makeApp(m.authClient, m.rescueClient, {
+      tokenRateLimiter,
+      onTokenRateLimitTrip,
+    });
+    try {
+      await app.inject({
+        method: 'POST',
+        url: '/api/v1/invitations/accept',
+        payload: { ...VALID_BODY, token: 'token-c' },
+      });
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/v1/invitations/accept',
+        payload: { ...VALID_BODY, token: 'token-c' },
+      });
+
+      expect(res.statusCode).toBe(429);
+      expect(onTokenRateLimitTrip).toHaveBeenCalledTimes(1);
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('does not throttle when no tokenRateLimiter is wired', async () => {
+    const m = makeClients();
+    successMocks(m);
+    const app = await makeApp(m.authClient, m.rescueClient);
+    try {
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/v1/invitations/accept',
+        payload: { ...VALID_BODY, token: 'token-d' },
+      });
+      expect(res.statusCode).toBe(201);
+    } finally {
+      await app.close();
+    }
   });
 });

--- a/services/gateway/src/routes/invitation-accept.ts
+++ b/services/gateway/src/routes/invitation-accept.ts
@@ -16,16 +16,34 @@
 //
 // Public — the invitation token IS the credential; no principal required.
 
-import type { FastifyInstance } from 'fastify';
+import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
 
 import type { AuthClient } from '../grpc-clients/auth-client.js';
 import type { RescueClient } from '../grpc-clients/rescue-client.js';
 import { buildMetadata } from '../middleware/metadata.js';
 import { handleGrpcError } from '../middleware/grpc-error.js';
 
+import type { EmailRateLimiter } from './email-rate-limiter.js';
+
+// Per-IP cap (ADS-961) — mirrors AUTH_RATE_LIMITS.redeemInvitation in
+// auth.ts, which carries identical account-provisioning weight.
+const IP_RATE_LIMIT = { max: 10, timeWindow: '1 minute' } as const;
+
 export type InvitationAcceptRoutesOptions = {
   authClient: AuthClient;
   rescueClient: RescueClient;
+  // Per-token rate limiter (ADS-961), keyed on body.token instead of an
+  // email — reuses the createEmailRateLimiter shape from
+  // email-rate-limiter.ts since it's just a generic string-keyed counter.
+  // Layered on top of the per-IP cap above so a token brute-force spread
+  // across rotating IPs (or a rotating X-Forwarded-For) is still capped.
+  // Optional so tests / dev that don't wire it keep the per-IP-only
+  // behaviour.
+  tokenRateLimiter?: EmailRateLimiter;
+  // Called each time the per-token cap trips. Lets the caller (server.ts)
+  // increment a Prometheus counter without this route module reaching into
+  // the metrics registry directly.
+  onTokenRateLimitTrip?: () => void;
 };
 
 type AcceptBody = {
@@ -41,11 +59,29 @@ export const registerInvitationAcceptRoutes = async (
   app: FastifyInstance,
   opts: InvitationAcceptRoutesOptions
 ): Promise<void> => {
-  const { authClient, rescueClient } = opts;
+  const { authClient, rescueClient, tokenRateLimiter, onTokenRateLimitTrip } = opts;
+
+  // Per-token cap preHandler (ADS-961) — a no-op when no limiter is wired,
+  // same pattern as auth.ts's emailRateLimit helper.
+  const tokenRateLimit = tokenRateLimiter
+    ? async (req: FastifyRequest, reply: FastifyReply) => {
+        const token = (req.body as { token?: string } | undefined)?.token;
+        if (!token) {
+          return;
+        }
+        const allowed = await tokenRateLimiter.consume(token);
+        if (!allowed) {
+          onTokenRateLimitTrip?.();
+          return reply.code(429).send({ error: 'Too many requests for this invitation' });
+        }
+      }
+    : undefined;
 
   app.post(
     '/api/v1/invitations/accept',
     {
+      config: { rateLimit: IP_RATE_LIMIT },
+      preHandler: tokenRateLimit,
       schema: {
         tags: ['invitations'],
         summary: 'Accept a rescue staff invitation and provision the user account',

--- a/services/gateway/src/server.test.ts
+++ b/services/gateway/src/server.test.ts
@@ -277,6 +277,26 @@ function makeLoginAuthClient(): Parameters<typeof createServer>[0]['authClient']
   } as unknown as Parameters<typeof createServer>[0]['authClient'];
 }
 
+// Minimal invitation-accept-capable client stubs (ADS-961) — only the
+// methods registerInvitationAcceptRoutes actually calls on a happy path.
+function makeInvitationAcceptClients(): {
+  authClient: Parameters<typeof createServer>[0]['authClient'];
+  rescueClient: Parameters<typeof createServer>[0]['rescueClient'];
+} {
+  const authClient = {
+    provisionInvitedUser: () => Promise.resolve({ user: { userId: 'usr-invited' } }),
+    close: () => undefined,
+  } as unknown as Parameters<typeof createServer>[0]['authClient'];
+  const rescueClient = {
+    getInvitationByToken: () =>
+      Promise.resolve({ invitation: { email: 'invitee@example.com', rescueId: 'rsc-1' } }),
+    acceptInvitation: () =>
+      Promise.resolve({ staffMember: { userId: 'usr-invited', rescueId: 'rsc-1' } }),
+    close: () => undefined,
+  } as unknown as Parameters<typeof createServer>[0]['rescueClient'];
+  return { authClient, rescueClient };
+}
+
 describe('createServer — per-route rate limit override (auth login)', () => {
   let server: FastifyInstance;
 
@@ -436,6 +456,46 @@ describe('createServer — Prometheus rate-limit counter', () => {
 
       const metrics = await server.inject({ method: 'GET', url: '/metrics' });
       expect(metrics.body).toContain('gateway_login_email_ratelimit_trips_total');
+    } finally {
+      await server.close();
+    }
+  });
+
+  it('exposes gateway_invitation_accept_ratelimit_trips_total metric after a per-token trip (ADS-961)', async () => {
+    const { authClient, rescueClient } = makeInvitationAcceptClients();
+    const server = await createServer({
+      config: {
+        ...baseConfig,
+        rateLimit: { redisUrl: undefined, max: 100, timeWindow: '1 minute' },
+      },
+      logger: quietLogger,
+      authClient,
+      rescueClient,
+    });
+    try {
+      const postAccept = (ip: string) =>
+        server.inject({
+          method: 'POST',
+          url: '/api/v1/invitations/accept',
+          headers: { 'x-forwarded-for': ip },
+          payload: {
+            token: 'shared-guessed-token',
+            password: 'hunter22',
+            firstName: 'Jo',
+            lastName: 'Bloggs',
+          },
+        });
+
+      // The per-token cap is 5/5min — spread across distinct IPs so the
+      // per-IP limiter (10/min) doesn't trip first.
+      for (let i = 0; i < 5; i++) {
+        await postAccept(`21.0.0.${i}`);
+      }
+      const sixth = await postAccept('21.0.0.99');
+      expect(sixth.statusCode).toBe(429);
+
+      const metrics = await server.inject({ method: 'GET', url: '/metrics' });
+      expect(metrics.body).toContain('gateway_invitation_accept_ratelimit_trips_total');
     } finally {
       await server.close();
     }

--- a/services/gateway/src/server.ts
+++ b/services/gateway/src/server.ts
@@ -140,6 +140,25 @@ const getOrCreateLoginEmailRateLimitCounter = (): Counter => {
   return counter;
 };
 
+// Per-token invitation-accept rate-limit trip counter (ADS-961). Same
+// lazily-created, registry-change-aware singleton pattern as the login
+// counter above.
+let _invitationAcceptCounterEntry: { registryRef: object; counter: Counter } | null = null;
+
+const getOrCreateInvitationAcceptRateLimitCounter = (): Counter => {
+  const reg = getMetricsRegistry();
+  if (_invitationAcceptCounterEntry && _invitationAcceptCounterEntry.registryRef === reg) {
+    return _invitationAcceptCounterEntry.counter;
+  }
+  const counter = new Counter({
+    name: 'gateway_invitation_accept_ratelimit_trips_total',
+    help: 'Total number of invitation-accept attempts rejected by the per-token rate limit (ADS-961).',
+    registers: [reg],
+  });
+  _invitationAcceptCounterEntry = { registryRef: reg, counter };
+  return counter;
+};
+
 export type CreateServerOptions = {
   config: GatewayConfig;
   // Optional logger injection — tests pass a quiet logger so the
@@ -546,9 +565,20 @@ export const createServer = async (opts: CreateServerOptions): Promise<FastifyIn
   // auth (provision the invited user) + rescue (consume the invitation +
   // attach staff membership), so it needs BOTH clients wired.
   if (opts.authClient && opts.rescueClient) {
+    // Per-token cap (ADS-961) — an invitation token IS the credential, so a
+    // token brute-force spread across rotating IPs must still be capped.
+    // 5 attempts / 5 minutes, same window shape as the login per-email cap.
+    const invitationAcceptTokenRateLimiter = createEmailRateLimiter({
+      max: 5,
+      windowMs: 5 * 60_000,
+      redis: rateLimitRedis,
+    });
+    const invitationAcceptRateLimitTripsTotal = getOrCreateInvitationAcceptRateLimitCounter();
     await registerInvitationAcceptRoutes(server, {
       authClient: opts.authClient,
       rescueClient: opts.rescueClient,
+      tokenRateLimiter: invitationAcceptTokenRateLimiter,
+      onTokenRateLimitTrip: () => invitationAcceptRateLimitTripsTotal.inc(),
     });
   }
   if (opts.auditClient) {


### PR DESCRIPTION
## Summary

Three independent security fixes bundled into one batch, each with its own commit:

- **ADS-976** — `enableTwoFactor` verified the confirmation TOTP code but stamped `two_factor_last_step = NULL` on the promoting UPDATE, so the same code used to confirm enrolment was still accepted by `Login` for the rest of its ~30s window. Now persists the accepted RFC 6238 time step instead of NULL, closing the replay window.
- **ADS-966** — `Login` checked `locked_until` / `status` (suspended/deactivated) *before* comparing the password, so any password — even a wrong one — revealed the account's state via a distinct 403. Reordered so the password is verified first; the distinct locked/suspended/deactivated message is only returned once the password is confirmed correct.
- **ADS-961** — `POST /api/v1/invitations/accept` had no per-route rate limit, relying only on the gateway's global 100 req/min/IP cap, despite provisioning an auth user + attaching rescue-staff membership from a single guessable token. Added a 10/min per-IP cap (matching `redeemInvitation`) plus a 5-attempts/5-minute per-token cap.

## Changes

- `services/auth/src/grpc/totp-verification.ts` — export `TOTP_PERIOD_SECONDS` so it can be shared with the enrolment path.
- `services/auth/src/grpc/two-factor-handlers.ts` — `enableTwoFactor` now computes and persists the accepted TOTP time step instead of writing `NULL`.
- `services/auth/src/grpc/two-factor-handlers.test.ts` — regression test reproducing the enrolment-code replay via `Login`; documents that `regenerateBackupCodes` was already safe (it verifies via `verifyAndConsumeTotp`, which persists the step correctly).
- `services/auth/src/grpc/handlers.ts` — `login()` now compares the password before checking `locked_until` / `status`; the account-state checks moved to run only after a correct password.
- `services/auth/src/grpc/handlers.test.ts`, `services/auth/src/grpc/auth-metrics.test.ts` — updated/added tests asserting the four wrong-password branches (unknown/locked/suspended/deactivated) return an identical `UNAUTHENTICATED "invalid credentials"`, and that the distinct locked/suspended message only appears with a correct password.
- `services/gateway/src/routes/invitation-accept.ts` — added `config.rateLimit` (10/min/IP) and a per-token preHandler (5/5min) reusing the `createEmailRateLimiter` shape from `email-rate-limiter.ts`.
- `services/gateway/src/server.ts` — wires the per-token limiter + a new `gateway_invitation_accept_ratelimit_trips_total` Prometheus counter, following the existing `gateway_login_email_ratelimit_trips_total` pattern (ADS-916).
- `services/gateway/src/routes/invitation-accept.test.ts`, `services/gateway/src/server.test.ts` — new tests for the per-IP cap, per-token cap, trip callback, and metric exposure.

## Before requesting review

- [x] Ran targeted tests + lint + type-check locally
- [x] Tests for new behaviour added (TDD — tests written before the fix in each case)
- [ ] N/A — no `.env` changes
- [ ] N/A — no `lib.*` changes

## Test plan

- [x] `pnpm exec turbo test --filter=@adopt-dont-shop/service.auth --filter=@adopt-dont-shop/service.gateway` — 392 + 1025 tests pass
- [x] New behaviour is covered by tests (see per-ticket test files above)
- [ ] Tested manually — not done in this batch (backend-only, gRPC/HTTP handler level)
- [x] `pnpm exec turbo type-check --filter=@adopt-dont-shop/service.auth --filter=@adopt-dont-shop/service.gateway` — clean
- [x] `pnpm exec turbo lint --filter=@adopt-dont-shop/service.auth --filter=@adopt-dont-shop/service.gateway` — clean (3 pre-existing warnings in unrelated files, untouched)

## Related

- Refs: ADS-976, ADS-966, ADS-961

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_015F6J4DXQ1Amyth4dwD5Q8P)_