### PR TITLE
feat(rescue): compute adoptionsFromEvent via registered-then-adopted attribution (ADS-941)

### DIFF
--- a/packages/proto/proto/adopt_dont_shop/applications/v1/application.proto
+++ b/packages/proto/proto/adopt_dont_shop/applications/v1/application.proto
@@ -92,6 +92,17 @@ service ApplicationService {
   // counts — the gateway collapses them to the SPA's 4-state shape.
   rpc GetStats(GetStatsRequest) returns (GetStatsResponse);
 
+  // Read-side: cross-service attribution count (ADS-941). Given a
+  // caller-supplied set of adopter user ids (e.g. an event's
+  // registrants, resolved by the calling service), returns how many of
+  // them have at least one application that reached APPROVED or
+  // ADOPTED status with created_at inside [created_after,
+  // created_before]. Deliberately narrow: the caller already knows the
+  // adopter_ids (it resolved them itself); the response reveals only
+  // the count, never which ids matched or which rescue/pet was
+  // involved. Caller MUST hold applications.read.
+  rpc CountAdoptedAdopters(CountAdoptedAdoptersRequest) returns (CountAdoptedAdoptersResponse);
+
   // Document metadata — append a row referencing an already-stored
   // file URL. The gateway owns the multipart upload + object storage;
   // this surface only persists the METADATA. Caller MUST hold
@@ -389,6 +400,26 @@ message GetStatsResponse {
   uint32 rejected = 8;
   uint32 withdrawn = 9;
   uint32 adopted = 10;
+}
+
+// --- CountAdoptedAdopters ---------------------------------------------
+
+message CountAdoptedAdoptersRequest {
+  // Candidate adopter user ids to check — e.g. an event's registrant
+  // list, resolved by the calling service. No filter/scope semantics;
+  // the caller decides which ids are in play.
+  repeated string adopter_ids = 1;
+  // Inclusive lower bound (RFC3339) on the application's created_at.
+  string created_after = 2;
+  // Inclusive upper bound (RFC3339) on the application's created_at.
+  string created_before = 3;
+}
+
+message CountAdoptedAdoptersResponse {
+  // Distinct count of adopter_ids (from the request) with at least one
+  // non-deleted application whose status is APPROVED or ADOPTED and
+  // whose created_at falls in [created_after, created_before].
+  uint32 count = 1;
 }
 
 // --- Documents -------------------------------------------------------

--- a/packages/proto/src/generated/proto/adopt_dont_shop/applications/v1/application.ts
+++ b/packages/proto/src/generated/proto/adopt_dont_shop/applications/v1/application.ts
@@ -377,6 +377,28 @@ export interface GetStatsResponse {
   adopted: number;
 }
 
+export interface CountAdoptedAdoptersRequest {
+  /**
+   * Candidate adopter user ids to check — e.g. an event's registrant
+   * list, resolved by the calling service. No filter/scope semantics;
+   * the caller decides which ids are in play.
+   */
+  adopterIds: string[];
+  /** Inclusive lower bound (RFC3339) on the application's created_at. */
+  createdAfter: string;
+  /** Inclusive upper bound (RFC3339) on the application's created_at. */
+  createdBefore: string;
+}
+
+export interface CountAdoptedAdoptersResponse {
+  /**
+   * Distinct count of adopter_ids (from the request) with at least one
+   * non-deleted application whose status is APPROVED or ADOPTED and
+   * whose created_at falls in [created_after, created_before].
+   */
+  count: number;
+}
+
 /**
  * Document — metadata for a file attached to an application. The file
  * bytes live in object storage (owned by the gateway); this row only
@@ -3464,6 +3486,182 @@ export const GetStatsResponse: MessageFns<GetStatsResponse> = {
   },
 };
 
+function createBaseCountAdoptedAdoptersRequest(): CountAdoptedAdoptersRequest {
+  return { adopterIds: [], createdAfter: '', createdBefore: '' };
+}
+
+export const CountAdoptedAdoptersRequest: MessageFns<CountAdoptedAdoptersRequest> = {
+  encode(
+    message: CountAdoptedAdoptersRequest,
+    writer: BinaryWriter = new BinaryWriter()
+  ): BinaryWriter {
+    for (const v of message.adopterIds) {
+      writer.uint32(10).string(v!);
+    }
+    if (message.createdAfter !== '') {
+      writer.uint32(18).string(message.createdAfter);
+    }
+    if (message.createdBefore !== '') {
+      writer.uint32(26).string(message.createdBefore);
+    }
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): CountAdoptedAdoptersRequest {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseCountAdoptedAdoptersRequest();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1: {
+          if (tag !== 10) {
+            break;
+          }
+
+          message.adopterIds.push(reader.string());
+          continue;
+        }
+        case 2: {
+          if (tag !== 18) {
+            break;
+          }
+
+          message.createdAfter = reader.string();
+          continue;
+        }
+        case 3: {
+          if (tag !== 26) {
+            break;
+          }
+
+          message.createdBefore = reader.string();
+          continue;
+        }
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): CountAdoptedAdoptersRequest {
+    return {
+      adopterIds: globalThis.Array.isArray(object?.adopterIds)
+        ? object.adopterIds.map((e: any) => globalThis.String(e))
+        : globalThis.Array.isArray(object?.adopter_ids)
+          ? object.adopter_ids.map((e: any) => globalThis.String(e))
+          : [],
+      createdAfter: isSet(object.createdAfter)
+        ? globalThis.String(object.createdAfter)
+        : isSet(object.created_after)
+          ? globalThis.String(object.created_after)
+          : '',
+      createdBefore: isSet(object.createdBefore)
+        ? globalThis.String(object.createdBefore)
+        : isSet(object.created_before)
+          ? globalThis.String(object.created_before)
+          : '',
+    };
+  },
+
+  toJSON(message: CountAdoptedAdoptersRequest): unknown {
+    const obj: any = {};
+    if (message.adopterIds?.length) {
+      obj.adopterIds = message.adopterIds;
+    }
+    if (message.createdAfter !== '') {
+      obj.createdAfter = message.createdAfter;
+    }
+    if (message.createdBefore !== '') {
+      obj.createdBefore = message.createdBefore;
+    }
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<CountAdoptedAdoptersRequest>, I>>(
+    base?: I
+  ): CountAdoptedAdoptersRequest {
+    return CountAdoptedAdoptersRequest.fromPartial(base ?? ({} as any));
+  },
+  fromPartial<I extends Exact<DeepPartial<CountAdoptedAdoptersRequest>, I>>(
+    object: I
+  ): CountAdoptedAdoptersRequest {
+    const message = createBaseCountAdoptedAdoptersRequest();
+    message.adopterIds = object.adopterIds?.map(e => e) || [];
+    message.createdAfter = object.createdAfter ?? '';
+    message.createdBefore = object.createdBefore ?? '';
+    return message;
+  },
+};
+
+function createBaseCountAdoptedAdoptersResponse(): CountAdoptedAdoptersResponse {
+  return { count: 0 };
+}
+
+export const CountAdoptedAdoptersResponse: MessageFns<CountAdoptedAdoptersResponse> = {
+  encode(
+    message: CountAdoptedAdoptersResponse,
+    writer: BinaryWriter = new BinaryWriter()
+  ): BinaryWriter {
+    if (message.count !== 0) {
+      writer.uint32(8).uint32(message.count);
+    }
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): CountAdoptedAdoptersResponse {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseCountAdoptedAdoptersResponse();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1: {
+          if (tag !== 8) {
+            break;
+          }
+
+          message.count = reader.uint32();
+          continue;
+        }
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): CountAdoptedAdoptersResponse {
+    return { count: isSet(object.count) ? globalThis.Number(object.count) : 0 };
+  },
+
+  toJSON(message: CountAdoptedAdoptersResponse): unknown {
+    const obj: any = {};
+    if (message.count !== 0) {
+      obj.count = Math.round(message.count);
+    }
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<CountAdoptedAdoptersResponse>, I>>(
+    base?: I
+  ): CountAdoptedAdoptersResponse {
+    return CountAdoptedAdoptersResponse.fromPartial(base ?? ({} as any));
+  },
+  fromPartial<I extends Exact<DeepPartial<CountAdoptedAdoptersResponse>, I>>(
+    object: I
+  ): CountAdoptedAdoptersResponse {
+    const message = createBaseCountAdoptedAdoptersResponse();
+    message.count = object.count ?? 0;
+    return message;
+  },
+};
+
 function createBaseDocument(): Document {
   return {
     documentId: '',
@@ -5173,6 +5371,30 @@ export const ApplicationServiceService = {
     responseDeserialize: (value: Buffer): GetStatsResponse => GetStatsResponse.decode(value),
   },
   /**
+   * Read-side: cross-service attribution count (ADS-941). Given a
+   * caller-supplied set of adopter user ids (e.g. an event's
+   * registrants, resolved by the calling service), returns how many of
+   * them have at least one application that reached APPROVED or
+   * ADOPTED status with created_at inside [created_after,
+   * created_before]. Deliberately narrow: the caller already knows the
+   * adopter_ids (it resolved them itself); the response reveals only
+   * the count, never which ids matched or which rescue/pet was
+   * involved. Caller MUST hold applications.read.
+   */
+  countAdoptedAdopters: {
+    path: '/adopt_dont_shop.applications.v1.ApplicationService/CountAdoptedAdopters' as const,
+    requestStream: false as const,
+    responseStream: false as const,
+    requestSerialize: (value: CountAdoptedAdoptersRequest): Buffer =>
+      Buffer.from(CountAdoptedAdoptersRequest.encode(value).finish()),
+    requestDeserialize: (value: Buffer): CountAdoptedAdoptersRequest =>
+      CountAdoptedAdoptersRequest.decode(value),
+    responseSerialize: (value: CountAdoptedAdoptersResponse): Buffer =>
+      Buffer.from(CountAdoptedAdoptersResponse.encode(value).finish()),
+    responseDeserialize: (value: Buffer): CountAdoptedAdoptersResponse =>
+      CountAdoptedAdoptersResponse.decode(value),
+  },
+  /**
    * Document metadata — append a row referencing an already-stored
    * file URL. The gateway owns the multipart upload + object storage;
    * this surface only persists the METADATA. Caller MUST hold
@@ -5399,6 +5621,18 @@ export interface ApplicationServiceServer extends UntypedServiceImplementation {
    * counts — the gateway collapses them to the SPA's 4-state shape.
    */
   getStats: handleUnaryCall<GetStatsRequest, GetStatsResponse>;
+  /**
+   * Read-side: cross-service attribution count (ADS-941). Given a
+   * caller-supplied set of adopter user ids (e.g. an event's
+   * registrants, resolved by the calling service), returns how many of
+   * them have at least one application that reached APPROVED or
+   * ADOPTED status with created_at inside [created_after,
+   * created_before]. Deliberately narrow: the caller already knows the
+   * adopter_ids (it resolved them itself); the response reveals only
+   * the count, never which ids matched or which rescue/pet was
+   * involved. Caller MUST hold applications.read.
+   */
+  countAdoptedAdopters: handleUnaryCall<CountAdoptedAdoptersRequest, CountAdoptedAdoptersResponse>;
   /**
    * Document metadata — append a row referencing an already-stored
    * file URL. The gateway owns the multipart upload + object storage;
@@ -5723,6 +5957,32 @@ export interface ApplicationServiceClient extends Client {
     metadata: Metadata,
     options: Partial<CallOptions>,
     callback: (error: ServiceError | null, response: GetStatsResponse) => void
+  ): ClientUnaryCall;
+  /**
+   * Read-side: cross-service attribution count (ADS-941). Given a
+   * caller-supplied set of adopter user ids (e.g. an event's
+   * registrants, resolved by the calling service), returns how many of
+   * them have at least one application that reached APPROVED or
+   * ADOPTED status with created_at inside [created_after,
+   * created_before]. Deliberately narrow: the caller already knows the
+   * adopter_ids (it resolved them itself); the response reveals only
+   * the count, never which ids matched or which rescue/pet was
+   * involved. Caller MUST hold applications.read.
+   */
+  countAdoptedAdopters(
+    request: CountAdoptedAdoptersRequest,
+    callback: (error: ServiceError | null, response: CountAdoptedAdoptersResponse) => void
+  ): ClientUnaryCall;
+  countAdoptedAdopters(
+    request: CountAdoptedAdoptersRequest,
+    metadata: Metadata,
+    callback: (error: ServiceError | null, response: CountAdoptedAdoptersResponse) => void
+  ): ClientUnaryCall;
+  countAdoptedAdopters(
+    request: CountAdoptedAdoptersRequest,
+    metadata: Metadata,
+    options: Partial<CallOptions>,
+    callback: (error: ServiceError | null, response: CountAdoptedAdoptersResponse) => void
   ): ClientUnaryCall;
   /**
    * Document metadata — append a row referencing an already-stored

--- a/packages/proto/src/index.ts
+++ b/packages/proto/src/index.ts
@@ -370,6 +370,8 @@ export type {
   ListApplicationsResponse,
   GetStatsRequest,
   GetStatsResponse,
+  CountAdoptedAdoptersRequest,
+  CountAdoptedAdoptersResponse,
   Document,
   AddDocumentRequest,
   AddDocumentResponse,

--- a/services/applications/src/grpc/attribution-handlers.test.ts
+++ b/services/applications/src/grpc/attribution-handlers.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { HandlerError, type HandlerDeps } from './adapter.js';
+import { countAdoptedAdopters } from './attribution-handlers.js';
+
+function makePrincipal(
+  overrides: Partial<{
+    userId: string;
+    roles: string[];
+    permissions: string[];
+    rescueId: string;
+  }> = {}
+) {
+  return {
+    userId: overrides.userId ?? 'usr-1',
+    roles: overrides.roles ?? ['rescue_staff'],
+    permissions: overrides.permissions ?? ['applications.read'],
+    ...(overrides.rescueId !== undefined ? { rescueId: overrides.rescueId } : {}),
+  } as unknown as Parameters<typeof countAdoptedAdopters>[1];
+}
+
+function makeDeps(): { deps: HandlerDeps; query: ReturnType<typeof vi.fn> } {
+  const query = vi.fn();
+  const pool = { query } as unknown as HandlerDeps['pool'];
+  return { deps: { pool, nats: {} } as unknown as HandlerDeps, query };
+}
+
+const baseReq = {
+  adopterIds: ['usr-adopter-1', 'usr-adopter-2'],
+  createdAfter: '2026-07-01T10:00:00.000Z',
+  createdBefore: '2026-09-29T10:00:00.000Z',
+};
+
+describe('countAdoptedAdopters', () => {
+  it('throws PERMISSION_DENIED without applications.read', async () => {
+    const { deps } = makeDeps();
+    await expect(
+      countAdoptedAdopters(deps, makePrincipal({ permissions: [] }), baseReq)
+    ).rejects.toBeInstanceOf(HandlerError);
+  });
+
+  it('throws INVALID_ARGUMENT when created_after is missing', async () => {
+    const { deps } = makeDeps();
+    await expect(
+      countAdoptedAdopters(deps, makePrincipal(), { ...baseReq, createdAfter: '' })
+    ).rejects.toMatchObject({ code: 'INVALID_ARGUMENT' });
+  });
+
+  it('throws INVALID_ARGUMENT when created_before is missing', async () => {
+    const { deps } = makeDeps();
+    await expect(
+      countAdoptedAdopters(deps, makePrincipal(), { ...baseReq, createdBefore: '' })
+    ).rejects.toMatchObject({ code: 'INVALID_ARGUMENT' });
+  });
+
+  it('returns zero without querying when adopter_ids is empty', async () => {
+    const { deps, query } = makeDeps();
+    const res = await countAdoptedAdopters(deps, makePrincipal(), { ...baseReq, adopterIds: [] });
+    expect(res).toEqual({ count: 0 });
+    expect(query).not.toHaveBeenCalled();
+  });
+
+  it('dedupes adopter_ids before querying', async () => {
+    const { deps, query } = makeDeps();
+    query.mockResolvedValueOnce({ rows: [{ count: '1' }] });
+
+    await countAdoptedAdopters(deps, makePrincipal(), {
+      ...baseReq,
+      adopterIds: ['usr-1', 'usr-1', 'usr-2'],
+    });
+
+    const params = query.mock.calls[0][1] as unknown[];
+    expect(params[0]).toEqual(['usr-1', 'usr-2']);
+  });
+
+  it('scopes to APPROVED/ADOPTED status, the candidate ids, and the created_at window', async () => {
+    const { deps, query } = makeDeps();
+    query.mockResolvedValueOnce({ rows: [{ count: '2' }] });
+
+    await countAdoptedAdopters(deps, makePrincipal(), baseReq);
+
+    const [sql, params] = query.mock.calls[0] as [string, unknown[]];
+    expect(sql).toContain("status IN ('approved', 'adopted')");
+    expect(sql).toContain('user_id = ANY($1)');
+    expect(sql).toContain('created_at >= $2');
+    expect(sql).toContain('created_at <= $3');
+    expect(sql).toContain('COUNT(DISTINCT user_id)');
+    expect(params).toEqual([baseReq.adopterIds, baseReq.createdAfter, baseReq.createdBefore]);
+  });
+
+  it('returns the distinct count from the query', async () => {
+    const { deps, query } = makeDeps();
+    query.mockResolvedValueOnce({ rows: [{ count: '3' }] });
+
+    const res = await countAdoptedAdopters(deps, makePrincipal(), baseReq);
+
+    expect(res).toEqual({ count: 3 });
+  });
+
+  it('returns zero when no adopters in the candidate set have qualifying applications', async () => {
+    const { deps, query } = makeDeps();
+    query.mockResolvedValueOnce({ rows: [{ count: '0' }] });
+
+    const res = await countAdoptedAdopters(deps, makePrincipal(), baseReq);
+
+    expect(res).toEqual({ count: 0 });
+  });
+
+  it('allows super_admin regardless of rescueId', async () => {
+    const { deps, query } = makeDeps();
+    query.mockResolvedValueOnce({ rows: [{ count: '0' }] });
+
+    await expect(
+      countAdoptedAdopters(
+        deps,
+        makePrincipal({ roles: ['super_admin'], permissions: [] }),
+        baseReq
+      )
+    ).resolves.toEqual({ count: 0 });
+  });
+});

--- a/services/applications/src/grpc/attribution-handlers.ts
+++ b/services/applications/src/grpc/attribution-handlers.ts
@@ -1,0 +1,59 @@
+// gRPC handler — CountAdoptedAdopters (ADS-941).
+//
+// Cross-service attribution primitive: given a caller-supplied set of
+// adopter user ids (e.g. service.rescue resolves an event's registrant
+// list from rescue.event_attendees), returns how many of them have at
+// least one non-deleted application that reached APPROVED or ADOPTED
+// status with created_at inside [created_after, created_before]. The
+// response is a single distinct-adopter count — the caller never
+// learns which ids matched or which rescue/pet was involved, so this
+// is safe to expose to any principal holding applications.read (the
+// same base gate List/GetStats use for their coarser reads).
+//
+// Reads straight off the `applications` read-model row (no event-fold
+// needed — status + created_at are both real columns).
+
+import { requirePermission, type Principal } from '@adopt-dont-shop/authz';
+import { APPLICATIONS_VIEW } from '@adopt-dont-shop/lib.types';
+import type {
+  CountAdoptedAdoptersRequest,
+  CountAdoptedAdoptersResponse,
+} from '@adopt-dont-shop/proto';
+
+import { HandlerError, type HandlerDeps } from './adapter.js';
+
+type CountRow = { count: string };
+
+export async function countAdoptedAdopters(
+  deps: HandlerDeps,
+  principal: Principal,
+  req: CountAdoptedAdoptersRequest
+): Promise<CountAdoptedAdoptersResponse> {
+  if (!requirePermission(principal, APPLICATIONS_VIEW)) {
+    throw new HandlerError('PERMISSION_DENIED', `'${APPLICATIONS_VIEW}' required`);
+  }
+  if (!req.createdAfter) {
+    throw new HandlerError('INVALID_ARGUMENT', 'created_after is required');
+  }
+  if (!req.createdBefore) {
+    throw new HandlerError('INVALID_ARGUMENT', 'created_before is required');
+  }
+
+  const adopterIds = [...new Set(req.adopterIds.filter(id => id !== ''))];
+  if (adopterIds.length === 0) {
+    return { count: 0 };
+  }
+
+  const { rows } = await deps.pool.query<CountRow>(
+    `SELECT COUNT(DISTINCT user_id) AS count
+       FROM applications
+      WHERE deleted_at IS NULL
+        AND status IN ('approved', 'adopted')
+        AND user_id = ANY($1)
+        AND created_at >= $2
+        AND created_at <= $3`,
+    [adopterIds, req.createdAfter, req.createdBefore]
+  );
+
+  return { count: Number(rows[0]?.count ?? '0') };
+}

--- a/services/applications/src/grpc/server.ts
+++ b/services/applications/src/grpc/server.ts
@@ -26,6 +26,7 @@ import {
   getApplicationDraft,
   saveApplicationDraft,
 } from './application-draft-handlers.js';
+import { countAdoptedAdopters } from './attribution-handlers.js';
 import { makeStartDraft, saveDraftAnswers, submitDraft } from './handlers.js';
 import { createPetsClient, type PetsClient } from './pets-client.js';
 import { addDocument, listDocuments, removeDocument } from './document-handlers.js';
@@ -79,6 +80,8 @@ export const createGrpcServer = (opts: CreateGrpcServerOptions): Server => {
     list: adapt(listApplications, { deps, logger }),
     // Stats (stats-handlers.ts)
     getStats: adapt(getStats, { deps, logger }),
+    // Cross-service attribution (attribution-handlers.ts)
+    countAdoptedAdopters: adapt(countAdoptedAdopters, { deps, logger }),
     // Document metadata (document-handlers.ts)
     addDocument: adapt(addDocument, { deps, logger }),
     listDocuments: adapt(listDocuments, { deps, logger }),
@@ -107,6 +110,7 @@ export const createGrpcServer = (opts: CreateGrpcServerOptions): Server => {
       'get',
       'list',
       'getStats',
+      'countAdoptedAdopters',
       'addDocument',
       'listDocuments',
       'removeDocument',

--- a/services/gateway/src/grpc-clients/applications-client.contract.test.ts
+++ b/services/gateway/src/grpc-clients/applications-client.contract.test.ts
@@ -59,6 +59,7 @@ const makeHandlers = (
   get: unimplemented,
   list: unimplemented,
   getStats: unimplemented,
+  countAdoptedAdopters: unimplemented,
   addDocument: unimplemented,
   listDocuments: unimplemented,
   removeDocument: unimplemented,

--- a/services/rescue/src/config.test.ts
+++ b/services/rescue/src/config.test.ts
@@ -17,6 +17,7 @@ describe('loadConfig', () => {
     expect(config.schema).toBe('rescue');
     expect(config.natsUrl).toBe('nats://nats:4222');
     expect(config.petsGrpcUrl).toBe('service-pets:6003');
+    expect(config.applicationsGrpcUrl).toBe('service-applications:6005');
   });
 
   it('honours all env overrides when set', () => {
@@ -29,6 +30,7 @@ describe('loadConfig', () => {
       DATABASE_URL: 'postgres://prod:secret@db.example.com:5432/rescue',
       NATS_URL: 'nats://nats.internal:4222',
       PETS_GRPC_URL: 'pets.internal:6003',
+      APPLICATIONS_GRPC_URL: 'applications.internal:6005',
     });
 
     expect(config.port).toBe(5500);
@@ -39,6 +41,7 @@ describe('loadConfig', () => {
     expect(config.databaseUrl).toBe('postgres://prod:secret@db.example.com:5432/rescue');
     expect(config.natsUrl).toBe('nats://nats.internal:4222');
     expect(config.petsGrpcUrl).toBe('pets.internal:6003');
+    expect(config.applicationsGrpcUrl).toBe('applications.internal:6005');
   });
 
   it('rejects a non-numeric RESCUE_PORT', () => {

--- a/services/rescue/src/config.ts
+++ b/services/rescue/src/config.ts
@@ -28,6 +28,9 @@ export type RescueConfig = {
   // service.pets gRPC address. createFosterPlacement resolves pet → rescue
   // here to reject a petId that doesn't belong to the placement's rescue.
   petsGrpcUrl: string;
+  // service.applications gRPC address. getEventAnalytics resolves
+  // registered-then-adopted attribution here (ADS-941).
+  applicationsGrpcUrl: string;
 };
 
 const DEFAULT_PORT = 5004;
@@ -36,6 +39,7 @@ const DEFAULT_HOST = '0.0.0.0';
 const DEFAULT_SCHEMA = 'rescue';
 const DEFAULT_NATS_URL = 'nats://nats:4222';
 const DEFAULT_PETS_GRPC_URL = 'service-pets:6003';
+const DEFAULT_APPLICATIONS_GRPC_URL = 'service-applications:6005';
 
 export const loadConfig = (env: NodeJS.ProcessEnv = process.env): RescueConfig => {
   const port = parsePort(env.RESCUE_PORT, DEFAULT_PORT, 'RESCUE_PORT');
@@ -52,5 +56,6 @@ export const loadConfig = (env: NodeJS.ProcessEnv = process.env): RescueConfig =
     schema: env.RESCUE_SCHEMA?.trim() || DEFAULT_SCHEMA,
     natsUrl: env.NATS_URL?.trim() || DEFAULT_NATS_URL,
     petsGrpcUrl: env.PETS_GRPC_URL?.trim() || DEFAULT_PETS_GRPC_URL,
+    applicationsGrpcUrl: env.APPLICATIONS_GRPC_URL?.trim() || DEFAULT_APPLICATIONS_GRPC_URL,
   };
 };

--- a/services/rescue/src/grpc/applications-client.test.ts
+++ b/services/rescue/src/grpc/applications-client.test.ts
@@ -1,0 +1,197 @@
+// Behaviour tests for the rescue → applications gRPC client (ADS-941):
+//   1. A server that never responds → DEADLINE_EXCEEDED within the
+//      configured deadline (bounded by time, not just error code).
+//   2. A server that fails once with UNAVAILABLE then succeeds →
+//      the call resolves and exactly 2 handler invocations occurred.
+//   3. A server that always returns PERMISSION_DENIED → no retry,
+//      error propagates after exactly 1 attempt.
+//   4. Caller-supplied metadata (the forwarded principal) reaches the
+//      server unchanged.
+//
+// Each test binds a real @grpc/grpc-js Server to 127.0.0.1:0 so there
+// are no port conflicts; the server is torn down in afterEach. Direct
+// port of services/chat/src/grpc/applications-client.test.ts.
+
+import {
+  Metadata,
+  Server,
+  ServerCredentials,
+  ServerUnaryCall,
+  sendUnaryData,
+  ServiceError,
+  status,
+} from '@grpc/grpc-js';
+
+import {
+  ApplicationsV1,
+  type CountAdoptedAdoptersRequest,
+  type CountAdoptedAdoptersResponse,
+} from '@adopt-dont-shop/proto';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { createApplicationsClient } from './applications-client.js';
+
+// ── helpers ──────────────────────────────────────────────────────────
+
+const makeServiceError = (code: number, details: string): ServiceError => {
+  const err = new Error(details) as ServiceError;
+  err.code = code;
+  err.details = details;
+  err.metadata = new Metadata();
+  return err;
+};
+
+const COUNT_REQUEST: CountAdoptedAdoptersRequest = {
+  adopterIds: ['usr-1', 'usr-2'],
+  createdAfter: '2026-07-01T10:00:00.000Z',
+  createdBefore: '2026-09-29T10:00:00.000Z',
+};
+
+const successResponse: CountAdoptedAdoptersResponse = { count: 2 };
+
+// ── test suite ───────────────────────────────────────────────────────
+
+describe('createApplicationsClient (rescue) — deadline + retry behaviour', () => {
+  let server: Server;
+
+  beforeEach(() => {
+    server = new Server();
+  });
+
+  afterEach(async () => {
+    await new Promise<void>(resolve => server.tryShutdown(() => resolve()));
+  });
+
+  const startServer = async (): Promise<number> =>
+    new Promise<number>((resolve, reject) => {
+      server.bindAsync('127.0.0.1:0', ServerCredentials.createInsecure(), (err, boundPort) =>
+        err ? reject(err) : resolve(boundPort)
+      );
+    });
+
+  it('rejects with DEADLINE_EXCEEDED when the server never responds, within the deadline window', async () => {
+    server.addService(ApplicationsV1.ApplicationServiceService, {
+      countAdoptedAdopters: (
+        _call: ServerUnaryCall<CountAdoptedAdoptersRequest, CountAdoptedAdoptersResponse>,
+        _cb: sendUnaryData<CountAdoptedAdoptersResponse>
+      ) => {
+        // Intentionally never call _cb — simulates a hung server.
+      },
+    });
+
+    const port = await startServer();
+    const client = createApplicationsClient({
+      address: `127.0.0.1:${port}`,
+      deadlineMs: 200,
+      maxRetries: 0, // no retries so the test is fast
+    });
+
+    const start = Date.now();
+    try {
+      await client.countAdoptedAdopters(COUNT_REQUEST, new Metadata());
+      expect.fail('expected rejection');
+    } catch (err: unknown) {
+      const elapsed = Date.now() - start;
+      expect((err as { code?: number }).code).toBe(status.DEADLINE_EXCEEDED);
+      // Should finish near the deadline — allow generous upper bound for CI.
+      expect(elapsed).toBeLessThan(2_000);
+    } finally {
+      client.close();
+    }
+  });
+
+  it('resolves on the second attempt when the first attempt returns UNAVAILABLE', async () => {
+    let callCount = 0;
+
+    server.addService(ApplicationsV1.ApplicationServiceService, {
+      countAdoptedAdopters: (
+        _call: ServerUnaryCall<CountAdoptedAdoptersRequest, CountAdoptedAdoptersResponse>,
+        cb: sendUnaryData<CountAdoptedAdoptersResponse>
+      ) => {
+        callCount += 1;
+        if (callCount === 1) {
+          cb(makeServiceError(status.UNAVAILABLE, 'service unavailable'), null);
+        } else {
+          cb(null, successResponse);
+        }
+      },
+    });
+
+    const port = await startServer();
+    const client = createApplicationsClient({
+      address: `127.0.0.1:${port}`,
+      deadlineMs: 2_000,
+      maxRetries: 2,
+    });
+
+    try {
+      const result = await client.countAdoptedAdopters(COUNT_REQUEST, new Metadata());
+      expect(result.count).toBe(2);
+      expect(callCount).toBe(2);
+    } finally {
+      client.close();
+    }
+  });
+
+  it('does not retry PERMISSION_DENIED and propagates the error after exactly 1 attempt', async () => {
+    let callCount = 0;
+
+    server.addService(ApplicationsV1.ApplicationServiceService, {
+      countAdoptedAdopters: (
+        _call: ServerUnaryCall<CountAdoptedAdoptersRequest, CountAdoptedAdoptersResponse>,
+        cb: sendUnaryData<CountAdoptedAdoptersResponse>
+      ) => {
+        callCount += 1;
+        cb(makeServiceError(status.PERMISSION_DENIED, 'not allowed'), null);
+      },
+    });
+
+    const port = await startServer();
+    const client = createApplicationsClient({
+      address: `127.0.0.1:${port}`,
+      deadlineMs: 2_000,
+      maxRetries: 2,
+    });
+
+    try {
+      await client.countAdoptedAdopters(COUNT_REQUEST, new Metadata());
+      expect.fail('expected rejection');
+    } catch (err: unknown) {
+      expect((err as { code?: number }).code).toBe(status.PERMISSION_DENIED);
+      expect(callCount).toBe(1);
+    } finally {
+      client.close();
+    }
+  });
+
+  it('forwards the caller-supplied metadata (the principal) to the server', async () => {
+    const captured: Metadata[] = [];
+
+    server.addService(ApplicationsV1.ApplicationServiceService, {
+      countAdoptedAdopters: (
+        call: ServerUnaryCall<CountAdoptedAdoptersRequest, CountAdoptedAdoptersResponse>,
+        cb: sendUnaryData<CountAdoptedAdoptersResponse>
+      ) => {
+        captured.push(call.metadata);
+        cb(null, successResponse);
+      },
+    });
+
+    const port = await startServer();
+    const client = createApplicationsClient({ address: `127.0.0.1:${port}` });
+
+    const metadata = new Metadata();
+    metadata.set('x-user-id', 'usr-staff');
+    metadata.set('x-user-roles', 'rescue_staff');
+
+    try {
+      await client.countAdoptedAdopters(COUNT_REQUEST, metadata);
+      expect(captured).toHaveLength(1);
+      expect(captured[0].get('x-user-id')).toEqual(['usr-staff']);
+      expect(captured[0].get('x-user-roles')).toEqual(['rescue_staff']);
+    } finally {
+      client.close();
+    }
+  });
+});

--- a/services/rescue/src/grpc/applications-client.ts
+++ b/services/rescue/src/grpc/applications-client.ts
@@ -1,0 +1,113 @@
+// Service-to-service gRPC client for service.applications.
+//
+// getEventAnalytics (ADS-941) is the only RescueService RPC that needs
+// this: to compute `adoptionsFromEvent` it resolves an event's
+// registrant user ids locally (rescue.event_attendees), then asks
+// service.applications how many of those ids have an application that
+// reached APPROVED/ADOPTED status within the post-event attribution
+// window ("registered → later adopted").
+//
+// Only CountAdoptedAdopters is wrapped — that's all this vertical
+// needs. The interface is exported so the gRPC server boot can inject
+// a real client and tests can substitute a stub. Direct port of
+// services/rescue/src/grpc/pets-client.ts.
+
+import { credentials, status, type CallOptions, type Metadata } from '@grpc/grpc-js';
+
+import {
+  ApplicationsV1,
+  type CountAdoptedAdoptersRequest,
+  type CountAdoptedAdoptersResponse,
+} from '@adopt-dont-shop/proto';
+
+export type ApplicationsClient = {
+  countAdoptedAdopters(
+    req: CountAdoptedAdoptersRequest,
+    metadata: Metadata
+  ): Promise<CountAdoptedAdoptersResponse>;
+  close(): void;
+};
+
+export type CreateApplicationsClientOptions = {
+  address: string;
+  // Per-call deadline in milliseconds. Without one, a hung downstream
+  // service would hang this request forever; 5s caps the blast radius
+  // and lets the caller fail fast with DEADLINE_EXCEEDED.
+  deadlineMs?: number;
+  // Maximum additional attempts after the first. Only UNAVAILABLE and
+  // DEADLINE_EXCEEDED trigger a retry (both are safe for idempotent
+  // reads). Defaults to 2 (i.e. up to 3 total attempts).
+  maxRetries?: number;
+};
+
+const DEFAULT_DEADLINE_MS = 5_000;
+const DEFAULT_MAX_RETRIES = 2;
+// Retry-eligible status codes for idempotent reads.
+const RETRYABLE_CODES = new Set([status.UNAVAILABLE, status.DEADLINE_EXCEEDED]);
+
+const isRetryableError = (err: unknown): boolean => {
+  if (err === null || typeof err !== 'object') {
+    return false;
+  }
+  const code = (err as { code?: unknown }).code;
+  return typeof code === 'number' && RETRYABLE_CODES.has(code);
+};
+
+const sleep = (ms: number): Promise<void> => new Promise(resolve => setTimeout(resolve, ms));
+
+const jitteredBackoff = (attempt: number, baseMs: number): number => {
+  // Exponential backoff with ±25% jitter: 100ms, 200ms (base defaults).
+  const base = baseMs * Math.pow(2, attempt - 1);
+  return base * (0.75 + Math.random() * 0.5);
+};
+
+export const createApplicationsClient = (
+  opts: CreateApplicationsClientOptions
+): ApplicationsClient => {
+  const stub = new ApplicationsV1.ApplicationServiceClient(
+    opts.address,
+    credentials.createInsecure()
+  );
+  const deadlineMs = opts.deadlineMs ?? DEFAULT_DEADLINE_MS;
+  const maxRetries = opts.maxRetries ?? DEFAULT_MAX_RETRIES;
+
+  const callWithRetry = <Req, Res>(
+    fn: (
+      req: Req,
+      metadata: Metadata,
+      options: Partial<CallOptions>,
+      cb: (err: unknown, res: Res) => void
+    ) => unknown,
+    req: Req,
+    metadata: Metadata
+  ): Promise<Res> => {
+    const attempt = (remaining: number): Promise<Res> =>
+      new Promise<Res>((resolve, reject) => {
+        const options: Partial<CallOptions> = {
+          deadline: new Date(Date.now() + deadlineMs),
+        };
+        fn.call(stub, req, metadata, options, (err: unknown, res: Res) => {
+          if (err) {
+            if (remaining > 0 && isRetryableError(err)) {
+              const retryIndex = maxRetries - remaining + 1;
+              sleep(jitteredBackoff(retryIndex, 100))
+                .then(() => attempt(remaining - 1))
+                .then(resolve, reject);
+            } else {
+              reject(err);
+            }
+            return;
+          }
+          resolve(res);
+        });
+      });
+
+    return attempt(maxRetries);
+  };
+
+  return {
+    countAdoptedAdopters: (req, metadata) =>
+      callWithRetry(stub.countAdoptedAdopters, req, metadata),
+    close: () => stub.close(),
+  };
+};

--- a/services/rescue/src/grpc/event-handlers.test.ts
+++ b/services/rescue/src/grpc/event-handlers.test.ts
@@ -6,6 +6,7 @@ import type { Principal } from '@adopt-dont-shop/authz';
 import type { Permission, RescueId, UserId } from '@adopt-dont-shop/lib.types';
 import { RescueV1 } from '@adopt-dont-shop/proto';
 
+import type { ApplicationsClient } from './applications-client.js';
 import type { HandlerDeps } from './handlers.js';
 import {
   addEventAttendee,
@@ -13,9 +14,9 @@ import {
   createEvent,
   deleteEvent,
   getEvent,
-  getEventAnalytics,
   getEventAttendees,
   listEvents,
+  makeGetEventAnalytics,
   updateEvent,
 } from './event-handlers.js';
 
@@ -526,8 +527,20 @@ describe('checkInAttendee', () => {
 
 describe('getEventAnalytics', () => {
   let mocks: ReturnType<typeof makeMocks>;
+  let applicationsStub: {
+    countAdoptedAdopters: ReturnType<typeof vi.fn>;
+    close: ReturnType<typeof vi.fn>;
+  };
+  let getEventAnalytics: ReturnType<typeof makeGetEventAnalytics>;
+
   beforeEach(() => {
     mocks = makeMocks();
+    // Default: nobody from the candidate set has adopted.
+    applicationsStub = {
+      countAdoptedAdopters: vi.fn(async () => ({ count: 0 })),
+      close: vi.fn(),
+    };
+    getEventAnalytics = makeGetEventAnalytics(applicationsStub as unknown as ApplicationsClient);
   });
 
   it('rejects callers without events.read', async () => {
@@ -546,7 +559,8 @@ describe('getEventAnalytics', () => {
   it('returns 100% attendanceRate when all registrants checked in', async () => {
     mocks.poolMock.query
       .mockResolvedValueOnce({ rows: [eventRow({ status: 'completed' })] })
-      .mockResolvedValueOnce({ rows: [{ total: '1', checked_in: '1' }] });
+      .mockResolvedValueOnce({ rows: [{ total: '1', checked_in: '1' }] })
+      .mockResolvedValueOnce({ rows: [{ user_id: 'usr-attendee' }] });
     const res = await getEventAnalytics(mocks.deps, STAFF, { eventId: EVENT_ID });
     expect(res.analytics?.totalRegistrations).toBe(1);
     expect(res.analytics?.actualAttendance).toBe(1);
@@ -556,7 +570,10 @@ describe('getEventAnalytics', () => {
   it('returns 50% attendanceRate when half of registrants checked in', async () => {
     mocks.poolMock.query
       .mockResolvedValueOnce({ rows: [eventRow({ status: 'active' })] })
-      .mockResolvedValueOnce({ rows: [{ total: '2', checked_in: '1' }] });
+      .mockResolvedValueOnce({ rows: [{ total: '2', checked_in: '1' }] })
+      .mockResolvedValueOnce({
+        rows: [{ user_id: 'usr-attendee' }, { user_id: 'usr-other' }],
+      });
     const res = await getEventAnalytics(mocks.deps, STAFF, { eventId: EVENT_ID });
     expect(res.analytics?.totalRegistrations).toBe(2);
     expect(res.analytics?.actualAttendance).toBe(1);
@@ -571,6 +588,8 @@ describe('getEventAnalytics', () => {
     expect(res.analytics?.totalRegistrations).toBe(0);
     expect(res.analytics?.actualAttendance).toBe(0);
     expect(res.analytics?.attendanceRate).toBe(0);
+    // No registrants → no attribution lookup needed.
+    expect(applicationsStub.countAdoptedAdopters).not.toHaveBeenCalled();
   });
 
   it('rejects principal with events.read but no rescueId', async () => {
@@ -578,5 +597,65 @@ describe('getEventAnalytics', () => {
     await expect(
       getEventAnalytics(mocks.deps, STAFF_NO_RESCUE, { eventId: EVENT_ID })
     ).rejects.toMatchObject({ code: 'PERMISSION_DENIED' });
+  });
+
+  // ── adoptionsFromEvent — registered-then-adopted attribution (ADS-941) ──
+
+  it('resolves the registrant ids (not just checked-in attendees) and reports the adopted count', async () => {
+    mocks.poolMock.query
+      .mockResolvedValueOnce({
+        rows: [eventRow({ status: 'completed', start_date: new Date('2026-07-01T10:00:00Z') })],
+      })
+      .mockResolvedValueOnce({ rows: [{ total: '2', checked_in: '1' }] })
+      .mockResolvedValueOnce({
+        rows: [{ user_id: 'usr-registrant-1' }, { user_id: 'usr-registrant-2' }],
+      });
+    applicationsStub.countAdoptedAdopters.mockResolvedValueOnce({ count: 2 });
+
+    const res = await getEventAnalytics(mocks.deps, STAFF, { eventId: EVENT_ID });
+
+    expect(res.analytics?.adoptionsFromEvent).toBe(2);
+    expect(applicationsStub.countAdoptedAdopters).toHaveBeenCalledTimes(1);
+    const [req] = applicationsStub.countAdoptedAdopters.mock.calls[0];
+    expect(req.adopterIds).toEqual(['usr-registrant-1', 'usr-registrant-2']);
+  });
+
+  it('queries a 90-day post-event window anchored on the event start date', async () => {
+    mocks.poolMock.query
+      .mockResolvedValueOnce({
+        rows: [eventRow({ status: 'completed', start_date: new Date('2026-07-01T10:00:00Z') })],
+      })
+      .mockResolvedValueOnce({ rows: [{ total: '1', checked_in: '0' }] })
+      .mockResolvedValueOnce({ rows: [{ user_id: 'usr-registrant-1' }] });
+
+    await getEventAnalytics(mocks.deps, STAFF, { eventId: EVENT_ID });
+
+    const [req] = applicationsStub.countAdoptedAdopters.mock.calls[0];
+    expect(req.createdAfter).toBe('2026-07-01T10:00:00.000Z');
+    expect(req.createdBefore).toBe('2026-09-29T10:00:00.000Z'); // +90 days
+  });
+
+  it('returns zero adoptions when nobody in the registrant set has adopted', async () => {
+    mocks.poolMock.query
+      .mockResolvedValueOnce({ rows: [eventRow({ status: 'completed' })] })
+      .mockResolvedValueOnce({ rows: [{ total: '1', checked_in: '0' }] })
+      .mockResolvedValueOnce({ rows: [{ user_id: 'usr-registrant-1' }] });
+    applicationsStub.countAdoptedAdopters.mockResolvedValueOnce({ count: 0 });
+
+    const res = await getEventAnalytics(mocks.deps, STAFF, { eventId: EVENT_ID });
+
+    expect(res.analytics?.adoptionsFromEvent).toBe(0);
+  });
+
+  it('surfaces a downstream attribution failure as INTERNAL rather than silently reporting zero', async () => {
+    mocks.poolMock.query
+      .mockResolvedValueOnce({ rows: [eventRow({ status: 'completed' })] })
+      .mockResolvedValueOnce({ rows: [{ total: '1', checked_in: '0' }] })
+      .mockResolvedValueOnce({ rows: [{ user_id: 'usr-registrant-1' }] });
+    applicationsStub.countAdoptedAdopters.mockRejectedValueOnce({ code: 14 });
+
+    await expect(getEventAnalytics(mocks.deps, STAFF, { eventId: EVENT_ID })).rejects.toMatchObject(
+      { code: 'INTERNAL' }
+    );
   });
 });

--- a/services/rescue/src/grpc/event-handlers.ts
+++ b/services/rescue/src/grpc/event-handlers.ts
@@ -39,7 +39,9 @@ import {
   type UpdateEventResponse,
 } from '@adopt-dont-shop/proto';
 
+import type { ApplicationsClient } from './applications-client.js';
 import { HandlerError, type HandlerDeps } from './handlers.js';
+import { principalToMetadata } from './principal.js';
 
 // ── Permissions ─────────────────────────────────────────────────────────
 
@@ -47,6 +49,29 @@ const EVENTS_READ: Permission = 'events.read' as Permission;
 const EVENTS_CREATE: Permission = 'events.create' as Permission;
 const EVENTS_UPDATE: Permission = 'events.update' as Permission;
 const EVENTS_DELETE: Permission = 'events.delete' as Permission;
+
+// ── Adoption attribution (ADS-941) ────────────────────────────────────────
+//
+// adoptionsFromEvent uses a "registered → later adopted" attribution
+// model: an adoption is attributed to event X when a user who
+// REGISTERED for event X (rescue.event_attendees — every registrant,
+// not just those who checked in) later has an application that reaches
+// APPROVED or ADOPTED status. Attribution is by adopter identity within
+// a bounded post-event window, not by any adoption↔event link table.
+//
+// The count is DISTINCT ADOPTERS, not applications — an adopter with
+// two qualifying applications after the event still counts once. The
+// proto field is named `adoptions_from_event`, and its own comment
+// ("how many adoptions were driven by this event") is satisfied either
+// way in the common case (one adopter, one adoption); we chose the
+// adopter-count reading because that's what the product decision this
+// ticket implements explicitly asked for.
+//
+// Window: 90 days after the event's start_date — a reasonable
+// adoption-cycle length (submit → review → home visit → decision).
+// Single named constant so it's easy to find and retune.
+const ATTRIBUTION_WINDOW_DAYS = 90;
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
 
 // ── DB row types ────────────────────────────────────────────────────────
 
@@ -676,42 +701,93 @@ export async function checkInAttendee(
 
 // ── GetEventAnalytics ───────────────────────────────────────────────────
 
-export async function getEventAnalytics(
+// getEventAnalytics is a factory closing over the ApplicationsClient so the
+// gRPC server boot injects the real client and tests inject a stub. See
+// "Adoption attribution (ADS-941)" above for the counting rule. Direct port
+// of staff-foster-handlers.ts's makeCreateFosterPlacement pattern.
+export function makeGetEventAnalytics(
+  applicationsClient: ApplicationsClient
+): (
   deps: HandlerDeps,
   principal: Principal,
   req: GetEventAnalyticsRequest
-): Promise<GetEventAnalyticsResponse> {
-  if (!isSuperAdmin(principal) && !hasPermission(principal, EVENTS_READ)) {
-    throw new HandlerError('PERMISSION_DENIED', `'${EVENTS_READ}' required`);
-  }
+) => Promise<GetEventAnalyticsResponse> {
+  return async (deps, principal, req) => {
+    if (!isSuperAdmin(principal) && !hasPermission(principal, EVENTS_READ)) {
+      throw new HandlerError('PERMISSION_DENIED', `'${EVENTS_READ}' required`);
+    }
 
-  const eventRes = await deps.pool.query<EventRow>(
-    `SELECT ${EVENT_SELECT} FROM rescue.events WHERE event_id = $1 AND deleted_at IS NULL`,
-    [req.eventId]
-  );
-  const row = eventRes.rows[0];
-  if (!row) {
-    throw new HandlerError('NOT_FOUND', `event ${req.eventId} not found`);
-  }
-  assertRescueAccess(principal, row.rescue_id, EVENTS_READ);
+    const eventRes = await deps.pool.query<EventRow>(
+      `SELECT ${EVENT_SELECT} FROM rescue.events WHERE event_id = $1 AND deleted_at IS NULL`,
+      [req.eventId]
+    );
+    const row = eventRes.rows[0];
+    if (!row) {
+      throw new HandlerError('NOT_FOUND', `event ${req.eventId} not found`);
+    }
+    assertRescueAccess(principal, row.rescue_id, EVENTS_READ);
 
-  const countRes = await deps.pool.query<{ total: string; checked_in: string }>(
-    `SELECT COUNT(*) AS total,
-            COUNT(*) FILTER (WHERE checked_in) AS checked_in
-       FROM rescue.event_attendees WHERE event_id = $1`,
-    [req.eventId]
-  );
-  const totalRegistrations = parseInt(countRes.rows[0]?.total ?? '0', 10);
-  const actualAttendance = parseInt(countRes.rows[0]?.checked_in ?? '0', 10);
-  const attendanceRate = totalRegistrations > 0 ? (actualAttendance / totalRegistrations) * 100 : 0;
+    const countRes = await deps.pool.query<{ total: string; checked_in: string }>(
+      `SELECT COUNT(*) AS total,
+              COUNT(*) FILTER (WHERE checked_in) AS checked_in
+         FROM rescue.event_attendees WHERE event_id = $1`,
+      [req.eventId]
+    );
+    const totalRegistrations = parseInt(countRes.rows[0]?.total ?? '0', 10);
+    const actualAttendance = parseInt(countRes.rows[0]?.checked_in ?? '0', 10);
+    const attendanceRate =
+      totalRegistrations > 0 ? (actualAttendance / totalRegistrations) * 100 : 0;
 
-  const analytics: RescueEventAnalytics = {
-    eventId: row.event_id,
-    totalRegistrations,
-    actualAttendance,
-    attendanceRate,
-    adoptionsFromEvent: 0,
+    const adoptionsFromEvent =
+      totalRegistrations > 0
+        ? await countAdoptionsFromEvent(deps, applicationsClient, principal, req.eventId, row)
+        : 0;
+
+    const analytics: RescueEventAnalytics = {
+      eventId: row.event_id,
+      totalRegistrations,
+      actualAttendance,
+      attendanceRate,
+      adoptionsFromEvent,
+    };
+
+    return { analytics };
   };
+}
 
-  return { analytics };
+// Resolves the event's registrant ids (every registrant, not just those
+// checked in — the attribution model is "registered → later adopted") and
+// asks service.applications how many of them have since adopted within the
+// window. Forwards the caller's identity so applications runs its own
+// applications.read gate.
+async function countAdoptionsFromEvent(
+  deps: HandlerDeps,
+  applicationsClient: ApplicationsClient,
+  principal: Principal,
+  eventId: string,
+  event: EventRow
+): Promise<number> {
+  const attendeeRes = await deps.pool.query<{ user_id: string }>(
+    `SELECT DISTINCT user_id FROM rescue.event_attendees WHERE event_id = $1`,
+    [eventId]
+  );
+  const adopterIds = attendeeRes.rows.map(r => r.user_id);
+  if (adopterIds.length === 0) {
+    return 0;
+  }
+
+  const createdAfter = event.start_date.toISOString();
+  const createdBefore = new Date(
+    event.start_date.getTime() + ATTRIBUTION_WINDOW_DAYS * MS_PER_DAY
+  ).toISOString();
+
+  try {
+    const res = await applicationsClient.countAdoptedAdopters(
+      { adopterIds, createdAfter, createdBefore },
+      principalToMetadata(principal)
+    );
+    return res.count;
+  } catch {
+    throw new HandlerError('INTERNAL', 'failed to resolve adoption attribution');
+  }
 }

--- a/services/rescue/src/grpc/server.test.ts
+++ b/services/rescue/src/grpc/server.test.ts
@@ -25,6 +25,7 @@ const config: RescueConfig = {
   schema: 'rescue',
   natsUrl: 'nats://localhost:4222',
   petsGrpcUrl: 'service-pets:6003',
+  applicationsGrpcUrl: 'service-applications:6005',
 };
 
 const pool = {} as unknown as Pool;
@@ -32,10 +33,21 @@ const nats = {} as unknown as NatsConnection;
 const petsClient = { getPet: async () => ({}), close: () => undefined } as unknown as Parameters<
   typeof createGrpcServer
 >[0]['petsClient'];
+const applicationsClient = {
+  countAdoptedAdopters: async () => ({ count: 0 }),
+  close: () => undefined,
+} as unknown as Parameters<typeof createGrpcServer>[0]['applicationsClient'];
 
 describe('createGrpcServer', () => {
   it('registers all six RescueService methods on the grpc.Server', () => {
-    const server = createGrpcServer({ config, pool, nats, logger: quietLogger, petsClient });
+    const server = createGrpcServer({
+      config,
+      pool,
+      nats,
+      logger: quietLogger,
+      petsClient,
+      applicationsClient,
+    });
     const handlers = (server as unknown as { handlers: Map<string, unknown> }).handlers;
 
     expect(handlers.has('/adopt_dont_shop.rescue.v1.RescueService/Create')).toBe(true);
@@ -50,7 +62,14 @@ describe('createGrpcServer', () => {
     const definition = RescueV1.RescueServiceService;
     const expectedPaths = Object.values(definition).map(d => (d as { path: string }).path);
 
-    const server = createGrpcServer({ config, pool, nats, logger: quietLogger, petsClient });
+    const server = createGrpcServer({
+      config,
+      pool,
+      nats,
+      logger: quietLogger,
+      petsClient,
+      applicationsClient,
+    });
     const handlers = (server as unknown as { handlers: Map<string, unknown> }).handlers;
 
     for (const p of expectedPaths) {

--- a/services/rescue/src/grpc/server.ts
+++ b/services/rescue/src/grpc/server.ts
@@ -55,11 +55,12 @@ import {
   createEvent,
   deleteEvent,
   getEvent,
-  getEventAnalytics,
   getEventAttendees,
   listEvents,
+  makeGetEventAnalytics,
   updateEvent,
 } from './event-handlers.js';
+import { createApplicationsClient, type ApplicationsClient } from './applications-client.js';
 import { createPetsClient, type PetsClient } from './pets-client.js';
 
 export type CreateGrpcServerOptions = {
@@ -69,6 +70,10 @@ export type CreateGrpcServerOptions = {
   logger: Logger;
   // Injectable for tests; defaults to a real client at config.petsGrpcUrl.
   petsClient?: PetsClient;
+  // Injectable for tests; defaults to a real client at
+  // config.applicationsGrpcUrl. getEventAnalytics uses this for the
+  // registered-then-adopted attribution count (ADS-941).
+  applicationsClient?: ApplicationsClient;
 };
 
 export type { RunningGrpcServer };
@@ -77,6 +82,8 @@ export const createGrpcServer = (opts: CreateGrpcServerOptions): Server => {
   const { config, pool, nats, logger } = opts;
   const deps = { pool, nats };
   const petsClient = opts.petsClient ?? createPetsClient({ address: config.petsGrpcUrl });
+  const applicationsClient =
+    opts.applicationsClient ?? createApplicationsClient({ address: config.applicationsGrpcUrl });
   const server = new Server();
 
   server.addService(RescueV1.RescueServiceService, {
@@ -115,7 +122,7 @@ export const createGrpcServer = (opts: CreateGrpcServerOptions): Server => {
     getEventAttendees: adapt(getEventAttendees, { deps, logger }),
     addEventAttendee: adapt(addEventAttendee, { deps, logger }),
     checkInAttendee: adapt(checkInAttendee, { deps, logger }),
-    getEventAnalytics: adapt(getEventAnalytics, { deps, logger }),
+    getEventAnalytics: adapt(makeGetEventAnalytics(applicationsClient), { deps, logger }),
   });
 
   logger.info('gRPC RescueService registered', {
@@ -166,9 +173,12 @@ export const startGrpcServer = async (
   opts: CreateGrpcServerOptions
 ): Promise<RunningGrpcServer> => {
   const { config, logger } = opts;
-  // Build + own the pets client here so it's closed on shutdown.
+  // Build + own the pets/applications clients here so they're closed on
+  // shutdown.
   const petsClient = opts.petsClient ?? createPetsClient({ address: config.petsGrpcUrl });
-  const server = createGrpcServer({ ...opts, petsClient });
+  const applicationsClient =
+    opts.applicationsClient ?? createApplicationsClient({ address: config.applicationsGrpcUrl });
+  const server = createGrpcServer({ ...opts, petsClient, applicationsClient });
   const running = await startGrpcServerShared(server, config, logger);
 
   return {
@@ -183,6 +193,11 @@ export const startGrpcServer = async (
             petsClient.close();
           } catch (closeErr) {
             logger.error('pets client close error', { err: closeErr });
+          }
+          try {
+            applicationsClient.close();
+          } catch (closeErr) {
+            logger.error('applications client close error', { err: closeErr });
           }
           resolve();
         });


### PR DESCRIPTION
## Summary

- Replaces the hard-coded `adoptionsFromEvent: 0` in `service.rescue`'s `getEventAnalytics` with a real, computed value.
- Attribution model (product decision, implemented as specified): **"registered → later adopted."** An adoption is attributed to event X when a user who registered for event X (every `rescue.event_attendees` row, not just checked-in ones) later has an application that reaches `APPROVED` or `ADOPTED` status within a bounded post-event window. Count = **distinct adopters**, not applications.
- Window: **90 days** after the event's `start_date`, as a single named constant `ATTRIBUTION_WINDOW_DAYS` (`services/rescue/src/grpc/event-handlers.ts`) — easy to find and retune.
- Adds a new, narrowly-scoped `ApplicationService.CountAdoptedAdopters` RPC on `service.applications` so `service.rescue` can resolve the count at query time without a new link table or event-driven read model.

## Changes

- `packages/proto/proto/adopt_dont_shop/applications/v1/application.proto` — new `CountAdoptedAdopters` RPC + request/response messages; regenerated TS via `buf generate` (`packages/proto/src/generated/...`, `packages/proto/src/index.ts`).
- `services/applications/src/grpc/attribution-handlers.ts` (+ test) — the new RPC handler: `applications.read`-gated, dedupes candidate adopter ids, `SELECT COUNT(DISTINCT user_id) ... WHERE status IN ('approved','adopted') AND user_id = ANY($1) AND created_at BETWEEN $2 AND $3`. Wired into `services/applications/src/grpc/server.ts`.
- `services/rescue/src/grpc/event-handlers.ts` — `getEventAnalytics` becomes `makeGetEventAnalytics(applicationsClient)` (factory pattern mirroring `staff-foster-handlers.ts`'s `makeCreateFosterPlacement`). Resolves the event's registrant ids, then calls the new RPC. A downstream failure surfaces as `INTERNAL` rather than silently reporting `0`, so an outage doesn't masquerade as "no adoptions."
- `services/rescue/src/grpc/applications-client.ts` (+ test) — new rescue → applications gRPC client (deadline/retry/metadata-forwarding, direct port of the existing `pets-client.ts` / chat's `applications-client.ts` pattern).
- `services/rescue/src/config.ts` (+ test) — new `applicationsGrpcUrl` (`APPLICATIONS_GRPC_URL`, default `service-applications:6005`, matching `service.chat`'s existing default — no docker-compose changes needed).
- `services/rescue/src/grpc/server.ts` (+ test) — builds/injects/closes the applications client alongside the existing pets client.
- `services/gateway/src/grpc-clients/applications-client.contract.test.ts` — added the new RPC to the manually-listed `ApplicationServiceServer` stub (TypeScript now requires it).

### Not changed: SPA

Investigated `apps/rescue` for the "event-analytics view" the ticket mentions. It doesn't exist yet — only the `EventAnalytics` type and `eventsService.getEventAnalytics()` exist; no page/component calls it or renders `adoptionsFromEvent`, and there's no defensive-hiding/placeholder to remove. Since there's nothing to wire up without inventing new UI (out of scope for this fix), I left the SPA untouched. Flagging this rather than guessing at a UI to build.

### Interpretation note (proto field semantics)

`adoptions_from_event` is named as if it counts adoptions, but the product decision this PR implements explicitly specifies counting **distinct adopters** ("count an adopter once even if they have multiple qualifying applications"). In the near-universal case (one adopter → one adoption) these coincide; I followed the explicit instruction since the field's own wording doesn't unambiguously rule out the adopter-count reading.

## Before requesting review

- [x] Ran targeted `pnpm exec turbo test type-check lint` for every touched package (see Test plan)
- [x] Tests for new behaviour added (TDD — handler/RPC tests written before implementation)
- [x] No `.env` changes required (default `APPLICATIONS_GRPC_URL` matches the existing `service-applications` container/port)
- [ ] N/A — no `lib.*` touched

## Test plan

- `service.applications`: `pnpm exec turbo test --filter=@adopt-dont-shop/service.applications` → **289 passed** (9 new in `attribution-handlers.test.ts`: permission gate, missing-window validation, empty-candidate-set short-circuit, dedup, SQL scoping to APPROVED/ADOPTED + window, count mapping, super_admin bypass).
- `service.rescue`: `pnpm exec turbo test --filter=@adopt-dont-shop/service.rescue` → **243 passed** (new: `applications-client.test.ts` deadline/retry/metadata behaviour; `event-handlers.test.ts` — registrant-id resolution, 90-day window math, zero-registrants short-circuit skips the RPC call, zero-adopters-in-cohort result, downstream failure → `INTERNAL`).
- `service.gateway`: `pnpm exec turbo test --filter=@adopt-dont-shop/service.gateway` → **1046 passed**.
- `packages/proto`: `pnpm exec turbo test --filter=@adopt-dont-shop/proto` → **66 passed**; `buf generate` re-run to confirm no drift beyond the intended `application.ts` diff (pre-existing formatting drift in a few unrelated generated files — `auth.ts`, `cms.ts`, `ping.ts` — was found and left untouched; not caused by this change, worth its own ticket).
- `pnpm exec turbo type-check` and `pnpm exec turbo lint` clean across `service.rescue`, `service.applications`, `service.gateway`, `packages/proto`, `app.rescue` (only a pre-existing unrelated lint warning in `services/applications/src/grpc/pets-client.test.ts`, present on `main`).

## Related

ADS-941

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_015F6J4DXQ1Amyth4dwD5Q8P)_