### PR TITLE
ci: consolidate ci.yml into reusable jobs + coverage/timings PR comment (ADS-953/947)

### DIFF
--- a/.github/actions/checkout-and-setup/action.yml
+++ b/.github/actions/checkout-and-setup/action.yml
@@ -1,11 +1,12 @@
 name: 'Checkout + Setup Workspace + Restore lib-dist'
 description: >-
-  Common preamble shared by every ci.yml test job (ADS-953): checkout the
-  repo, install the workspace (Node + pnpm via the setup-workspace composite),
-  and optionally restore the packages/lib.*/dist cache populated by the
-  build-libs job. Centralising this here means the checkout SHA, the
-  setup-workspace call, and the lib-dist cache key only need to change in one
-  place.
+  Common preamble shared by every ci.yml test job (ADS-953): install the
+  workspace (Node + pnpm via the setup-workspace composite) and optionally
+  restore the packages/lib.*/dist cache populated by the build-libs job.
+  NOTE: the caller job must run actions/checkout first — a local composite
+  cannot check out the repo it is loaded from. Centralising the rest here
+  means the setup-workspace call and the lib-dist cache key only need to
+  change in one place.
 inputs:
   download-lib-dist:
     description: >-
@@ -17,7 +18,6 @@ inputs:
 runs:
   using: 'composite'
   steps:
-    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
     - uses: ./.github/actions/setup-workspace
 
     # ADS-909: read the same actions/cache entry build-libs populated,

--- a/.github/actions/checkout-and-setup/action.yml
+++ b/.github/actions/checkout-and-setup/action.yml
@@ -1,0 +1,31 @@
+name: 'Checkout + Setup Workspace + Restore lib-dist'
+description: >-
+  Common preamble shared by every ci.yml test job (ADS-953): checkout the
+  repo, install the workspace (Node + pnpm via the setup-workspace composite),
+  and optionally restore the packages/lib.*/dist cache populated by the
+  build-libs job. Centralising this here means the checkout SHA, the
+  setup-workspace call, and the lib-dist cache key only need to change in one
+  place.
+inputs:
+  download-lib-dist:
+    description: >-
+      Restore the packages/lib.*/dist cache built by the build-libs job.
+      Set to 'false' for jobs that don't consume compiled libs (e.g.
+      build-libs itself, which populates the cache instead).
+    required: false
+    default: 'true'
+runs:
+  using: 'composite'
+  steps:
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+    - uses: ./.github/actions/setup-workspace
+
+    # ADS-909: read the same actions/cache entry build-libs populated,
+    # instead of downloading its (conditionally-uploaded) artifact — see
+    # the comment on build-libs' cache-lib-dist step in ci.yml.
+    - name: Restore pre-built libraries
+      if: inputs.download-lib-dist == 'true'
+      uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      with:
+        path: packages/lib.*/dist
+        key: lib-dist-${{ runner.os }}-${{ hashFiles('packages/lib.*/src/**', 'packages/lib.*/package.json', 'packages/lib.*/tsconfig*.json', 'pnpm-lock.yaml') }}

--- a/.github/actions/coverage-report/action.yml
+++ b/.github/actions/coverage-report/action.yml
@@ -1,0 +1,203 @@
+name: 'Coverage & Timing Report'
+description: >-
+  ci.yml's coverage-report job body (ADS-947). On a pull_request run: restores
+  this run's coverage (saved by run-package-tests via its coverage-cache-key
+  input) and the main-branch baseline (an actions/cache snapshot), computes
+  the per-package coverage delta, fetches this run's job timings from the
+  Actions API, and posts/updates a single sticky PR comment. On a push to
+  main: snapshots this run's coverage as the new baseline for future PRs to
+  diff against. Informational only — never fails the job on API/permission
+  errors (e.g. a fork PR's read-only token), so it can't block merge.
+inputs:
+  lib-dist-cache-hit:
+    description: "build-libs' lib-dist cache-hit output, surfaced as a CI health signal."
+    required: false
+    default: ''
+runs:
+  using: 'composite'
+  steps:
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+    # ADS-947: restore this run's coverage-summary.json files, saved by each
+    # producer job's run-package-tests call under the matching exact key.
+    # A key that was never written (job skipped by a path filter) is simply
+    # a no-op miss — coverage-report just has less data for that family.
+    - name: Restore current coverage (frontend client)
+      uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      with:
+        path: |
+          apps/*/coverage/coverage-summary.json
+          packages/*/coverage/coverage-summary.json
+          services/*/coverage/coverage-summary.json
+        key: coverage-current-${{ github.run_id }}-client
+    - name: Restore current coverage (frontend admin)
+      uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      with:
+        path: |
+          apps/*/coverage/coverage-summary.json
+          packages/*/coverage/coverage-summary.json
+          services/*/coverage/coverage-summary.json
+        key: coverage-current-${{ github.run_id }}-admin
+    - name: Restore current coverage (frontend rescue)
+      uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      with:
+        path: |
+          apps/*/coverage/coverage-summary.json
+          packages/*/coverage/coverage-summary.json
+          services/*/coverage/coverage-summary.json
+        key: coverage-current-${{ github.run_id }}-rescue
+    - name: Restore current coverage (libs)
+      uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      with:
+        path: |
+          apps/*/coverage/coverage-summary.json
+          packages/*/coverage/coverage-summary.json
+          services/*/coverage/coverage-summary.json
+        key: coverage-current-${{ github.run_id }}-libs
+    - name: Restore current coverage (services)
+      uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      with:
+        path: |
+          apps/*/coverage/coverage-summary.json
+          packages/*/coverage/coverage-summary.json
+          services/*/coverage/coverage-summary.json
+        key: coverage-current-${{ github.run_id }}-services
+
+    # ADS-947: the main-branch snapshot to diff against. restore-keys prefix
+    # match returns the most recently saved entry — GitHub's cross-branch
+    # cache fallback lets a PR branch read a cache saved from main natively.
+    - name: Restore main coverage baseline
+      if: github.event_name == 'pull_request'
+      uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      with:
+        path: coverage-baseline
+        key: coverage-baseline-main-unused
+        restore-keys: |
+          coverage-baseline-main-
+
+    - name: Post/update coverage report comment
+      if: github.event_name == 'pull_request'
+      uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+      env:
+        LIB_DIST_CACHE_HIT: ${{ inputs.lib-dist-cache-hit }}
+      with:
+        script: |
+          const fs = require('fs');
+          const path = require('path');
+
+          // Everything is wrapped in one try/catch: a fork PR's GITHUB_TOKEN
+          // is read-only regardless of this workflow's `permissions:` block,
+          // so listComments/createComment/updateComment (and, in principle,
+          // listJobsForWorkflowRun) can 403. This job is purely informational
+          // — never fail it, just skip with a warning.
+          try {
+            const coverageCore = await import(
+              `${process.env.GITHUB_WORKSPACE}/scripts/lib/coverage-delta-core.mjs`
+            );
+            const ratchetCore = await import(
+              `${process.env.GITHUB_WORKSPACE}/scripts/lib/ratchet-coverage-core.mjs`
+            );
+
+            function collectCoverage(root) {
+              const byPackage = {};
+              for (const family of ['apps', 'packages', 'services']) {
+                const familyDir = path.join(root, family);
+                if (!fs.existsSync(familyDir)) continue;
+                for (const pkg of fs.readdirSync(familyDir)) {
+                  const summaryPath = path.join(familyDir, pkg, 'coverage', 'coverage-summary.json');
+                  if (!fs.existsSync(summaryPath)) continue;
+                  try {
+                    const summary = JSON.parse(fs.readFileSync(summaryPath, 'utf8'));
+                    byPackage[pkg] = ratchetCore.measuredFromSummaryTotal(summary.total ?? {});
+                  } catch (parseError) {
+                    core.warning(`Skipping unreadable coverage summary at ${summaryPath}: ${parseError.message}`);
+                  }
+                }
+              }
+              return byPackage;
+            }
+
+            const current = collectCoverage(process.env.GITHUB_WORKSPACE);
+            const baseline = collectCoverage(path.join(process.env.GITHUB_WORKSPACE, 'coverage-baseline'));
+            const coverageTable = coverageCore.formatCoverageTable(
+              coverageCore.computePackageDeltas(baseline, current)
+            );
+
+            const { data: jobsPage } = await github.rest.actions.listJobsForWorkflowRun({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: context.runId,
+              per_page: 100,
+            });
+            const jobs = jobsPage.jobs
+              .filter(job => job.started_at && job.completed_at)
+              .map(job => ({
+                name: job.name,
+                durationMs: new Date(job.completed_at).getTime() - new Date(job.started_at).getTime(),
+                status: job.status,
+                conclusion: job.conclusion,
+              }));
+            const timingsTable = coverageCore.formatJobTimingsTable(jobs);
+
+            const libDistCacheHit =
+              process.env.LIB_DIST_CACHE_HIT === 'true'
+                ? true
+                : process.env.LIB_DIST_CACHE_HIT === 'false'
+                  ? false
+                  : undefined;
+
+            const body = coverageCore.buildCommentBody({ coverageTable, timingsTable, libDistCacheHit });
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              per_page: 100,
+            });
+            const existing = comments.find(comment => comment.body?.startsWith(coverageCore.COMMENT_MARKER));
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+            }
+          } catch (error) {
+            core.warning(`Skipping coverage report comment: ${error.message}`);
+          }
+
+    # ADS-947: snapshot this run's coverage as the new baseline for future
+    # PRs. Staged into its own directory (not the live apps/*|packages/*|
+    # services/* trees) so it can't collide with a PR run's "current" restore
+    # above landing at the same live paths.
+    - name: Stage coverage baseline for main
+      if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+      shell: bash
+      run: |
+        rm -rf coverage-baseline
+        for family in apps packages services; do
+          [ -d "$family" ] || continue
+          for pkg_dir in "$family"/*/; do
+            summary="${pkg_dir}coverage/coverage-summary.json"
+            if [ -f "$summary" ]; then
+              mkdir -p "coverage-baseline/${pkg_dir}coverage"
+              cp "$summary" "coverage-baseline/${pkg_dir}coverage/"
+            fi
+          done
+        done
+
+    - name: Save coverage baseline for main
+      if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+      uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      with:
+        path: coverage-baseline
+        key: coverage-baseline-main-${{ github.sha }}

--- a/.github/actions/coverage-report/action.yml
+++ b/.github/actions/coverage-report/action.yml
@@ -16,7 +16,6 @@ inputs:
 runs:
   using: 'composite'
   steps:
-    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
     # ADS-947: restore this run's coverage-summary.json files, saved by each
     # producer job's run-package-tests call under the matching exact key.

--- a/.github/actions/dev-auth-guard/action.yml
+++ b/.github/actions/dev-auth-guard/action.yml
@@ -1,0 +1,52 @@
+name: 'Dev Auth Guard'
+description: >-
+  ci.yml's dev-auth-guard job body (ADS-953): scans production frontend
+  source for dev-auth bypass patterns (dev_user / dev-token-) outside their
+  allowed DEV-gated locations (ADS-676). Extracted into a composite action
+  purely to shrink ci.yml — the job itself (name, needs, if-gating) stays in
+  ci.yml so its status-check identity is unchanged.
+runs:
+  using: 'composite'
+  steps:
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+    # ADS-676: verify that dev-auth bypass patterns only appear inside
+    # import.meta.env.DEV guards (which Vite replaces with `false` and
+    # tree-shakes in production builds). Fail if any reference to
+    # dev_user / dev-token- appears outside lib.auth's DEV-gated
+    # AuthContext or the explicitly dev-only files below.
+    #
+    # Allowed locations (dev-only by design):
+    #   packages/lib.auth/src/contexts/AuthContext.tsx — DEV-gated
+    #   apps/*/src/components/dev/*                    — dev panels
+    #   apps/*/src/utils/devAuth.ts                     — dev utilities
+    #   apps/*/src/contexts/base/devUtils.ts            — dev utilities
+    #   **/*.test.* / **/*.spec.*                       — test files
+    - name: Scan source for ungated dev auth bypass patterns
+      shell: bash
+      run: |
+        # Find dev_user or dev-token- references in production source
+        # (exclude test files, dev-only directories, and the known
+        # DEV-gated AuthContext).
+        HITS=$(grep -rn 'dev_user\|dev-token-' \
+          apps/*/src/ packages/lib.*/src/ \
+          --include='*.ts' --include='*.tsx' \
+          --exclude='*.test.*' --exclude='*.spec.*' \
+          | grep -v '/components/dev/' \
+          | grep -v '/utils/devAuth' \
+          | grep -v '/contexts/base/devUtils' \
+          | grep -v 'AuthContext.tsx' \
+          || true)
+
+        if [ -n "$HITS" ]; then
+          echo "ERROR: Dev auth bypass patterns found outside allowed locations:"
+          echo "$HITS"
+          echo ""
+          echo "dev_user / dev-token- must only appear in:"
+          echo "  - packages/lib.auth/src/contexts/AuthContext.tsx (DEV-gated)"
+          echo "  - apps/*/src/components/dev/* (dev-only panels)"
+          echo "  - apps/*/src/utils/devAuth.ts (dev-only utilities)"
+          echo "  - Test files (*.test.*, *.spec.*)"
+          exit 1
+        fi
+        echo "All dev auth patterns are properly gated."

--- a/.github/actions/dev-auth-guard/action.yml
+++ b/.github/actions/dev-auth-guard/action.yml
@@ -8,7 +8,6 @@ description: >-
 runs:
   using: 'composite'
   steps:
-    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
     # ADS-676: verify that dev-auth bypass patterns only appear inside
     # import.meta.env.DEV guards (which Vite replaces with `false` and

--- a/.github/actions/e2e-suite/action.yml
+++ b/.github/actions/e2e-suite/action.yml
@@ -9,7 +9,6 @@ description: >-
 runs:
   using: 'composite'
   steps:
-    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
     - name: Free up disk space
       # The 14-image compose build needs ~25GB; the hosted runner has ~14GB

--- a/.github/actions/e2e-suite/action.yml
+++ b/.github/actions/e2e-suite/action.yml
@@ -1,0 +1,363 @@
+name: 'E2E Suite (Playwright)'
+description: >-
+  Full body of ci.yml's test-e2e job (ADS-953): builds the docker-compose
+  stack, boots it, runs the Playwright suite against it, and tears it down.
+  Extracted verbatim into a composite action purely to shrink ci.yml — the
+  job itself (name, needs, if-gating, env, timeout) stays in ci.yml so its
+  status-check identity is unchanged. See that job for the opt-in-on-PRs
+  rationale (`run-e2e` label / push to main / workflow_dispatch).
+runs:
+  using: 'composite'
+  steps:
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+    - name: Free up disk space
+      # The 14-image compose build needs ~25GB; the hosted runner has ~14GB
+      # free. Evict the big preinstalled toolchains (Android SDK, .NET, GHC,
+      # Swift, CodeQL, runner docker images) before building. Without this
+      # the build dies with ENOSPC mid-export, or — worse — limps through
+      # and the services then sit "unhealthy" because nothing inside the
+      # containers can write (the failure signature ADS-792 describes).
+      shell: bash
+      run: |
+        df -h /
+        sudo rm -rf /usr/share/dotnet /opt/ghc "/usr/local/share/boost" \
+          /usr/local/lib/android /usr/share/swift /opt/hostedtoolcache/CodeQL \
+          "$AGENT_TOOLSDIRECTORY"
+        sudo docker image prune -af
+        df -h /
+
+    - uses: ./.github/actions/setup-workspace
+
+    # ADS-792: expose ACTIONS_RUNTIME_TOKEN + cache-service URLs to plain
+    # `run:` steps so the raw `docker buildx bake` call below can use
+    # cache-from/cache-to type=gha. JS actions (docker/build-push-action)
+    # receive these implicitly; shell steps do not.
+    - uses: crazy-max/ghaction-github-runtime@04d248b84655b509d8c44dc1d6f990c879747487 # v4.0.0
+
+    # ADS-792: type=gha cache import/export requires a docker-container
+    # builder — the daemon's integrated BuildKit does not support it.
+    # Known tradeoff (this previously kept buildx out of this job): the
+    # container builder stores layers twice at peak — BuildKit cache plus
+    # the tarball re-import into the daemon ("sending tarball"). Two
+    # things keep that inside the runner's disk budget now:
+    #   - warm GHA cache hits skip re-executing (and re-storing
+    #     intermediates for) the expensive npm-ci/turbo layers;
+    #   - the build step prunes the BuildKit cache immediately after
+    #     --load, before the stack boots.
+    # ENOSPC under a fully cold cache is the residual risk — see the
+    # build step below. max-parallelism=4 replaces the old
+    # COMPOSE_PARALLEL_LIMIT=4: 12 concurrent `pnpm install` runs against the
+    # registry was the ECONNRESET source ADS-792 describes.
+    - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+      with:
+        driver-opts: |
+          image=moby/buildkit:v0.23.0
+          network=host
+        buildkitd-config-inline: |
+          [worker.oci]
+            max-parallelism = 4
+
+    - name: Resolve Playwright version
+      id: pw
+      shell: bash
+      run: |
+        version=$(node -p "require('./e2e/package.json').devDependencies['@playwright/test']")
+        echo "version=${version}" >> "$GITHUB_OUTPUT"
+
+    - name: Cache Playwright browsers
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      with:
+        path: ~/.cache/ms-playwright
+        # ADS-901: this is a single-lockfile workspace (e2e/ has no lockfile
+        # of its own — pnpm-workspace.yaml includes it), so the root
+        # pnpm-lock.yaml hash is what actually changes when @playwright/test
+        # bumps. Without it, a patch bump that doesn't change `steps.pw`'s
+        # resolved version string could keep a stale cache and mismatch the
+        # installed browsers against the newer test runner.
+        key: playwright-${{ runner.os }}-${{ steps.pw.outputs.version }}-${{ hashFiles('pnpm-lock.yaml') }}
+
+    - name: Install Playwright browsers
+      shell: bash
+      run: pnpm test:e2e:install
+
+    - name: Generate secrets and write .env
+      shell: bash
+      run: |
+        {
+          echo "NODE_ENV=development"
+          echo "POSTGRES_USER=postgres"
+          # Hex, not base64, for the same reason as REDIS_PASSWORD below:
+          # compose interpolates this into DATABASE_URL=postgresql://user:
+          # ${POSTGRES_PASSWORD}@database:5432/db and base64's / + = break
+          # `new URL()` in every service's db:migrate — intermittently,
+          # whenever the random draw happens to contain one.
+          echo "POSTGRES_PASSWORD=$(openssl rand -hex 32)"
+          echo "POSTGRES_DB=adopt_dont_shop_dev"
+          echo "JWT_SECRET=$(openssl rand -base64 32)"
+          echo "JWT_REFRESH_SECRET=$(openssl rand -base64 32)"
+          echo "SESSION_SECRET=$(openssl rand -base64 32)"
+          echo "ENCRYPTION_KEY=$(openssl rand -hex 32)"
+          # HMAC key for the service-to-service principal tokens minted
+          # and verified by packages/service-bootstrap (read via
+          # config-secrets as PRINCIPAL_SIGNING_KEY).
+          echo "PRINCIPAL_SIGNING_KEY=$(openssl rand -hex 32)"
+          # ADS-600 made REDIS_PASSWORD a required secret in
+          # docker-compose.yml; the CI stack-up step refuses to
+          # start without it. Generate it here so every E2E run
+          # gets a fresh, non-default value.
+          #
+          # Hex (not base64) because docker-compose interpolates
+          # this into REDIS_URL=redis://:${REDIS_PASSWORD}@redis:6379
+          # and `openssl rand -base64` includes `/`, `+`, `=` —
+          # `/` terminates the URL userinfo so the backend's
+          # `new URL(REDIS_URL)` rejects it with "Invalid URL"
+          # before validateEnv can finish.
+          echo "REDIS_PASSWORD=$(openssl rand -hex 32)"
+          # ADS-542 made UPLOAD_SIGNING_SECRET a required env var on
+          # the backend (32+ chars). Without it the /health probe
+          # never goes ready and the Wait-for-services step times
+          # out.
+          echo "UPLOAD_SIGNING_SECRET=$(openssl rand -base64 32)"
+          echo "CORS_ORIGIN=http://localhost:3000,http://localhost:3001,http://localhost:3002"
+          # Raise the gateway's global per-IP rate limit for e2e. A full
+          # Playwright run drives the whole SPA (favourites, chats,
+          # notifications, permissions, legal, match, csrf) across parallel
+          # workers from a single docker-side IP, bursting past the 100/min
+          # production default and 429-ing page loads. (apiAs also caches its
+          # login token per role to stay under the stricter 10/min auth-login
+          # limit.) Production keeps the 100/min default.
+          echo "GATEWAY_RATE_LIMIT_MAX=100000"
+          # Also lift the stricter per-route auth limits (login 10/min,
+          # register 5/min, ...) — a full suite logs in/registers many times
+          # from one IP across workers. Production leaves this unset.
+          echo "GATEWAY_AUTH_RATE_LIMIT_MAX=100000"
+          # ADS-871: enable the gateway's test-only token-peek seam so the
+          # e2e suite can read one-time reset/verify/invitation tokens and
+          # drive the full auth round-trips. Safe here — NODE_ENV is
+          # development above, and the gateway refuses to boot with this on
+          # under NODE_ENV=production. Production/staging never set it.
+          echo "E2E_TOKEN_PEEK=true"
+        } > .env
+
+    - name: Start database and cache
+      shell: bash
+      run: |
+        docker compose -f docker-compose.yml up -d database redis
+        timeout 90 bash -c 'until docker compose -f docker-compose.yml exec -T database pg_isready -U postgres; do sleep 2; done'
+
+    - name: Build images
+      # ADS-792: `buildx bake` against docker-compose.yml with BuildKit GHA
+      # layer caching. Design notes:
+      #
+      # PER-TARGET scopes (scope=e2e-<service>): GHA cache writes are
+      # last-write-wins per scope, so a single shared scope with 12 targets
+      # exporting concurrently thrashes — each save evicts the previous
+      # target's layers and the hit rate collapses.
+      #
+      # mode=min, not mode=max, against the repo's 10GB Actions cache
+      # budget (shared with the pnpm/turbo/lib-dist/Playwright caches and
+      # docker.yml's type=gha caches):
+      #   - the `development` targets inherit FROM the build stage, so the
+      #     expensive pnpm-install + turbo-build layers ARE final-image
+      #     layers and mode=min still caches them;
+      #   - mode=max would additionally export intermediates like the
+      #     `pruner` stage, whose COPY-the-whole-repo layer changes every
+      #     commit — pure churn, several GB per scope, guaranteed eviction
+      #     pressure across 12 scopes;
+      #   - estimated mode=min footprint: ~0.3-0.6GB x 12 scopes. Layers
+      #     shared between images are still stored once per scope — the
+      #     price of not thrashing;
+      #   - ignore-error=true: a cache-backend outage degrades to an
+      #     uncached build instead of failing CI.
+      #
+      # Targets are discovered from the compose file via `bake --print`
+      # (buildx parses compose profiles as "all", so every buildable
+      # service is included) — compose-stack changes need no edits here.
+      # Bake assigns NO tags when compose services have no `image:` field,
+      # so each target's tag is set explicitly to the <project>-<service>
+      # name that `docker compose up --no-build` later resolves (project =
+      # lowercased checkout directory name, the same default compose uses).
+      # If bake ever fails to resolve targets (e.g. a compose-file feature
+      # it can't parse), fall back to the previous uncached compose build
+      # rather than breaking the job.
+      shell: bash
+      run: |
+        set -euo pipefail
+        # bake interpolates the compose file itself, so the ${VAR:?} guards
+        # (REDIS_PASSWORD, JWT_SECRET, ...) need the generated .env values
+        # in the process env.
+        set -a; source ./.env; set +a
+
+        project="$(basename "$PWD" | tr '[:upper:]' '[:lower:]')"
+        mapfile -t targets < <(docker buildx bake -f docker-compose.yml --print 2>/dev/null | jq -r '.group.default.targets[]' || true)
+
+        if [ "${#targets[@]}" -eq 0 ]; then
+          echo "::warning title=bake fallback::buildx bake resolved no targets from docker-compose.yml — falling back to uncached docker compose build"
+          COMPOSE_PARALLEL_LIMIT=4 docker compose -f docker-compose.yml --profile full build
+          exit 0
+        fi
+
+        echo "Building ${#targets[@]} targets: ${targets[*]}"
+        set_args=()
+        for t in "${targets[@]}"; do
+          set_args+=(
+            --set "${t}.tags=${project}-${t}"
+            --set "${t}.cache-from=type=gha,scope=e2e-${t}"
+            --set "${t}.cache-to=type=gha,mode=min,scope=e2e-${t},ignore-error=true"
+          )
+        done
+
+        # --load = output=type=docker: images land in the daemon store
+        # under the tags set above, where `up --no-build` expects them.
+        docker buildx bake -f docker-compose.yml --load "${set_args[@]}"
+
+        # The BuildKit cache is dead weight once the images are in the
+        # daemon store — reclaim the disk before the stack boots.
+        docker buildx prune -af > /dev/null
+        docker image ls --format '{{.Repository}}:{{.Tag}}  {{.Size}}' | grep "^${project}-" || true
+        df -h /
+
+    - name: Start the full stack (images already built)
+      # Phase 11 follow-up: bring the apps + gateway + services + nginx up
+      # in ONE compose invocation under the `full` profile. The previous
+      # two-step `--profile services up` + `up app-client app-admin
+      # app-rescue` left nginx (which has no profile and therefore
+      # auto-starts on the first invocation) crash-looping for six minutes
+      # because its `app-client:3000` upstream wasn't resolvable. nginx is
+      # now in the `full`/`proxy` profiles so it starts only alongside the
+      # apps it proxies, and a single `up` honours the compose dependency
+      # graph instead of racing two independent stacks.
+      # ADS-792: --no-build because images were pre-built above.
+      shell: bash
+      run: |
+        docker compose -f docker-compose.yml --profile full up -d --no-build
+        df -h /
+
+    - name: Wait for services
+      # The gateway is first in the list and carries the whole budget: it
+      # boots 10 sibling services' worth of migrations + tsx compiles on a
+      # contended 4-core runner, so it gets 240×2s (8 min) rather than the
+      # 90×2s that used to time out. Log dumps need --profile full — the
+      # service/app containers live in that profile, so a bare `compose
+      # logs` shows only the infra containers and hides the actual failure.
+      shell: bash
+      run: |
+        set -euo pipefail
+        for url in http://localhost:4000/health/simple http://localhost:3000 http://localhost:3001 http://localhost:3002; do
+          echo "Waiting for $url"
+          for i in $(seq 1 240); do
+            if curl -fsS --max-time 5 "$url" >/dev/null 2>&1; then
+              echo "  ready: $url"
+              break
+            fi
+            if [ "$i" = "240" ]; then
+              echo "  timeout: $url"
+              docker compose -f docker-compose.yml --profile full ps
+              docker compose -f docker-compose.yml --profile full logs --tail=300
+              exit 1
+            fi
+            sleep 2
+          done
+        done
+
+        # The URL loop only proves the gateway + apps are up. The gateway
+        # answers /health/simple before its sibling gRPC services finish
+        # their own migrate→seed→boot cycle, so a Playwright login probe
+        # fired now hits ECONNREFUSED on service-auth:6002. Every service
+        # binds gRPC before its HTTP health server (see services/*/src/
+        # index.ts), so compose-healthy ⇒ gRPC ready — wait for that.
+        echo "Waiting for service containers to report healthy"
+        for i in $(seq 1 120); do
+          not_healthy=$(docker compose -f docker-compose.yml --profile full ps --format '{{.Service}} {{.Health}}' \
+            | awk '$1 ~ /^service-/ && $2 != "healthy" {print $1}')
+          if [ -z "$not_healthy" ]; then
+            echo "  all service containers healthy"
+            break
+          fi
+          if [ "$i" = "120" ]; then
+            echo "  timeout waiting for: $not_healthy"
+            docker compose -f docker-compose.yml --profile full ps
+            docker compose -f docker-compose.yml --profile full logs --tail=300
+            exit 1
+          fi
+          sleep 2
+        done
+
+    - name: Warm up Vite bundles
+      # Vite dev servers compile on first request. Hit /login on each app
+      # so the JS is built before Playwright tries to interact with it.
+      shell: bash
+      run: |
+        for url in \
+          http://localhost:3000/login \
+          http://localhost:3001/login \
+          http://localhost:3002/login; do
+          echo "Warming $url"
+          curl -fsS --max-time 60 "$url" >/dev/null || true
+        done
+
+    - name: Run Playwright suite
+      # E2E only reaches this point when explicitly requested (main push,
+      # `run-e2e` label, or manual dispatch), so always run the full suite —
+      # the point of opting in is to get complete integration coverage, not a
+      # smoke subset. Tag tests with @smoke and run `pnpm test:e2e:smoke`
+      # locally for a quick subset.
+      #
+      # Retries are configured in e2e/playwright.config.ts (retries: CI ? 2 : 0).
+      shell: bash
+      run: |
+        echo "${{ github.event_name }} on ${{ github.ref }} — running full suite"
+        pnpm test:e2e
+
+    # ADS-386: Surface flaky-retry signal so engineers can see which tests
+    # needed retries without having to open the full HTML report.
+    # This step never blocks CI — it is informational only.
+    - name: Report E2E retry counts
+      if: always()
+      shell: bash
+      run: |
+        report_dir="e2e/test-results"
+        if [ ! -d "$report_dir" ]; then
+          echo "No test-results directory found — Playwright may not have run."
+          exit 0
+        fi
+        retried=$(find "$report_dir" -name '*.json' -exec grep -l '"retry":[^0]' {} \; 2>/dev/null | wc -l)
+        if [ "$retried" -gt 0 ]; then
+          echo "::warning::$retried test result file(s) contain retries — check the Playwright report artifact for details."
+        else
+          echo "No retried tests detected in this run."
+        fi
+
+    - name: Dump service logs on failure
+      # Inline (not just the artifact): the artifact requires a download to
+      # inspect, while the job log is immediately searchable. gRPC adapters
+      # mask unexpected handler errors as INTERNAL 'internal error', so the
+      # real exception only exists in the owning service's stdout.
+      if: failure()
+      shell: bash
+      run: |
+        docker compose -f docker-compose.yml --profile full logs --no-color --tail=150
+
+    - name: Capture docker-compose logs on failure
+      if: failure()
+      # --profile full: without it the dump only contains the default-profile
+      # infra containers (database/redis/nats/...) and silently omits every
+      # service and app container — the part that actually fails.
+      shell: bash
+      run: docker compose -f docker-compose.yml --profile full logs --no-color > docker-compose.log
+
+    - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      if: always()
+      with:
+        name: e2e-playwright-report
+        path: |
+          e2e/playwright-report/
+          e2e/test-results/
+          docker-compose.log
+        retention-days: 7
+
+    - name: Tear down stack
+      if: always()
+      shell: bash
+      run: docker compose -f docker-compose.yml down -v

--- a/.github/actions/run-package-tests/action.yml
+++ b/.github/actions/run-package-tests/action.yml
@@ -41,6 +41,14 @@ inputs:
     description: 'Path glob for the uploaded junit test-results artifact.'
     required: false
     default: '**/test-results/junit.xml'
+  coverage-cache-key:
+    description: >-
+      ADS-947: when set, cache every coverage-summary.json this job produced
+      (across apps/*, packages/*, services/*) under this exact key, so the
+      coverage-report job can restore this run's coverage without re-running
+      tests. Leave unset to skip (e.g. test-contracts has no coverage).
+    required: false
+    default: ''
 runs:
   using: 'composite'
   steps:
@@ -84,3 +92,15 @@ runs:
         name: ${{ inputs.upload-artifact-name }}
         path: ${{ inputs.upload-artifact-path }}
         retention-days: 7
+
+    # ADS-947: run-scoped, so it's always a cache miss and always saves —
+    # same pattern build-libs uses for lib-dist. coverage-report restores it
+    # by the exact same key.
+    - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      if: always() && inputs.coverage-cache-key != ''
+      with:
+        path: |
+          apps/*/coverage/coverage-summary.json
+          packages/*/coverage/coverage-summary.json
+          services/*/coverage/coverage-summary.json
+        key: ${{ inputs.coverage-cache-key }}

--- a/.github/actions/run-package-tests/action.yml
+++ b/.github/actions/run-package-tests/action.yml
@@ -1,0 +1,86 @@
+name: 'Run Package Tests'
+description: >-
+  Shared test-job body for ci.yml's test-frontend / test-libs / test-services
+  jobs (ADS-953): checkout + setup-workspace + restore lib-dist (via
+  checkout-and-setup), lint/test/type-check via Turbo, and upload the junit
+  results. Two shapes are supported:
+    - combined (working-directory unset): a single Turbo call running
+      lint + test(:coverage) + type-check against `filter`, matching the
+      test-libs / test-services pattern.
+    - per-app (working-directory set): separate Lint / Test / Type check /
+      Build steps, matching the test-frontend pattern — `pnpm test:coverage`
+      and `pnpm build` run directly in `working-directory` rather than via
+      Turbo so per-app coverage/build output lands in that app's own tree.
+inputs:
+  filter:
+    description: 'Turbo filter pattern, e.g. @adopt-dont-shop/lib.*'
+    required: true
+  run-coverage:
+    description: "Run the ':coverage' variant of the test task."
+    required: false
+    default: 'true'
+  download-lib-dist:
+    description: 'Restore the packages/lib.*/dist cache before testing.'
+    required: false
+    default: 'true'
+  working-directory:
+    description: >-
+      When set, switches to the per-app step shape and runs the Test/Build
+      steps via plain `pnpm` in this directory instead of a single combined
+      Turbo call.
+    required: false
+    default: ''
+  run-build:
+    description: 'Add a Build step (only meaningful with working-directory set).'
+    required: false
+    default: 'false'
+  upload-artifact-name:
+    description: 'Name for the uploaded junit test-results artifact.'
+    required: true
+  upload-artifact-path:
+    description: 'Path glob for the uploaded junit test-results artifact.'
+    required: false
+    default: '**/test-results/junit.xml'
+runs:
+  using: 'composite'
+  steps:
+    - uses: ./.github/actions/checkout-and-setup
+      with:
+        download-lib-dist: ${{ inputs.download-lib-dist }}
+
+    - name: Lint, test and type-check
+      if: inputs.working-directory == ''
+      shell: bash
+      run: |
+        pnpm exec turbo run lint ${{ inputs.run-coverage == 'true' && 'test:coverage' || 'test' }} type-check --filter='${{ inputs.filter }}'
+
+    - name: Lint
+      if: inputs.working-directory != ''
+      shell: bash
+      run: pnpm exec turbo run lint --filter='${{ inputs.filter }}'
+
+    - name: Test (with coverage thresholds)
+      if: inputs.working-directory != ''
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
+      run: pnpm ${{ inputs.run-coverage == 'true' && 'test:coverage' || 'test' }}
+
+    - name: Type check
+      if: inputs.working-directory != ''
+      shell: bash
+      run: pnpm exec turbo run type-check --filter='${{ inputs.filter }}'
+
+    - name: Build
+      if: inputs.working-directory != '' && inputs.run-build == 'true'
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
+      env:
+        CI: true
+      run: pnpm build
+
+    - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      if: always()
+      with:
+        name: ${{ inputs.upload-artifact-name }}
+        path: ${{ inputs.upload-artifact-path }}
+        retention-days: 7

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -55,6 +55,8 @@ quick critical-path subset.
 
 **Triggers**: Push/PR to `main` or `develop` branches
 
+**Coverage & timing report (ADS-947)**: after `test-frontend`/`test-libs`/`test-services` finish, the `coverage-report` job posts a single sticky comment on the PR with per-package coverage delta vs `main` (only packages whose coverage changed) and this run's job timings — see `.github/actions/coverage-report`. It's purely informational (`continue-on-error: true`, not in `ci-required`'s needs) and degrades gracefully on forks, where the default `GITHUB_TOKEN` is read-only.
+
 ---
 
 ### 🔒 **Security Workflow** (`security.yml`)
@@ -136,6 +138,7 @@ lib-dist → run-turbo-filter preamble. That's now centralised in
 | `run-package-tests` | `test-frontend`, `test-libs`, `test-services` | `checkout-and-setup` + lint/test(:coverage)/type-check via Turbo (and, for frontend apps, a `pnpm build` step), then uploads the junit results. |
 | `e2e-suite` | `test-e2e` | The full Playwright E2E body: image build, stack boot, suite run, teardown. |
 | `dev-auth-guard` | `dev-auth-guard` | Scans production source for ungated dev-auth bypass patterns. |
+| `coverage-report` | `coverage-report` | ADS-947: posts/updates a sticky PR comment with per-package coverage delta vs `main` and this run's job timings. See `## Workflow Overview` below. |
 
 These are composite actions, not `workflow_call` reusable workflows: a job
 that calls a reusable workflow gets its status-check name prefixed with the

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -123,6 +123,28 @@ GitHub Releases themselves are produced by `release-please.yml` from conventiona
 
 ---
 
+## Composite actions used by `ci.yml` (ADS-953)
+
+`ci.yml`'s test jobs repeated the same checkout → setup-workspace → restore
+lib-dist → run-turbo-filter preamble. That's now centralised in
+`.github/actions/`, one edit point per contract change:
+
+| Action | Used by | Purpose |
+| ------ | ------- | ------- |
+| `setup-workspace` | `checkout-and-setup`, `e2e-suite` | Install Node + pnpm (Corepack), cache the pnpm store, install workspace deps. |
+| `checkout-and-setup` | `build-libs`, `run-package-tests`, `test-contracts` | Checkout + `setup-workspace`, plus an optional restore of the `packages/lib.*/dist` cache populated by `build-libs`. |
+| `run-package-tests` | `test-frontend`, `test-libs`, `test-services` | `checkout-and-setup` + lint/test(:coverage)/type-check via Turbo (and, for frontend apps, a `pnpm build` step), then uploads the junit results. |
+| `e2e-suite` | `test-e2e` | The full Playwright E2E body: image build, stack boot, suite run, teardown. |
+| `dev-auth-guard` | `dev-auth-guard` | Scans production source for ungated dev-auth bypass patterns. |
+
+These are composite actions, not `workflow_call` reusable workflows: a job
+that calls a reusable workflow gets its status-check name prefixed with the
+caller job's name (`<caller> / <callee>`), which would silently rename every
+check in this file. Composite actions splice their steps into the *same*
+job, so job names, `needs:`, and `if:` gating are unchanged — required for
+`ci-required` and the branch-protection checks in this repo to keep working
+across the refactor.
+
 ## Workflow Features
 
 ### 🚀 **Performance Optimizations**

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,6 +149,9 @@ jobs:
       needs.changes.outputs.libs == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    outputs:
+      # ADS-947: surfaced as a CI-health signal on the coverage-report comment.
+      lib-dist-cache-hit: ${{ steps.cache-lib-dist.outputs.cache-hit }}
 
     env:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
@@ -203,6 +206,7 @@ jobs:
           working-directory: 'apps/${{ matrix.app }}'
           run-build: 'true'
           upload-artifact-name: 'test-results-${{ matrix.app }}'
+          coverage-cache-key: 'coverage-current-${{ github.run_id }}-${{ matrix.app }}'
 
   # ============================================================================
   # SHARED LIBRARIES — lint/test/type-check the libs themselves
@@ -226,6 +230,7 @@ jobs:
         with:
           filter: '@adopt-dont-shop/lib.*'
           upload-artifact-name: 'test-results-libs'
+          coverage-cache-key: 'coverage-current-${{ github.run_id }}-libs'
 
   # ============================================================================
   # SERVICE TESTS — lint/test:coverage/type-check all service.* packages
@@ -254,6 +259,7 @@ jobs:
         with:
           filter: '@adopt-dont-shop/service.*'
           upload-artifact-name: 'test-results-services'
+          coverage-cache-key: 'coverage-current-${{ github.run_id }}-services'
 
   # ============================================================================
   # CONTRACT TESTS — consumer-driven Pact verification matrix (ADS-816).
@@ -350,6 +356,30 @@ jobs:
 
     steps:
       - uses: ./.github/actions/e2e-suite
+
+  # ============================================================================
+  # COVERAGE REPORT — ADS-947: sticky PR comment with per-package coverage
+  # delta vs main + this run's job timings. Purely informational: not in
+  # ci-required's needs, and continue-on-error so a script/API hiccup (e.g.
+  # a fork PR's read-only token) can never block merge.
+  # ============================================================================
+  coverage-report:
+    name: Coverage & Timing Report
+    needs: [build-libs, test-frontend, test-libs, test-services]
+    if: |
+      always() &&
+      (github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref == 'refs/heads/main'))
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    continue-on-error: true
+    permissions:
+      contents: read
+      actions: read
+      pull-requests: write
+    steps:
+      - uses: ./.github/actions/coverage-report
+        with:
+          lib-dist-cache-hit: ${{ needs.build-libs.outputs.lib-dist-cache-hit }}
 
   # ============================================================================
   # CI REQUIRED — single aggregator gate for branch protection. Branch

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,6 +158,8 @@ jobs:
       TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
 
     steps:
+      # Local composite actions can only load after the repo is checked out.
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: ./.github/actions/checkout-and-setup
         with:
           download-lib-dist: 'false'
@@ -200,6 +202,8 @@ jobs:
         app: [client, admin, rescue]
 
     steps:
+      # Local composite actions can only load after the repo is checked out.
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: ./.github/actions/run-package-tests
         with:
           filter: '@adopt-dont-shop/app.${{ matrix.app }}'
@@ -226,6 +230,8 @@ jobs:
       TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
 
     steps:
+      # Local composite actions can only load after the repo is checked out.
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: ./.github/actions/run-package-tests
         with:
           filter: '@adopt-dont-shop/lib.*'
@@ -255,6 +261,8 @@ jobs:
       TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
 
     steps:
+      # Local composite actions can only load after the repo is checked out.
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: ./.github/actions/run-package-tests
         with:
           filter: '@adopt-dont-shop/service.*'
@@ -285,6 +293,8 @@ jobs:
       PACT_DO_NOT_TRACK: 'true'
 
     steps:
+      # Local composite actions can only load after the repo is checked out.
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: ./.github/actions/checkout-and-setup
 
       # Phase 1 — consumers write pact files to pacts/
@@ -320,6 +330,8 @@ jobs:
     timeout-minutes: 15
 
     steps:
+      # Local composite actions can only load after the repo is checked out.
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: ./.github/actions/dev-auth-guard
 
   # ============================================================================
@@ -355,6 +367,8 @@ jobs:
       E2E_RUN_ID: ${{ github.run_id }}-${{ github.run_attempt }}
 
     steps:
+      # Local composite actions can only load after the repo is checked out.
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: ./.github/actions/e2e-suite
 
   # ============================================================================
@@ -377,6 +391,8 @@ jobs:
       actions: read
       pull-requests: write
     steps:
+      # Local composite actions can only load after the repo is checked out.
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: ./.github/actions/coverage-report
         with:
           lib-dist-cache-hit: ${{ needs.build-libs.outputs.lib-dist-cache-hit }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,8 +155,9 @@ jobs:
       TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
 
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
-      - uses: ./.github/actions/setup-workspace
+      - uses: ./.github/actions/checkout-and-setup
+        with:
+          download-lib-dist: 'false'
 
       # ADS-390: Cache compiled lib.*/dist across CI runs.
       # Key covers all lib source files, package manifests, tsconfig files and
@@ -173,14 +174,9 @@ jobs:
       - name: Build shared libraries
         if: steps.cache-lib-dist.outputs.cache-hit != 'true'
         run: pnpm build:libs
-      # ADS-909: downstream jobs restore packages/lib.*/dist from this same
-      # actions/cache entry (see their "Restore pre-built libraries" step)
-      # rather than downloading an artifact from this job — `actions/cache`
-      # auto-saves on a miss via its post-job hook, so the cache is populated
-      # either way by the time a `needs: build-libs` job starts. That made
-      # the separate upload-artifact step (previously unconditional, wasting
-      # ~10s per run even on a cache hit) redundant; removed rather than
-      # just gated.
+      # ADS-909: downstream jobs restore this same actions/cache entry
+      # (see .github/actions/checkout-and-setup) rather than downloading an
+      # artifact from this job — no separate upload step needed.
 
   # FRONTEND APPS — one runner per app, fail-fast disabled so all three report
   # ============================================================================
@@ -201,40 +197,12 @@ jobs:
         app: [client, admin, rescue]
 
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
-      - uses: ./.github/actions/setup-workspace
-
-      - name: Restore pre-built libraries
-        # ADS-909: read the same actions/cache entry build-libs populated,
-        # instead of downloading its (conditionally-uploaded) artifact — see
-        # the comment on build-libs' upload-artifact step.
-        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
+      - uses: ./.github/actions/run-package-tests
         with:
-          path: packages/lib.*/dist
-          key: lib-dist-${{ runner.os }}-${{ hashFiles('packages/lib.*/src/**', 'packages/lib.*/package.json', 'packages/lib.*/tsconfig*.json', 'pnpm-lock.yaml') }}
-
-      - name: Lint
-        run: pnpm exec turbo run lint --filter='@adopt-dont-shop/app.${{ matrix.app }}'
-
-      - name: Test (with coverage thresholds)
-        run: pnpm test:coverage
-        working-directory: apps/${{ matrix.app }}
-
-      - name: Type check
-        run: pnpm exec turbo run type-check --filter='@adopt-dont-shop/app.${{ matrix.app }}'
-
-      - name: Build
-        run: pnpm build
-        working-directory: apps/${{ matrix.app }}
-        env:
-          CI: true
-
-      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
-        if: always()
-        with:
-          name: test-results-${{ matrix.app }}
-          path: '**/test-results/junit.xml'
-          retention-days: 7
+          filter: '@adopt-dont-shop/app.${{ matrix.app }}'
+          working-directory: 'apps/${{ matrix.app }}'
+          run-build: 'true'
+          upload-artifact-name: 'test-results-${{ matrix.app }}'
 
   # ============================================================================
   # SHARED LIBRARIES — lint/test/type-check the libs themselves
@@ -254,43 +222,21 @@ jobs:
       TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
 
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
-      - uses: ./.github/actions/setup-workspace
-
-      - name: Restore pre-built libraries
-        # ADS-909: read the same actions/cache entry build-libs populated,
-        # instead of downloading its (conditionally-uploaded) artifact — see
-        # the comment on build-libs' upload-artifact step.
-        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
+      - uses: ./.github/actions/run-package-tests
         with:
-          path: packages/lib.*/dist
-          key: lib-dist-${{ runner.os }}-${{ hashFiles('packages/lib.*/src/**', 'packages/lib.*/package.json', 'packages/lib.*/tsconfig*.json', 'pnpm-lock.yaml') }}
-
-      - name: Lint, test and type-check all libraries
-        run: pnpm exec turbo run lint test:coverage type-check --filter='@adopt-dont-shop/lib.*'
-
-      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
-        if: always()
-        with:
-          name: test-results-libs
-          path: '**/test-results/junit.xml'
-          retention-days: 7
+          filter: '@adopt-dont-shop/lib.*'
+          upload-artifact-name: 'test-results-libs'
 
   # ============================================================================
   # SERVICE TESTS — lint/test:coverage/type-check all service.* packages
   # (ADS-822, coverage added in ADS-831). Mirrors test-libs in structure.
-  # Every service defines `test:coverage` (vitest run --coverage).
   #
-  # ADS-831: this job now COLLECTS coverage but does not yet GATE on it. No
-  # service vitest.config.ts declares coverage thresholds, so the effective floor
-  # is 0% — chosen deliberately so this change cannot break current CI (the
-  # cms/chat test gap that prompted the ticket is already closed). The next step
-  # is to ratchet a low, safely-passing floor per service via each service's
-  # vitest.config.ts (owned by the service teams), the same way lib.* packages
-  # ratchet against vitest.shared.config.ts (ADS-708 / ADS-717).
+  # ADS-831: COLLECTS coverage but does not yet GATE on it — no service
+  # vitest.config.ts declares thresholds, so the floor is 0% (deliberate, so
+  # this cannot break current CI). Next step: ratchet a per-service floor the
+  # same way lib.* packages do (ADS-708 / ADS-717).
   #
-  # Gated on the `backend` path filter so a frontend-only PR skips this job
-  # (ci-required treats skipped as pass — see aggregator comment below).
+  # Gated on the `backend` path filter — ci-required treats skipped as pass.
   # ============================================================================
   test-services:
     name: Service Tests
@@ -304,43 +250,20 @@ jobs:
       TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
 
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
-      - uses: ./.github/actions/setup-workspace
-
-      - name: Restore pre-built libraries
-        # ADS-909: read the same actions/cache entry build-libs populated,
-        # instead of downloading its (conditionally-uploaded) artifact — see
-        # the comment on build-libs' upload-artifact step.
-        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
+      - uses: ./.github/actions/run-package-tests
         with:
-          path: packages/lib.*/dist
-          key: lib-dist-${{ runner.os }}-${{ hashFiles('packages/lib.*/src/**', 'packages/lib.*/package.json', 'packages/lib.*/tsconfig*.json', 'pnpm-lock.yaml') }}
-
-      - name: Lint, test (with coverage) and type-check all services
-        run: pnpm exec turbo run lint test:coverage type-check --filter='@adopt-dont-shop/service.*'
-
-      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
-        if: always()
-        with:
-          name: test-results-services
-          path: '**/test-results/junit.xml'
-          retention-days: 7
+          filter: '@adopt-dont-shop/service.*'
+          upload-artifact-name: 'test-results-services'
 
   # ============================================================================
   # CONTRACT TESTS — consumer-driven Pact verification matrix (ADS-816).
   #
-  # Runs as a separate job from test-services because contract tests have a
-  # strict two-phase ordering requirement: consumers must write their pact
-  # files BEFORE providers read them. Folding them into test-services (which
-  # runs each service in parallel under Turbo) would not guarantee that order.
+  # Separate job from test-services: contract tests need a strict two-phase
+  # order (consumers write pact files BEFORE providers read them), which
+  # test-services' parallel-under-Turbo execution can't guarantee.
   #
-  # Phase 1 — consumer tests: gateway (ValidateToken + GetApplication) and
-  #            notifications (gdpr.erasureRequested) write pact files to pacts/.
-  # Phase 2 — provider tests: auth, applications, and gateway-as-publisher
-  #            read those files and verify the interactions pass.
-  #
-  # Gated on the `backend` path filter (same as test-services) — a frontend-only
-  # PR skips this job. ci-required treats skipped as success.
+  # Gated on the `backend` path filter (same as test-services) — ci-required
+  # treats skipped as success.
   # ============================================================================
   test-contracts:
     name: Contract Tests (Pact)
@@ -356,17 +279,7 @@ jobs:
       PACT_DO_NOT_TRACK: 'true'
 
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
-      - uses: ./.github/actions/setup-workspace
-
-      - name: Restore pre-built libraries
-        # ADS-909: read the same actions/cache entry build-libs populated,
-        # instead of downloading its (conditionally-uploaded) artifact — see
-        # the comment on build-libs' upload-artifact step.
-        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
-        with:
-          path: packages/lib.*/dist
-          key: lib-dist-${{ runner.os }}-${{ hashFiles('packages/lib.*/src/**', 'packages/lib.*/package.json', 'packages/lib.*/tsconfig*.json', 'pnpm-lock.yaml') }}
+      - uses: ./.github/actions/checkout-and-setup
 
       # Phase 1 — consumers write pact files to pacts/
       - name: Contract tests — consumer phase
@@ -401,47 +314,7 @@ jobs:
     timeout-minutes: 15
 
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
-
-      # ADS-676: verify that dev-auth bypass patterns only appear inside
-      # import.meta.env.DEV guards (which Vite replaces with `false` and
-      # tree-shakes in production builds). Fail if any reference to
-      # dev_user / dev-token- appears outside lib.auth's DEV-gated
-      # AuthContext or the explicitly dev-only files below.
-      #
-      # Allowed locations (dev-only by design):
-      #   packages/lib.auth/src/contexts/AuthContext.tsx — DEV-gated
-      #   apps/*/src/components/dev/*                    — dev panels
-      #   apps/*/src/utils/devAuth.ts                    — dev utilities
-      #   apps/*/src/contexts/base/devUtils.ts           — dev utilities
-      #   **/*.test.* / **/*.spec.*                      — test files
-      - name: Scan source for ungated dev auth bypass patterns
-        run: |
-          # Find dev_user or dev-token- references in production source
-          # (exclude test files, dev-only directories, and the known
-          # DEV-gated AuthContext).
-          HITS=$(grep -rn 'dev_user\|dev-token-' \
-            apps/*/src/ packages/lib.*/src/ \
-            --include='*.ts' --include='*.tsx' \
-            --exclude='*.test.*' --exclude='*.spec.*' \
-            | grep -v '/components/dev/' \
-            | grep -v '/utils/devAuth' \
-            | grep -v '/contexts/base/devUtils' \
-            | grep -v 'AuthContext.tsx' \
-            || true)
-
-          if [ -n "$HITS" ]; then
-            echo "ERROR: Dev auth bypass patterns found outside allowed locations:"
-            echo "$HITS"
-            echo ""
-            echo "dev_user / dev-token- must only appear in:"
-            echo "  - packages/lib.auth/src/contexts/AuthContext.tsx (DEV-gated)"
-            echo "  - apps/*/src/components/dev/* (dev-only panels)"
-            echo "  - apps/*/src/utils/devAuth.ts (dev-only utilities)"
-            echo "  - Test files (*.test.*, *.spec.*)"
-            exit 1
-          fi
-          echo "All dev auth patterns are properly gated."
+      - uses: ./.github/actions/dev-auth-guard
 
   # ============================================================================
   # E2E — Playwright journeys against the full docker-compose stack
@@ -452,15 +325,9 @@ jobs:
   test-e2e:
     name: E2E Tests (Playwright)
     needs: [test-frontend, test-services]
-    # E2E is opt-in on pull requests — the full docker-stack build + Playwright
-    # run is too slow to pay on every push during development, and gating it on
-    # the `run-e2e` label keeps unlabelled PRs fast and lets us land small,
-    # isolated changes without waiting on the suite. It runs when:
-    #   * pushing to main (the pre-deploy integration gate), or
-    #   * a PR carries the `run-e2e` label (opt in when the branch is ready), or
-    #   * triggered manually via workflow_dispatch.
-    # On any other PR it is skipped, which the `ci-required` aggregator treats as
-    # success — so E2E never blocks normal in-progress PRs.
+    # E2E is opt-in on PRs (too slow to pay on every push): runs on push to
+    # main, on a PR labelled `run-e2e`, or on workflow_dispatch. Otherwise
+    # skipped — which `ci-required` treats as success.
     if: |
       always() &&
       (
@@ -482,359 +349,18 @@ jobs:
       E2E_RUN_ID: ${{ github.run_id }}-${{ github.run_attempt }}
 
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
-
-      - name: Free up disk space
-        # The 14-image compose build needs ~25GB; the hosted runner has ~14GB
-        # free. Evict the big preinstalled toolchains (Android SDK, .NET, GHC,
-        # Swift, CodeQL, runner docker images) before building. Without this
-        # the build dies with ENOSPC mid-export, or — worse — limps through
-        # and the services then sit "unhealthy" because nothing inside the
-        # containers can write (the failure signature ADS-792 describes).
-        run: |
-          df -h /
-          sudo rm -rf /usr/share/dotnet /opt/ghc "/usr/local/share/boost" \
-            /usr/local/lib/android /usr/share/swift /opt/hostedtoolcache/CodeQL \
-            "$AGENT_TOOLSDIRECTORY"
-          sudo docker image prune -af
-          df -h /
-
-      - uses: ./.github/actions/setup-workspace
-
-      # ADS-792: expose ACTIONS_RUNTIME_TOKEN + cache-service URLs to plain
-      # `run:` steps so the raw `docker buildx bake` call below can use
-      # cache-from/cache-to type=gha. JS actions (docker/build-push-action)
-      # receive these implicitly; shell steps do not.
-      - uses: crazy-max/ghaction-github-runtime@04d248b84655b509d8c44dc1d6f990c879747487  # v4.0.0
-
-      # ADS-792: type=gha cache import/export requires a docker-container
-      # builder — the daemon's integrated BuildKit does not support it.
-      # Known tradeoff (this previously kept buildx out of this job): the
-      # container builder stores layers twice at peak — BuildKit cache plus
-      # the tarball re-import into the daemon ("sending tarball"). Two
-      # things keep that inside the runner's disk budget now:
-      #   - warm GHA cache hits skip re-executing (and re-storing
-      #     intermediates for) the expensive npm-ci/turbo layers;
-      #   - the build step prunes the BuildKit cache immediately after
-      #     --load, before the stack boots.
-      # ENOSPC under a fully cold cache is the residual risk — see the
-      # build step below. max-parallelism=4 replaces the old
-      # COMPOSE_PARALLEL_LIMIT=4: 12 concurrent `pnpm install` runs against the
-      # registry was the ECONNRESET source ADS-792 describes.
-      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c  # v4.2.0
-        with:
-          driver-opts: |
-            image=moby/buildkit:v0.23.0
-            network=host
-          buildkitd-config-inline: |
-            [worker.oci]
-              max-parallelism = 4
-
-      - name: Resolve Playwright version
-        id: pw
-        run: |
-          version=$(node -p "require('./e2e/package.json').devDependencies['@playwright/test']")
-          echo "version=${version}" >> "$GITHUB_OUTPUT"
-
-      - name: Cache Playwright browsers
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
-        with:
-          path: ~/.cache/ms-playwright
-          # ADS-901: this is a single-lockfile workspace (e2e/ has no lockfile
-          # of its own — pnpm-workspace.yaml includes it), so the root
-          # pnpm-lock.yaml hash is what actually changes when @playwright/test
-          # bumps. Without it, a patch bump that doesn't change `steps.pw`'s
-          # resolved version string could keep a stale cache and mismatch the
-          # installed browsers against the newer test runner.
-          key: playwright-${{ runner.os }}-${{ steps.pw.outputs.version }}-${{ hashFiles('pnpm-lock.yaml') }}
-
-      - name: Install Playwright browsers
-        run: pnpm test:e2e:install
-
-      - name: Generate secrets and write .env
-        run: |
-          {
-            echo "NODE_ENV=development"
-            echo "POSTGRES_USER=postgres"
-            # Hex, not base64, for the same reason as REDIS_PASSWORD below:
-            # compose interpolates this into DATABASE_URL=postgresql://user:
-            # ${POSTGRES_PASSWORD}@database:5432/db and base64's / + = break
-            # `new URL()` in every service's db:migrate — intermittently,
-            # whenever the random draw happens to contain one.
-            echo "POSTGRES_PASSWORD=$(openssl rand -hex 32)"
-            echo "POSTGRES_DB=adopt_dont_shop_dev"
-            echo "JWT_SECRET=$(openssl rand -base64 32)"
-            echo "JWT_REFRESH_SECRET=$(openssl rand -base64 32)"
-            echo "SESSION_SECRET=$(openssl rand -base64 32)"
-            echo "ENCRYPTION_KEY=$(openssl rand -hex 32)"
-            # HMAC key for the service-to-service principal tokens minted
-            # and verified by packages/service-bootstrap (read via
-            # config-secrets as PRINCIPAL_SIGNING_KEY).
-            echo "PRINCIPAL_SIGNING_KEY=$(openssl rand -hex 32)"
-            # ADS-600 made REDIS_PASSWORD a required secret in
-            # docker-compose.yml; the CI stack-up step refuses to
-            # start without it. Generate it here so every E2E run
-            # gets a fresh, non-default value.
-            #
-            # Hex (not base64) because docker-compose interpolates
-            # this into REDIS_URL=redis://:${REDIS_PASSWORD}@redis:6379
-            # and `openssl rand -base64` includes `/`, `+`, `=` —
-            # `/` terminates the URL userinfo so the backend's
-            # `new URL(REDIS_URL)` rejects it with "Invalid URL"
-            # before validateEnv can finish.
-            echo "REDIS_PASSWORD=$(openssl rand -hex 32)"
-            # ADS-542 made UPLOAD_SIGNING_SECRET a required env var on
-            # the backend (32+ chars). Without it the /health probe
-            # never goes ready and the Wait-for-services step times
-            # out.
-            echo "UPLOAD_SIGNING_SECRET=$(openssl rand -base64 32)"
-            echo "CORS_ORIGIN=http://localhost:3000,http://localhost:3001,http://localhost:3002"
-            # Raise the gateway's global per-IP rate limit for e2e. A full
-            # Playwright run drives the whole SPA (favourites, chats,
-            # notifications, permissions, legal, match, csrf) across parallel
-            # workers from a single docker-side IP, bursting past the 100/min
-            # production default and 429-ing page loads. (apiAs also caches its
-            # login token per role to stay under the stricter 10/min auth-login
-            # limit.) Production keeps the 100/min default.
-            echo "GATEWAY_RATE_LIMIT_MAX=100000"
-            # Also lift the stricter per-route auth limits (login 10/min,
-            # register 5/min, ...) — a full suite logs in/registers many times
-            # from one IP across workers. Production leaves this unset.
-            echo "GATEWAY_AUTH_RATE_LIMIT_MAX=100000"
-            # ADS-871: enable the gateway's test-only token-peek seam so the
-            # e2e suite can read one-time reset/verify/invitation tokens and
-            # drive the full auth round-trips. Safe here — NODE_ENV is
-            # development above, and the gateway refuses to boot with this on
-            # under NODE_ENV=production. Production/staging never set it.
-            echo "E2E_TOKEN_PEEK=true"
-          } > .env
-
-      - name: Start database and cache
-        run: |
-          docker compose -f docker-compose.yml up -d database redis
-          timeout 90 bash -c 'until docker compose -f docker-compose.yml exec -T database pg_isready -U postgres; do sleep 2; done'
-
-      - name: Build images
-        # ADS-792: `buildx bake` against docker-compose.yml with BuildKit GHA
-        # layer caching. Design notes:
-        #
-        # PER-TARGET scopes (scope=e2e-<service>): GHA cache writes are
-        # last-write-wins per scope, so a single shared scope with 12 targets
-        # exporting concurrently thrashes — each save evicts the previous
-        # target's layers and the hit rate collapses.
-        #
-        # mode=min, not mode=max, against the repo's 10GB Actions cache
-        # budget (shared with the pnpm/turbo/lib-dist/Playwright caches and
-        # docker.yml's type=gha caches):
-        #   - the `development` targets inherit FROM the build stage, so the
-        #     expensive pnpm-install + turbo-build layers ARE final-image
-        #     layers and mode=min still caches them;
-        #   - mode=max would additionally export intermediates like the
-        #     `pruner` stage, whose COPY-the-whole-repo layer changes every
-        #     commit — pure churn, several GB per scope, guaranteed eviction
-        #     pressure across 12 scopes;
-        #   - estimated mode=min footprint: ~0.3-0.6GB x 12 scopes. Layers
-        #     shared between images are still stored once per scope — the
-        #     price of not thrashing;
-        #   - ignore-error=true: a cache-backend outage degrades to an
-        #     uncached build instead of failing CI.
-        #
-        # Targets are discovered from the compose file via `bake --print`
-        # (buildx parses compose profiles as "all", so every buildable
-        # service is included) — compose-stack changes need no edits here.
-        # Bake assigns NO tags when compose services have no `image:` field,
-        # so each target's tag is set explicitly to the <project>-<service>
-        # name that `docker compose up --no-build` later resolves (project =
-        # lowercased checkout directory name, the same default compose uses).
-        # If bake ever fails to resolve targets (e.g. a compose-file feature
-        # it can't parse), fall back to the previous uncached compose build
-        # rather than breaking the job.
-        run: |
-          set -euo pipefail
-          # bake interpolates the compose file itself, so the ${VAR:?} guards
-          # (REDIS_PASSWORD, JWT_SECRET, ...) need the generated .env values
-          # in the process env.
-          set -a; source ./.env; set +a
-
-          project="$(basename "$PWD" | tr '[:upper:]' '[:lower:]')"
-          mapfile -t targets < <(docker buildx bake -f docker-compose.yml --print 2>/dev/null | jq -r '.group.default.targets[]' || true)
-
-          if [ "${#targets[@]}" -eq 0 ]; then
-            echo "::warning title=bake fallback::buildx bake resolved no targets from docker-compose.yml — falling back to uncached docker compose build"
-            COMPOSE_PARALLEL_LIMIT=4 docker compose -f docker-compose.yml --profile full build
-            exit 0
-          fi
-
-          echo "Building ${#targets[@]} targets: ${targets[*]}"
-          set_args=()
-          for t in "${targets[@]}"; do
-            set_args+=(
-              --set "${t}.tags=${project}-${t}"
-              --set "${t}.cache-from=type=gha,scope=e2e-${t}"
-              --set "${t}.cache-to=type=gha,mode=min,scope=e2e-${t},ignore-error=true"
-            )
-          done
-
-          # --load = output=type=docker: images land in the daemon store
-          # under the tags set above, where `up --no-build` expects them.
-          docker buildx bake -f docker-compose.yml --load "${set_args[@]}"
-
-          # The BuildKit cache is dead weight once the images are in the
-          # daemon store — reclaim the disk before the stack boots.
-          docker buildx prune -af > /dev/null
-          docker image ls --format '{{.Repository}}:{{.Tag}}  {{.Size}}' | grep "^${project}-" || true
-          df -h /
-
-      - name: Start the full stack (images already built)
-        # Phase 11 follow-up: bring the apps + gateway + services + nginx up
-        # in ONE compose invocation under the `full` profile. The previous
-        # two-step `--profile services up` + `up app-client app-admin
-        # app-rescue` left nginx (which has no profile and therefore
-        # auto-starts on the first invocation) crash-looping for six minutes
-        # because its `app-client:3000` upstream wasn't resolvable. nginx is
-        # now in the `full`/`proxy` profiles so it starts only alongside the
-        # apps it proxies, and a single `up` honours the compose dependency
-        # graph instead of racing two independent stacks.
-        # ADS-792: --no-build because images were pre-built above.
-        run: |
-          docker compose -f docker-compose.yml --profile full up -d --no-build
-          df -h /
-
-      - name: Wait for services
-        # The gateway is first in the list and carries the whole budget: it
-        # boots 10 sibling services' worth of migrations + tsx compiles on a
-        # contended 4-core runner, so it gets 240×2s (8 min) rather than the
-        # 90×2s that used to time out. Log dumps need --profile full — the
-        # service/app containers live in that profile, so a bare `compose
-        # logs` shows only the infra containers and hides the actual failure.
-        run: |
-          set -euo pipefail
-          for url in http://localhost:4000/health/simple http://localhost:3000 http://localhost:3001 http://localhost:3002; do
-            echo "Waiting for $url"
-            for i in $(seq 1 240); do
-              if curl -fsS --max-time 5 "$url" >/dev/null 2>&1; then
-                echo "  ready: $url"
-                break
-              fi
-              if [ "$i" = "240" ]; then
-                echo "  timeout: $url"
-                docker compose -f docker-compose.yml --profile full ps
-                docker compose -f docker-compose.yml --profile full logs --tail=300
-                exit 1
-              fi
-              sleep 2
-            done
-          done
-
-          # The URL loop only proves the gateway + apps are up. The gateway
-          # answers /health/simple before its sibling gRPC services finish
-          # their own migrate→seed→boot cycle, so a Playwright login probe
-          # fired now hits ECONNREFUSED on service-auth:6002. Every service
-          # binds gRPC before its HTTP health server (see services/*/src/
-          # index.ts), so compose-healthy ⇒ gRPC ready — wait for that.
-          echo "Waiting for service containers to report healthy"
-          for i in $(seq 1 120); do
-            not_healthy=$(docker compose -f docker-compose.yml --profile full ps --format '{{.Service}} {{.Health}}' \
-              | awk '$1 ~ /^service-/ && $2 != "healthy" {print $1}')
-            if [ -z "$not_healthy" ]; then
-              echo "  all service containers healthy"
-              break
-            fi
-            if [ "$i" = "120" ]; then
-              echo "  timeout waiting for: $not_healthy"
-              docker compose -f docker-compose.yml --profile full ps
-              docker compose -f docker-compose.yml --profile full logs --tail=300
-              exit 1
-            fi
-            sleep 2
-          done
-
-      - name: Warm up Vite bundles
-        # Vite dev servers compile on first request. Hit /login on each app
-        # so the JS is built before Playwright tries to interact with it.
-        run: |
-          for url in \
-            http://localhost:3000/login \
-            http://localhost:3001/login \
-            http://localhost:3002/login; do
-            echo "Warming $url"
-            curl -fsS --max-time 60 "$url" >/dev/null || true
-          done
-
-      - name: Run Playwright suite
-        # E2E only reaches this point when explicitly requested (main push,
-        # `run-e2e` label, or manual dispatch), so always run the full suite —
-        # the point of opting in is to get complete integration coverage, not a
-        # smoke subset. Tag tests with @smoke and run `pnpm test:e2e:smoke`
-        # locally for a quick subset.
-        #
-        # Retries are configured in e2e/playwright.config.ts (retries: CI ? 2 : 0).
-        run: |
-          echo "${{ github.event_name }} on ${{ github.ref }} — running full suite"
-          pnpm test:e2e
-
-      # ADS-386: Surface flaky-retry signal so engineers can see which tests
-      # needed retries without having to open the full HTML report.
-      # This step never blocks CI — it is informational only.
-      - name: Report E2E retry counts
-        if: always()
-        run: |
-          report_dir="e2e/test-results"
-          if [ ! -d "$report_dir" ]; then
-            echo "No test-results directory found — Playwright may not have run."
-            exit 0
-          fi
-          retried=$(find "$report_dir" -name '*.json' -exec grep -l '"retry":[^0]' {} \; 2>/dev/null | wc -l)
-          if [ "$retried" -gt 0 ]; then
-            echo "::warning::$retried test result file(s) contain retries — check the Playwright report artifact for details."
-          else
-            echo "No retried tests detected in this run."
-          fi
-
-      - name: Dump service logs on failure
-        # Inline (not just the artifact): the artifact requires a download to
-        # inspect, while the job log is immediately searchable. gRPC adapters
-        # mask unexpected handler errors as INTERNAL 'internal error', so the
-        # real exception only exists in the owning service's stdout.
-        if: failure()
-        run: |
-          docker compose -f docker-compose.yml --profile full logs --no-color --tail=150
-
-      - name: Capture docker-compose logs on failure
-        if: failure()
-        # --profile full: without it the dump only contains the default-profile
-        # infra containers (database/redis/nats/...) and silently omits every
-        # service and app container — the part that actually fails.
-        run: docker compose -f docker-compose.yml --profile full logs --no-color > docker-compose.log
-
-      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
-        if: always()
-        with:
-          name: e2e-playwright-report
-          path: |
-            e2e/playwright-report/
-            e2e/test-results/
-            docker-compose.log
-          retention-days: 7
-
-      - name: Tear down stack
-        if: always()
-        run: docker compose -f docker-compose.yml down -v
+      - uses: ./.github/actions/e2e-suite
 
   # ============================================================================
-  # CI REQUIRED — single aggregator gate for branch protection.
+  # CI REQUIRED — single aggregator gate for branch protection. Branch
+  # protection references this one job name, so adding/renaming a job below
+  # doesn't require touching the ruleset.
   #
-  # Branch protection / Rulesets reference this one job name. It fans-in to
-  # every regression-blocking job above so adding/renaming a job below does
-  # not require touching the ruleset.
-  #
-  # Several needs report `skipped` rather than `success`: the path-filtered
-  # jobs (test-frontend, test-libs, dev-auth-guard) on PRs that do not touch
-  # their paths, and test-e2e on any PR not labelled `run-e2e` (E2E is opt-in
-  # — see that job). Classic branch protection treats `skipped` as a failure,
-  # which is why a plain list of required checks is fragile. This aggregator
-  # only fails on `failure` or `cancelled`, treating `skipped` as success — the
-  # standard "merge gate" pattern. So an absent/skipped E2E never blocks merge.
+  # Path-filtered jobs (test-frontend, test-libs, dev-auth-guard) and test-e2e
+  # (opt-in via `run-e2e`) report `skipped` rather than `success` when they
+  # don't run. Classic branch protection treats `skipped` as a failure, so
+  # this aggregator only fails on `failure`/`cancelled` — the standard
+  # "merge gate" pattern — treating `skipped` as success.
   # ============================================================================
   ci-required:
     name: CI Required

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -98,6 +98,8 @@ pnpm exec turbo run test:coverage                 # every package, with threshol
 pnpm exec turbo run test:coverage --filter='@adopt-dont-shop/lib.api'   # scope to what you changed
 ```
 
+**Coverage & timing PR comment (ADS-947).** Once `test-frontend`, `test-libs`, and `test-services` finish, `ci.yml`'s `coverage-report` job posts a sticky comment on the PR showing per-package coverage delta vs `main` (only packages whose coverage changed) and this run's job timings. It updates the same comment in place on every push rather than posting a new one, and it's purely informational — it never blocks merge.
+
 #### Pre-commit hook (lint-staged)
 
 `.husky/pre-commit` runs [`.lintstagedrc.mjs`](./.lintstagedrc.mjs): Prettier formats the exact staged files, and ESLint runs via `pnpm exec turbo run lint --filter="...[HEAD]"` (ADS-905) — scoped to only the workspace packages your commit touches, using each package's own `eslint.config.js` (matching CI) rather than a single shared root config. A commit that only touches one package only lints that package.

--- a/apps/admin/vitest.config.ts
+++ b/apps/admin/vitest.config.ts
@@ -26,7 +26,9 @@ export default defineConfig({
     },
     coverage: {
       provider: 'v8',
-      reporter: ['text', 'json', 'html'],
+      // ADS-947: json-summary is read by scripts/ci/coverage-delta.mjs to
+      // post the PR coverage-delta comment.
+      reporter: ['text', 'json', 'html', 'json-summary'],
       include: ['src/**/*.{ts,tsx}'],
       exclude: [
         'src/**/*.d.ts',

--- a/apps/client/vitest.config.ts
+++ b/apps/client/vitest.config.ts
@@ -26,7 +26,9 @@ export default defineConfig({
     },
     coverage: {
       provider: 'v8',
-      reporter: ['text', 'json', 'html'],
+      // ADS-947: json-summary is read by scripts/ci/coverage-delta.mjs to
+      // post the PR coverage-delta comment.
+      reporter: ['text', 'json', 'html', 'json-summary'],
       include: ['src/**/*.{ts,tsx}'],
       exclude: [
         'src/**/*.d.ts',

--- a/apps/rescue/vitest.config.ts
+++ b/apps/rescue/vitest.config.ts
@@ -20,7 +20,9 @@ export default defineConfig({
     testTimeout: 10000,
     coverage: {
       provider: 'v8',
-      reporter: ['text', 'json', 'html'],
+      // ADS-947: json-summary is read by scripts/ci/coverage-delta.mjs to
+      // post the PR coverage-delta comment.
+      reporter: ['text', 'json', 'html', 'json-summary'],
       include: ['src/**/*.{ts,tsx}'],
       exclude: [
         'src/**/*.d.ts',

--- a/scripts/lib/coverage-delta-core.mjs
+++ b/scripts/lib/coverage-delta-core.mjs
@@ -1,0 +1,165 @@
+/**
+ * Pure coverage-delta / PR-comment formatting logic (ADS-947).
+ *
+ * Kept free of any filesystem / network access so it can be unit-tested as a
+ * black box. The orchestration (reading coverage-summary.json files off
+ * disk, calling the GitHub API for job timings, upserting the sticky PR
+ * comment) lives in the `Post/update coverage report comment` step of
+ * .github/actions/coverage-report/action.yml, which imports these functions.
+ *
+ * All coverage values are percentages in the range [0, 100], shaped like
+ * `measuredFromSummaryTotal()`'s return value from ratchet-coverage-core.mjs:
+ * `{ statements?, branches?, functions?, lines? }`.
+ */
+
+const METRICS = ['statements', 'branches', 'functions', 'lines'];
+
+// Below this, a coverage move is noise (rounding / CI variance), not a
+// reportable delta.
+const CHANGE_EPSILON = 0.1;
+
+/**
+ * Compare a package's before/after coverage totals and decide whether the
+ * change is worth reporting.
+ *
+ * @param {Record<string, number>|undefined} before
+ * @param {Record<string, number>} after
+ * @returns {boolean}
+ */
+function hasReportableChange(before, after) {
+  return METRICS.some(metric => {
+    const afterValue = after[metric];
+    if (typeof afterValue !== 'number') {
+      return false;
+    }
+    const beforeValue = before?.[metric];
+    if (typeof beforeValue !== 'number') {
+      // No baseline for this metric — a newly-measured package/metric is
+      // always reportable.
+      return true;
+    }
+    return Math.abs(afterValue - beforeValue) >= CHANGE_EPSILON;
+  });
+}
+
+/**
+ * Compute per-package coverage deltas between a baseline (main) snapshot and
+ * the current run, keeping only packages whose coverage actually changed.
+ *
+ * @param {Record<string, Record<string, number>>} baselineByPackage
+ * @param {Record<string, Record<string, number>>} currentByPackage
+ * @returns {Array<{ package: string, before: Record<string, number>|undefined, after: Record<string, number> }>}
+ *   Sorted by package name. A package with no baseline entry is reported as
+ *   new (before: undefined). A package present only in the baseline (removed
+ *   or not run this build) is omitted — there's nothing current to show.
+ */
+export function computePackageDeltas(baselineByPackage, currentByPackage) {
+  return Object.keys(currentByPackage)
+    .filter(pkg => hasReportableChange(baselineByPackage[pkg], currentByPackage[pkg]))
+    .sort((a, b) => a.localeCompare(b))
+    .map(pkg => ({
+      package: pkg,
+      before: baselineByPackage[pkg],
+      after: currentByPackage[pkg],
+    }));
+}
+
+function formatMetric(before, after) {
+  if (typeof after !== 'number') {
+    return 'n/a';
+  }
+  if (typeof before !== 'number') {
+    return `${after.toFixed(1)}% (new)`;
+  }
+  const delta = after - before;
+  const sign = delta > 0 ? '+' : '';
+  return `${after.toFixed(1)}% (${sign}${delta.toFixed(1)})`;
+}
+
+/**
+ * Render the per-package coverage-delta rows as a Markdown table.
+ *
+ * @param {ReturnType<typeof computePackageDeltas>} rows
+ * @returns {string}
+ */
+export function formatCoverageTable(rows) {
+  if (rows.length === 0) {
+    return '_No package coverage changes vs the base branch._';
+  }
+  const header =
+    '| Package | Statements | Branches | Functions | Lines |\n| --- | --- | --- | --- | --- |';
+  const body = rows
+    .map(row => {
+      const cells = METRICS.map(metric => formatMetric(row.before?.[metric], row.after[metric]));
+      return `| ${row.package} | ${cells.join(' | ')} |`;
+    })
+    .join('\n');
+  return `${header}\n${body}`;
+}
+
+/**
+ * @param {number} ms
+ * @returns {string} e.g. "3m 12s" or "45s"
+ */
+export function formatDurationLabel(ms) {
+  if (typeof ms !== 'number' || Number.isNaN(ms) || ms < 0) {
+    return 'n/a';
+  }
+  const totalSeconds = Math.round(ms / 1000);
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  return minutes > 0 ? `${minutes}m ${seconds}s` : `${seconds}s`;
+}
+
+/**
+ * Render per-job wall-clock timings as a Markdown table, slowest first.
+ *
+ * @param {Array<{ name: string, durationMs: number, conclusion?: string, status: string }>} jobs
+ * @returns {string}
+ */
+export function formatJobTimingsTable(jobs) {
+  if (jobs.length === 0) {
+    return '_No job timing data available._';
+  }
+  const header = '| Job | Duration | Result |\n| --- | --- | --- |';
+  const body = [...jobs]
+    .sort((a, b) => b.durationMs - a.durationMs)
+    .map(
+      job =>
+        `| ${job.name} | ${formatDurationLabel(job.durationMs)} | ${job.conclusion ?? job.status} |`
+    )
+    .join('\n');
+  return `${header}\n${body}`;
+}
+
+// Marker used to find (and overwrite in place) this bot's own comment on
+// later pushes, instead of posting a new one each time.
+export const COMMENT_MARKER = '<!-- ads-ci-coverage-report -->';
+
+/**
+ * Assemble the full sticky PR comment body.
+ *
+ * @param {{ coverageTable: string, timingsTable: string, libDistCacheHit: boolean|undefined }} params
+ * @returns {string}
+ */
+export function buildCommentBody({ coverageTable, timingsTable, libDistCacheHit }) {
+  const cacheLabel =
+    typeof libDistCacheHit === 'boolean' ? (libDistCacheHit ? 'hit' : 'miss') : 'unknown';
+  return [
+    COMMENT_MARKER,
+    '## CI report',
+    '',
+    '**Coverage delta vs main** (only packages whose coverage changed)',
+    '',
+    coverageTable,
+    '',
+    '<details>',
+    `<summary>CI health — job timings (lib-dist cache: ${cacheLabel})</summary>`,
+    '',
+    timingsTable,
+    '',
+    '</details>',
+    '',
+    '_Informational only — does not block merge._',
+  ].join('\n');
+}

--- a/scripts/lib/coverage-delta-core.test.mjs
+++ b/scripts/lib/coverage-delta-core.test.mjs
@@ -1,0 +1,148 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  buildCommentBody,
+  COMMENT_MARKER,
+  computePackageDeltas,
+  formatCoverageTable,
+  formatDurationLabel,
+  formatJobTimingsTable,
+} from './coverage-delta-core.mjs';
+
+describe('computePackageDeltas', () => {
+  it('reports a package whose statements moved by more than the noise margin', () => {
+    const baseline = { 'lib.api': { statements: 90, branches: 80, functions: 90, lines: 90 } };
+    const current = { 'lib.api': { statements: 92, branches: 80, functions: 90, lines: 90 } };
+
+    expect(computePackageDeltas(baseline, current)).toEqual([
+      { package: 'lib.api', before: baseline['lib.api'], after: current['lib.api'] },
+    ]);
+  });
+
+  it('omits a package whose coverage is unchanged within the noise margin', () => {
+    const baseline = { 'lib.api': { statements: 90, branches: 80, functions: 90, lines: 90 } };
+    const current = { 'lib.api': { statements: 90.05, branches: 80, functions: 90, lines: 90 } };
+
+    expect(computePackageDeltas(baseline, current)).toEqual([]);
+  });
+
+  it('reports a package with no baseline as new', () => {
+    const current = { 'lib.new': { statements: 75, branches: 60, functions: 80, lines: 75 } };
+
+    expect(computePackageDeltas({}, current)).toEqual([
+      { package: 'lib.new', before: undefined, after: current['lib.new'] },
+    ]);
+  });
+
+  it('omits a package present only in the baseline (removed / not run this build)', () => {
+    const baseline = { 'lib.gone': { statements: 90, branches: 80, functions: 90, lines: 90 } };
+
+    expect(computePackageDeltas(baseline, {})).toEqual([]);
+  });
+
+  it('sorts results by package name', () => {
+    const current = {
+      'lib.zeta': { statements: 50, branches: 50, functions: 50, lines: 50 },
+      'lib.alpha': { statements: 50, branches: 50, functions: 50, lines: 50 },
+    };
+
+    expect(computePackageDeltas({}, current).map(row => row.package)).toEqual([
+      'lib.alpha',
+      'lib.zeta',
+    ]);
+  });
+});
+
+describe('formatCoverageTable', () => {
+  it('renders a placeholder when there are no reportable deltas', () => {
+    expect(formatCoverageTable([])).toBe('_No package coverage changes vs the base branch._');
+  });
+
+  it('renders before/after with a signed delta for an existing package', () => {
+    const table = formatCoverageTable([
+      {
+        package: 'lib.api',
+        before: { statements: 90, branches: 80, functions: 90, lines: 90 },
+        after: { statements: 92.5, branches: 80, functions: 90, lines: 89.2 },
+      },
+    ]);
+
+    expect(table).toContain(
+      '| lib.api | 92.5% (+2.5) | 80.0% (0.0) | 90.0% (0.0) | 89.2% (-0.8) |'
+    );
+  });
+
+  it('marks a package with no baseline as new', () => {
+    const table = formatCoverageTable([
+      {
+        package: 'lib.new',
+        before: undefined,
+        after: { statements: 75, branches: 60, functions: 80, lines: 75 },
+      },
+    ]);
+
+    expect(table).toContain('75.0% (new)');
+  });
+});
+
+describe('formatDurationLabel', () => {
+  it('formats sub-minute durations as seconds', () => {
+    expect(formatDurationLabel(45_000)).toBe('45s');
+  });
+
+  it('formats multi-minute durations as minutes and seconds', () => {
+    expect(formatDurationLabel(192_000)).toBe('3m 12s');
+  });
+
+  it('returns n/a for missing or invalid input', () => {
+    expect(formatDurationLabel(undefined)).toBe('n/a');
+    expect(formatDurationLabel(-5)).toBe('n/a');
+    expect(formatDurationLabel(Number.NaN)).toBe('n/a');
+  });
+});
+
+describe('formatJobTimingsTable', () => {
+  it('renders a placeholder when there is no timing data', () => {
+    expect(formatJobTimingsTable([])).toBe('_No job timing data available._');
+  });
+
+  it('sorts jobs slowest-first', () => {
+    const table = formatJobTimingsTable([
+      { name: 'Library Tests', durationMs: 30_000, status: 'completed', conclusion: 'success' },
+      {
+        name: 'E2E Tests (Playwright)',
+        durationMs: 600_000,
+        status: 'completed',
+        conclusion: 'success',
+      },
+    ]);
+
+    const lines = table.split('\n');
+    expect(lines[2]).toContain('E2E Tests (Playwright)');
+    expect(lines[3]).toContain('Library Tests');
+  });
+});
+
+describe('buildCommentBody', () => {
+  it('includes the sticky marker so the comment can be found and updated in place', () => {
+    const body = buildCommentBody({
+      coverageTable: 'table',
+      timingsTable: 'timings',
+      libDistCacheHit: true,
+    });
+
+    expect(body.startsWith(COMMENT_MARKER)).toBe(true);
+    expect(body).toContain('lib-dist cache: hit');
+    expect(body).toContain('does not block merge');
+  });
+
+  it('reports the cache status as unknown when not provided', () => {
+    const body = buildCommentBody({
+      coverageTable: 't',
+      timingsTable: 'j',
+      libDistCacheHit: undefined,
+    });
+
+    expect(body).toContain('lib-dist cache: unknown');
+  });
+});

--- a/services/chat/vitest.config.ts
+++ b/services/chat/vitest.config.ts
@@ -19,7 +19,9 @@ export default defineServiceConfig({
         'src/db/spam.ts',
         'src/**/index.ts',
       ],
-      reporter: ['text', 'lcov'],
+      // ADS-947: json-summary is read by scripts/ci/coverage-delta.mjs to
+      // post the PR coverage-delta comment.
+      reporter: ['text', 'lcov', 'json-summary'],
       // ratcheted to measured baseline (2026-06-16): the service owns its own
       // floor the same way lib.* packages ratchet against vitest.shared.config.
       // Measured: statements=92.44 branches=96.44 functions=90.69 lines=92.3

--- a/services/cms/vitest.config.ts
+++ b/services/cms/vitest.config.ts
@@ -7,7 +7,9 @@ export default defineServiceConfig({
       all: true,
       include: ['src/**/*.ts'],
       exclude: ['src/**/*.test.ts', 'src/**/*.d.ts', 'src/migrations/**', 'src/**/index.ts'],
-      reporter: ['text', 'lcov'],
+      // ADS-947: json-summary is read by scripts/ci/coverage-delta.mjs to
+      // post the PR coverage-delta comment.
+      reporter: ['text', 'lcov', 'json-summary'],
       // ratcheted to measured baseline (2026-06-16): the service owns its own
       // floor the same way lib.* packages ratchet against vitest.shared.config.
       // Measured: statements=90.78 branches=85.4 functions=90.9 lines=90.73

--- a/vitest.shared.config.ts
+++ b/vitest.shared.config.ts
@@ -79,7 +79,9 @@ const sharedConfig = defineConfig({
     ],
     coverage: {
       provider: 'v8',
-      reporter: ['text', 'lcov', 'html'],
+      // ADS-947: json-summary is read by scripts/ci/coverage-delta.mjs to post
+      // the PR coverage-delta comment.
+      reporter: ['text', 'lcov', 'html', 'json-summary'],
       reportsDirectory: 'coverage',
       include: ['src/**/*.ts', 'src/**/*.tsx'],
       exclude: [
@@ -134,6 +136,13 @@ const sharedServiceConfig = defineConfig({
     environment: 'node',
     include: ['src/**/*.test.ts'],
     testTimeout: 10_000,
+    coverage: {
+      provider: 'v8',
+      // ADS-947: json-summary is read by scripts/ci/coverage-delta.mjs to
+      // post the PR coverage-delta comment.
+      reporter: ['text', 'json-summary'],
+      reportsDirectory: 'coverage',
+    },
   },
 });
 


### PR DESCRIPTION
## Summary

- **ADS-953**: shrink `ci.yml` (869 → 424 lines) by extracting the repeated checkout → setup-workspace → restore lib-dist → run-turbo preamble, the ~380-line E2E body, and the dev-auth-guard scan into composite actions under `.github/actions/`.
- **ADS-947**: add a `coverage-report` job that posts (and updates in place) a single sticky PR comment with per-package coverage delta vs `main` and this run's job timings.

## Changes

- `.github/actions/checkout-and-setup/` — checkout + `setup-workspace` + optional lib-dist cache restore (the actual repeated preamble); consumed by `build-libs`, `run-package-tests`, `test-contracts`.
- `.github/actions/run-package-tests/` — the test-frontend/test-libs/test-services job body (lint/test(:coverage)/type-check via Turbo, or per-app steps + build), now also caches this run's `coverage-summary.json` files under a run-scoped key (ADS-947).
- `.github/actions/e2e-suite/` — the entire Playwright E2E job body, moved verbatim.
- `.github/actions/dev-auth-guard/` — the dev-auth bypass scan, moved verbatim.
- `.github/actions/coverage-report/` (ADS-947) — restores this run's + main's coverage snapshots, computes the delta, fetches job timings via the Actions API, and upserts the sticky comment; also snapshots main's coverage as the next baseline on push-to-main.
- `scripts/lib/coverage-delta-core.mjs` (+ `.test.mjs`) — pure delta-computation / Markdown-formatting functions, unit-tested independently of the GitHub-API/filesystem orchestration that calls them.
- `vitest.shared.config.ts`, `apps/{admin,client,rescue}/vitest.config.ts`, `services/{chat,cms}/vitest.config.ts` — added `json-summary` to each package family's coverage reporter list (needed to produce `coverage-summary.json` for the delta computation).
- `.github/workflows/README.md`, `CONTRIBUTING.md` — documented the new composite actions and the PR comment.

### Design deviation from ADS-953's literal wording (flagged per CLAUDE.md)

The ticket's "Proposed Solution" suggests `workflow_call` reusable workflows. I used **composite actions** instead, for a specific, load-bearing reason: when a job calls a reusable workflow, GitHub prefixes that job's status-check name with `<caller job name> / <callee job name>` (documented behaviour). Since my brief required "same required-check names… per-job names must not change unless the ticket explicitly says so," and the ticket doesn't address this, `workflow_call` would have silently renamed every test/E2E/dev-auth-guard check. Composite actions splice their steps into the *same* job, so job identity, `needs:`, and `if:` gating are byte-for-byte unchanged, and `ci-required`'s aggregation (which only reads `needs.<job>.result`, unaffected by any of this either way) keeps working exactly as before. I did not implement the ticket's other "Proposed Solution" bullet (a single `actions.env`-style file indirecting every `uses:` pin across *all* workflows) — that would touch far more files than "shrink ci.yml," and GitHub's `uses:` doesn't support that indirection without breaking Dependabot's SHA-pin scanning (this repo's documented Action Pinning Policy). Instead, the setup-contract duplication is now centralized in the composite actions above, which is the concrete problem the ticket describes ("editing many places" for a setup-contract change).

`ci.yml` was 394 lines after ADS-953 alone (under the ≤400 target); ADS-947 adds one new job (`coverage-report`, ~23 lines, delegating its whole body to a composite like the others) bringing the final total to 424 — still less than half the original 869, with no repetition reintroduced.

### Job/check inventory (unchanged job names, confirms `same jobs, same triggers`)

Before and after (`grep -E '^  [a-z][a-z0-9-]*:$' .github/workflows/ci.yml`):

```
workspace-drift    workspace-drift
changes            changes
build-libs         build-libs
test-frontend      test-frontend
test-libs          test-libs
test-services      test-services
test-contracts     test-contracts
dev-auth-guard     dev-auth-guard
test-e2e           test-e2e
                   coverage-report   <- new (ADS-947), NOT in ci-required's needs
ci-required        ci-required
```

`workspace-drift` (dependency-free `check-workspace-consistency` run, plus `check-env-example`/`check-docs-index`/`check-docs-script-references`/`check-docker-pinning`/`check-csp-headers`) was left completely untouched, per the explicit instruction that it must keep running without `node_modules`. The standalone `onboarding-smoke.yml`, `docs-freshness.yml`, `dependency-graph.yml`, and `storybook.yml`'s `stories-coverage` job were not touched or folded in.

## Before requesting review

- [x] Ran the equivalent of `pnpm ci:local:quick` checks locally (see Test plan)
- [x] Tests for new behaviour added (TDD) — `scripts/lib/coverage-delta-core.test.mjs`
- [ ] N/A — no `.env` changes
- [ ] N/A — no `lib.*` public API changes

## Test plan

- [x] `corepack enable && pnpm install --frozen-lockfile` — succeeds
- [x] Every touched/added workflow + composite-action YAML file parses (`python3 -c 'yaml.safe_load(...)'` over all 24 `.github/workflows/*.yml` + `.github/actions/*/action.yml`)
- [x] `node scripts/check-workflow-paths.mjs` — OK
- [x] `node scripts/check-workspace-consistency.mjs` (dependency-free) — OK
- [x] `pnpm test:scripts` — 94/94 passing, including the 15 new `coverage-delta-core` tests
- [x] `pnpm exec turbo run test:coverage --filter='@adopt-dont-shop/lib.utils'` and `apps/client`'s `pnpm test:coverage` — both produce `coverage/coverage-summary.json` with the new `json-summary` reporter
- [x] `pnpm exec turbo run type-check` on the touched lib/service packages — passes
- [x] `pnpm exec eslint` + `pnpm exec turbo run lint` on touched packages — clean (pre-existing warnings in unrelated files only)
- [x] Syntax-checked the embedded `actions/github-script` JS (`node --check`) and the embedded bash (`bash -n`) in the new `coverage-report` composite
- [x] Manual diff review: every job present in `origin/main`'s `ci.yml` still exists, same name, same `needs`, same `if` gating (see inventory above)
- [ ] Not verified: an actual GitHub Actions run (no live Actions runner in this environment) — the cache-key round-trip (`run-package-tests` saves → `coverage-report` restores) and the sticky-comment upsert are exercised only by syntax/unit checks, not a real workflow execution

## Related

- ADS-953 — https://linear.app/ideasquared/issue/ADS-953
- ADS-947 — https://linear.app/ideasquared/issue/ADS-947

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_015F6J4DXQ1Amyth4dwD5Q8P)_