### PR TITLE
fix(deps): patch 5 advisories failing the Dependency Audit gate (brace-expansion/js-yaml/shell-quote/protobufjs/dompurify)

### DIFF
--- a/package.json
+++ b/package.json
@@ -119,7 +119,12 @@
     "@types/react": "Pinned to an exact version (not a `^19` range) so npm collapses the type package to a single copy. With a range, transitive consumers (e.g. @types/react-dom) can resolve a different 19.x patch, leaving two physically separate @types/react copies — which makes tsc treat React's `Ref`/element types as unrelated and fails the lib.components build (TS2322). Bump this exact version when intentionally updating React types.",
     "react": "react and react-dom are pinned to the same exact version (not a `^19.2.x` range) because npm's deduper can otherwise hoist a different react-dom patch to the root than react (e.g. react 19.2.7 / react-dom 19.2.6), which trips react-dom's `react`/`react-dom` exact-version-match guard and crashes every React test. The `react-zdog` nested override keeps that subtree on react 18, which it requires. Bump react and react-dom together when updating React.",
     "undici": "Force undici >=7.28.0 to patch the TLS certificate-validation bypass (GHSA-vmh5-mc38-953g). undici is a transitive dependency (jsdom > undici in the React apps' test toolchain), so the root-level override is the only way to reach the nested copy that `pnpm audit` flags. Do not downgrade below 7.28.0.",
-    "underscore": "Force underscore >=1.13.8 to patch the unbounded-recursion DoS in _.flatten / _.isEqual (GHSA-qpx9-hpmf-5gmw). underscore is a dev-only transitive dependency (@pact-foundation/pact > @pact-foundation/pact-core > underscore in the contract-test toolchain), so the root-level override is the only way to reach the nested copy that `pnpm audit` flags. Do not downgrade below 1.13.8."
+    "underscore": "Force underscore >=1.13.8 to patch the unbounded-recursion DoS in _.flatten / _.isEqual (GHSA-qpx9-hpmf-5gmw). underscore is a dev-only transitive dependency (@pact-foundation/pact > @pact-foundation/pact-core > underscore in the contract-test toolchain), so the root-level override is the only way to reach the nested copy that `pnpm audit` flags. Do not downgrade below 1.13.8.",
+    "brace-expansion": "Patch the exponential-time-expansion DoS in brace-expansion (GHSA-3jxr-9vmj-r5cp). The advisory spans three disjoint ranges across the major lines the tree resolves (1.x <1.1.16, 2.x <2.1.2, 3.x-5.x <5.0.7), so each vulnerable range is overridden to its own nearest patched release rather than force-collapsing every transitive copy to one major. Transitive via many build/glob tools (minimatch etc.). Do not lower the patched targets.",
+    "js-yaml": "Force js-yaml >=4.3.0 to patch the quadratic-CPU DoS via YAML merge-key chains (GHSA-52cp-r559-cp3m); the 4.x line is vulnerable below 4.3.0. Kept on 4.3.0 (not the 5.x latest) to stay API-compatible for transitive consumers. Do not downgrade below 4.3.0.",
+    "shell-quote": "Force shell-quote >=1.9.0 to patch the quadratic-complexity DoS in parse() (GHSA-395f-4hp3-45gv, CWE-407); everything <=1.8.4 is vulnerable and 1.9.0 is the first published release above the range. Dev/build-chain transitive dependency. Do not downgrade below 1.9.0.",
+    "protobufjs": "Force protobufjs >=7.6.5 to patch the infinite-loop DoS in .proto option parsing (GHSA-j3f2-48v5-ccww); the 7.5.0-7.6.4 range is vulnerable. Kept on the 7.6.5 patch (not the 8.x latest) to avoid a runtime major bump for @grpc/proto-loader / packages/proto consumers. Do not downgrade below 7.6.5.",
+    "dompurify": "Force dompurify >=3.4.11 to patch the permanent ALLOWED_ATTR pollution via setConfig() (GHSA-cmwh-pvxp-8882); <=3.4.10 is vulnerable. dompurify sanitises chat-attachment previews (lib.chat), so keeping it patched is defence-relevant, not just an audit-gate fix. Do not downgrade below 3.4.11."
   },
   "pnpm": {
     "onlyBuiltDependencies": [
@@ -145,7 +150,14 @@
       "react-zdog>react-dom": "18.3.1",
       "ws@>=8.0.0 <8.21.0": "8.21.0",
       "undici@>=7.23.0 <7.28.0": "^7.28.0",
-      "underscore": "^1.13.8"
+      "underscore": "^1.13.8",
+      "brace-expansion@<1.1.16": "1.1.16",
+      "brace-expansion@>=2.0.0 <2.1.2": "2.1.2",
+      "brace-expansion@>=3.0.0 <5.0.7": "5.0.7",
+      "js-yaml@>=4.0.0 <4.3.0": "4.3.0",
+      "shell-quote@<1.9.0": "1.9.0",
+      "protobufjs@>=7.5.0 <7.6.5": "7.6.5",
+      "dompurify@<3.4.11": "3.4.11"
     }
   },
   "engines": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,6 +19,13 @@ overrides:
   ws@>=8.0.0 <8.21.0: 8.21.0
   undici@>=7.23.0 <7.28.0: ^7.28.0
   underscore: ^1.13.8
+  brace-expansion@<1.1.16: 1.1.16
+  brace-expansion@>=2.0.0 <2.1.2: 2.1.2
+  brace-expansion@>=3.0.0 <5.0.7: 5.0.7
+  js-yaml@>=4.0.0 <4.3.0: 4.3.0
+  shell-quote@<1.9.0: 1.9.0
+  protobufjs@>=7.5.0 <7.6.5: 7.6.5
+  dompurify@<3.4.11: 3.4.11
 
 importers:
 
@@ -6515,14 +6522,14 @@ packages:
   bowser@2.14.1:
     resolution: {integrity: sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==}
 
-  brace-expansion@1.1.15:
-    resolution: {integrity: sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==}
+  brace-expansion@1.1.16:
+    resolution: {integrity: sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==}
 
-  brace-expansion@2.1.1:
-    resolution: {integrity: sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==}
+  brace-expansion@2.1.2:
+    resolution: {integrity: sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==}
 
-  brace-expansion@5.0.6:
-    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
+  brace-expansion@5.0.7:
+    resolution: {integrity: sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==}
     engines: {node: 18 || 20 || >=22}
 
   braces@3.0.3:
@@ -7053,9 +7060,6 @@ packages:
 
   dompurify@3.4.11:
     resolution: {integrity: sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==}
-
-  dompurify@3.4.9:
-    resolution: {integrity: sha512-4dPSRMRDqHvs0V4YDFCsaIZo4if5u0xM+llyxiM2fwuZFdKArUBAF3VtI2+n8NKg9P870WMdYk0UhqQNoWXbfQ==}
 
   domutils@3.2.2:
     resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
@@ -8099,8 +8103,8 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@4.2.0:
-    resolution: {integrity: sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==}
+  js-yaml@4.3.0:
+    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
     hasBin: true
 
   jsc-safe-url@0.2.4:
@@ -8986,8 +8990,8 @@ packages:
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
 
-  protobufjs@7.6.4:
-    resolution: {integrity: sha512-RJJPTTpvFfHcWLkIa2JFWK4XvtSzS0yEWDmunqHXli1h3JlkbcQZXDZdcWxv+JK3Xsl5/UFDPZ0iGm7DAengYw==}
+  protobufjs@7.6.5:
+    resolution: {integrity: sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==}
     engines: {node: '>=12.0.0'}
 
   proxy-addr@2.0.7:
@@ -9528,10 +9532,6 @@ packages:
   shebang-regex@3.0.0:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
-
-  shell-quote@1.8.4:
-    resolution: {integrity: sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==}
-    engines: {node: '>= 0.4'}
 
   shell-quote@1.9.0:
     resolution: {integrity: sha512-Iov+JwFv/2HcTpcwNMKd8+IWNb8tboQJNQTkAY/LLVK7gGH9jy+LGkVqPxfekHl+yMmiqXszdGWXgkfml7hjqA==}
@@ -12004,7 +12004,7 @@ snapshots:
     dependencies:
       lodash.camelcase: 4.3.0
       long: 5.3.2
-      protobufjs: 7.6.4
+      protobufjs: 7.6.5
       yargs: 17.7.2
 
   '@hookform/resolvers@5.4.0(react-hook-form@7.80.0(react@19.2.7))':
@@ -14373,7 +14373,7 @@ snapshots:
 
   '@types/bunyan@1.8.11':
     dependencies:
-      '@types/node': 26.0.0
+      '@types/node': 26.0.1
 
   '@types/chai@5.2.3':
     dependencies:
@@ -14382,11 +14382,11 @@ snapshots:
 
   '@types/connect@3.4.38':
     dependencies:
-      '@types/node': 26.0.0
+      '@types/node': 26.0.1
 
   '@types/cors@2.8.19':
     dependencies:
-      '@types/node': 26.0.0
+      '@types/node': 26.0.1
 
   '@types/css-font-loading-module@0.0.7': {}
 
@@ -14454,13 +14454,13 @@ snapshots:
 
   '@types/memcached@2.2.10':
     dependencies:
-      '@types/node': 26.0.0
+      '@types/node': 26.0.1
 
   '@types/ms@2.1.0': {}
 
   '@types/mysql@2.15.27':
     dependencies:
-      '@types/node': 26.0.0
+      '@types/node': 26.0.1
 
   '@types/node@25.9.3':
     dependencies:
@@ -14480,7 +14480,7 @@ snapshots:
 
   '@types/oracledb@6.5.2':
     dependencies:
-      '@types/node': 26.0.0
+      '@types/node': 26.0.1
 
   '@types/pako@2.0.4': {}
 
@@ -14494,7 +14494,7 @@ snapshots:
 
   '@types/pg@8.15.6':
     dependencies:
-      '@types/node': 26.0.0
+      '@types/node': 26.0.1
       pg-protocol: 1.15.0
       pg-types: 2.2.0
 
@@ -14533,13 +14533,13 @@ snapshots:
 
   '@types/set-cookie-parser@2.4.10':
     dependencies:
-      '@types/node': 26.0.0
+      '@types/node': 26.0.1
 
   '@types/statuses@2.0.6': {}
 
   '@types/tedious@4.0.14':
     dependencies:
-      '@types/node': 26.0.0
+      '@types/node': 26.0.1
 
   '@types/triple-beam@1.3.5': {}
 
@@ -14551,7 +14551,7 @@ snapshots:
 
   '@types/ws@8.18.1':
     dependencies:
-      '@types/node': 26.0.0
+      '@types/node': 26.0.1
 
   '@types/yargs-parser@21.0.3': {}
 
@@ -15244,16 +15244,16 @@ snapshots:
 
   bowser@2.14.1: {}
 
-  brace-expansion@1.1.15:
+  brace-expansion@1.1.16:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
 
-  brace-expansion@2.1.1:
+  brace-expansion@2.1.2:
     dependencies:
       balanced-match: 1.0.2
 
-  brace-expansion@5.0.6:
+  brace-expansion@5.0.7:
     dependencies:
       balanced-match: 4.0.4
 
@@ -15458,7 +15458,7 @@ snapshots:
     dependencies:
       chalk: 5.6.2
       rxjs: 7.8.2
-      shell-quote: 1.8.4
+      shell-quote: 1.9.0
       supports-color: 10.2.2
       tree-kill: 1.2.2
       yargs: 18.0.0
@@ -15528,7 +15528,7 @@ snapshots:
     dependencies:
       env-paths: 2.2.1
       import-fresh: 3.3.1
-      js-yaml: 4.2.0
+      js-yaml: 4.3.0
       parse-json: 5.2.0
     optionalDependencies:
       typescript: 6.0.3
@@ -15740,11 +15740,6 @@ snapshots:
   dompurify@3.4.11:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
-
-  dompurify@3.4.9:
-    optionalDependencies:
-      '@types/trusted-types': 2.0.7
-    optional: true
 
   domutils@3.2.2:
     dependencies:
@@ -17049,7 +17044,7 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@4.2.0:
+  js-yaml@4.3.0:
     dependencies:
       argparse: 2.0.1
 
@@ -17144,7 +17139,7 @@ snapshots:
     optionalDependencies:
       canvg: 3.0.11
       core-js: 3.49.0
-      dompurify: 3.4.9
+      dompurify: 3.4.11
       html2canvas: 1.4.1
 
   jsx-ast-utils@3.3.5:
@@ -17583,19 +17578,19 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.6
+      brace-expansion: 5.0.7
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 1.1.15
+      brace-expansion: 1.1.16
 
   minimatch@5.1.9:
     dependencies:
-      brace-expansion: 2.1.1
+      brace-expansion: 2.1.2
 
   minimatch@9.0.9:
     dependencies:
-      brace-expansion: 2.1.1
+      brace-expansion: 2.1.2
 
   minimist@1.2.8: {}
 
@@ -18113,7 +18108,7 @@ snapshots:
       object-assign: 4.1.1
       react-is: 16.13.1
 
-  protobufjs@7.6.4:
+  protobufjs@7.6.5:
     dependencies:
       '@protobufjs/aspromise': 1.1.2
       '@protobufjs/base64': 1.1.2
@@ -18124,7 +18119,7 @@ snapshots:
       '@protobufjs/path': 1.1.2
       '@protobufjs/pool': 1.1.0
       '@protobufjs/utf8': 1.1.1
-      '@types/node': 26.0.0
+      '@types/node': 26.0.1
       long: 5.3.2
 
   proxy-addr@2.0.7:
@@ -18833,8 +18828,6 @@ snapshots:
       shebang-regex: 3.0.0
 
   shebang-regex@3.0.0: {}
-
-  shell-quote@1.8.4: {}
 
   shell-quote@1.9.0: {}
 
@@ -19784,7 +19777,7 @@ snapshots:
     dependencies:
       async-exit-hook: 2.0.1
       btoa: 1.2.1
-      protobufjs: 7.6.4
+      protobufjs: 7.6.5
       url-polyfill: 1.1.14
       winston-transport: 4.9.0
     optionalDependencies:


### PR DESCRIPTION
## Summary

The repo-wide **Dependency Audit** check is red on `main` and on every open PR — five newly-published advisories began matching already-installed transitive versions. This adds `pnpm.overrides` pinning each to a patched release, turning the gate green everywhere at once.

| Package | Sev | Advisory | Installed | Patched to |
| --- | --- | --- | --- | --- |
| `brace-expansion` | high | GHSA-3jxr-9vmj-r5cp (exponential-time expansion DoS) | 1.1.15 / 2.1.1 / 5.0.6 | 1.1.16 / 2.1.2 / 5.0.7 |
| `js-yaml` | high | GHSA-52cp-r559-cp3m (quadratic CPU via merge keys) | 4.2.0 | 4.3.0 |
| `shell-quote` | high | GHSA-395f-4hp3-45gv (quadratic DoS in `parse()`) | 1.8.4 | 1.9.0 |
| `protobufjs` | moderate | GHSA-j3f2-48v5-ccww (infinite loop in `.proto` option parse) | 7.6.4 | 7.6.5 |
| `dompurify` | moderate | GHSA-cmwh-pvxp-8882 (`ALLOWED_ATTR` pollution) | 3.4.9 | 3.4.11 |

The 3 **high** advisories are what trip the merge gate (`--audit-level high`); the 2 moderates are cleared too for a fully-clean audit.

## Changes

- `package.json` `pnpm.overrides` — 7 new entries. `brace-expansion` spans three disjoint vulnerable ranges across the majors the tree resolves (`<1.1.16`, `>=2.0.0 <2.1.2`, `>=3.0.0 <5.0.7`), so each range is pinned to its own nearest patch rather than force-collapsing every copy to one major — mirrors the existing `ws`/`undici` range-scoped pins.
- `overridesDocumentation` — a rationale entry per package, per the repo's existing convention.
- `pnpm-lock.yaml` — regenerated.
- All bumps stay within the current major (patch/minor). `js-yaml` and `protobufjs` deliberately stay on the 4.x / 7.x lines (not the 5.x / 8.x latest) to avoid a runtime major bump for their consumers.

## Test plan

- [x] `node scripts/audit-bulk.mjs` → **"No advisories match the installed dependency versions."** (exit 0) — was 5 matches / exit 1 before.
- [x] Resolved versions confirmed in the lockfile: brace-expansion 1.1.16/2.1.2/5.0.7, js-yaml 4.3.0, shell-quote 1.9.0, protobufjs 7.6.5, dompurify 3.4.11.
- [x] `pnpm exec turbo test --filter=@adopt-dont-shop/proto --filter=@adopt-dont-shop/lib.chat` — the two packages consuming the bumped **runtime** deps (protobufjs, dompurify) — pass (lib.chat 172 tests).
- [x] `pnpm install` clean (pre-existing unrelated peer warnings only).

## Related

Unblocks the Dependency Audit check on `main` and all currently-open PRs (#1240 and the in-flight ADS-946/962/992/993/994 branches). No Linear ticket — infra/CI fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015F6J4DXQ1Amyth4dwD5Q8P

---
_Generated by [Claude Code](https://claude.ai/code/session_015F6J4DXQ1Amyth4dwD5Q8P)_