### PR TITLE
fix(security): gateway hardening — error/URL hygiene, event URL validation, HSTS (ADS-972/973/974/977/978/979)

### DIFF
--- a/packages/observability/src/index.ts
+++ b/packages/observability/src/index.ts
@@ -7,7 +7,7 @@ export type { SentryOptions } from './sentry.js';
 export { createLogger } from './logger.js';
 export type { LoggerOptions } from './logger.js';
 
-export { redactSecretFields, REDACTED, SECRET_KEY_PATTERN } from './redact.js';
+export { redactSecretFields, redactUrl, REDACTED, SECRET_KEY_PATTERN } from './redact.js';
 
 export {
   Counter,

--- a/packages/observability/src/redact.test.ts
+++ b/packages/observability/src/redact.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { redactSecretFields, REDACTED } from './redact.js';
+import { redactSecretFields, redactUrl, REDACTED } from './redact.js';
 
 describe('redactSecretFields', () => {
   it('redacts secret-shaped top-level keys regardless of casing or affixes', () => {
@@ -56,5 +56,31 @@ describe('redactSecretFields', () => {
     expect(redactSecretFields(42)).toBe(42);
     expect(redactSecretFields(null)).toBeNull();
     expect(redactSecretFields(undefined)).toBeUndefined();
+  });
+});
+
+describe('redactUrl', () => {
+  it('strips the query string', () => {
+    expect(redactUrl('/api/v1/pets?resetToken=abc123&apiKey=xyz')).toBe('/api/v1/pets');
+  });
+
+  it('leaves a URL with no query string unchanged', () => {
+    expect(redactUrl('/api/v1/pets/123')).toBe('/api/v1/pets/123');
+  });
+
+  it('redacts the secret in a signed-upload-serve path', () => {
+    expect(redactUrl('/uploads-signed/1700000000/abc123signature/foo/bar.png')).toBe(
+      `/uploads-signed/${REDACTED}`
+    );
+  });
+
+  it('redacts a signed-upload path even when it also carries a query string', () => {
+    expect(redactUrl('/uploads-signed/1700000000/abc123signature/foo.png?x=1')).toBe(
+      `/uploads-signed/${REDACTED}`
+    );
+  });
+
+  it('handles a bare path with no leading slash oddities gracefully', () => {
+    expect(redactUrl('/health/simple')).toBe('/health/simple');
   });
 });

--- a/packages/observability/src/redact.ts
+++ b/packages/observability/src/redact.ts
@@ -36,3 +36,28 @@ export const redactSecretFields = (value: unknown): unknown => {
   }
   return value;
 };
+
+// Path segments that carry a secret directly in the URL (not a query
+// param) — the segment immediately after the prefix is replaced with
+// REDACTED rather than the whole path, so the route is still visible in
+// logs. `/uploads-signed/:expiresAt/:signature/*` (services/gateway/src/
+// routes/uploads.ts) puts an HMAC signature at this position.
+const SENSITIVE_PATH_PREFIXES = ['/uploads-signed/'];
+
+// Strips a URL down to something safe to put in a Loki log line:
+//   - the query string is dropped entirely (ADS-972) — redactSecretFields
+//     only redacts by object key, so a token/signature passed as
+//     `?token=...` would otherwise round-trip into logs verbatim.
+//   - known secret-bearing path segments (signed-upload signatures) are
+//     replaced with REDACTED.
+// Method + route pattern are still logged separately by call sites, so
+// this only needs to keep the path segment itself safe.
+export const redactUrl = (url: string): string => {
+  const path = url.split('?')[0] ?? '';
+  for (const prefix of SENSITIVE_PATH_PREFIXES) {
+    if (path.startsWith(prefix)) {
+      return `${prefix}${REDACTED}`;
+    }
+  }
+  return path;
+};

--- a/services/chat/src/grpc/handlers.test.ts
+++ b/services/chat/src/grpc/handlers.test.ts
@@ -367,6 +367,30 @@ describe('openChat', () => {
     });
   });
 
+  // ADS-978: resolveOpenChatRescueId's adopter-initiated branch wraps
+  // listStaffMembers the same way getApplication above is wrapped, so a
+  // downstream failure never surfaces as an opaque INTERNAL with the raw
+  // @grpc/grpc-js message attached.
+  it('maps an UNAVAILABLE from listStaffMembers to a stable INTERNAL message', async () => {
+    stubs.listStaffMembers.mockRejectedValueOnce(
+      Object.assign(new Error('14 UNAVAILABLE: no connection established'), { code: 14 })
+    );
+    await expect(openChat(mocks.deps, ADOPTER_PRINCIPAL, BASE_OPEN)).rejects.toMatchObject({
+      code: 'INTERNAL',
+      message: 'failed to resolve rescue staff',
+    });
+  });
+
+  it('maps a PERMISSION_DENIED from listStaffMembers to a distinct, stable INTERNAL message', async () => {
+    stubs.listStaffMembers.mockRejectedValueOnce(
+      Object.assign(new Error('7 PERMISSION_DENIED: x-principal-token rejected'), { code: 7 })
+    );
+    await expect(openChat(mocks.deps, ADOPTER_PRINCIPAL, BASE_OPEN)).rejects.toMatchObject({
+      code: 'INTERNAL',
+      message: 'failed to resolve rescue staff (auth)',
+    });
+  });
+
   it('treats a response without an application as INVALID_ARGUMENT', async () => {
     stubs.getApplication.mockResolvedValueOnce({ application: undefined, timeline: [] });
     await expect(openChat(mocks.deps, ADOPTER_PRINCIPAL, BASE_OPEN)).rejects.toMatchObject({

--- a/services/chat/src/grpc/handlers.ts
+++ b/services/chat/src/grpc/handlers.ts
@@ -421,7 +421,24 @@ async function resolveOpenChatRescueId(
   }
 
   if (principal.userId === app.adopterId) {
-    const staff = await rescueClient.listStaffMembers({ rescueId: app.rescueId });
+    let staff;
+    try {
+      staff = await rescueClient.listStaffMembers({ rescueId: app.rescueId });
+    } catch (err) {
+      // ADS-978: mirror the getApplication mapping above — an unmapped
+      // failure here (DEADLINE_EXCEEDED under load, UNAVAILABLE, a
+      // signing-key-rotation PERMISSION_DENIED on svc-chat's system
+      // principal) would otherwise surface as an opaque INTERNAL with the
+      // raw @grpc/grpc-js message attached. Both branches stay INTERNAL —
+      // this is an infra fault, not a user-input error — but the message
+      // is stable and distinguishes an auth-token rejection from a plain
+      // availability blip for on-call.
+      const code = (err as { code?: number }).code;
+      if (code === CROSS_SERVICE_GRPC_PERMISSION_DENIED) {
+        throw new HandlerError('INTERNAL', 'failed to resolve rescue staff (auth)');
+      }
+      throw new HandlerError('INTERNAL', 'failed to resolve rescue staff');
+    }
     const isStaff = staff.staffMembers.some(member => member.userId === otherUserId);
     if (!isStaff) {
       throw new HandlerError('INVALID_ARGUMENT', 'other_user_id must be rescue staff');

--- a/services/gateway/src/middleware/grpc-error.test.ts
+++ b/services/gateway/src/middleware/grpc-error.test.ts
@@ -180,6 +180,52 @@ describe('handleGrpcError', () => {
     expect(reply.send).toHaveBeenCalledWith({ error: 'details text' });
   });
 
+  // ── ADS-973: per-code allowlist for 4xx — some codes get a generic
+  // message instead of the forwarded upstream text, because that text can
+  // carry internal identifiers or policy detail not meant for the caller.
+
+  it('sends a generic message for PERMISSION_DENIED, not the upstream details', () => {
+    handleGrpcError(
+      { code: status.PERMISSION_DENIED, details: 'user usr-123 lacks role admin on rescue rsc-9' },
+      reply
+    );
+    expect(reply.code).toHaveBeenCalledWith(403);
+    expect(reply.send).toHaveBeenCalledWith({ error: 'forbidden' });
+  });
+
+  it('sends a generic message for FAILED_PRECONDITION, not the upstream details', () => {
+    handleGrpcError(
+      { code: status.FAILED_PRECONDITION, details: 'row version 4 conflicts with row version 7' },
+      reply
+    );
+    expect(reply.code).toHaveBeenCalledWith(409);
+    expect(reply.send).toHaveBeenCalledWith({ error: 'precondition failed' });
+  });
+
+  it('sends a generic message for UNAUTHENTICATED, not the upstream details', () => {
+    handleGrpcError(
+      { code: status.UNAUTHENTICATED, details: 'signing key rotated at 2026-07-18T00:00:00Z' },
+      reply
+    );
+    expect(reply.code).toHaveBeenCalledWith(401);
+    expect(reply.send).toHaveBeenCalledWith({ error: 'unauthenticated' });
+  });
+
+  it('still forwards detailed messages for INVALID_ARGUMENT', () => {
+    handleGrpcError({ code: status.INVALID_ARGUMENT, details: 'email is required' }, reply);
+    expect(reply.send).toHaveBeenCalledWith({ error: 'email is required' });
+  });
+
+  it('still forwards detailed messages for NOT_FOUND', () => {
+    handleGrpcError({ code: status.NOT_FOUND, details: 'pet pet-42 not found' }, reply);
+    expect(reply.send).toHaveBeenCalledWith({ error: 'pet pet-42 not found' });
+  });
+
+  it('still forwards detailed messages for ALREADY_EXISTS', () => {
+    handleGrpcError({ code: status.ALREADY_EXISTS, details: 'email already registered' }, reply);
+    expect(reply.send).toHaveBeenCalledWith({ error: 'email already registered' });
+  });
+
   // ── Return value ───────────────────────────────────────────────────────────
 
   it('returns the FastifyReply instance', () => {

--- a/services/gateway/src/middleware/grpc-error.ts
+++ b/services/gateway/src/middleware/grpc-error.ts
@@ -48,6 +48,22 @@ const GENERIC_5XX_MESSAGE: Record<number, string> = {
   504: 'gateway_timeout',
 };
 
+// ADS-973: forwarding upstream `details`/`message` verbatim for every 4xx
+// assumed every downstream service is disciplined about what it puts in a
+// 4xx message — no test enforced that, and some services echo untrusted
+// input into error strings. Per-code allowlist instead:
+//   INVALID_ARGUMENT, NOT_FOUND, ALREADY_EXISTS — validation / business-logic
+//   errors that are meant for the caller, so the upstream text is forwarded.
+//   PERMISSION_DENIED, FAILED_PRECONDITION, UNAUTHENTICATED — may echo
+//   internal identifiers or policy detail, so a generic message is sent
+//   instead; the upstream text is still available server-side (whatever
+//   logged the original error), never in the HTTP response.
+const GENERIC_4XX_MESSAGE: Record<number, string> = {
+  [status.PERMISSION_DENIED]: 'forbidden',
+  [status.FAILED_PRECONDITION]: 'precondition failed',
+  [status.UNAUTHENTICATED]: 'unauthenticated',
+};
+
 export const handleGrpcError = (err: unknown, reply: FastifyReply): FastifyReply => {
   const grpcErr = err as GrpcError;
   const httpStatus = (grpcErr?.code !== undefined && GRPC_TO_HTTP[grpcErr.code]) || 500;
@@ -55,6 +71,11 @@ export const handleGrpcError = (err: unknown, reply: FastifyReply): FastifyReply
     return reply
       .code(httpStatus)
       .send({ error: GENERIC_5XX_MESSAGE[httpStatus] ?? 'internal_error' });
+  }
+  const genericMessage =
+    grpcErr?.code !== undefined ? GENERIC_4XX_MESSAGE[grpcErr.code] : undefined;
+  if (genericMessage) {
+    return reply.code(httpStatus).send({ error: genericMessage });
   }
   return reply.code(httpStatus).send({
     error: grpcErr?.details ?? grpcErr?.message ?? 'internal_error',

--- a/services/gateway/src/routes/audit.test.ts
+++ b/services/gateway/src/routes/audit.test.ts
@@ -136,11 +136,11 @@ describe('GET /api/v1/audit', () => {
   });
 
   it.each([
-    [grpcStatus.PERMISSION_DENIED, 403],
-    [grpcStatus.INVALID_ARGUMENT, 400],
-    [grpcStatus.UNAUTHENTICATED, 401],
-    [grpcStatus.INTERNAL, 500],
-  ])('maps gRPC code %i to HTTP %i', async (gCode, httpCode) => {
+    [grpcStatus.PERMISSION_DENIED, 403, 'forbidden'],
+    [grpcStatus.INVALID_ARGUMENT, 400, 'test'],
+    [grpcStatus.UNAUTHENTICATED, 401, 'unauthenticated'],
+    [grpcStatus.INTERNAL, 500, 'internal_error'],
+  ])('maps gRPC code %i to HTTP %i', async (gCode, httpCode, expectedError) => {
     queryMock.mockRejectedValue({ code: gCode, details: 'test' });
 
     const httpRes = await app.inject({
@@ -150,11 +150,11 @@ describe('GET /api/v1/audit', () => {
     });
 
     expect(httpRes.statusCode).toBe(httpCode);
-    // 4xx codes echo the upstream detail; 5xx are sanitised so internal
-    // text never reaches the client.
-    expect(httpRes.json()).toMatchObject({
-      error: httpCode >= 500 ? 'internal_error' : 'test',
-    });
+    // INVALID_ARGUMENT echoes the upstream detail (validation error, meant
+    // for the caller); PERMISSION_DENIED/UNAUTHENTICATED get a generic
+    // message (ADS-973) and 5xx are sanitised — internal text never
+    // reaches the client either way.
+    expect(httpRes.json()).toMatchObject({ error: expectedError });
   });
 });
 

--- a/services/gateway/src/routes/auth.test.ts
+++ b/services/gateway/src/routes/auth.test.ts
@@ -222,7 +222,9 @@ describe('POST /api/v1/auth/login', () => {
       payload: { email: 'alex@example.com', password: 'wrong' },
     });
     expect(res.statusCode).toBe(401);
-    expect(res.json()).toEqual({ error: 'invalid credentials' });
+    // ADS-973: UNAUTHENTICATED gets a generic message, not the forwarded
+    // upstream detail — it may echo internal auth-service policy text.
+    expect(res.json()).toEqual({ error: 'unauthenticated' });
   });
 
   it('maps INVALID_ARGUMENT → 400 on missing email', async () => {
@@ -489,7 +491,9 @@ describe('POST /api/v1/auth/assign-role', () => {
       payload: { targetUserId: 'usr-1', role: 'admin' },
     });
     expect(res.statusCode).toBe(403);
-    expect(res.json()).toEqual({ error: 'admin.security.manage required' });
+    // ADS-973: PERMISSION_DENIED gets a generic message, not the forwarded
+    // upstream detail — it may echo internal permission-name detail.
+    expect(res.json()).toEqual({ error: 'forbidden' });
   });
 });
 

--- a/services/gateway/src/routes/events.schemas.ts
+++ b/services/gateway/src/routes/events.schemas.ts
@@ -27,12 +27,78 @@ const pickRaw = (body: Record<string, unknown>, keys: readonly string[]): unknow
 const EventTypeEnum = z.enum(['adoption', 'fundraising', 'volunteer', 'community']);
 const EventStatusEnum = z.enum(['draft', 'published', 'in_progress', 'completed', 'cancelled']);
 
+// ADS-979 / ADS-930: imageUrl (and virtualLink below) previously accepted
+// any string up to 2048 chars, including `javascript:`/`data:` schemes.
+// imageUrl mirrors assertValidDocumentUrl in
+// services/applications/src/grpc/document-handlers.ts — a same-origin
+// relative path (the local-storage dev/CI shape), or an https URL on the
+// platform's own storage/CDN host. The host allowlist tracks the same env
+// vars packages/storage's S3 provider uses to build public URLs.
+function allowedImageHosts(env: NodeJS.ProcessEnv = process.env): Set<string> {
+  const hosts = new Set<string>();
+  const cloudFrontDomain = env.CLOUDFRONT_DOMAIN?.trim();
+  if (cloudFrontDomain) {
+    hosts.add(cloudFrontDomain);
+  }
+  const bucket = env.S3_BUCKET_NAME?.trim();
+  if (bucket) {
+    const region = env.S3_REGION?.trim() || 'us-east-1';
+    hosts.add(`${bucket}.s3.${region}.amazonaws.com`);
+  }
+  return hosts;
+}
+
+const isSafeImageUrl = (value: string): boolean => {
+  if (value === '') {
+    return true;
+  }
+  // `//host/...` is protocol-relative — browsers resolve it off-origin, so
+  // it's excluded from the same-origin relative-path allowance below.
+  if (value.startsWith('/') && !value.startsWith('//')) {
+    return true;
+  }
+  let parsed: URL;
+  try {
+    parsed = new URL(value);
+  } catch {
+    return false;
+  }
+  return parsed.protocol === 'https:' && allowedImageHosts().has(parsed.host);
+};
+
+const imageUrlSchema = z
+  .string()
+  .max(2048)
+  .refine(isSafeImageUrl, { message: 'must be a same-origin path or https platform URL' });
+
+// virtualLink holds third-party meeting URLs (Zoom / Meet / Teams), which
+// aren't platform storage, so — unlike imageUrl — it isn't restricted to
+// the storage host allowlist. It must still be a well-formed https:// URL,
+// which rejects javascript:, data:, and protocol-relative //host schemes.
+const isSafeVirtualLink = (value: string): boolean => {
+  if (value === '') {
+    return true;
+  }
+  let parsed: URL;
+  try {
+    parsed = new URL(value);
+  } catch {
+    return false;
+  }
+  return parsed.protocol === 'https:';
+};
+
+const virtualLinkSchema = z
+  .string()
+  .max(2048)
+  .refine(isSafeVirtualLink, { message: 'must be an https:// URL' });
+
 const EventLocationSchema = z.object({
   type: z.string().min(1),
   address: z.string().max(500).optional(),
   city: z.string().max(100).optional(),
   postcode: z.string().max(16).optional(),
-  virtualLink: z.string().max(2048).optional(),
+  virtualLink: virtualLinkSchema.optional(),
   venue: z.string().max(256).optional(),
 });
 
@@ -48,7 +114,7 @@ export const CreateEventBodySchema = z.object({
   featuredPets: z.array(z.string().uuid()).default([]),
   assignedStaff: z.array(z.string().uuid()).default([]),
   isPublic: z.boolean().default(true),
-  imageUrl: z.string().max(2048).optional(),
+  imageUrl: imageUrlSchema.optional(),
 });
 
 export type CreateEventBody = z.infer<typeof CreateEventBodySchema>;
@@ -82,7 +148,7 @@ export const UpdateEventBodySchema = z.object({
   featuredPets: z.array(z.string().uuid()).optional(),
   assignedStaff: z.array(z.string().uuid()).optional(),
   isPublic: z.boolean().optional(),
-  imageUrl: z.string().max(2048).optional(),
+  imageUrl: imageUrlSchema.optional(),
   status: EventStatusEnum.optional(),
 });
 

--- a/services/gateway/src/routes/events.test.ts
+++ b/services/gateway/src/routes/events.test.ts
@@ -153,7 +153,7 @@ describe('POST /api/v1/events', () => {
           featured_pets: [],
           assigned_staff: [],
           is_public: false,
-          image_url: 'https://example.com/img.png',
+          image_url: '/uploads/events/img.png',
         },
       });
       expect(res.statusCode).toBe(201);
@@ -163,7 +163,140 @@ describe('POST /api/v1/events', () => {
       expect(grpcArg.endDate).toBe('2026-09-01T15:00:00Z');
       expect(grpcArg.registrationRequired).toBe(false);
       expect(grpcArg.isPublic).toBe(false);
-      expect(grpcArg.imageUrl).toBe('https://example.com/img.png');
+      expect(grpcArg.imageUrl).toBe('/uploads/events/img.png');
+    } finally {
+      await app.close();
+    }
+  });
+
+  // ADS-979: imageUrl/virtualLink previously accepted any string up to
+  // 2048 chars, including javascript:/data: schemes. They now run through
+  // the same URL-boundary validation ADS-930 added for document URLs.
+  it('rejects a javascript: imageUrl with 400 and does not call gRPC', async () => {
+    const { client, createEventMock } = makeClient();
+    const app = await makeApp(client);
+    try {
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/v1/events',
+        payload: {
+          name: 'Test',
+          startDate: '2026-08-01T10:00:00Z',
+          endDate: '2026-08-01T16:00:00Z',
+          imageUrl: 'javascript:alert(1)',
+        },
+      });
+      expect(res.statusCode).toBe(400);
+      expect(createEventMock).not.toHaveBeenCalled();
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('rejects a javascript: virtualLink with 400 and does not call gRPC', async () => {
+    const { client, createEventMock } = makeClient();
+    const app = await makeApp(client);
+    try {
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/v1/events',
+        payload: {
+          name: 'Test',
+          startDate: '2026-08-01T10:00:00Z',
+          endDate: '2026-08-01T16:00:00Z',
+          location: { type: 'virtual', virtualLink: "javascript:fetch('https://x/y')" },
+        },
+      });
+      expect(res.statusCode).toBe(400);
+      expect(createEventMock).not.toHaveBeenCalled();
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('rejects a plain http:// imageUrl on an allowlisted host with 400 (https only)', async () => {
+    const { client, createEventMock } = makeClient();
+    const app = await makeApp(client);
+    try {
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/v1/events',
+        payload: {
+          name: 'Test',
+          startDate: '2026-08-01T10:00:00Z',
+          endDate: '2026-08-01T16:00:00Z',
+          imageUrl: 'http://cdn.example.com/img.png',
+        },
+      });
+      expect(res.statusCode).toBe(400);
+      expect(createEventMock).not.toHaveBeenCalled();
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('rejects an imageUrl on a non-allowlisted https host with 400', async () => {
+    const { client, createEventMock } = makeClient();
+    const app = await makeApp(client);
+    try {
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/v1/events',
+        payload: {
+          name: 'Test',
+          startDate: '2026-08-01T10:00:00Z',
+          endDate: '2026-08-01T16:00:00Z',
+          imageUrl: 'https://attacker.example/img.png',
+        },
+      });
+      expect(res.statusCode).toBe(400);
+      expect(createEventMock).not.toHaveBeenCalled();
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('accepts a same-origin relative imageUrl', async () => {
+    const { client, createEventMock } = makeClient();
+    const app = await makeApp(client);
+    try {
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/v1/events',
+        payload: {
+          name: 'Test',
+          startDate: '2026-08-01T10:00:00Z',
+          endDate: '2026-08-01T16:00:00Z',
+          imageUrl: '/uploads/events/foo.jpg',
+        },
+      });
+      expect(res.statusCode).toBe(201);
+      expect(createEventMock).toHaveBeenCalledOnce();
+      expect(createEventMock.mock.calls[0][0].imageUrl).toBe('/uploads/events/foo.jpg');
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('accepts an https:// virtualLink to a third-party meeting host (not restricted to the storage allowlist)', async () => {
+    const { client, createEventMock } = makeClient();
+    const app = await makeApp(client);
+    try {
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/v1/events',
+        payload: {
+          name: 'Test',
+          startDate: '2026-08-01T10:00:00Z',
+          endDate: '2026-08-01T16:00:00Z',
+          location: { type: 'virtual', virtualLink: 'https://zoom.us/j/123456789' },
+        },
+      });
+      expect(res.statusCode).toBe(201);
+      expect(createEventMock).toHaveBeenCalledOnce();
+      expect(createEventMock.mock.calls[0][0].location.virtualLink).toBe(
+        'https://zoom.us/j/123456789'
+      );
     } finally {
       await app.close();
     }

--- a/services/gateway/src/routes/matching.test.ts
+++ b/services/gateway/src/routes/matching.test.ts
@@ -183,11 +183,11 @@ describe('POST /api/v1/matching/sessions', () => {
   });
 
   it.each([
-    [grpcStatus.INVALID_ARGUMENT, 400],
-    [grpcStatus.UNAUTHENTICATED, 401],
-    [grpcStatus.PERMISSION_DENIED, 403],
-    [grpcStatus.INTERNAL, 500],
-  ])('maps gRPC code %i to HTTP %i', async (gCode, httpCode) => {
+    [grpcStatus.INVALID_ARGUMENT, 400, 'oops'],
+    [grpcStatus.UNAUTHENTICATED, 401, 'unauthenticated'],
+    [grpcStatus.PERMISSION_DENIED, 403, 'forbidden'],
+    [grpcStatus.INTERNAL, 500, 'internal_error'],
+  ])('maps gRPC code %i to HTTP %i', async (gCode, httpCode, expectedError) => {
     startSessionMock.mockRejectedValue({ code: gCode, details: 'oops' });
 
     const httpRes = await app.inject({
@@ -198,11 +198,11 @@ describe('POST /api/v1/matching/sessions', () => {
     });
 
     expect(httpRes.statusCode).toBe(httpCode);
-    // 4xx codes echo the upstream detail; 5xx are sanitised so internal
-    // text never reaches the client.
-    expect(httpRes.json()).toMatchObject({
-      error: httpCode >= 500 ? 'internal_error' : 'oops',
-    });
+    // INVALID_ARGUMENT echoes the upstream detail (validation error, meant
+    // for the caller); PERMISSION_DENIED/UNAUTHENTICATED get a generic
+    // message (ADS-973) and 5xx are sanitised — internal text never
+    // reaches the client either way.
+    expect(httpRes.json()).toMatchObject({ error: expectedError });
   });
 });
 

--- a/services/gateway/src/routes/reports.test.ts
+++ b/services/gateway/src/routes/reports.test.ts
@@ -448,8 +448,36 @@ describe('/api/v1/reports gateway routes', () => {
     expect(ok.data).toEqual([{ date: '2026-01-01', count: 5 }]);
     expect(failed.id).toBe('w-fail');
     expect(failed.status).toBe('error');
-    expect(failed.error).toBe('service unavailable');
+    // ADS-977: the client only ever sees a fixed, caller-safe string — the
+    // raw downstream error message stays server-side (in the log).
+    expect(failed.error).toBe('Aggregation unavailable');
     expect(failed.data).toEqual([]);
+  });
+
+  it('POST /execute never leaks a raw downstream error message to the client', async () => {
+    petsMocks.getAdoptionTrend.mockResolvedValue({
+      points: [{ date: '2026-01-01', count: 5 }],
+    });
+    applicationsMocks.getStats.mockRejectedValue(
+      new Error('13 INTERNAL: relation "public.users" does not exist')
+    );
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/v1/reports/execute',
+      headers: ADMIN_HEADERS,
+      payload: {
+        config: {
+          filters: {},
+          widgets: [{ id: 'w-fail', metric: 'application', chartType: 'bar', options: {} }],
+        },
+      },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.body).not.toContain('relation');
+    expect(res.body).not.toContain('public.users');
+    const body = res.json() as { data: { widgets: Array<{ status: string; error?: string }> } };
+    expect(body.data.widgets[0].status).toBe('error');
+    expect(body.data.widgets[0].error).toBe('Aggregation unavailable');
   });
 
   // ── execute (saved) ──────────────────────────────────────────────────

--- a/services/gateway/src/routes/reports.ts
+++ b/services/gateway/src/routes/reports.ts
@@ -366,6 +366,11 @@ async function executeConfig(
     const metric = typeof widget?.metric === 'string' ? widget.metric : '';
     const errorMessage =
       result.reason instanceof Error ? result.reason.message : String(result.reason ?? 'unknown');
+    // ADS-977: the full message (which can carry SQL fragments, table/DNS
+    // names, or gRPC status text) stays server-side in the log, correlated
+    // by widgetId/metric. The client only ever sees a fixed, caller-safe
+    // string — the SPA treats status:'error' as the render trigger, so the
+    // text itself is cosmetic and doesn't need to be specific.
     log.error({ widgetId, metric, error: errorMessage }, 'Widget aggregation failed');
     return {
       id: widgetId,
@@ -376,7 +381,7 @@ async function executeConfig(
         computedAt: new Date().toISOString(),
       },
       status: 'error',
-      error: errorMessage,
+      error: 'Aggregation unavailable',
     };
   });
   return {

--- a/services/gateway/src/server.test.ts
+++ b/services/gateway/src/server.test.ts
@@ -1,5 +1,5 @@
 import { type FastifyInstance } from 'fastify';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { GatewayConfig } from './config.js';
 import { createServer } from './server.js';
@@ -101,6 +101,64 @@ describe('createServer — /api/* fallback', () => {
     const res = await server.inject({ method: 'GET', url: '/health/simple' });
     expect(res.statusCode).toBe(200);
     expect(res.json()).toMatchObject({ service: 'service.gateway' });
+  });
+
+  // ADS-972: the unmatched-route warn log must not carry a query string —
+  // future routes could put a token/signature there, and redactSecretFields
+  // only redacts by object key, not by scanning string values.
+  it('logs the unmatched-route warn without the query string', async () => {
+    const warn = vi.fn();
+    server = await createServer({
+      config: baseConfig,
+      logger: { ...quietLogger, warn } as unknown as typeof quietLogger,
+    });
+    await server.inject({
+      method: 'GET',
+      url: '/api/some/unknown/path?resetToken=super-secret',
+    });
+    expect(warn).toHaveBeenCalledWith(
+      'unmatched API route',
+      expect.objectContaining({ url: '/api/some/unknown/path' })
+    );
+    // warn.mock.calls[0] isn't necessarily this call — boot logs its own
+    // warnings (e.g. "REDIS_URL not set") before any request is injected.
+    const call = warn.mock.calls.find(c => c[0] === 'unmatched API route') as [
+      string,
+      { url: string },
+    ];
+    expect(call[1].url).not.toContain('super-secret');
+  });
+});
+
+// ADS-972: the global error handler's 'request failed' log must not carry a
+// query string either — same reasoning as the unmatched-route warn above.
+describe('createServer — error handler URL logging', () => {
+  let server: FastifyInstance;
+  afterEach(async () => {
+    await server?.close();
+  });
+
+  it('logs the request-failed error without the query string', async () => {
+    const error = vi.fn();
+    server = await createServer({
+      config: baseConfig,
+      logger: { ...quietLogger, error } as unknown as typeof quietLogger,
+    });
+    // Malformed JSON body triggers Fastify's default JSON body parser to
+    // throw before the route handler runs, which lands in setErrorHandler.
+    const res = await server.inject({
+      method: 'POST',
+      url: '/api/some/path?resetToken=super-secret',
+      headers: { 'content-type': 'application/json' },
+      payload: 'not-json',
+    });
+    expect(res.statusCode).toBe(400);
+    expect(error).toHaveBeenCalledWith(
+      'request failed',
+      expect.objectContaining({ url: '/api/some/path' })
+    );
+    const [, meta] = error.mock.calls[0] as [string, { url: string }];
+    expect(meta.url).not.toContain('super-secret');
   });
 });
 
@@ -624,6 +682,18 @@ describe('createServer — security headers (Helmet)', () => {
   it('sets x-frame-options on responses', async () => {
     const res = await server.inject({ method: 'GET', url: '/health/simple' });
     expect(res.headers['x-frame-options']).toBeDefined();
+  });
+
+  // ADS-974: Helmet's HSTS default (180 days) conflicts with prod nginx's
+  // 2-year preload-eligible value — since nginx's `add_header ... always`
+  // merges with rather than replaces an upstream HSTS header, a gateway-
+  // direct response must already carry the same value nginx sends, so the
+  // two never disagree.
+  it('sets a single HSTS header matching nginx (2y, includeSubDomains, preload)', async () => {
+    const res = await server.inject({ method: 'GET', url: '/health/simple' });
+    expect(res.headers['strict-transport-security']).toBe(
+      'max-age=63072000; includeSubDomains; preload'
+    );
   });
 });
 

--- a/services/gateway/src/server.ts
+++ b/services/gateway/src/server.ts
@@ -26,6 +26,7 @@
 import {
   createLogger,
   getMetricsRegistry,
+  redactUrl,
   registerMetrics,
   registerRequestId,
 } from '@adopt-dont-shop/observability';
@@ -219,9 +220,13 @@ export const createServer = async (opts: CreateServerOptions): Promise<FastifyIn
   // in this thin pass-through phase. Per-route logging arrives when
   // we add real routes in Phase 1+.
   server.setErrorHandler((err: Error & { statusCode?: number }, req, reply) => {
+    // ADS-972: log only the path, not the full req.url — a query string or
+    // signed-URL path segment (e.g. /uploads-signed/*) can carry a secret,
+    // and redactSecretFields only redacts by object key, not by scanning
+    // string values for embedded tokens.
     logger.error('request failed', {
       method: req.method,
-      url: req.url,
+      url: redactUrl(req.url),
       message: err.message,
     });
     void reply.status(err.statusCode ?? 500).send({ error: 'internal_error' });
@@ -231,7 +236,20 @@ export const createServer = async (opts: CreateServerOptions): Promise<FastifyIn
   // here because nginx enforces a strict policy at the edge and Swagger
   // UI requires 'unsafe-inline' relaxation that would weaken that policy
   // for gateway-direct callers. All other Helmet defaults are applied.
-  await server.register(helmet, { contentSecurityPolicy: false });
+  //
+  // ADS-974: Helmet's HSTS default is max-age=15552000 (180 days), but
+  // prod nginx (deploy/gateway/nginx.conf) sends max-age=63072000 (2y)
+  // with includeSubDomains + preload. nginx's `add_header ... always`
+  // merges with — does not replace — an upstream header of the same
+  // name, so a browser behind nginx would see two conflicting HSTS
+  // headers. Matching nginx's value here means the header is still
+  // correct on any path that bypasses nginx (internal LB, gateway-direct
+  // debug runs), and a browser hitting nginx sees a single, consistent
+  // value either way (both headers now agree).
+  await server.register(helmet, {
+    contentSecurityPolicy: false,
+    strictTransportSecurity: { maxAge: 63072000, includeSubDomains: true, preload: true },
+  });
 
   // CORS — explicit allowed-origins list from config. nginx also handles
   // CORS at the edge; this layer protects direct-gateway scenarios
@@ -710,7 +728,9 @@ export const createServer = async (opts: CreateServerOptions): Promise<FastifyIn
   // calling a path that doesn't exist. Without this line the failure is
   // invisible in the logs (Fastify's own request logging is disabled).
   const apiNotFound = async (req: FastifyRequest, reply: FastifyReply) => {
-    logger.warn('unmatched API route', { method: req.method, url: req.url });
+    // ADS-972: strip query string / signed-URL secrets before logging — see
+    // the setErrorHandler comment above for why req.url isn't safe verbatim.
+    logger.warn('unmatched API route', { method: req.method, url: redactUrl(req.url) });
     return reply.code(404).send({ error: 'not_found' });
   };
   server.get('/api/*', apiNotFound);


### PR DESCRIPTION
<!-- Before opening: make sure you've read CONTRIBUTING.md and that all CI checks pass. -->

## Summary

- Security hardening batch across `service.gateway` and `service.chat`: stop leaking secrets/internal errors into logs and client responses, close a URL-validation gap on event routes, and align the gateway's HSTS header with nginx's.
- Six Linear tickets, one commit each (ADS-972 and ADS-974 share `server.ts` so they're combined into a single commit).

## Changes

- **ADS-972** — `services/gateway/src/server.ts` logged `req.url` verbatim in the error handler and the unmatched-route 404 warn, which would leak a query-string secret or a signed-upload-serve path signature to Loki. Added `redactUrl()` to `packages/observability/src/redact.ts` (strips the query string, redacts `/uploads-signed/*` path secrets) and wired it into both call sites.
- **ADS-973** — `services/gateway/src/middleware/grpc-error.ts`'s `handleGrpcError` forwarded every downstream gRPC 4xx `details`/`message` verbatim. Added a per-code allowlist: `INVALID_ARGUMENT`/`NOT_FOUND`/`ALREADY_EXISTS` still forward upstream text (validation errors meant for the caller); `PERMISSION_DENIED`/`FAILED_PRECONDITION`/`UNAUTHENTICATED` now return a fixed generic message. Updated the handful of route tests (`audit.test.ts`, `auth.test.ts`, `matching.test.ts`) that asserted the old forwarding behaviour for those three codes.
- **ADS-977** — `services/gateway/src/routes/reports.ts`'s `POST /api/v1/reports/execute` put the raw downstream error message (SQL fragments, service DNS names, gRPC status text) into the per-widget `error` field. The full message still goes to the server-side log (correlated by widgetId/metric); the client now only sees a fixed `'Aggregation unavailable'` string.
- **ADS-978** — `services/chat/src/grpc/handlers.ts`'s `resolveOpenChatRescueId` wrapped `applicationsClient.getApplication` errors but not `rescueClient.listStaffMembers`, so a downstream failure surfaced as an opaque `INTERNAL` with the raw gRPC message attached. Wrapped `listStaffMembers` the same way, mapping `PERMISSION_DENIED` and everything else to stable `INTERNAL` messages that distinguish an auth-token rejection from a plain availability blip.
- **ADS-979** — `services/gateway/src/routes/events.schemas.ts`'s `imageUrl` and `virtualLink` accepted any string up to 2048 chars, including `javascript:`/`data:` schemes. `imageUrl` now mirrors the ADS-930 `assertValidDocumentUrl` pattern (same-origin relative path, or https on the platform storage/CDN host allowlist); `virtualLink` (third-party meeting URLs) is only required to be a well-formed `https://` URL.
- **ADS-974** — `services/gateway/src/server.ts` registered `@fastify/helmet` with default HSTS (180 days), which conflicted with prod nginx's 2-year preload-eligible value — nginx's `add_header ... always` merges with rather than replaces an upstream header of the same name, so a browser behind nginx would see two disagreeing HSTS headers. Configured Helmet's `strictTransportSecurity` to match nginx (`max-age=63072000; includeSubDomains; preload`).

## Before requesting review

- [x] Ran the targeted verification below locally
- [x] Tests for new behaviour added (TDD)
- [ ] If touching `.env` requirements, updated `.env.example`'s REQUIRED block — N/A, no new env vars
- [ ] If touching a `lib.*`, considered consumer impact across `app.*` and `service.backend` — N/A, no `lib.*` changes

## Test plan

- [x] `pnpm exec turbo test lint type-check --filter=@adopt-dont-shop/service.gateway --filter=@adopt-dont-shop/service.chat` — all 16 tasks pass (1035 gateway tests, 155 chat tests)
- [x] `pnpm exec turbo test lint type-check --filter=@adopt-dont-shop/observability` — all 3 tasks pass (45 tests)
- [x] New behaviour is covered by tests (see per-ticket commits)
- [ ] Tested manually — not run; this is a backend-only security batch verified via the test suites above
- [x] No TypeScript errors
- [x] Lint passes

## Related

- ADS-972, ADS-973, ADS-974, ADS-977, ADS-978, ADS-979 (Linear, team AdoptDontShop)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_015F6J4DXQ1Amyth4dwD5Q8P)_