### PR TITLE
docs: fact-check pass — core docs, service/app READMEs, runbooks, JSDoc

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -157,8 +157,9 @@ The required checks that gate merge (all feed into the `ci-required` aggregator 
 3. **Frontend Tests (app.client / app.admin / app.rescue)** (`ci.yml` → `test-frontend` matrix, ×3) — lint + test + type-check + build per app.
 4. **Library Tests** (`ci.yml` → `test-libs`) — lint, test and type-check across every `lib.*`.
 5. **Service Tests** (`ci.yml` → `test-services`) — lint + test + type-check across every `services/*` package. Added in ADS-822 so zero-test services no longer merge green.
-6. **Dev-Auth Guard** (`ci.yml` → `dev-auth-guard`) — production bundle scan ensuring dev-auth bypass code is properly gated (ADS-676).
-7. **E2E Tests (Playwright)** (`ci.yml` → `test-e2e`) — full Docker stack + browser suite. **Opt-in on PRs:** runs on `main` pushes and `workflow_dispatch`, or on a PR carrying the **`run-e2e`** label; otherwise skipped (treated as success). When it runs, a failure blocks the PR. Reworked for the post-monolith gateway stack in ADS-792.
+6. **Contract Tests (Pact)** (`ci.yml` → `test-contracts`) — two-phase consumer-driven Pact verification (consumers write pact files, providers verify them). Gated on the `backend` path filter — frontend-only PRs skip it (treated as success). See [ADR 0005](./docs/adr/0005-pact-contract-tests.md) (ADS-816).
+7. **Dev-Auth Guard** (`ci.yml` → `dev-auth-guard`) — production bundle scan ensuring dev-auth bypass code is properly gated (ADS-676).
+8. **E2E Tests (Playwright)** (`ci.yml` → `test-e2e`) — full Docker stack + browser suite. **Opt-in on PRs:** runs on `main` pushes and `workflow_dispatch`, or on a PR carrying the **`run-e2e`** label; otherwise skipped (treated as success). When it runs, a failure blocks the PR. Reworked for the post-monolith gateway stack in ADS-792.
 
 Additional checks that run but are not part of `ci-required`:
 
@@ -168,7 +169,7 @@ Additional checks that run but are not part of `ci-required`:
 
 The Quality workflow's `pnpm outdated -r` step is informational (`continue-on-error: true`) and does not block merge.
 
-If you skip the slow tier locally, expect CI feedback within ~10 minutes — just be ready to fix and push again. PRs that fail any of the seven `ci-required` checks above will not be merged.
+If you skip the slow tier locally, expect CI feedback within ~10 minutes — just be ready to fix and push again. PRs that fail any of the eight `ci-required` checks above will not be merged.
 
 ## Code style
 

--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ pnpm docker:dev:build         # rebuild images from scratch
 
 Common issues:
 
-- **Port conflict** — check 3000-3002 (apps), 4000 (gateway), 5001-5009 (services), 5432 (Postgres), 6379 (Redis), 4222/8222 (NATS) are free
+- **Port conflict** — check 3000-3002 (apps), 4000 (gateway), 5001-5010 (services), 5432 (Postgres), 6379 (Redis), 4222/8222 (NATS) are free
 - **HMR not firing** — on macOS/Windows, verify `CHOKIDAR_USEPOLLING=true` is set in container env (`pnpm run setup` writes it per-host since [ADS-766](https://linear.app/ideasquared/issue/ADS-766) — it is **not** set on Linux, which uses native inotify instead)
 - **Slow builds** — ensure BuildKit is on: `export DOCKER_BUILDKIT=1`
 

--- a/apps/client/README.md
+++ b/apps/client/README.md
@@ -2,7 +2,7 @@
 
 Public adoption portal for pet adopters.
 
-See the full product spec: [docs/frontend/app-client-prd.md](../docs/frontend/app-client-prd.md).
+See the full product spec: [docs/frontend/app-client-prd.md](../../docs/frontend/app-client-prd.md).
 
 ## Quick Start
 

--- a/apps/rescue/README.md
+++ b/apps/rescue/README.md
@@ -2,7 +2,7 @@
 
 Rescue organization portal for the Adopt Don't Shop platform.
 
-See the full product spec: [docs/frontend/app-rescue-prd.md](../docs/frontend/app-rescue-prd.md).
+See the full product spec: [docs/frontend/app-rescue-prd.md](../../docs/frontend/app-rescue-prd.md).
 
 ## Stack
 
@@ -46,7 +46,7 @@ Or from this directory: `pnpm dev` — Vite serves on http://localhost:3000 (con
 ```
 src/
 ├── components/     Reusable UI components
-├── contexts/       React contexts (Analytics, Chat, Notifications, Permissions, Statsig)
+├── contexts/       React contexts (Chat, Statsig)
 ├── pages/          Route-level components
 ├── hooks/          Custom React hooks
 ├── services/       API clients and external services

--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -71,7 +71,7 @@ Result: 40-60% faster builds on warm cache, smaller layer graph.
 
 ### Security
 
-- Non-root users in all containers (`viteuser` for frontend apps, `appuser` for microservice containers).
+- Non-root users in all containers (`viteuser` for frontend apps, `svcuser` for microservice containers).
 - Nginx adds OWASP headers (X-Frame-Options, X-Content-Type-Options, X-XSS-Protection, Referrer-Policy).
 - Health checks on every service so orchestrators can detect bad state.
 - Production overlay (`docker-compose.prod.yml`) requires every secret as `${VAR:?error}` — no defaults, fails fast.

--- a/docs/GETTING-STARTED.md
+++ b/docs/GETTING-STARTED.md
@@ -22,7 +22,7 @@ pnpm setup
 ```
 
 `pnpm setup` enables Corepack, creates `.env` from `.env.example`, generates
-fresh JWT/session/CSRF/encryption secrets into it, and installs every
+fresh JWT/session/encryption secrets into it, and installs every
 workspace dependency. It'll also prompt you about the opt-in pre-push hook
 (answering yes is recommended for your first month) — see
 [CONTRIBUTING.md "Pre-push hook"](../CONTRIBUTING.md#pre-push-hook-ads-732--ads-905)

--- a/docs/backend/deployment.md
+++ b/docs/backend/deployment.md
@@ -8,9 +8,9 @@ The backend ships as a Docker image alongside three frontend images. Production 
 
 ### Runtime
 
-- **Node.js**: v22 (pinned in `.nvmrc` and `package.json` engines `>=22 <23`). The production images are `node:22-alpine` (each service ships its own `services/<name>/Dockerfile`).
+- **Node.js**: v22 (pinned in `.nvmrc` and `package.json` engines `>=22 <23`). All backend services share the top-level `Dockerfile.service` (parameterised via the `SERVICE` / `SERVICE_DIR` build args), built on `node:22-alpine`.
 - **PostgreSQL**: 16 with the **PostGIS** extension (`postgis/postgis:16-3.4` in `docker-compose.yml`). Location features depend on PostGIS — a plain Postgres install is not enough.
-- **Redis**: 7+ (`redis:7-alpine`) — used for sessions, BullMQ job queues, and rate-limiting.
+- **Redis**: 7+ (`redis:7-alpine`) — used by the gateway for the shared rate-limit store and by services for idempotency keys.
 
 ### Storage and external services
 
@@ -63,11 +63,14 @@ CORS_ORIGIN=https://adoptdontshop.example,https://admin.adoptdontshop.example
 ```bash
 JWT_EXPIRES_IN=1h          # default 1h
 JWT_REFRESH_EXPIRES_IN=7d  # default 7d
-RATE_LIMIT_WINDOW_MS=900000
-RATE_LIMIT_MAX_REQUESTS=100
-DB_POOL_MAX=10
-DB_POOL_MIN=2
+GATEWAY_RATE_LIMIT_MAX=100     # per-IP requests per window (default 100)
+GATEWAY_RATE_LIMIT_WINDOW="1 minute"  # any @lukeed/ms format
 ```
+
+> DB pool sizing is not env-tunable today — `packages/db/src/client.ts`
+> hardcodes the timeout defaults and delegates max-connection sizing to
+> pg's built-in default (10). If you need to change these, edit
+> `TIMEOUT_DEFAULTS` in `packages/db/src/client.ts` and redeploy.
 
 ## Deploy
 
@@ -105,12 +108,15 @@ For destructive or long migrations see [`docs/migrations/schema-equivalence-runb
 
 ## Health and observability
 
-- `GET /health` — basic liveness probe.
-- `GET /health/simple` — minimal probe (no DB touch).
-- `GET /health/ready` — readiness; checks DB + Redis.
-- Swagger UI at `/api/docs`.
+- `GET /health/simple` — the sole health endpoint the gateway exposes
+  (liveness only, no DB touch). Every backing service exposes the same
+  path on its own container port.
+- Swagger UI at `/docs` (served by `@fastify/swagger-ui` on the gateway,
+  with the raw OpenAPI JSON at `/openapi.json`).
+- `/metrics` — Prometheus text exposition on the gateway and each service.
 - Sentry init via `lib.observability` when `SENTRY_DSN` is set.
-- Logs are structured JSON (Winston). Aggregate via your platform of choice.
+- Logs are structured JSON. Aggregate via your platform of choice; a Loki
+  transport is enabled when `LOKI_URL` is set.
 
 ## See also
 

--- a/docs/backend/troubleshooting.md
+++ b/docs/backend/troubleshooting.md
@@ -21,16 +21,16 @@ LOG_LEVEL=debug pnpm dev
 
 ### Health Check Diagnostics
 
+The gateway exposes a single `/health/simple` liveness probe on port 4000
+(no aggregated / DB / detailed endpoint — the LB probe is liveness-only):
+
 ```bash
-# Basic health check
-curl http://localhost:5000/health
-
-# Detailed health check with service status
-curl http://localhost:5000/health/detailed
-
-# Database health check
-curl http://localhost:5000/health/db
+curl http://localhost:4000/health/simple
 ```
+
+To check a specific backing service, hit its own `/health/simple` on its
+container port (5001–5010) via `docker compose exec`, or inspect its
+container state directly with `docker compose ps`.
 
 ## Database Issues
 
@@ -119,43 +119,39 @@ echo $DB_HOST $DB_PORT $DB_NAME $DB_USER
 **Diagnostics:**
 
 ```bash
-# Check migration status (via custom Umzug runner)
-pnpm db:migrate:status
-
-# View migration history
-SELECT * FROM "SequelizeMeta";
+# View migration history (each service owns a pgmigrations table in its own schema)
+psql -c "SELECT name, run_on FROM auth.pgmigrations ORDER BY id DESC LIMIT 10;"
+# repeat with pets.pgmigrations / rescue.pgmigrations / … as needed
 
 # Check current database schema
-\d+ users
-\d+ pets
+\dn+                                     -- list schemas
+\dt+ auth.*                              -- tables in a schema
 ```
 
 **Solutions:**
 
 1. **Failed migration:**
 
-   ```bash
-   # Rollback last migration
-   pnpm db:migrate:undo
-
-   # Fix migration file and re-run
-   pnpm db:migrate
-   ```
+   There is **no `pnpm db:migrate:undo` script** — the shared runner in
+   `packages/db/src/migrate.ts` only runs migrations forward. See
+   [`docs/runbooks/migration-failure.md`](../runbooks/migration-failure.md)
+   paths B (write a corrective forward migration) and E (manual pgmigrations
+   surgery) for the actual recovery procedures.
 
 2. **Out of sync migrations:**
 
    ```bash
-   # Reset database (development only — run inside backend container)
+   # Reset database (development only — wipes ALL data)
    pnpm docker:reset
    pnpm docker:dev:detach
-   pnpm db:migrate
+   # Each service re-runs its own migrations on container start.
    ```
 
 3. **Manual migration fix:**
 
    ```sql
-   -- Remove migration record
-   DELETE FROM "SequelizeMeta" WHERE name = 'problematic-migration.js';
+   -- Remove migration record (per schema — each service owns its own table)
+   DELETE FROM auth.pgmigrations WHERE name = 'problematic-migration';
 
    -- Fix database manually
    ALTER TABLE users ADD COLUMN new_column VARCHAR(255);

--- a/docs/deploy/per-service-rollback.md
+++ b/docs/deploy/per-service-rollback.md
@@ -121,23 +121,21 @@ Each service runs `pnpm db:migrate --if-present` on container boot
   `NOT NULL` constraint the old code does not populate, rollback will cause
   errors.
 
-**Before rolling back an image that ran migrations**, check whether the
-migration has a working `down()` method. If it does, and the schema change is
-incompatible, you must revert the migration first:
+**Before rolling back an image that ran migrations**, be aware that there is
+**no `pnpm db:migrate:undo` script** — the shared runner in
+`packages/db/src/migrate.ts` only runs migrations forward. If the forward
+migration is incompatible with the older binary, you cannot simply "undo" it
+on the deploy host. The options are:
 
-```bash
-# On the deploy host:
-docker compose -f docker-compose.prod.yml exec service-auth \
-  pnpm db:migrate:undo
-```
+1. Write a corrective forward migration that restores the shape the older
+   binary needs, ship it as a new hotfix release, and roll forward.
+2. Manually revert the schema change via psql on the deploy host, then flip
+   the `pgmigrations` row so the migration can be re-applied later.
 
-Then re-dispatch the rollback deploy. See
-[`docs/runbooks/migration-failure.md`](../runbooks/migration-failure.md) and
-[`docs/runbooks/deploy-rollback.md`](../runbooks/deploy-rollback.md) for
-detailed recovery paths.
-
-If the migration has no `down()` (forward-only), a clean image rollback is not
-possible — follow the migration-failure runbook.
+See [`docs/runbooks/deploy-rollback.md`](../runbooks/deploy-rollback.md)
+("Backward-compatible migration only" section) and
+[`docs/runbooks/migration-failure.md`](../runbooks/migration-failure.md)
+for detailed recovery paths.
 
 ## Available per-service tag variables
 

--- a/docs/env-reference.md
+++ b/docs/env-reference.md
@@ -149,8 +149,9 @@ providers, in order of what's actually wired into `services/notifications`
 # DEFAULT_FROM_NAME="Adopt Don't Shop"
 # DEFAULT_REPLY_TO_EMAIL=support@adoptdontshop.com
 
-# EMAIL_PROVIDER=ethereal           # fake SMTP catcher — test/dev only,
-                                    # refused in production
+# EMAIL_PROVIDER=ethereal           # fake SMTP catcher — test/dev only
+                                    # (unlike `console`, not refused in
+                                    # production — do not set it there)
 ```
 
 The following vars exist for a **possible future** provider switch but are

--- a/docs/infrastructure/DEPLOYMENT-PLAN.md
+++ b/docs/infrastructure/DEPLOYMENT-PLAN.md
@@ -210,14 +210,13 @@ Auto-renewal handled by certbot container in gateway stack (renews every 12h via
 
 ### First deploy — baseline
 
-Migration `00-baseline` uses `sync({ force: true })` — **destructive**. For first prod deploy, create the SequelizeMeta table and mark baseline as already run:
-
-```sql
-CREATE TABLE IF NOT EXISTS "SequelizeMeta" (name VARCHAR(255) PRIMARY KEY);
-INSERT INTO "SequelizeMeta" VALUES ('00-baseline.js');
-```
-
-Then `pnpm migrate` will only run migrations 01+.
+There is no `00-baseline` migration and no `SequelizeMeta` table — those
+belonged to the deleted monolith. Each service now uses `node-pg-migrate`
+with per-service migrations numbered `001_*.ts` under
+`services/<name>/src/migrations/` and its own `pgmigrations` bookkeeping
+table inside its owning schema. On first boot, each service creates its
+`pgmigrations` table automatically and runs migrations `001+` forward.
+Nothing to seed by hand.
 
 ### Backups
 
@@ -250,7 +249,8 @@ echo "0 2 * * * deploy /opt/ads/backup.sh" >> /etc/crontab
 - [ ] Copy files to server (gateway, compose, etc.)
 - [ ] Create `.env` files on server for both environments
 - [ ] Start gateway: `cd /opt/ads/gateway && docker compose up -d`
-- [ ] Start prod stack: `cd /opt/ads/production && docker compose up -d` (uses `:latest` tag initially)
+- [ ] Set `DEPLOY_SHA=<git-sha>` in `/opt/ads/production/.env` first — every image line in `docker-compose.prod.yml` resolves as `${SERVICE_*_TAG:-${DEPLOY_SHA:?DEPLOY_SHA must be set to a specific git SHA}}`, so `docker compose up` aborts with a hard error without it (there is **no `:latest` fallback**)
+- [ ] Start prod stack: `cd /opt/ads/production && docker compose up -d`
 - [ ] Wait for each schema-owning service to apply its own migrations on first boot (visible in `docker compose logs service-<name>`); the `pgmigrations` table per schema is created automatically
 - [ ] First deploy via workflow: `make staging`
 - [ ] Verify staging works end-to-end

--- a/docs/observability/tracing.md
+++ b/docs/observability/tracing.md
@@ -33,14 +33,19 @@ docker run --rm --name jaeger \
   jaegertracing/all-in-one:latest
 ```
 
-Then point the backend at it:
+Then point the stack at it:
 
 ```bash
-OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318 pnpm dev:backend
+# All services (gateway + microservices) — each boots its own OTel SDK
+OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318 pnpm dev
+
+# Or a single service — set the endpoint before starting it
+OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318 \
+  pnpm exec turbo dev --filter=@adopt-dont-shop/service.gateway
 ```
 
-Open <http://localhost:16686> and select the
-`adopt-dont-shop-backend` service.
+Open <http://localhost:16686>. Each service registers its own service
+name (`service.gateway`, `service.auth`, …).
 
 ## What gets instrumented
 
@@ -48,31 +53,22 @@ Open <http://localhost:16686> and select the
 instrumentation that ships in the bundle. The relevant ones for this
 service are:
 
-| Module        | Spans                                |
-|---------------|--------------------------------------|
-| `http`        | inbound + outbound HTTP              |
-| `express`     | route handlers + middleware          |
-| `pg`          | every SQL statement (Sequelize → pg) |
-| `ioredis`     | every Redis command                  |
-| `socket.io`   | server-side connection events        |
-| `undici`      | `fetch()` calls                      |
-| `winston`     | log-record attribution to a span     |
+| Module         | Spans                                                     |
+|----------------|-----------------------------------------------------------|
+| `http`         | inbound + outbound HTTP                                    |
+| `fastify`      | route handlers + hooks (gateway + each service)            |
+| `grpc`         | gRPC client + server calls between the gateway and services |
+| `pg`           | every SQL statement (direct via `@adopt-dont-shop/db`)     |
+| `ioredis`      | every Redis command                                        |
+| `socket.io`    | server-side connection events (gateway)                    |
+| `undici`       | `fetch()` calls                                            |
+| `winston`      | log-record attribution to a span                           |
 
 `@opentelemetry/instrumentation-fs` is **disabled** because it emits
 one span per `readFile` / `stat` and floods exporters with no
 operational signal. Override via the standard
 `OTEL_NODE_DISABLED_INSTRUMENTATIONS` /
 `OTEL_NODE_ENABLED_INSTRUMENTATIONS` env vars if you need it.
-
-### BullMQ — known gap
-
-There is no first-party OTel instrumentation for BullMQ in the
-auto-bundle. Redis traffic is still captured (BullMQ uses ioredis
-under the hood) so queue ops appear as `ioredis` spans — enough to
-debug latency but without job-level metadata. Custom instrumentation
-is out of scope for ADS-660; if job tracing is required, follow up
-with a manual `startSpan` wrapper around the queue's `process`
-callback.
 
 ## Trace flow
 
@@ -108,17 +104,15 @@ The SDK respects the standard env vars:
 - `OTEL_TRACES_SAMPLER_ARG` — ratio in `[0, 1]` for the ratio
   samplers.
 
-## Worker processes
+## Background work
 
-Background workers (`reports.worker`, `retention.job`,
-`legal-reminder.worker`, etc.) run in the same Node process as the
-HTTP server, so the single SDK boot inside `src/index.ts` covers
-them. The standalone `legal-reminder.cli.ts` CLI inherits the same
-import-time boot when run via `pnpm legal-reminder:run` because
-it imports from `src/workers/legal-reminder.worker` which transitively
-loads `src/instrumentation.ts` via the project boot path — for that
-CLI, traces require `OTEL_EXPORTER_OTLP_ENDPOINT` to be set in the
-shell that invokes it.
+There are no in-process worker daemons in the microservices — recurring
+work happens via NATS JetStream consumers (durable subscriptions started
+by `src/index.ts` in the owning service) and standalone `docker compose
+run` cron jobs configured in `docker-compose.yml`. Both inherit the
+per-service SDK boot, so their spans appear under the same service name
+as the HTTP surface. Standalone one-shot scripts need
+`OTEL_EXPORTER_OTLP_ENDPOINT` set in the shell that invokes them.
 
 ## Disabling
 

--- a/docs/operations/deploy.md
+++ b/docs/operations/deploy.md
@@ -54,7 +54,7 @@ development or staging environment.
 
 ### 2. Verify secrets are valid and distinct
 
-`validate-env.ts` enforces that all six secrets are present, at least 32 characters
+`validate-env.ts` enforces that all five secrets are present, at least 32 characters
 long, not a placeholder (`CHANGE_THIS…`), and distinct from each other. Run it against
 your production env file before deploying:
 
@@ -92,8 +92,8 @@ or secured ops log. At minimum: `date`, `rotated_by`, `reason`.
 
 | Trigger | Action |
 |---|---|
-| Initial production launch | Full rotation of all six application secrets |
-| Quarterly (~every 90 days) | Full rotation of all six application secrets |
+| Initial production launch | Full rotation of all five application secrets |
+| Quarterly (~every 90 days) | Full rotation of all five application secrets |
 | Suspected compromise | Immediate rotation of affected secret(s); full rotation if scope is unclear |
 | Team member off-boarding | Rotate any secret the person had access to |
 | Staging value detected in prod | Immediate full rotation |

--- a/docs/operations/restore.md
+++ b/docs/operations/restore.md
@@ -11,9 +11,10 @@ in the snapshot policy doc, it regenerates on its own.
 
 ## Before you start
 
-- Confirm you have the right dump. Snapshots are keyed by UTC date under
-  `s3://${BACKUP_BUCKET}/postgres/YYYY/MM/DD/dump.sql.gz` (Postgres) and
-  `s3://${BACKUP_BUCKET}/uploads/YYYY/MM/DD/` (uploads).
+- Confirm you have the right dump. Postgres snapshots are keyed by UTC
+  timestamp under `s3://${BACKUP_BUCKET}/postgres/YYYY/MM/DD/HHMMSS/dump.sql.gz`
+  (the HHMMSS subdirectory lets multiple daily runs coexist). Upload
+  snapshots live under `s3://${BACKUP_BUCKET}/uploads/YYYY/MM/DD/`.
 - Restoring Postgres from a full dump requires the target database to be
   empty (or you accept `pg_restore`/`psql` erroring on already-existing
   objects). For a same-environment disaster recovery this usually means
@@ -27,7 +28,11 @@ in the snapshot policy doc, it regenerates on its own.
 1. Download the target dump from S3:
 
    ```bash
-   aws s3 cp "s3://${BACKUP_BUCKET}/postgres/2026/07/18/dump.sql.gz" ./dump.sql.gz
+   # List available snapshots for a day first — one folder per HHMMSS run:
+   aws s3 ls "s3://${BACKUP_BUCKET}/postgres/2026/07/18/"
+
+   # Then download the specific one you want:
+   aws s3 cp "s3://${BACKUP_BUCKET}/postgres/2026/07/18/020000/dump.sql.gz" ./dump.sql.gz
    ```
 
 2. **Fresh environment / disaster recovery** — bring up an empty database

--- a/docs/operations/snapshot-policy.md
+++ b/docs/operations/snapshot-policy.md
@@ -21,9 +21,12 @@ production stack. The script:
 1. Acquires a logical dump via `docker compose exec database pg_dump`
    (no downtime; consistent snapshot using `--serializable-deferrable`).
 2. Compresses with `gzip -9`.
-3. Uploads to `s3://${BACKUP_BUCKET}/postgres/$(date -u +%Y/%m/%d)/dump.sql.gz`.
-4. Tags the object with `Class=tier1, Retention=30d` so the bucket lifecycle
-   policy auto-prunes after 30 days.
+3. Uploads to `s3://${BACKUP_BUCKET}/postgres/$(date -u +%Y/%m/%d/%H%M%S)/dump.sql.gz`
+   (one directory per snapshot — the HHMMSS suffix lets multiple daily runs
+   coexist).
+4. Sets S3 user-metadata `Class=tier1, Retention=30d` on the object. Lifecycle
+   pruning must be configured on the `postgres/` prefix — S3 lifecycle rules
+   cannot filter by user-metadata, so the metadata is descriptive only.
 
 ### Cron snippet
 

--- a/docs/runbooks/5xx-spike.md
+++ b/docs/runbooks/5xx-spike.md
@@ -13,9 +13,11 @@
 
 ```bash
 # 1. Confirm the alert is still firing (not a stale page).
+#    The gateway exposes only the http_request_duration_seconds histogram
+#    (no http_requests_total counter). Grep the histogram's _count series.
 curl -s -H "Authorization: Bearer $METRICS_AUTH_TOKEN" \
   https://${PROD_HOSTNAME}/metrics \
-  | grep -E '^http_requests_total{.*status_code="5'
+  | grep -E '^http_request_duration_seconds_count{.*status_code="5'
 
 # 2. Which routes are bleeding? (last 30m of gateway access logs)
 docker compose -f docker-compose.prod.yml logs --since 30m service-gateway \
@@ -30,7 +32,7 @@ docker compose -f docker-compose.prod.yml logs --since 30m service-gateway \
 In Grafana, open the **Error rate by route** panel:
 
 ```promql
-sum by (route, status_code) (rate(http_requests_total{status_code=~"5.."}[5m]))
+sum by (route, status_code) (rate(http_request_duration_seconds_count{status_code=~"5.."}[5m]))
 ```
 
 The route with the highest rate is your starting point.

--- a/docs/runbooks/db-pool-exhaustion.md
+++ b/docs/runbooks/db-pool-exhaustion.md
@@ -17,20 +17,19 @@ otherwise `warning` (`P95LatencyHigh`).
 
 ## Pool config (current defaults)
 
-From the service's database connection config:
+Pool sizing and timeouts are **not env-tunable today** — they live in
+`TIMEOUT_DEFAULTS` in [`packages/db/src/client.ts`](../../packages/db/src/client.ts):
 
-| Env var                              | Default | Meaning                                   |
-| ------------------------------------ | ------- | ----------------------------------------- |
-| `DB_POOL_MAX`                        | `20`    | Max concurrent connections per replica    |
-| `DB_POOL_MIN`                        | `2`     | Min idle connections held                 |
-| `DB_POOL_ACQUIRE_MS`                 | `30000` | How long a request waits for a connection |
-| `DB_POOL_IDLE_MS`                    | `10000` | Idle connection eviction                  |
-| `DB_STATEMENT_TIMEOUT_MS`            | `30000` | Per-query ceiling                         |
-| `DB_LOCK_TIMEOUT_MS`                 | `10000` | Lock-wait ceiling                         |
-| `DB_IDLE_IN_TRANSACTION_TIMEOUT_MS`  | `60000` | Kills idle-in-tx sessions                 |
+| Setting                    | Default   | Meaning                                                       |
+| -------------------------- | --------- | ------------------------------------------------------------- |
+| `connectionTimeoutMillis`  | `10_000`  | How long a request waits for a connection from the pool.      |
+| `idleTimeoutMillis`        | `30_000`  | Idle-connection eviction.                                     |
+| `statement_timeout`        | `30_000`  | Postgres session `statement_timeout` — per-query ceiling.     |
+| `query_timeout`            | `30_000`  | Client-side query timeout applied by node-postgres.           |
+| `max`                      | `10`      | pg default — the code does not override it.                   |
 
-Effective settings are logged at boot:
-`[db] pool max=20 min=2 acquireMs=30000 ...`
+`packages/db/src/client.ts` does not emit a `[db] pool …` log line at
+boot; there is no boot-time report of the effective values.
 
 ## Triage in 60 seconds
 
@@ -60,7 +59,7 @@ docker compose -f docker-compose.prod.yml exec -T database \
 | ------------------------------------------------------- | ------------------------------------ |
 | Many `idle in transaction` rows, `age` > 1m             | A handler is leaking a transaction   |
 | One query holding for minutes, others queued behind it  | Missing index / runaway report query |
-| `active` count == `DB_POOL_MAX * replicas`              | Traffic genuinely exceeds capacity   |
+| `active` count == `pool max × replicas × services`      | Traffic genuinely exceeds capacity   |
 | Many sessions holding the same table-level lock         | Migration / VACUUM FULL in flight    |
 
 Cross-check with the Grafana **Request volume** panel. If volume is
@@ -77,17 +76,18 @@ is up and tracking the saturation, capacity is the cause.
    ```
    Watch the `state` distribution drop back to mostly `idle`.
 
-2. **Bump the pool** (temporary; requires the affected service to
-   restart and pick up the new env):
-   ```bash
-   # Edit .env on the prod host
-   DB_POOL_MAX=40
-   docker compose -f docker-compose.prod.yml up -d service-<name>
-   ```
-   Do **not** exceed the Postgres `max_connections` ceiling
+2. **Bump the pool** — the pool `max` is currently **not env-tunable**;
+   it defaults to pg's built-in `10`. To raise it, edit
+   `TIMEOUT_DEFAULTS` in [`packages/db/src/client.ts`](../../packages/db/src/client.ts)
+   to set an explicit `max`, rebuild the affected service image, and
+   redeploy. Do **not** exceed the Postgres `max_connections` ceiling
    (typically 100 on a small managed instance). Every schema-owning
-   service holds up to `DB_POOL_MAX` connections; budget across all
-   of them and leave headroom for `psql` + the operator.
+   service holds up to `max` connections; budget across all of them
+   (auth, pets, rescue, applications, chat, notifications, moderation,
+   matching, cms, audit) and leave headroom for `psql` + the operator.
+   Because this requires a code change, it is rarely the fastest
+   mitigation — usually a targeted `pg_terminate_backend` or a
+   feature-flag flip is faster.
 
 3. **Disable a hot endpoint** — if a known feature is driving the
    load (e.g. a search endpoint hitting a missing index), flip its
@@ -100,10 +100,11 @@ is up and tracking the saturation, capacity is the cause.
 
 ## Verify
 
-- `pg_stat_activity` count returns to baseline (`active` <
-  `DB_POOL_MAX`).
+- `pg_stat_activity` `active` count returns to baseline (well below
+  each service's pool max).
 - p95 latency drops below 500ms; `P95LatencyHigh` resolves.
-- No new `acquire timeout` lines in the last 5 min of logs.
+- No new `acquire timeout` / `pool is draining` /
+  `timeout exceeded when trying to connect` lines in the last 5 min of logs.
 
 ## Capture
 
@@ -113,10 +114,6 @@ docker compose -f docker-compose.prod.yml exec -T database \
   psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" \
   -c "SELECT * FROM pg_stat_activity WHERE datname=current_database() AND state <> 'idle';" \
   > /tmp/pgstat-$(date +%s).txt
-
-# Pool config + boot env that was in effect on the affected service
-docker compose -f docker-compose.prod.yml logs service-<name> \
-  | grep '\[db\] pool' | tail -1
 ```
 
 The query snapshot is gone the moment you `pg_terminate_backend` —

--- a/docs/runbooks/redis-outage.md
+++ b/docs/runbooks/redis-outage.md
@@ -77,9 +77,8 @@ Match the symptom:
      config --volumes | grep redis_data)
    docker compose -f docker-compose.prod.yml up -d redis
    ```
-   Cost: rate-limit windows reset, in-flight BullMQ jobs lost,
-   namespace version stamps reset (full cache miss for ~minutes).
-   Acceptable in an outage.
+   Cost: rate-limit windows reset and namespace version stamps
+   reset (full cache miss for ~minutes). Acceptable in an outage.
 
 3. **If Redis is down for >5 min** — flip
    `APPLICATION_SETTINGS.maintenance_mode = true` to shed write

--- a/docs/security/image-signing.md
+++ b/docs/security/image-signing.md
@@ -38,8 +38,12 @@ The `build-and-push` job:
    - Uploads the signature + cert + Rekor inclusion proof to GHCR (next
      to the image, as a `sha256-<digest>.sig` tag).
 
-Each of the four images (backend, app-client, app-admin, app-rescue) is
-signed individually.
+Each of the fourteen images built by `deploy.yml` is signed individually:
+the eleven `service-*` images (`service-gateway`, `service-auth`,
+`service-notifications`, `service-pets`, `service-rescue`,
+`service-applications`, `service-chat`, `service-moderation`,
+`service-matching`, `service-audit`, `service-cms`) and the three `app-*`
+images (`app-client`, `app-admin`, `app-rescue`).
 
 ## How verification works
 
@@ -62,7 +66,13 @@ To verify an image yourself (e.g. before bringing it up on a non-CI host):
 ```bash
 # Install cosign — see https://docs.sigstore.dev/cosign/installation
 SHA=<git-sha-you-want-to-verify>
-for image in backend app-client app-admin app-rescue; do
+IMAGES=(
+  service-gateway service-auth service-notifications service-pets
+  service-rescue service-applications service-chat service-moderation
+  service-matching service-audit service-cms
+  app-client app-admin app-rescue
+)
+for image in "${IMAGES[@]}"; do
   cosign verify \
     --certificate-identity-regexp '^https://github.com/ideaSquared/adopt-dont-shop/\.github/workflows/.+@refs/heads/main$' \
     --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' \

--- a/packages/lib.analytics/src/hooks/useReports.ts
+++ b/packages/lib.analytics/src/hooks/useReports.ts
@@ -5,10 +5,11 @@ import type { ReportConfig } from '../schemas/reports';
 /**
  * ADS-105: React Query hooks (@tanstack/react-query v5) over the report API.
  *
- * Query keys: `['reports']` is the list, `['reports', id]` is the
- * single report, `['reports', id, 'execute']` is the executed payload.
- * Mutations invalidate the list key on success — single-report
- * fetches refetch on the next mount.
+ * Query keys: the list is `['reports', { includeArchived }]`, a single
+ * report is `['reports', id]`, an executed saved report is
+ * `['reports', id, 'execute']`, and templates are `['report-templates']`.
+ * Mutations invalidate the list key on success — single-report fetches
+ * refetch on the next mount.
  */
 
 const REPORTS_KEY = 'reports';

--- a/packages/lib.analytics/src/schemas/reports.ts
+++ b/packages/lib.analytics/src/schemas/reports.ts
@@ -3,10 +3,12 @@ import { z } from 'zod';
 /**
  * ADS-105: Frontend Zod schemas for the analytics report builder.
  *
- * Mirrors the backend schemas in
- * `service.backend/src/schemas/reports.schema.ts`. Both files must
- * stay in sync — the backend is canonical for validation, this file
- * provides typed API responses + form validation in the builder UI.
+ * Mirrors the analytics/reports contract owned by `services/audit`
+ * (see `services/gateway/src/routes/reports.ts` and
+ * `services/audit/src/grpc/reports-handlers.ts`). Keep this file in
+ * sync with the backing service's request/response schemas — the
+ * service is canonical for validation; this file provides typed API
+ * responses + form validation in the builder UI.
  *
  * Per ADS-187 (lib.analytics should adopt schema-first), all new
  * report types are derived from these schemas via `z.infer`.

--- a/packages/lib.applications/src/schemas.ts
+++ b/packages/lib.applications/src/schemas.ts
@@ -15,11 +15,11 @@ export const ApplicationPrioritySchema = z.enum(APPLICATION_PRIORITIES);
 
 // ── ApplicationData sub-schemas ───────────────────────────────────────────────
 //
-// These schemas describe the `data` payload returned by the backend's
-// transformApplicationModel (service.backend/src/controllers/application.controller.ts).
-// Every field inside `data` is best-effort: the transform projects loose
-// application_answers rows into a frontend shape, so any individual field
-// may be missing depending on which answers the adopter has supplied.
+// These schemas describe the `data` payload returned by the applications
+// service (services/applications/) — the gRPC handlers project loose
+// `application_answers` rows into a frontend shape. Every field inside
+// `data` is best-effort: any individual field may be missing depending
+// on which answers the adopter has supplied.
 // Keep these schemas permissive — strict typing belongs at the form
 // validator, not at the read boundary.
 

--- a/packages/lib.dev-tools/src/index.ts
+++ b/packages/lib.dev-tools/src/index.ts
@@ -35,9 +35,8 @@ export const isDevelopmentMode = () => {
     // production-adjacent hosts like dev.example.com — removed intentionally.
     return window.location.hostname === 'localhost' || window.location.hostname === '127.0.0.1';
   }
-  // Case-insensitive match — matches isProductionLike() in
-  // service.backend/src/config/env.ts so a "Development" or "DEVELOPMENT"
-  // NODE_ENV doesn't silently disable dev tooling on the server side.
+  // Case-insensitive so a "Development" or "DEVELOPMENT" NODE_ENV
+  // doesn't silently disable dev tooling on the server side.
   return process.env.NODE_ENV?.trim().toLowerCase() === 'development';
 };
 

--- a/packages/lib.legal/src/services/attach-stored-consent.ts
+++ b/packages/lib.legal/src/services/attach-stored-consent.ts
@@ -8,8 +8,10 @@ import { readStoredConsent } from './cookie-consent-storage';
  * The cookie banner persists the user's choice to localStorage even when
  * they're not signed in. When `auth_session_authenticated` fires for the
  * first time per `(userId, cookiesVersion)`, we POST the stored choice
- * to /api/v1/privacy/consent so the audit log captures the decision
- * against the account.
+ * to /api/v1/privacy/cookies-consent (the cookies-only endpoint added
+ * in ADS-550 — NOT the general /privacy/consent endpoint, which would
+ * silently stamp ToS + Privacy re-acceptance the user never gave) so
+ * the audit log captures the decision against the account.
  *
  * Idempotency (ADS-555): a side-table keyed by userId remembers the
  * cookiesVersion last attached for each user. The previous shape held a

--- a/packages/lib.matching/src/index.ts
+++ b/packages/lib.matching/src/index.ts
@@ -2,9 +2,9 @@
  * @adopt-dont-shop/lib.matching
  *
  * Shared types for the AI/ML pet-adopter matching feature. Mirrors
- * the backend `service.backend/src/matching/types.ts` surface for
- * data crossing the API boundary (top-picks response, discovery
- * pet card, match profile read/write).
+ * the matching gRPC surface exposed by `services/matching` (MatchingV1
+ * proto in `@adopt-dont-shop/proto`) for data crossing the API boundary
+ * (top-picks response, discovery pet card, match profile read/write).
  */
 
 export const REASON_CHIP_KINDS = [

--- a/packages/lib.observability/src/sentry.ts
+++ b/packages/lib.observability/src/sentry.ts
@@ -31,7 +31,12 @@ export type SentryInitOptions = {
   release?: string;
   /** Sample rate for performance traces. Defaults to 0.1. */
   tracesSampleRate?: number;
-  /** Sample rate for replay sessions. Defaults to 0 (off). Caller may opt in after consent. */
+  /**
+   * Sample rate for replay sessions. Defaults to 0 (off). Session-replay
+   * content can carry PII, so callers must only raise this after
+   * analytics consent has been recorded — Sentry itself runs
+   * unconditionally per the class-level note below.
+   */
   replaysSessionSampleRate?: number;
   /** Replay sample rate when an error occurs. Defaults to 0. */
   replaysOnErrorSampleRate?: number;

--- a/packages/lib.pets/src/services/pets-management-service.ts
+++ b/packages/lib.pets/src/services/pets-management-service.ts
@@ -2,9 +2,9 @@ import { ApiService, ApiResponse } from '@adopt-dont-shop/lib.api';
 import { Pet, PetCreateData, PetUpdateData, PetStatus, PetsServiceConfig } from '../types';
 import { PETS_ENDPOINTS } from '../constants/endpoints';
 
-// Mirrors the backend's PetService.bulkUpdatePets return shape (see
-// service.backend/src/services/pet.service.ts). `errors` is a list of
-// per-pet failures so the UI can show partial-success summaries.
+// Mirrors the return shape of the pets service's bulk-update endpoint
+// (services/pets/). `errors` is a list of per-pet failures so the UI can
+// show partial-success summaries.
 export type BulkPetOperationResult = {
   successCount: number;
   failedCount: number;
@@ -19,11 +19,10 @@ export type BulkPetOperationResult = {
  *
  * Features:
  * - Full CRUD operations for pets
- * - Image upload and management
+ * - Image upload / removal
  * - Status updates and tracking
- * - Bulk operations support
- * - Medical history management
- * - Behavioral assessment tracking
+ * - Bulk status update + bulk archive
+ * - Per-rescue pet statistics
  */
 export class PetManagementService {
   private apiService: ApiService;

--- a/packages/lib.pets/src/services/pets-service.ts
+++ b/packages/lib.pets/src/services/pets-service.ts
@@ -44,7 +44,7 @@ const normalisePet = (raw: unknown): Pet => {
  * - Advanced search with 15+ filter types
  * - Pet data transformation (snake_case ↔ camelCase)
  * - PostGIS location handling
- * - Favorites management with localStorage caching
+ * - Favorites management via the backend API (no client-side cache)
  * - Pet reporting functionality
  * - Statistics and analytics
  */

--- a/packages/lib.search/src/services/search-service.ts
+++ b/packages/lib.search/src/services/search-service.ts
@@ -219,7 +219,6 @@ export class SearchService {
    *
    * @param query - Partial search query
    * @param type - Type of suggestions ('pets', 'messages', 'all')
-   * @param options - Request options
    * @returns Promise<SearchSuggestion[]> - Search suggestions
    */
   async getSearchSuggestions(
@@ -246,7 +245,6 @@ export class SearchService {
    *
    * @param query - Search query
    * @param advancedOptions - Advanced search options
-   * @param options - Request options
    * @returns Promise<FacetedSearchResponse> - Faceted search results
    */
   async facetedSearch(

--- a/packages/lib.support-tickets/src/support-ticket-service.ts
+++ b/packages/lib.support-tickets/src/support-ticket-service.ts
@@ -167,7 +167,11 @@ export class SupportTicketService {
   }
 
   /**
-   * Rate a ticket (helper method for satisfaction surveys)
+   * Rate a ticket (helper method for satisfaction surveys).
+   *
+   * NOTE: pending a dedicated rating endpoint on the backend, this
+   * closes the ticket as a side effect and stores the rating in
+   * `internalNotes`. Do not call on a ticket you still want open.
    */
   async rateTicket(ticketId: string, data: RateTicketRequest): Promise<SupportTicket> {
     // Note: This might need a specific endpoint on the backend

--- a/services/auth/README.md
+++ b/services/auth/README.md
@@ -2,10 +2,9 @@
 
 Auth vertical — Phase 2 of the microservices migration.
 
-Owns the `auth.*` schema (User, RefreshToken, RevokedToken, Role,
-Permission, UserRole, RolePermission, TwoFactorRecovery, DeviceToken,
-IpRule, UserConsent) and exposes `AuthService.{Login, Logout,
-RefreshToken, ValidateToken, GetMe, AssignRole}` over gRPC.
+Owns the `auth.*` schema and exposes `AuthService` over gRPC. See the
+canonical reference at the bottom of this file for the exact table + RPC
+lists — the rest of the doc is historical migration context.
 
 CAD Phase 4 equivalent — the auth pattern that brought CAD's gate
 online (Lucia + JWT + bcrypt + CASL ability serialisation), restated
@@ -205,8 +204,10 @@ the gateway validates on every request. Schema: `auth`.
 | `revoked_tokens` | JTI denylist for access + old refresh tokens. |
 | `user_privacy_prefs` | Per-user privacy preferences. |
 | `field_permissions` | Overrides to the default field-level access matrix. |
+| `ip_rules` | Admin-managed IP allow/deny rules. |
+| `user_invitations` | Staff / rescue invitation tokens. |
 
-Migrations: `services/auth/src/migrations/001`–`025`.
+Migrations: `services/auth/src/migrations/001`–`028`.
 
 ### gRPC RPCs
 

--- a/services/gateway/README.md
+++ b/services/gateway/README.md
@@ -1,63 +1,75 @@
 # service.gateway
 
-BFF / API gateway for the microservices migration.
+The single REST + WebSocket edge in front of the ten domain gRPC services.
 
-## What this service is for
+## Responsibility
 
-Phase 0f stands the gateway up as a **strangler-fig start**: a Fastify
-pass-through proxy in front of the residual `service.backend`. Every
-`/api/*` request goes through here and gets forwarded to the monolith
-unchanged. Adding routes for extracted services (Phase 1+) is a
-per-PR Fastify plugin registration — `first-registered-wins` semantics
-mean a new service's prefix gets picked off before the catch-all
-proxy sees it.
+Authenticates every request (validates `Authorization: Bearer` via
+`service.auth.ValidateToken` and stamps server-derived `x-user-*` metadata,
+stripping any spoofed inbound headers), fans REST routes out to the right
+service over gRPC, terminates the Socket.IO connection and broadcasts NATS
+events to clients, enforces global rate limiting, and wraps each downstream
+client in a circuit breaker. A handful of small surfaces are served
+in-process (legal markdown, `/config`, analytics, dashboard composition,
+uploads, GDPR erasure kickoff). **No schema** — the gateway owns no Postgres
+tables.
 
-The end-state, once Phase 11 deletes the residual monolith:
+## Downstream gRPC clients
 
-```
-  /api/auth/*         → service.auth         (Phase 2)
-  /api/applications/* → service.applications (Phase 5)
-  /api/chat/*         → service.chat         (Phase 6)
-  /api/pets/*         → service.pets         (Phase 3)
-  …
-```
+`auth`, `notifications`, `pets`, `rescue`, `applications`, `chat`,
+`moderation`, `matching`, `audit`, `cms` — one client per service, addressed
+at `service-<name>:<grpcPort>` (`*_GRPC_URL` env vars, see Configuration
+below).
 
-For now it's just:
+## Route groups (`/api/v1/*`)
 
-```
-  /api/*              → service.backend (residual)
-  /health/simple      → owned by the gateway itself
-```
+`auth`, `sessions`, `field-permissions`, `users` → auth; `notifications`,
+`devices`, `email`, `broadcast` → notifications; `pets` → pets; `rescue`,
+`rescues` (public), `staff`/`foster`/`invitations` → rescue; `applications`,
+`application-documents` → applications; `chats` → chat; `moderation`,
+`admin/moderation`, `support` → moderation; `matching` → matching; `audit`,
+`reports` → audit; `cms` → cms. Gateway-folded (in-process): `legal`,
+`config`, `analytics`, `dashboard`, `uploads`, and
+`users/me/erasure-request` (GDPR). **There is no catch-all monolith proxy**
+— unowned `/api/*` paths return 404.
 
-## What's deliberately NOT here yet
+## gRPC RPCs
 
-- **WebSocket proxying.** Future `service.notifications` (Phase 1)
-  owns the WS spine. Forwarding sockets through `@fastify/http-proxy`
-  would couple the gateway to the monolith's socket lifecycle right
-  when we want the opposite.
-- **Auth gate (`ability.can(...)`).** Lands with `service.auth` in
-  Phase 2 — uses `@adopt-dont-shop/authz` against the principal
-  metadata the auth service supplies.
-- **gRPC translation.** No service speaks gRPC yet; the gateway's
-  REST → gRPC layer arrives when the first gRPC-speaking service
-  ships.
-- **Per-request access logs.** Disabled Fastify's built-in pino so it
-  doesn't double-log on top of OpenTelemetry's HTTP auto-instrumentation.
-  Per-route logging via `onResponse` hooks arrives with real routes.
+None — the gateway is a gRPC **client**, not a server. It exposes the
+REST/WS surface above plus the health + `/metrics` endpoints.
+
+## NATS subjects
+
+**Emits:** `gdpr.erasureRequested` (from
+`POST /api/v1/users/me/erasure-request`, kicking off the erasure saga).
+
+**Consumes (for WebSocket fan-out):** `notifications.created`,
+`notifications.dismissed`, `chat.messageCreated`, `chat.messageRead`,
+`chat.reactionAdded`, `chat.reactionRemoved`. It also ensures the
+`DOMAIN_EVENTS` JetStream stream exists at boot.
 
 ## Configuration
 
-| Env var                | Default                          | Purpose                                    |
-| ---------------------- | -------------------------------- | ------------------------------------------ |
-| `GATEWAY_PORT`         | `4000`                           | Port the gateway binds.                    |
-| `GATEWAY_HOST`         | `0.0.0.0`                        | Bind interface.                            |
-| `UPSTREAM_BACKEND_URL` | `http://service-backend:5000`    | URL of the residual monolith.              |
-| `NODE_ENV`             | `development`                    | Surfaces in `/health/simple` + log lines.  |
+| Env var                       | Default                        | Purpose                                                                        |
+| ----------------------------- | ------------------------------ | ------------------------------------------------------------------------------ |
+| `GATEWAY_PORT`                | `4000`                         | Port the gateway binds.                                                        |
+| `GATEWAY_HOST`                | `0.0.0.0`                      | Bind interface.                                                                |
+| `NODE_ENV`                    | `development`                  | Surfaces in `/health/simple` + log lines.                                      |
+| `NOTIFICATIONS_GRPC_URL`      | `service-notifications:6001`   | Downstream gRPC address for `service.notifications`.                           |
+| `AUTH_GRPC_URL`               | `service-auth:6002`            | Downstream gRPC address for `service.auth`.                                    |
+| `PETS_GRPC_URL`               | `service-pets:6003`            | Downstream gRPC address for `service.pets`.                                    |
+| `RESCUE_GRPC_URL`             | `service-rescue:6004`          | Downstream gRPC address for `service.rescue`.                                  |
+| `APPLICATIONS_GRPC_URL`       | `service-applications:6005`    | Downstream gRPC address for `service.applications`.                            |
+| `CHAT_GRPC_URL`               | `service-chat:6006`            | Downstream gRPC address for `service.chat`.                                    |
+| `MODERATION_GRPC_URL`         | `service-moderation:6007`      | Downstream gRPC address for `service.moderation`.                              |
+| `MATCHING_GRPC_URL`           | `service-matching:6008`        | Downstream gRPC address for `service.matching`.                                |
+| `AUDIT_GRPC_URL`              | `service-audit:6009`           | Downstream gRPC address for `service.audit`.                                   |
+| `CMS_GRPC_URL`                | `service-cms:6010`             | Downstream gRPC address for `service.cms`.                                     |
 
 Plus all the standard observability env vars consumed by
 `@adopt-dont-shop/observability`: `OTEL_EXPORTER_OTLP_ENDPOINT`,
-`OTEL_SERVICE_NAME`, `SENTRY_DSN`, `LOG_LEVEL`, `LOKI_URL` — see
-that package's README.
+`OTEL_SERVICE_NAME`, `SENTRY_DSN`, `LOG_LEVEL`, `LOKI_URL` — see that
+package's README.
 
 ### gRPC resilience tunables
 
@@ -128,6 +140,30 @@ In degraded mode the limit reverts to per-replica behaviour. The gateway never c
 
 `gateway_rate_limit_hits_total{route}` — Counter exported on `/metrics`, incremented on every 429 response. The `route` label is the Fastify route template (e.g. `/api/v1/auth/login`).
 
+## Metrics (beyond the shared substrate)
+
+- `gateway_rate_limit_hits_total{route}` — counter, incremented on every 429
+  (`src/server.ts`).
+- `grpc_circuit_state{service}` — gauge, `0`=closed / `1`=half-open / `2`=open,
+  one per downstream service (`src/grpc-clients/resilience.ts`).
+
+Both feed the alerts in
+[`infra/prometheus/rules/gateway-resilience.yml`](../../infra/prometheus/rules/gateway-resilience.yml).
+
+## Dependencies
+
+`@adopt-dont-shop/{config-secrets, events, observability, proto,
+service-bootstrap, storage}` plus the generated clients for all ten services.
+No own database.
+
+## Testing strategy
+
+Vitest. Route handlers are tested against stubbed gRPC clients (the REST→gRPC
+translation + response adaptation), the authenticate middleware against a
+stub `ValidateToken`, the rate-limit + circuit-breaker behaviour directly,
+and the WS subscribers against a fake NATS — asserting header-stripping,
+401/404 paths, and event→socket fan-out without a live transport.
+
 ## Running
 
 ```bash
@@ -138,104 +174,3 @@ pnpm dev
 pnpm build
 pnpm start
 ```
-
-## Routing model
-
-`@fastify/http-proxy` mounts a catch-all under the `/api` prefix that
-forwards to `UPSTREAM_BACKEND_URL`. The prefix is preserved on the way
-through (`rewritePrefix: '/api'`) so the upstream sees the same path
-the client sent.
-
-When extracting a service, register its plugin BEFORE the catch-all in
-`createServer` so Fastify resolves the more specific prefix first.
-Concretely, in Phase 2 the order will be:
-
-```ts
-server.register(authRoutes, { prefix: '/api/auth' });   // new service
-server.register(httpProxy, { prefix: '/api', upstream }); // residual
-```
-
-The auth plugin handles `/api/auth/*`; everything else falls through
-to the monolith.
-
-## What this brings to the table for Phase 1
-
-- A stable place for `service.notifications` to terminate WebSockets
-  (gateway holds the socket; NATS fans events to it from the service).
-- A single edge for the future auth gate to live (gateway runs the
-  `ability.can` check; downstream services re-check via gRPC metadata
-  as defence-in-depth, matching the CAD pattern).
-- A natural strangler-fig boundary — extracting any service is "add a
-  route plugin to the gateway, delete the route from the monolith."
-
----
-
-## Canonical reference (ADS-817)
-
-### Responsibility
-
-The single REST/WebSocket edge in front of the gRPC services. It authenticates
-every request (validates `Authorization: Bearer` via `service.auth.ValidateToken`
-and stamps server-derived `x-user-*` metadata, stripping any spoofed inbound
-headers), fans REST routes out to the right service over gRPC, terminates the
-Socket.IO connection and broadcasts NATS events to clients, enforces global rate
-limiting, and wraps each downstream client in a circuit breaker. A handful of
-small surfaces are served in-process (legal markdown, `/config`, analytics,
-dashboard composition, uploads, GDPR erasure kickoff). **No schema** — the
-gateway owns no Postgres tables.
-
-### Downstream gRPC clients
-
-`auth`, `notifications`, `pets`, `rescue`, `applications`, `chat`, `moderation`,
-`matching`, `audit`, `cms` — one client per service, addressed at
-`service-<name>:<grpcPort>` (`*_GRPC_URL` env vars).
-
-### Route groups (`/api/v1/*`)
-
-`auth`, `sessions`, `field-permissions`, `users` → auth; `notifications`,
-`devices`, `email`, `broadcast` → notifications; `pets` → pets; `rescue`,
-`rescues` (public), `staff`/`foster`/`invitations` → rescue; `applications`,
-`application-documents` → applications; `chats` → chat; `moderation`,
-`admin/moderation`, `support` → moderation; `matching` → matching; `audit`,
-`reports` → audit; `cms` → cms. Gateway-folded (in-process): `legal`, `config`,
-`analytics`, `dashboard`, `uploads`, and `users/me/erasure-request` (GDPR).
-There is **no catch-all monolith proxy** — unowned `/api/*` paths return 404.
-
-### gRPC RPCs
-
-None — the gateway is a gRPC **client**, not a server. It exposes the REST/WS
-surface above plus the health + `/metrics` endpoints.
-
-### NATS subjects
-
-**Emits:** `gdpr.erasureRequested` (from `POST /api/v1/users/me/erasure-request`,
-kicking off the erasure saga).
-
-**Consumes (for WebSocket fan-out):** `notifications.created`,
-`notifications.dismissed`, `chat.messageCreated`, `chat.messageRead`,
-`chat.reactionAdded`, `chat.reactionRemoved`. It also ensures the
-`DOMAIN_EVENTS` JetStream stream exists at boot.
-
-### Metrics (beyond the shared substrate)
-
-- `gateway_rate_limit_hits_total{route}` — counter, incremented on every 429
-  (`src/server.ts`).
-- `grpc_circuit_state{service}` — gauge, `0`=closed / `1`=half-open / `2`=open,
-  one per downstream service (`src/grpc-clients/resilience.ts`).
-
-Both feed the alerts in
-[`infra/prometheus/rules/gateway-resilience.yml`](../../infra/prometheus/rules/gateway-resilience.yml).
-
-### Dependencies
-
-`@adopt-dont-shop/{config-secrets, events, observability, proto,
-service-bootstrap, storage}` plus the generated clients for all ten services. No
-own database.
-
-### Testing strategy
-
-Vitest. Route handlers are tested against stubbed gRPC clients (the REST→gRPC
-translation + response adaptation), the authenticate middleware against a stub
-`ValidateToken`, the rate-limit + circuit-breaker behaviour directly, and the WS
-subscribers against a fake NATS — asserting header-stripping, 401/404 paths, and
-event→socket fan-out without a live transport.

--- a/services/matching/README.md
+++ b/services/matching/README.md
@@ -7,8 +7,8 @@ Matching vertical — Phase 9 of the microservices migration.
 Stateless recommender (CAD `service.dispatch` shape) — given a user,
 queries `service.pets` for candidates over gRPC, ranks by stored
 preferences + match-profile, returns top-K. Owns the `matching.*`
-schema (`SwipeSession`, `SwipeAction`). Absorbs the monolith's
-discovery + search + swipe modules.
+schema (`SwipeSession`, `SwipeAction`, `AdopterMatchProfile`). Absorbs
+the monolith's discovery + search + swipe modules.
 
 ## Location in the architecture
 

--- a/services/matching/src/grpc/handlers.ts
+++ b/services/matching/src/grpc/handlers.ts
@@ -1,9 +1,10 @@
 // gRPC handler implementations for MatchingService.
 //
-// Phase 9.3b — ships StartSession + EndSession + RecordSwipe +
-// ListSwipeHistory. Recommend + SearchPets follow once the service
-// gains a service.pets gRPC client (both RPCs need to read pet
-// candidates from the pets vertical).
+// This file ships StartSession + EndSession + RecordSwipe +
+// ListSwipeHistory. Recommend + SearchPets are implemented alongside
+// in recommend-handlers.ts and share the PetsClient wired in
+// server.ts — the "follows in a later phase" note that used to live
+// here is out of date.
 //
 // Discipline:
 //   - State-changing writes wrap @adopt-dont-shop/events.withTransaction

--- a/services/moderation/README.md
+++ b/services/moderation/README.md
@@ -2,9 +2,9 @@
 
 Moderation vertical — Phase 8 of the microservices migration.
 
-Owns the `moderation.*` schema (Report, ModeratorAction,
-ModerationEvidence, UserSanction, SupportTicket, SupportTicketResponse)
-and exposes `ModerationService` over gRPC. Cross-cutting reads via
+Owns the `moderation.*` schema (Report, ReportStatusTransition,
+ModeratorAction, ModerationEvidence, UserSanction, SupportTicket,
+SupportTicketResponse) and exposes `ModerationService` over gRPC. Cross-cutting reads via
 gRPC; consumes events (`chat.messageCreated`, `pets.created`,
 `applications.submitted`) for content scanning + auto-report triggers.
 

--- a/services/notifications/README.md
+++ b/services/notifications/README.md
@@ -2,9 +2,10 @@
 
 The first stateful extraction of the Phase 1 migration. Owns
 **`notifications.*`** (Notification, DeviceToken, UserNotificationPrefs,
-EmailPreference, EmailQueue), exposes a gRPC API for create / list /
-dismiss, subscribes to NATS for cross-service fan-out, and feeds the
-gateway's WebSocket spine so connected clients see notifications live.
+EmailPreference, EmailQueue, EmailTemplate, ProcessedEvent), exposes a
+gRPC API for create / list / dismiss, subscribes to NATS for cross-service
+fan-out, and feeds the gateway's WebSocket spine so connected clients see
+notifications live.
 
 CAD Phase 1 equivalent — the same pattern that brought CAD's WebSocket
 spine online, restated for adopt-dont-shop's domain.

--- a/services/rescue/README.md
+++ b/services/rescue/README.md
@@ -3,8 +3,8 @@
 Rescue vertical — Phase 4 of the microservices migration.
 
 Owns the `rescue.*` schema (Rescue, RescueSettings, StaffMember,
-Invitation, FosterPlacement, ApplicationQuestion) and exposes
-`RescueService` over gRPC.
+Invitation, FosterPlacement, ApplicationQuestion, Event, EventAttendee)
+and exposes `RescueService` over gRPC.
 
 Classical (no event sourcing — mostly CRUD with a few status
 transitions). The `staff_members` join row denormalises `user_id` +
@@ -172,6 +172,8 @@ foster pet ownership via a gRPC call to service.pets. Schema: `rescue`.
 | `invitations` | Pending staff invitations — email, token, expiry, used flag. |
 | `foster_placements` | Foster assignments — rescue, pet, foster user, dates, status. |
 | `application_questions` | Custom adoption-application questions a rescue defines. |
+| `events` | Adoption / community events a rescue hosts. |
+| `event_attendees` | Per-user attendance for a rescue event. |
 
 Migrations: `services/rescue/src/migrations/001`–`010`.
 


### PR DESCRIPTION
## Summary

- Ran a factual accuracy sweep across the 227 markdown files + high-signal JSDoc comments in the repo. Cross-checked every claim against actual code / migrations / compose files / CI workflows before editing.
- Doc-only change (no code paths, tests, or runtime config touched).
- Landed as **four themed commits** — one per batch — so review can be paged.

## Changes

### Batch 1 — root docs (`6f6f57d`)
- **README.md** — port range `5001-5009 (services)` → `5001-5010`. `service-cms` (ADS-898) lives on `127.0.0.1:5010:5010`.
- **CONTRIBUTING.md** — `ci-required` aggregator actually `needs:` **8** jobs, not 7. Added the missing Pact `test-contracts` step.
- **docs/DOCKER.md** — microservice containers run as `svcuser`, not `appuser` (`Dockerfile.service:35`).
- **docs/GETTING-STARTED.md** — `pnpm setup` does NOT generate a CSRF secret. Dropped "CSRF" from the list.
- **docs/env-reference.md** — `EMAIL_PROVIDER=ethereal` is not refused in production; only `console` is. Rewrote the comment.

### Batch 2 — service + app READMEs (`4637afd`)
- **services/gateway/README.md** — the entire opening narrative ("Phase 0f strangler-fig pass-through proxy in front of `service.backend`", `UPSTREAM_BACKEND_URL`, `@fastify/http-proxy` catch-all, "gRPC translation not here yet") describes a state that no longer exists. Lifted the canonical (ADS-817) reference to be the primary content and rewrote the Configuration table with the actual `*_GRPC_URL` env vars (6001–6010).
- **services/auth/README.md** — opening paragraph listed tables that don't exist (TwoFactorRecovery, DeviceToken, UserConsent) and missed real ones (ip_rules, user_invitations). Migration range 001–025 → 001–028. Canonical Schema table now lists `ip_rules` + `user_invitations`.
- **services/rescue/README.md** — added `events` + `event_attendees` (migrations 009/010) to both the opening tuple and the canonical Schema table.
- **services/matching/README.md** — added `AdopterMatchProfile` (migration 003).
- **services/notifications/README.md** — added `EmailTemplate` + `ProcessedEvent` (migrations 005/008).
- **services/moderation/README.md** — added `ReportStatusTransition` (migration 002).
- **apps/client/README.md**, **apps/rescue/README.md** — PRD links used `../docs/frontend/…` which resolves to `apps/docs/frontend/…` (doesn't exist). Corrected to `../../docs/frontend/…`.
- **apps/rescue/README.md** — contexts list claimed Analytics, Notifications, and Permissions contexts; `apps/rescue/src/contexts/` only ships `ChatContext.tsx` + `StatsigContext.tsx`.

### Batch 3 — operational runbooks + backend/infra docs (`7b0c1b9`)
Clustered around monolith-era leftovers (Sequelize / SequelizeMeta / BullMQ / `db:migrate:undo` / `service.backend`), phantom env vars, and metric/route names that never existed:

- **docs/operations/deploy.md** — "six secrets" → "five" (`SECRET_VARS` in `scripts/validate-env.ts` has 5 entries; the doc's own table also lists 5).
- **docs/deploy/per-service-rollback.md** — dropped the `pnpm db:migrate:undo` command block (no such script; runner is forward-only).
- **docs/backend/troubleshooting.md** — health checks: `localhost:5000/health` (gateway is on 4000) / `/health/detailed` / `/health/db` don't exist — only `/health/simple` does. Migrations: `db:migrate:status` / `db:migrate:undo` don't exist; replaced `SequelizeMeta` with per-schema `pgmigrations` tables.
- **docs/backend/deployment.md** — `services/<name>/Dockerfile` doesn't exist; all services share `Dockerfile.service`. Removed BullMQ from Redis usage (no BullMQ in codebase). Removed `DB_POOL_MAX`/`DB_POOL_MIN` (not read anywhere). Health section pruned to only endpoints that exist (`/health/simple`, `/docs`).
- **docs/runbooks/db-pool-exhaustion.md** — rewrote the pool-config section: none of `DB_POOL_*` / `DB_STATEMENT_TIMEOUT_MS` / `DB_LOCK_TIMEOUT_MS` / `DB_IDLE_IN_TRANSACTION_TIMEOUT_MS` is read anywhere. Timeouts are hardcoded in `TIMEOUT_DEFAULTS` in `packages/db/src/client.ts`. Removed the `[db] pool max=…` grep target (no such log line). Rewrote the "Bump the pool" mitigation to say it requires a code change.
- **docs/runbooks/redis-outage.md** — dropped "in-flight BullMQ jobs lost".
- **docs/runbooks/5xx-spike.md** — the gateway exposes only the `http_request_duration_seconds` histogram; there is no `http_requests_total` counter. Corrected grep + PromQL to use the histogram `_count` series.
- **docs/operations/snapshot-policy.md**, **docs/operations/restore.md** — S3 key includes `HHMMSS` (`postgres/YYYY/MM/DD/HHMMSS/dump.sql.gz`, not `.../DD/dump.sql.gz`). Also called out that lifecycle rules can only filter by prefix or tags — the `Class=tier1,Retention=30d` value is S3 user-metadata, not tags, so it is descriptive only.
- **docs/security/image-signing.md** — "four images" list was monolith-era. `deploy.yml` builds/signs **14** images (11 `service-*` + 3 `app-*`); no `backend` image exists.
- **docs/observability/tracing.md** — removed `pnpm dev:backend` (no such script). Instrumentation table: dropped `express` + "Sequelize → pg" (services use Fastify + pg directly), added `fastify` + `grpc`. Removed the BullMQ known-gap section. Rewrote Worker-processes — `reports.worker` / `retention.job` / `legal-reminder.worker` no longer exist.
- **docs/infrastructure/DEPLOYMENT-PLAN.md** — removed the `00-baseline` / `SequelizeMeta` bootstrap step. Corrected the pre-flight step that claimed `docker compose up -d` "uses `:latest` tag initially" — `docker-compose.prod.yml` requires `DEPLOY_SHA` with no fallback.

### Batch 4 — JSDoc / block comments in lib.* + services (`7cb3e1b`)
Sampled JSDoc across packages/lib.* and services/*. Fixed comments that would mislead a reader:

- **lib.legal** — `attach-stored-consent.ts` pointed at `/api/v1/privacy/consent`; actually POSTs to `/api/v1/privacy/cookies-consent`.
- **lib.pets** — `pets-service.ts` claimed "Favorites management with localStorage caching" (no localStorage code); `pets-management-service.ts` claimed medical-history + behavioral-assessment features that don't exist, and pointed at a deleted `service.backend` file.
- **lib.support-tickets** — added a NOTE that `rateTicket()` **closes the ticket** as a side effect.
- **lib.matching**, **lib.analytics**, **lib.dev-tools**, **lib.applications** — dropped stale pointers at the deleted `service.backend/**` files; redirected each to the current authoritative source (proto / services/audit / services/applications).
- **lib.search** — removed phantom `@param options` from `getSearchSuggestions` and `facetedSearch` (a third options param that does not exist in either signature).
- **lib.analytics/hooks/useReports.ts** — documented list-query key `['reports']` is actually `['reports', { includeArchived }]`. Consumers using the doc'd key never invalidated the real cache entry.
- **lib.observability/sentry.ts** — reconciled a contradiction between the replay-sample-rate field doc and the class-level "not consent-gated" note.
- **services/matching/src/grpc/handlers.ts** — file comment said `Recommend + SearchPets` "follow once the service gains a `service.pets` gRPC client". Both are implemented (recommend-handlers.ts, top-picks-handlers.ts) and `pets-client.ts` already exists.

## Before requesting review

- [x] Ran `pnpm ci:local:quick` locally (or installed the pre-push hook — see CONTRIBUTING.md) — n/a, doc-only
- [x] Tests for new behaviour added (TDD) — n/a, doc-only
- [x] If touching `.env` requirements, updated `.env.example`'s REQUIRED block — n/a, no env changes
- [x] If touching a `lib.*`, considered consumer impact across `app.*` and `service.backend` — n/a; comment-only changes

## Test plan

- [x] Existing tests pass (`pnpm test`) — doc / comment-only, no runtime changes
- [x] Tested manually — every claim was verified against the referenced file/script/config before the edit landed. Verification tools: reading migration files (`services/*/src/migrations/`), reading service configs (`services/*/src/config.ts`), reading `docker-compose.yml` / `docker-compose.prod.yml`, reading `scripts/*.mjs`, and reading the CI workflow at `.github/workflows/ci.yml`.
- [x] No TypeScript errors (`pnpm type-check`) — no runtime signatures changed; JSDoc-only edits inside comment blocks.
- [x] Lint passes (`pnpm lint`) — n/a

## Screenshots / recordings

n/a — doc changes only.

## Related

Doc-freshness sweep. No linked ticket — surfaced by running the docs-freshness scanner and the code-vs-comment diff against the recent monolith-removal work.
