### PR TITLE
docs(gdpr): complete ROPA sub-processor DPA/location details (ADS-992)

### DIFF
--- a/docs/GDPR-ROPA.md
+++ b/docs/GDPR-ROPA.md
@@ -161,8 +161,18 @@ re-verify this section whenever a provider changes.
 - **Email delivery:** Resend (transactional email API). `services/notifications`
   selects the provider via `EMAIL_PROVIDER`; production permits only `resend`
   (`console` and `ethereal` are dev/test-only sinks and are refused at boot in
-  production — ADS-549). Location / transfer mechanism / DPA link: _pending —
-  see ADS-992_. The `SMTP_HOST`, `SENDGRID_API_KEY`, and AWS SES variables in
+  production — ADS-549). The `resend` provider config
+  (`services/notifications/src/config.ts`) takes only `RESEND_API_KEY` /
+  `DEFAULT_FROM_EMAIL` — there is no region/location parameter, so Resend's
+  data-processing location cannot be derived from this codebase.
+  - Location: _To be confirmed by DPO / vendor-contracts owner — [ADS-992]_.
+    Resend, Inc. is a US-incorporated vendor; the specific data-processing
+    region(s) must come from their DPA/sub-processor list, not this repo.
+  - Transfer mechanism (SCCs / adequacy): _To be confirmed by DPO / vendor-contracts
+    owner — [ADS-992]_.
+  - DPA link: _To be confirmed by DPO / vendor-contracts owner — [ADS-992]_.
+
+  The `SMTP_HOST`, `SENDGRID_API_KEY`, and AWS SES variables in
   `.env.example` are reserved for a possible future provider switch and are
   **not** wired into any code path today — they are not sub-processors.
 - **SMS delivery:** Not implemented. `lib.validation` accepts an
@@ -174,9 +184,28 @@ re-verify this section whenever a provider changes.
 - **File storage:** AWS S3 via `@adopt-dont-shop/storage`'s `S3StorageProvider`,
   optionally fronted by an Amazon CloudFront distribution
   (`CLOUDFRONT_DOMAIN`). Selected with `STORAGE_PROVIDER=s3` (`S3_BUCKET_NAME`,
-  `S3_REGION`, default `us-east-1`). Location / transfer mechanism / DPA link:
-  _pending — see ADS-992_. Local disk storage (`STORAGE_PROVIDER=local`, the
-  dev/test default) involves no third-party sub-processor.
+  `S3_REGION`).
+  - Location: the example/default value shipped in `.env.example` and
+    `docs/env-reference.md` is `S3_REGION=us-east-1` (US East, N. Virginia).
+    That is a config default, not a confirmed production value — this repo
+    has no record of the region/account actually configured for the live
+    bucket. _Actual deployed bucket region and AWS account to be confirmed by
+    Infrastructure/DevOps — [ADS-992]_.
+  - Transfer mechanism (SCCs / adequacy): AWS incorporates its GDPR Data
+    Processing Addendum — which itself incorporates the EU Standard
+    Contractual Clauses / UK International Data Transfer Addendum for
+    transfers outside the UK/EEA — into the AWS Customer Agreement by
+    default for all customers; this is a standing AWS policy, not something
+    negotiated per-customer. _Confirmation that this addendum is in effect
+    for our AWS account (and the acceptance record) to be supplied by DPO /
+    vendor-contracts owner — [ADS-992]_.
+  - DPA link: _To be confirmed by DPO / vendor-contracts owner — [ADS-992]_.
+    AWS publishes its standard DPA via the AWS GDPR Center; the owner should
+    record the specific accepted version/link here rather than have this
+    doc infer one.
+
+  Local disk storage (`STORAGE_PROVIDER=local`, the dev/test default)
+  involves no third-party sub-processor.
 
 ## Review log
 


### PR DESCRIPTION
## Summary

- Follow-up to ADS-910 (#1235): fills in the `docs/GDPR-ROPA.md` Sub-processors section's remaining "pending — see ADS-992" markers (location / transfer mechanism / DPA link) for Resend (email) and AWS S3 (file storage).
- No code changes — documentation only.

## Changes

- `docs/GDPR-ROPA.md` — Sub-processors section:
  - **Resend (email):** noted that `services/notifications/src/config.ts`'s `resend` provider config only takes `RESEND_API_KEY`/`DEFAULT_FROM_EMAIL` — no region/location parameter exists in this codebase, so location/transfer-mechanism/DPA-link are **left as explicit "To be confirmed by DPO / vendor-contracts owner — [ADS-992]" placeholders**, with a note that Resend, Inc. is a US-incorporated vendor.
  - **AWS S3 (file storage):**
    - Location — **filled from the repo**: `.env.example`/`docs/env-reference.md`'s example default is `S3_REGION=us-east-1` (US East, N. Virginia). Flagged that this is a config *default*, not a confirmed production value — the actual deployed bucket region/account is left as an **owner-confirm placeholder** (Infrastructure/DevOps), since this repo has no record of it.
    - Transfer mechanism — **filled from public/known facts**: AWS incorporates its GDPR DPA (including EU SCCs / UK IDTA) into the AWS Customer Agreement by default for all customers, as a standing AWS policy. Confirmation that this applies to our specific AWS account is left as an **owner-confirm placeholder**.
    - DPA link — **left as an owner-confirm placeholder**: per ADS-992's own scope note, signed/accepted-DPA links shouldn't be inferred by this doc; the DPO/vendor-contracts owner should record the specific accepted version.

## Before requesting review

- [x] Ran `pnpm ci:local:quick`-equivalent checks locally (see Test plan)
- [ ] Tests for new behaviour added (TDD) — N/A, docs-only change
- [ ] If touching `.env` requirements, updated `.env.example`'s REQUIRED block — N/A, no `.env` changes
- [ ] If touching a `lib.*`, considered consumer impact across `app.*` and `service.backend` — N/A

## Test plan

- [x] `node scripts/check-docs-index.mjs` passes
- [x] `node scripts/check-docs-script-references.mjs` passes
- [x] `pnpm format:root:check` passes on the touched markdown
- [ ] Existing tests pass (`pnpm test`) — N/A, no code touched
- [ ] No TypeScript errors (`pnpm type-check`) — N/A, no code touched
- [ ] Lint passes (`pnpm lint`) — N/A, no code touched

## Related

- ADS-992: https://linear.app/ideasquared/issue/ADS-992/populate-gdpr-ropa-sub-processor-dpa-transfer-mechanism-details-for
- Follow-up to ADS-910, merged in #1235

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_015F6J4DXQ1Amyth4dwD5Q8P)_