### PR TITLE
chore(test): consolidate vitest configs + workspace coverage wiring (ADS-991/985/986/908/944)

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -11,7 +11,10 @@
   "typescript.tsdk": "node_modules/typescript/lib",
   "typescript.enablePromptUseWorkspaceTsdk": true,
   "vitest.workspaceConfig": "./vitest.workspace.ts",
-  "vitest.maximumConfigs": 30,
+  // ADS-986: workspace now globs lib.* + app.* + services/* (24 + 3 + 11 = 38
+  // configs) — raised from 30 so the Vitest extension doesn't silently drop
+  // packages past its default cap.
+  "vitest.maximumConfigs": 40,
   "eslint.workingDirectories": [
     { "pattern": "apps/*" },
     { "pattern": "packages/*" },

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -193,6 +193,8 @@ A repo-root `.editorconfig` enforces 2-space indent, LF line endings, UTF-8, fin
 
 Every package uses **Vitest** (`vitest run`). The React apps and `lib.components` add React Testing Library on top. Use the `pnpm test` / `pnpm test:watch` / `pnpm test:coverage` scripts defined in each package.
 
+The tightest inner loop is `pnpm --filter <pkg> test:watch` — run it from the repo root, scoped to the package you're editing (e.g. `pnpm --filter @adopt-dont-shop/lib.api test:watch`). The root `pnpm test:watch` / `pnpm test:changed` scripts (ADS-944) exist for discoverability and repo-wide use, but for a single package `--filter` is still preferred.
+
 Tests must cover **behaviour**, not implementation. 100% coverage is expected but tests must always be grounded in business requirements, not internal structure.
 
 ### Test layout

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -253,6 +253,11 @@ A scheduled/`main` CI job can then re-run the ratchet and open a follow-up PR.
 `thresholds` block in its own `vitest.config.ts` with a comment linking the
 tracking ticket. The override always wins over the shared baseline.
 
+**Cache invalidation (ADS-908):** `turbo.json` lists `coverage-thresholds.json`
+as an input for the `test` and `test:coverage` tasks, so committing a ratcheted
+threshold busts the Turbo cache for every package on the next run — a warm
+cache from before the bump can't hide a newly-failing threshold.
+
 ## Reporting bugs / proposing features
 
 Use the issue templates in [`.github/ISSUE_TEMPLATE/`](./.github/ISSUE_TEMPLATE/):

--- a/README.md
+++ b/README.md
@@ -130,6 +130,8 @@ pnpm build                    # build everything (Turbo handles ordering)
 pnpm build:libs               # libraries only
 pnpm build:apps               # apps only
 pnpm test                     # all tests
+pnpm test:watch               # Vitest watch mode (pass --filter for one package)
+pnpm test:changed             # Vitest --changed mode against your git diff
 pnpm lint / lint:fix
 pnpm type-check
 pnpm format / format:check

--- a/apps/rescue/src/pages/RescueSettings.test.tsx
+++ b/apps/rescue/src/pages/RescueSettings.test.tsx
@@ -65,45 +65,45 @@ const renderWithRoute = (initialRoute: string) =>
 
 const waitForTabsToLoad = () =>
   waitFor(() => {
-    expect(screen.getByRole('button', { name: /rescue profile/i })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: /rescue profile/i })).toBeInTheDocument();
   });
 
 describe('RescueSettings tab persistence via URL hash', () => {
   it('defaults to profile tab when no hash is present', async () => {
     renderWithRoute('/settings');
     await waitForTabsToLoad();
-    const profileButton = screen.getByRole('button', { name: /rescue profile/i });
-    expect(profileButton.className).toContain('tabActive');
+    const profileButton = screen.getByRole('tab', { name: /rescue profile/i });
+    expect(profileButton).toHaveAttribute('aria-selected', 'true');
   });
 
   it('restores the security tab from #security hash', async () => {
     renderWithRoute('/settings#security');
     await waitForTabsToLoad();
-    const securityButton = screen.getByRole('button', { name: /^security$/i });
-    expect(securityButton.className).toContain('tabActive');
+    const securityButton = screen.getByRole('tab', { name: /^security$/i });
+    expect(securityButton).toHaveAttribute('aria-selected', 'true');
   });
 
   it('restores the appearance tab from #appearance hash', async () => {
     renderWithRoute('/settings#appearance');
     await waitForTabsToLoad();
-    const appearanceButton = screen.getByRole('button', { name: /appearance/i });
-    expect(appearanceButton.className).toContain('tabActive');
+    const appearanceButton = screen.getByRole('tab', { name: /appearance/i });
+    expect(appearanceButton).toHaveAttribute('aria-selected', 'true');
   });
 
   it('falls back to profile for invalid hash values', async () => {
     renderWithRoute('/settings#nonexistent');
     await waitForTabsToLoad();
-    const profileButton = screen.getByRole('button', { name: /rescue profile/i });
-    expect(profileButton.className).toContain('tabActive');
+    const profileButton = screen.getByRole('tab', { name: /rescue profile/i });
+    expect(profileButton).toHaveAttribute('aria-selected', 'true');
   });
 
   it('switches tab when a tab button is clicked', async () => {
     renderWithRoute('/settings');
     await waitForTabsToLoad();
-    fireEvent.click(screen.getByRole('button', { name: /adoption policies/i }));
+    fireEvent.click(screen.getByRole('tab', { name: /adoption policies/i }));
     // Navigate triggers re-render; wait for tabs to re-appear
     await waitForTabsToLoad();
-    const policiesButton = screen.getByRole('button', { name: /adoption policies/i });
-    expect(policiesButton.className).toContain('tabActive');
+    const policiesButton = screen.getByRole('tab', { name: /adoption policies/i });
+    expect(policiesButton).toHaveAttribute('aria-selected', 'true');
   });
 });

--- a/apps/rescue/src/pages/RescueSettings.tsx
+++ b/apps/rescue/src/pages/RescueSettings.tsx
@@ -214,39 +214,51 @@ const RescueSettings: React.FC = () => {
       </div>
 
       <div className={styles.tabContainer}>
-        <div className={styles.tabList}>
+        <div className={styles.tabList} role="tablist">
           <button
             className={clsx(styles.tab, activeTab === 'profile' && styles.tabActive)}
+            role="tab"
+            aria-selected={activeTab === 'profile'}
             onClick={() => setActiveTab('profile')}
           >
             Rescue Profile
           </button>
           <button
             className={clsx(styles.tab, activeTab === 'policies' && styles.tabActive)}
+            role="tab"
+            aria-selected={activeTab === 'policies'}
             onClick={() => setActiveTab('policies')}
           >
             Adoption Policies
           </button>
           <button
             className={clsx(styles.tab, activeTab === 'questions' && styles.tabActive)}
+            role="tab"
+            aria-selected={activeTab === 'questions'}
             onClick={() => setActiveTab('questions')}
           >
             Application Questions
           </button>
           <button
             className={clsx(styles.tab, activeTab === 'preferences' && styles.tabActive)}
+            role="tab"
+            aria-selected={activeTab === 'preferences'}
             onClick={() => setActiveTab('preferences')}
           >
             Preferences
           </button>
           <button
             className={clsx(styles.tab, activeTab === 'security' && styles.tabActive)}
+            role="tab"
+            aria-selected={activeTab === 'security'}
             onClick={() => setActiveTab('security')}
           >
             Security
           </button>
           <button
             className={clsx(styles.tab, activeTab === 'appearance' && styles.tabActive)}
+            role="tab"
+            aria-selected={activeTab === 'appearance'}
             onClick={() => setActiveTab('appearance')}
           >
             Appearance

--- a/apps/rescue/vitest.config.ts
+++ b/apps/rescue/vitest.config.ts
@@ -1,8 +1,7 @@
-import { vanillaExtractPlugin } from '@vanilla-extract/vite-plugin';
 import react from '@vitejs/plugin-react';
 import path from 'path';
 import { defineConfig } from 'vitest/config';
-import { getLibraryAliases } from '../../vite.shared.config';
+import { getLibraryAliases, veCssMock } from '../../vite.shared.config';
 
 export default defineConfig({
   plugins: [
@@ -11,7 +10,7 @@ export default defineConfig({
         plugins: [['babel-plugin-react-compiler', { compilationMode: 'annotation' }]],
       },
     }),
-    vanillaExtractPlugin(),
+    veCssMock,
   ],
   test: {
     globals: true,

--- a/package.json
+++ b/package.json
@@ -33,6 +33,8 @@
     "build:libs": "turbo run build --filter='@adopt-dont-shop/lib.*'",
     "build:apps": "turbo run build --filter='@adopt-dont-shop/app.*'",
     "test": "turbo run test",
+    "test:watch": "turbo run test:watch --parallel --concurrency=1",
+    "test:changed": "turbo run test -- --changed",
     "test:e2e": "pnpm --filter @adopt-dont-shop/e2e test",
     "test:e2e:single": "pnpm --filter @adopt-dont-shop/e2e test",
     "test:e2e:smoke": "pnpm --filter @adopt-dont-shop/e2e test:smoke",

--- a/scripts/check-workspace-consistency.mjs
+++ b/scripts/check-workspace-consistency.mjs
@@ -35,6 +35,9 @@
  *     overlap the workspace root's own pinned range/override (ADS-980).
  *  11. .tool-versions (asdf/mise) must declare the same Node major and pnpm
  *     version as .nvmrc / package.json "packageManager" (ADS-943).
+ *  12. Every services/*.vitest.config.ts imports defineServiceConfig from
+ *     vitest.shared.config.ts — no ad-hoc defineConfig at service scope
+ *     (ADS-985).
  *
  * Common script bodies (lint = 'eslint .'|'eslint src', type-check =
  * 'tsc --noEmit', test = 'vitest run') drift produces a warning, not failure.
@@ -560,6 +563,31 @@ export function checkTemplateDepDrift(templateFile, templatePkg, rootPkg) {
   return failures;
 }
 
+// ADS-985: every services/*/vitest.config.ts must import defineServiceConfig
+// from the shared vitest.shared.config.ts helper — no ad-hoc defineConfig()
+// at service scope, so a Vitest upgrade or coverage-exclusion change stays a
+// single-file edit.
+function checkServiceVitestConfig(services) {
+  const failures = [];
+  for (const svc of services) {
+    const cfgPath = join(ROOT, 'services', svc, 'vitest.config.ts');
+    let contents;
+    try {
+      contents = readFileSync(cfgPath, 'utf8');
+    } catch {
+      continue;
+    }
+    const importsSharedHelper = /from ['"]\.\.\/\.\.\/vitest\.shared\.config['"]/.test(contents);
+    if (!importsSharedHelper) {
+      failures.push(
+        `[services/${svc}/vitest.config.ts] must import 'defineServiceConfig' from '../../vitest.shared.config' ` +
+          `(ADS-985) — no ad-hoc defineConfig() at service scope`
+      );
+    }
+  }
+  return failures;
+}
+
 function findTemplatePackageJsonFiles() {
   const templatesDir = join(ROOT, 'scripts', 'templates');
   const found = [];
@@ -766,6 +794,9 @@ function main() {
   // 11. .tool-versions must agree with .nvmrc / package.json packageManager
   //     (ADS-943)
   failures.push(...checkToolVersions(rootPkg));
+
+  // 12. Every service vitest.config.ts must import the shared helper (ADS-985)
+  failures.push(...checkServiceVitestConfig(services));
 
   if (warnings.length > 0) {
     console.warn('Warnings (non-fatal — script body drift):');

--- a/scripts/script-descriptions.json
+++ b/scripts/script-descriptions.json
@@ -27,6 +27,8 @@
   "build:libs": "Build only the lib.* packages.",
   "build:apps": "Build only the three frontend apps.",
   "test": "Run tests for every workspace package via Turbo (no coverage thresholds — see test:coverage tier in CONTRIBUTING.md).",
+  "test:watch": "Vitest watch mode at the workspace root — reruns affected tests on save; pass a path/pattern to filter (ADS-944).",
+  "test:changed": "Run only tests affected by files changed since origin/main (Vitest --changed; ADS-944).",
   "test:e2e": "Run the full Playwright suite against a running Docker stack.",
   "test:e2e:single": "Alias of test:e2e (kept for muscle-memory / CI script parity).",
   "test:e2e:smoke": "Run only the @smoke-tagged Playwright specs.",

--- a/services/applications/vitest.config.ts
+++ b/services/applications/vitest.config.ts
@@ -1,9 +1,3 @@
-import { defineConfig } from 'vitest/config';
+import { defineServiceConfig } from '../../vitest.shared.config';
 
-export default defineConfig({
-  test: {
-    environment: 'node',
-    include: ['src/**/*.test.ts'],
-    testTimeout: 10_000,
-  },
-});
+export default defineServiceConfig();

--- a/services/audit/vitest.config.ts
+++ b/services/audit/vitest.config.ts
@@ -1,9 +1,3 @@
-import { defineConfig } from 'vitest/config';
+import { defineServiceConfig } from '../../vitest.shared.config';
 
-export default defineConfig({
-  test: {
-    environment: 'node',
-    include: ['src/**/*.test.ts'],
-    testTimeout: 10_000,
-  },
-});
+export default defineServiceConfig();

--- a/services/auth/vitest.config.ts
+++ b/services/auth/vitest.config.ts
@@ -1,9 +1,3 @@
-import { defineConfig } from 'vitest/config';
+import { defineServiceConfig } from '../../vitest.shared.config';
 
-export default defineConfig({
-  test: {
-    environment: 'node',
-    include: ['src/**/*.test.ts'],
-    testTimeout: 10_000,
-  },
-});
+export default defineServiceConfig();

--- a/services/chat/vitest.config.ts
+++ b/services/chat/vitest.config.ts
@@ -1,10 +1,7 @@
-import { defineConfig } from 'vitest/config';
+import { defineServiceConfig } from '../../vitest.shared.config';
 
-export default defineConfig({
+export default defineServiceConfig({
   test: {
-    environment: 'node',
-    include: ['src/**/*.test.ts'],
-    testTimeout: 10_000,
     coverage: {
       provider: 'v8',
       all: true,

--- a/services/cms/vitest.config.ts
+++ b/services/cms/vitest.config.ts
@@ -1,10 +1,7 @@
-import { defineConfig } from 'vitest/config';
+import { defineServiceConfig } from '../../vitest.shared.config';
 
-export default defineConfig({
+export default defineServiceConfig({
   test: {
-    environment: 'node',
-    include: ['src/**/*.test.ts'],
-    testTimeout: 10_000,
     coverage: {
       provider: 'v8',
       all: true,

--- a/services/gateway/vitest.config.ts
+++ b/services/gateway/vitest.config.ts
@@ -1,11 +1,5 @@
-import { defineConfig } from 'vitest/config';
+import { defineServiceConfig } from '../../vitest.shared.config';
 
-export default defineConfig({
-  test: {
-    environment: 'node',
-    include: ['src/**/*.test.ts'],
-    // Server tests bind real ports and spin up upstream stubs — give them
-    // some headroom over the 5s default but keep them tight.
-    testTimeout: 10_000,
-  },
-});
+// Server tests bind real ports and spin up upstream stubs — give them some
+// headroom over the 5s default but keep them tight (see shared testTimeout).
+export default defineServiceConfig();

--- a/services/matching/vitest.config.ts
+++ b/services/matching/vitest.config.ts
@@ -1,9 +1,3 @@
-import { defineConfig } from 'vitest/config';
+import { defineServiceConfig } from '../../vitest.shared.config';
 
-export default defineConfig({
-  test: {
-    environment: 'node',
-    include: ['src/**/*.test.ts'],
-    testTimeout: 10_000,
-  },
-});
+export default defineServiceConfig();

--- a/services/moderation/vitest.config.ts
+++ b/services/moderation/vitest.config.ts
@@ -1,9 +1,3 @@
-import { defineConfig } from 'vitest/config';
+import { defineServiceConfig } from '../../vitest.shared.config';
 
-export default defineConfig({
-  test: {
-    environment: 'node',
-    include: ['src/**/*.test.ts'],
-    testTimeout: 10_000,
-  },
-});
+export default defineServiceConfig();

--- a/services/notifications/vitest.config.ts
+++ b/services/notifications/vitest.config.ts
@@ -1,9 +1,3 @@
-import { defineConfig } from 'vitest/config';
+import { defineServiceConfig } from '../../vitest.shared.config';
 
-export default defineConfig({
-  test: {
-    environment: 'node',
-    include: ['src/**/*.test.ts'],
-    testTimeout: 10_000,
-  },
-});
+export default defineServiceConfig();

--- a/services/pets/vitest.config.ts
+++ b/services/pets/vitest.config.ts
@@ -1,9 +1,3 @@
-import { defineConfig } from 'vitest/config';
+import { defineServiceConfig } from '../../vitest.shared.config';
 
-export default defineConfig({
-  test: {
-    environment: 'node',
-    include: ['src/**/*.test.ts'],
-    testTimeout: 10_000,
-  },
-});
+export default defineServiceConfig();

--- a/services/rescue/vitest.config.ts
+++ b/services/rescue/vitest.config.ts
@@ -1,9 +1,3 @@
-import { defineConfig } from 'vitest/config';
+import { defineServiceConfig } from '../../vitest.shared.config';
 
-export default defineConfig({
-  test: {
-    environment: 'node',
-    include: ['src/**/*.test.ts'],
-    testTimeout: 10_000,
-  },
-});
+export default defineServiceConfig();

--- a/turbo.json
+++ b/turbo.json
@@ -32,6 +32,11 @@
         "$TURBO_ROOT$/coverage-thresholds.json"
       ]
     },
+    "test:watch": {
+      "cache": false,
+      "persistent": true,
+      "dependsOn": []
+    },
     "test:coverage": {
       "dependsOn": ["^build"],
       "outputs": ["coverage/**"],

--- a/turbo.json
+++ b/turbo.json
@@ -28,7 +28,8 @@
         "vitest.config.ts",
         "package.json",
         "$TURBO_ROOT$/vitest.shared.config.ts",
-        "$TURBO_ROOT$/tsconfig.base.json"
+        "$TURBO_ROOT$/tsconfig.base.json",
+        "$TURBO_ROOT$/coverage-thresholds.json"
       ]
     },
     "test:coverage": {
@@ -40,7 +41,8 @@
         "test/**/*.ts",
         "test/**/*.tsx",
         "$TURBO_ROOT$/vitest.shared.config.ts",
-        "$TURBO_ROOT$/tsconfig.base.json"
+        "$TURBO_ROOT$/tsconfig.base.json",
+        "$TURBO_ROOT$/coverage-thresholds.json"
       ]
     },
     "lint": {

--- a/vitest.shared.config.ts
+++ b/vitest.shared.config.ts
@@ -123,3 +123,27 @@ export function defineLibConfig(overrides: UserConfig = {}): UserConfig {
   const withName = mergeConfig(sharedConfig, defineConfig({ test: { name } }));
   return mergeConfig(withName, overrides);
 }
+
+/**
+ * Shared Vitest configuration for all services/* packages (Node, not jsdom —
+ * services have no DOM). Each service extends this and overrides only what
+ * it needs (typically `test.coverage`).
+ */
+const sharedServiceConfig = defineConfig({
+  test: {
+    environment: 'node',
+    include: ['src/**/*.test.ts'],
+    testTimeout: 10_000,
+  },
+});
+
+/**
+ * ADS-985: helper that removes the per-service mergeConfig + imports
+ * boilerplate — mirrors `defineLibConfig` above. Every service's
+ * `vitest.config.ts` collapses to `export default defineServiceConfig()`,
+ * or `defineServiceConfig({ ...overrides })` for services that need coverage
+ * overrides (e.g. `test.coverage`).
+ */
+export function defineServiceConfig(overrides: UserConfig = {}): UserConfig {
+  return mergeConfig(sharedServiceConfig, overrides);
+}

--- a/vitest.workspace.ts
+++ b/vitest.workspace.ts
@@ -1,8 +1,50 @@
-import { defineWorkspace } from 'vitest/config';
+import { existsSync, readdirSync } from 'fs';
+import { basename, dirname, join, resolve } from 'path';
+import { fileURLToPath } from 'url';
+import { defineConfig, type UserProjectConfigExport } from 'vitest/config';
 
-/**
- * Vitest workspace — discovers every lib.* package via glob so newly added
- * libraries are picked up automatically. Each package has its own
- * vitest.config.ts with lib-specific overrides.
- */
-export default defineWorkspace(['packages/lib.*/vitest.config.ts']);
+// Vitest 4 removed `defineWorkspace()` / workspace-file auto-discovery (the
+// pre-Vitest-4 `defineWorkspace(['packages/lib.*/vitest.config.ts', ...])`
+// form this file used to export no longer loads). Multi-project runs are now
+// expressed as `test.projects` on a root Vitest config — see
+// https://vitest.dev/guide/migration#workspace. This file fills that role and
+// is still what .vscode/settings.json's `vitest.workspaceConfig` points the
+// VS Code Vitest extension at (ADS-986), and what `pnpm test` at the root
+// aggregates apps into (ADS-908).
+//
+// Every aggregated project needs a unique `test.name` (Vitest 4 enforces
+// this), which none of the per-package vitest.config.ts files set on their
+// own — so each project is included via `extends` (reuse that package's own
+// config as-is) plus an explicit `root` and a derived, collision-free `name`
+// rather than a bare glob string.
+const repoRoot = dirname(fileURLToPath(import.meta.url));
+
+function discoverProjects(
+  dir: string,
+  namePrefix: string,
+  nameFilter: (name: string) => boolean = () => true
+): UserProjectConfigExport[] {
+  return readdirSync(resolve(repoRoot, dir), { withFileTypes: true })
+    .filter(entry => entry.isDirectory())
+    .map(entry => entry.name)
+    .filter(nameFilter)
+    .filter(name => existsSync(resolve(repoRoot, dir, name, 'vitest.config.ts')))
+    .map(name => {
+      const root = join(dir, name);
+      return {
+        extends: join(root, 'vitest.config.ts'),
+        root,
+        test: { name: `${namePrefix}${basename(name)}` },
+      };
+    });
+}
+
+export default defineConfig({
+  test: {
+    projects: [
+      ...discoverProjects('packages', '', name => name.startsWith('lib.')),
+      ...discoverProjects('apps', 'app.'),
+      ...discoverProjects('services', 'service.'),
+    ],
+  },
+});


### PR DESCRIPTION
## Summary

- **ADS-991**: `apps/rescue/vitest.config.ts` now uses `veCssMock` like admin/client instead of the real `vanillaExtractPlugin`, cutting CSS-in-TS compile overhead out of every rescue unit-test run.
- **ADS-985**: extracted `defineServiceConfig()` into `vitest.shared.config.ts` (mirrors the existing `defineLibConfig()`); all 11 `services/*/vitest.config.ts` collapse to 1–4 lines, with chat/cms keeping coverage overrides and gateway keeping its rationale comment. Added a `check:workspaces` guard against ad-hoc `defineConfig()` at service scope.
- **ADS-986 / ADS-908**: `vitest.workspace.ts` now aggregates `packages/lib.*`, `apps/*`, and `services/*` (38 projects total) instead of just libs. `coverage-thresholds.json` is now a Turbo input for `test`/`test:coverage` so ratcheting a threshold busts the cache.
- **ADS-944**: added root `pnpm test:watch` / `pnpm test:changed` convenience scripts, documented in README and CONTRIBUTING.

## Changes

- `apps/rescue/vitest.config.ts` — swap `vanillaExtractPlugin()` for `veCssMock`
- `apps/rescue/src/pages/RescueSettings.tsx` / `.test.tsx` — the mock breaks 5 pre-existing tests that asserted on compiled vanilla-extract class-name substrings (implementation detail, and inconsistent between apps per the ticket's own "Impact" section). Replaced with `role="tab"` / `aria-selected` — a real accessibility improvement that also makes the assertions implementation-independent.
- `vitest.shared.config.ts` — new `defineServiceConfig()` helper
- `services/*/vitest.config.ts` (11 files) — one-liners against the shared helper
- `scripts/check-workspace-consistency.mjs` — new guard requiring services to import the shared helper
- `vitest.workspace.ts` — rewritten; see "Important finding" below
- `.vscode/settings.json` — `vitest.maximumConfigs` 30 → 40 (38 projects now discovered)
- `turbo.json` — `coverage-thresholds.json` added as an input to `test`/`test:coverage`; new `test:watch` task (persistent, uncached) so the root script can run
- `package.json` — `test:watch`, `test:changed` scripts
- `README.md`, `CONTRIBUTING.md` — doc updates for the above

### Important finding: `vitest.workspace.ts` was non-functional under the installed Vitest

The pre-existing `vitest.workspace.ts` used `defineWorkspace([...])`. Vitest 4 (installed: `4.1.9`) **removed `defineWorkspace()` and workspace-file auto-discovery entirely** — `vitest/config` no longer exports it, and there's no `vitest.workspace.*` filename handling left in the Vitest 4 CLI. This means the file has been completely broken (not just narrower in scope than ADS-986 assumed) since whenever this repo moved to Vitest 4 — every invocation of it would throw at config-load time. I migrated it to Vitest 4's real mechanism (`test.projects` on a root-loadable config), which additionally required giving every aggregated project a unique `test.name` (Vitest 4 enforces this and none of the per-package configs set one) — done via `{extends, root, test.name}` entries built from a filesystem scan rather than bare glob strings. Verified by listing all 38 projects (24 libs + 3 apps + 11 services) with `vitest list --config vitest.workspace.ts` — no name collisions, no load errors.

Also worth noting: `pnpm test` (`turbo run test`) already ran all three apps before this PR (verified via `turbo run test --dry=json`, 88 tasks including `app.admin`/`app.client`/`app.rescue`) — that half of ADS-908 was already satisfied; only the workspace-file / VS Code panel angle needed the fix.

### Known limitation (ADS-944)

`pnpm test:changed` forwards `--changed` to every workspace's `test` script via Turbo, including `e2e`'s (`playwright test`), which doesn't understand that flag — a repo-wide `pnpm test:changed` run will error on the `e2e` package. This is inherent to aggregating a non-Vitest `test` script under the same Turbo task name and matches the ticket's literal proposed script; scope with `pnpm --filter <pkg> test -- --changed` to avoid it.

## Before requesting review

- [x] Ran the equivalent of `pnpm ci:local:quick` locally (lint + type-check for touched packages)
- [x] Tests for new/changed behaviour added (RescueSettings tab tests rewritten to assert `aria-selected`)
- [ ] N/A — no `.env` changes
- [ ] N/A — no `lib.*` consumer-facing changes

## Test plan

- [x] `corepack enable && pnpm install --frozen-lockfile`
- [x] `pnpm exec turbo test --filter=@adopt-dont-shop/app.rescue` — 60 files / 524 tests pass (transform phase ~7.9s → ~4.6s with the mock; total wall time in this sandbox was within noise of background contention)
- [x] `pnpm exec turbo test --filter=@adopt-dont-shop/service.auth` — 24 files / 392 tests pass
- [x] `pnpm exec turbo test --filter=@adopt-dont-shop/service.chat` — 10 files / 155 tests pass
- [x] `pnpm exec turbo test --filter=@adopt-dont-shop/service.cms` — 6 files / 116 tests pass
- [x] `pnpm exec turbo test --filter=@adopt-dont-shop/service.gateway` — 75 files / 1046 tests pass
- [x] `pnpm check:workspaces` — passes, including the new service-vitest-config guard
- [x] `vitest list --config vitest.workspace.ts` — all 38 projects resolve, no name collisions, no load errors
- [x] `pnpm exec turbo lint type-check` for touched packages (`app.rescue`, `service.auth/chat/cms/gateway`) — 0 errors (pre-existing warnings only)
- [x] `pnpm test:watch --filter=@adopt-dont-shop/lib.utils` and `pnpm test:changed` — manually verified they invoke Vitest correctly

## Related

ADS-991, ADS-985, ADS-986, ADS-908, ADS-944

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_015F6J4DXQ1Amyth4dwD5Q8P)_