### PR TITLE
fix(tooling): repair new-app/new-lib generators for pnpm-workspace layout (ADS-994)

### DIFF
--- a/scripts/create-new-app.js
+++ b/scripts/create-new-app.js
@@ -3,7 +3,13 @@
 import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
-import { ROOT_DIR, copyTemplateDir, log, registerWorkspace } from './lib/template-engine.mjs';
+import {
+  ROOT_DIR,
+  copyTemplateDir,
+  log,
+  registerWorkspace,
+  remindDevVolumesMount,
+} from './lib/template-engine.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const TEMPLATES_DIR = path.join(__dirname, 'templates', 'app');
@@ -116,7 +122,12 @@ async function main() {
   }
 
   const templateConfig = TEMPLATES[template];
-  const appDir = path.join(ROOT_DIR, appName);
+  // App directories live under apps/ named WITHOUT the `app.` prefix
+  // (apps/admin, apps/client, …) while the package keeps the full
+  // `@adopt-dont-shop/app.<slug>` name. The CLI arg is the full `app.<slug>`.
+  const appSlug = appName.replace(/^app\./, '');
+  const appRelPath = path.join('apps', appSlug);
+  const appDir = path.join(ROOT_DIR, appRelPath);
 
   if (fs.existsSync(appDir) && !overwrite) {
     log(`❌ Error: App "${appName}" already exists. Use --overwrite to replace it.`, 'red');
@@ -162,16 +173,13 @@ async function main() {
     }
   }
 
-  try {
-    registerWorkspace(appName);
-  } catch (error) {
-    log(`⚠️  Warning: Could not update workspace package.json: ${error.message}`, 'yellow');
-  }
+  registerWorkspace(appRelPath);
 
-  printSuccess(appName, templateConfig);
+  printSuccess(appName, appRelPath, templateConfig);
+  remindDevVolumesMount(appRelPath);
 }
 
-function printSuccess(appName, templateConfig) {
+function printSuccess(appName, appRelPath, templateConfig) {
   log('', 'reset');
   log('🎉 Success!', 'green');
   log(`✨ Created React app: ${appName}`, 'bright');
@@ -183,7 +191,7 @@ function printSuccess(appName, templateConfig) {
   }
   log('', 'reset');
   log('📋 Next steps:', 'cyan');
-  log(`   cd ${appName}`, 'reset');
+  log(`   cd ${appRelPath}`, 'reset');
   log(`   pnpm install`, 'reset');
   log(`   pnpm dev`, 'reset');
   log('', 'reset');

--- a/scripts/create-new-lib.js
+++ b/scripts/create-new-lib.js
@@ -10,7 +10,7 @@ import {
   copyTemplateDir,
   log,
   registerWorkspace,
-  updateAppOptimizedDockerfile,
+  remindDevVolumesMount,
 } from './lib/template-engine.mjs';
 
 const execAsync = promisify(exec);
@@ -24,6 +24,7 @@ function parseArgs(argv) {
   }
 
   const useLibApi = args.includes('--with-api');
+  const skipInstall = args.includes('--skip-install');
   const typeArg = args.find(arg => arg.startsWith('--type='));
   const libType = typeArg ? typeArg.split('=')[1] : 'service';
   const positional = args.filter(arg => !arg.startsWith('--'));
@@ -33,6 +34,7 @@ function parseArgs(argv) {
     libDescription: positional[1],
     libType,
     useLibApi,
+    skipInstall,
   };
 }
 
@@ -116,7 +118,7 @@ async function main() {
     process.exit(1);
   }
 
-  const { libName, libType, useLibApi } = parsed;
+  const { libName, libType, useLibApi, skipInstall } = parsed;
   const libDescription =
     parsed.libDescription || `Shared ${libName} functionality for the pet adoption platform`;
 
@@ -130,7 +132,10 @@ async function main() {
     process.exit(1);
   }
 
-  const libDir = path.join(ROOT_DIR, `lib.${libName}`);
+  // Libraries live under packages/ as packages/lib.<name> (matching the
+  // `packages/*` workspace glob and every existing lib.* package).
+  const libRelPath = path.join('packages', `lib.${libName}`);
+  const libDir = path.join(ROOT_DIR, libRelPath);
   if (fs.existsSync(libDir)) {
     log(`❌ Library lib.${libName} already exists!`, 'red');
     process.exit(1);
@@ -161,16 +166,14 @@ async function main() {
       }
     }
 
-    registerWorkspace(`lib.${libName}`, {
-      [`dev:lib-${libName}`]: `turbo run dev --filter=@adopt-dont-shop/lib-${libName}`,
-      [`build:lib-${libName}`]: `turbo run build --filter=@adopt-dont-shop/lib-${libName}`,
-      [`test:lib-${libName}`]: `turbo run test --filter=@adopt-dont-shop/lib-${libName}`,
-    });
+    registerWorkspace(libRelPath);
 
-    updateAppOptimizedDockerfile(libName);
-    await installDependencies(libDir);
+    if (!skipInstall) {
+      await installDependencies(libDir);
+    }
 
     printSuccess(libName, libType);
+    remindDevVolumesMount(libRelPath);
   } catch (error) {
     log(`❌ Error creating library: ${error.message}`, 'red');
     process.exit(1);
@@ -182,7 +185,7 @@ function printSuccess(libName, libType) {
   log('🎉 Library created successfully!', 'green');
   log('', 'reset');
   log('📋 Next steps:', 'bright');
-  log(`   1. cd lib.${libName}`, 'cyan');
+  log(`   1. cd packages/lib.${libName}`, 'cyan');
   log('   2. pnpm dev     # Start development build', 'cyan');
   log('   3. pnpm test        # Run tests', 'cyan');
 

--- a/scripts/generators.test.mjs
+++ b/scripts/generators.test.mjs
@@ -1,0 +1,107 @@
+// Smoke tests for the pnpm new-app / new-lib generators (ADS-994).
+//
+// Runs the REAL generator scripts into a throwaway temp root (via the
+// ADS_GENERATOR_ROOT override) and asserts the generated package lands at the
+// correct pnpm-workspace location with a convention-matching package name —
+// the two things that were broken (output at repo root + npm-style
+// "workspaces" registration). Deps are never installed (the app generator
+// doesn't, and the lib generator is run with --skip-install), so these stay
+// hermetic and fast.
+
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, rmSync, writeFileSync, readFileSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { isWorkspaceCovered } from './lib/template-engine.mjs';
+
+const SCRIPTS_DIR = dirname(fileURLToPath(import.meta.url));
+
+const WORKSPACE_MANIFEST = [
+  'packages:',
+  "  - 'apps/*'",
+  "  - 'packages/*'",
+  "  - 'services/*'",
+  "  - 'e2e'",
+  '',
+].join('\n');
+
+let root;
+
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), 'ads-gen-'));
+  // The generators resolve their output base from ADS_GENERATOR_ROOT and read
+  // pnpm-workspace.yaml from it, so seed a realistic manifest.
+  writeFileSync(join(root, 'pnpm-workspace.yaml'), WORKSPACE_MANIFEST);
+});
+
+afterEach(() => {
+  rmSync(root, { recursive: true, force: true });
+});
+
+const runGenerator = (script, args) =>
+  execFileSync('node', [join(SCRIPTS_DIR, script), ...args], {
+    env: { ...process.env, ADS_GENERATOR_ROOT: root },
+    encoding: 'utf8',
+  });
+
+describe('pnpm new-app (create-new-app.js)', () => {
+  it('generates the app under apps/<slug> with the @adopt-dont-shop/app.<slug> name', () => {
+    runGenerator('create-new-app.js', ['app.dashboard', '--template', 'minimal']);
+
+    const pkgPath = join(root, 'apps', 'dashboard', 'package.json');
+    expect(existsSync(pkgPath)).toBe(true);
+    // NOT at the old broken location (repo root / app.dashboard).
+    expect(existsSync(join(root, 'app.dashboard'))).toBe(false);
+
+    const pkg = JSON.parse(readFileSync(pkgPath, 'utf8'));
+    expect(pkg.name).toBe('@adopt-dont-shop/app.dashboard');
+  });
+
+  it('leaves pnpm-workspace.yaml unchanged (apps/* already covers the new app)', () => {
+    const before = readFileSync(join(root, 'pnpm-workspace.yaml'), 'utf8');
+    runGenerator('create-new-app.js', ['app.portal', '--template', 'minimal']);
+    expect(readFileSync(join(root, 'pnpm-workspace.yaml'), 'utf8')).toBe(before);
+  });
+});
+
+describe('pnpm new-lib (create-new-lib.js)', () => {
+  it('generates the lib under packages/lib.<name> with the @adopt-dont-shop/lib.<name> name', () => {
+    runGenerator('create-new-lib.js', [
+      'widgets',
+      'Widget helpers',
+      '--type=utility',
+      '--skip-install',
+    ]);
+
+    const pkgPath = join(root, 'packages', 'lib.widgets', 'package.json');
+    expect(existsSync(pkgPath)).toBe(true);
+    expect(existsSync(join(root, 'lib.widgets'))).toBe(false);
+
+    const pkg = JSON.parse(readFileSync(pkgPath, 'utf8'));
+    expect(pkg.name).toBe('@adopt-dont-shop/lib.widgets');
+  });
+
+  it('does not add npm-style per-lib scripts to a root package.json', () => {
+    // The old generator mutated a package.json "workspaces" array + added
+    // dev:lib-*/build:lib-*/test:lib-* scripts. Nothing should touch a root
+    // package.json now (there isn't even one in the temp root).
+    runGenerator('create-new-lib.js', ['gadgets', '--type=utility', '--skip-install']);
+    expect(existsSync(join(root, 'package.json'))).toBe(false);
+  });
+});
+
+describe('isWorkspaceCovered', () => {
+  it('recognises a package already covered by a parent glob', () => {
+    expect(isWorkspaceCovered(WORKSPACE_MANIFEST, 'apps/dashboard')).toBe(true);
+    expect(isWorkspaceCovered(WORKSPACE_MANIFEST, 'packages/lib.widgets')).toBe(true);
+    expect(isWorkspaceCovered(WORKSPACE_MANIFEST, 'e2e')).toBe(true);
+  });
+
+  it('reports an uncovered top-level location', () => {
+    expect(isWorkspaceCovered(WORKSPACE_MANIFEST, 'tools/foo')).toBe(false);
+  });
+});

--- a/scripts/lib/template-engine.mjs
+++ b/scripts/lib/template-engine.mjs
@@ -3,7 +3,11 @@ import path from 'path';
 import { fileURLToPath } from 'url';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const ROOT_DIR = path.resolve(__dirname, '..', '..');
+// Repo root. Overridable via ADS_GENERATOR_ROOT so the generator smoke tests
+// can run the real generators into a throwaway temp dir instead of the repo.
+const ROOT_DIR = process.env.ADS_GENERATOR_ROOT
+  ? path.resolve(process.env.ADS_GENERATOR_ROOT)
+  : path.resolve(__dirname, '..', '..');
 
 // ANSI color codes for console output
 export const colors = {
@@ -77,56 +81,73 @@ export function copyTemplateDir(srcDir, destDir, vars, options = {}) {
   return written;
 }
 
-/**
- * Update the root package.json: insert `workspaceEntry` into the workspaces
- * array (sorted, deduped) and apply additional script entries.
- */
-export function registerWorkspace(workspaceEntry, extraScripts = {}) {
-  const packageJsonPath = path.join(ROOT_DIR, 'package.json');
-  const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
-
-  if (!packageJson.workspaces.includes(workspaceEntry)) {
-    packageJson.workspaces.push(workspaceEntry);
-    packageJson.workspaces.sort();
-  }
-
-  for (const [name, value] of Object.entries(extraScripts)) {
-    packageJson.scripts[name] = value;
-  }
-
-  fs.writeFileSync(packageJsonPath, JSON.stringify(packageJson, null, 2));
-  log(`📦 Updated root package.json with ${workspaceEntry}`, 'green');
+// Pure: does the pnpm-workspace manifest already match `workspaceRelPath`
+// (either an exact entry or a `<parent>/*` | `<parent>/**` glob)? Exported so
+// the generator smoke tests can assert the registration logic directly.
+export function isWorkspaceCovered(manifestText, workspaceRelPath) {
+  const parent = path.dirname(workspaceRelPath); // 'apps' | 'packages' | ...
+  const globs = [...manifestText.matchAll(/^\s*-\s*'([^']+)'/gm)].map(m => m[1]);
+  return globs.some(g => g === workspaceRelPath || g === `${parent}/*` || g === `${parent}/**`);
 }
 
 /**
- * Insert a `COPY lib.<name>/ ./lib.<name>/` line into Dockerfile.app
- * after the last existing such line. Skips silently when the dockerfile or
- * marker is missing.
+ * Ensure a newly-generated workspace is discoverable by pnpm.
+ *
+ * This repo uses pnpm workspaces (pnpm-workspace.yaml), not npm/yarn
+ * `package.json` "workspaces". The manifest globs `apps/*` and `packages/*`
+ * already cover every generated app (apps/<name>) and lib (packages/lib.<name>),
+ * so registration is normally a no-op: pnpm picks the new package up on the
+ * next install with no manifest edit. We only append a glob when the target's
+ * parent directory isn't already matched — a genuinely new top-level location.
+ *
+ * `workspaceRelPath` is the new package's path relative to the repo root,
+ * e.g. `apps/dashboard` or `packages/lib.chat`.
  */
-export function updateAppOptimizedDockerfile(libName) {
-  const dockerfilePath = path.join(ROOT_DIR, 'Dockerfile.app');
-  if (!fs.existsSync(dockerfilePath)) {
+export function registerWorkspace(workspaceRelPath) {
+  const manifestPath = path.join(ROOT_DIR, 'pnpm-workspace.yaml');
+  let manifest;
+  try {
+    manifest = fs.readFileSync(manifestPath, 'utf8');
+  } catch {
+    log(`⚠️  pnpm-workspace.yaml not found — add ${workspaceRelPath} to it manually`, 'yellow');
     return;
   }
 
-  let content = fs.readFileSync(dockerfilePath, 'utf8');
-  const newLine = `COPY lib.${libName}/ ./lib.${libName}/`;
+  const parent = path.dirname(workspaceRelPath); // 'apps' | 'packages' | ...
 
-  const libCopyRegex = /COPY lib\.[^/]+\/ \.\/lib\.[^/]+\/$/gm;
-  const matches = [...content.matchAll(libCopyRegex)];
-
-  if (matches.length === 0) {
-    log(`⚠️  Could not find library copy section in Dockerfile.app`, 'yellow');
-    log(`💡 Manually add: ${newLine}`, 'cyan');
+  if (isWorkspaceCovered(manifest, workspaceRelPath)) {
+    log(
+      `📦 pnpm-workspace.yaml already covers ${parent}/* — ${workspaceRelPath} is registered`,
+      'green'
+    );
     return;
   }
 
-  const last = matches[matches.length - 1];
-  const insertIndex = last.index + last[0].length;
-  content = content.slice(0, insertIndex) + '\n' + newLine + content.slice(insertIndex);
+  // Append the new parent glob under the `packages:` list.
+  const glob = `${parent}/*`;
+  const updated = manifest.replace(/(packages:\s*\n)/, `$1  - '${glob}'\n`);
+  fs.writeFileSync(manifestPath, updated);
+  log(`📦 Added '${glob}' to pnpm-workspace.yaml for ${workspaceRelPath}`, 'green');
+}
 
-  fs.writeFileSync(dockerfilePath, content);
-  log(`🐳 Updated Dockerfile.app with lib.${libName}`, 'green');
+/**
+ * Print a reminder that a new workspace package needs a node_modules mount in
+ * docker-compose.dev.yml's x-dev-volumes anchor. The ADS-987 drift guard
+ * (scripts/check-workspace-consistency.mjs) fails CI otherwise, and the dev
+ * container silently shadows the package's deps until it's added.
+ */
+export function remindDevVolumesMount(workspaceRelPath) {
+  log('', 'reset');
+  log('🐳 One manual step for the Docker dev stack:', 'cyan');
+  log(
+    `   Add a mount for ${workspaceRelPath} to docker-compose.dev.yml's x-dev-volumes anchor:`,
+    'reset'
+  );
+  log(`     - /app/${workspaceRelPath}/node_modules`, 'yellow');
+  log(
+    '   (scripts/check-workspace-consistency.mjs / `pnpm check:workspaces` enforces this.)',
+    'reset'
+  );
 }
 
 export { ROOT_DIR };

--- a/scripts/templates/app/common/src/contexts/AuthContext.tsx
+++ b/scripts/templates/app/common/src/contexts/AuthContext.tsx
@@ -51,7 +51,11 @@ export const AuthProvider = ({ children }: AuthProviderProps) => {
   const login = async (credentials: LoginRequest) => {
     try {
       const response = await authService.login(credentials);
-      localStorage.setItem('authToken', response.token);
+      // Post-ADS-919 the token pair rides home as HttpOnly cookies; the
+      // access token is only present in the body for legacy/dev flows.
+      if (response.tokens?.accessToken) {
+        localStorage.setItem('authToken', response.tokens.accessToken);
+      }
       setUser(response.user);
     } catch (error) {
       console.error('Login failed:', error);

--- a/scripts/templates/app/common/tsconfig.json
+++ b/scripts/templates/app/common/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "ignoreDeprecations": "6.0",
     "target": "ES2020",
     "useDefineForClassFields": true,
     "lib": [

--- a/scripts/templates/app/enterprise/src/contexts/FeatureFlagsContext.tsx
+++ b/scripts/templates/app/enterprise/src/contexts/FeatureFlagsContext.tsx
@@ -1,8 +1,10 @@
-import { FeatureFlagsService } from '@adopt-dont-shop/lib.feature-flags';
 import { createContext, useContext, ReactNode, useMemo, useState } from 'react';
 
+// lib.feature-flags is now hook-based (Statsig): use `useFeatureGate`,
+// `useDynamicConfig`, `useConfigValue` directly in components. This context is
+// a minimal scaffold stub for app-wide loading state; wire `isFeatureEnabled`
+// to a real source (or drop it in favour of the hooks) once your gates exist.
 interface FeatureFlagsContextType {
-  featureFlagsService: FeatureFlagsService;
   isFeatureEnabled: (flag: string) => Promise<boolean>;
   isLoading: boolean;
 }
@@ -23,29 +25,21 @@ interface FeatureFlagsProviderProps {
 
 export const FeatureFlagsProvider = ({ children }: FeatureFlagsProviderProps) => {
   const [isLoading] = useState(false);
-  
-  const featureFlagsService = useMemo(() => {
-    return new FeatureFlagsService({
-      apiUrl: import.meta.env.VITE_API_BASE_URL,
-      debug: import.meta.env.NODE_ENV === 'development'
-    });
-  }, []);
 
   const isFeatureEnabled = async (flag: string): Promise<boolean> => {
-    // Simplified implementation - can be enhanced when APIs are finalized
+    // Scaffold stub — replace with a real gate lookup (or the useFeatureGate
+    // hook) once your feature flags are defined.
     console.log(`Feature flag ${flag} checked - defaulting to false`);
     return false;
   };
 
-  const value = useMemo(() => ({
-    featureFlagsService,
-    isFeatureEnabled,
-    isLoading,
-  }), [featureFlagsService, isLoading]);
-
-  return (
-    <FeatureFlagsContext.Provider value={value}>
-      {children}
-    </FeatureFlagsContext.Provider>
+  const value = useMemo(
+    () => ({
+      isFeatureEnabled,
+      isLoading,
+    }),
+    [isLoading]
   );
+
+  return <FeatureFlagsContext.Provider value={value}>{children}</FeatureFlagsContext.Provider>;
 };

--- a/scripts/templates/lib/service/package.json
+++ b/scripts/templates/lib/service/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@adopt-dont-shop/lib-{{LIB_NAME}}",
+  "name": "@adopt-dont-shop/lib.{{LIB_NAME}}",
   "version": "1.0.0",
   "engines": {
     "node": ">=22.0.0"

--- a/scripts/templates/lib/service/tsconfig.json
+++ b/scripts/templates/lib/service/tsconfig.json
@@ -1,34 +1,21 @@
 {
+  "extends": "../../tsconfig.lib.base.json",
   "compilerOptions": {
-    "target": "ES2020",
-    "module": "ESNext",
-    "moduleResolution": "node",
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "jsx": "react-jsx",
+    "types": ["node"],
+    "outDir": "./dist",
+    "rootDir": "./src",
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true,
-    "outDir": "./dist",
-    "rootDir": "./src",
-    "strict": true,
+    "isolatedModules": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,
-    "skipLibCheck": true,
-    "forceConsistentCasingInFileNames": true,
-    "esModuleInterop": true,
-    "allowSyntheticDefaultImports": true,
-    "resolveJsonModule": true,
-    "isolatedModules": true,
-    "noEmit": false,
     "incremental": true,
     "tsBuildInfoFile": "./dist/.tsbuildinfo"
   },
-  "include": [
-    "src/**/*"
-  ],
-  "exclude": [
-    "node_modules",
-    "dist",
-    "**/*.test.ts",
-    "**/*.spec.ts"
-  ]
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.test.tsx", "**/*.spec.ts", "src/test-utils"]
 }

--- a/scripts/templates/lib/utility/package.json
+++ b/scripts/templates/lib/utility/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@adopt-dont-shop/lib-{{LIB_NAME}}",
+  "name": "@adopt-dont-shop/lib.{{LIB_NAME}}",
   "version": "1.0.0",
   "engines": {
     "node": ">=22.0.0"

--- a/scripts/templates/lib/utility/tsconfig.json
+++ b/scripts/templates/lib/utility/tsconfig.json
@@ -1,42 +1,21 @@
 {
+  "extends": "../../tsconfig.lib.base.json",
   "compilerOptions": {
-    "target": "ES2020",
-    "lib": [
-      "DOM",
-      "DOM.Iterable",
-      "ES6"
-    ],
-    "allowJs": false,
-    "module": "ESNext",
-    "moduleResolution": "bundler",
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "jsx": "react-jsx",
+    "types": ["node"],
+    "outDir": "./dist",
+    "rootDir": "./src",
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true,
-    "outDir": "./dist",
-    "rootDir": "./src",
-    "strict": true,
+    "isolatedModules": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,
-    "skipLibCheck": true,
-    "forceConsistentCasingInFileNames": true,
-    "esModuleInterop": true,
-    "allowSyntheticDefaultImports": true,
-    "resolveJsonModule": true,
-    "isolatedModules": true,
-    "noEmit": false,
-    "jsx": "react-jsx",
     "incremental": true,
     "tsBuildInfoFile": "./dist/.tsbuildinfo"
   },
-  "include": [
-    "src/**/*"
-  ],
-  "exclude": [
-    "node_modules",
-    "dist",
-    "**/*.test.ts",
-    "**/*.test.tsx",
-    "**/*.spec.ts"
-  ]
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.test.tsx", "**/*.spec.ts", "src/test-utils"]
 }


### PR DESCRIPTION
## Summary

The `pnpm new-app` / `new-lib` scaffold generators predated the Phase 0 restructure and produced broken output (found while fixing the templates in ADS-980):

- **Output landed at the repo root** — `<root>/app.foo`, `<root>/lib.foo` — instead of `apps/foo` / `packages/lib.foo`.
- **`registerWorkspace()` mutated a `package.json` "workspaces" array** (an npm/yarn concept). This repo uses `pnpm-workspace.yaml`, which has no such field, so registration threw or silently no-op'd.
- The lib template even named packages `@adopt-dont-shop/lib-<name>` (dash) rather than the convention `lib.<name>`.

## Changes

**Generator machinery**
- `create-new-app.js` — output to `apps/<slug>` (slug = the name minus the `app.` prefix, matching `apps/admin`); the package keeps `@adopt-dont-shop/app.<slug>`. Next-steps + registration updated.
- `create-new-lib.js` — output to `packages/lib.<name>`; drop the obsolete `Dockerfile.app` COPY updater (Dockerfile.app uses `turbo prune` now) and the per-lib root-script injection; add `--skip-install` for hermetic testing.
- `lib/template-engine.mjs` — rewrite `registerWorkspace` to be pnpm-workspace-aware: a **no-op** when a parent glob already covers the path (`apps/*`, `packages/*` cover every generated package), else append the glob. New pure `isWorkspaceCovered` helper (tested) and a `remindDevVolumesMount()` note (points at the ADS-987 dev-volumes drift guard). `ROOT_DIR` is overridable via `ADS_GENERATOR_ROOT` so tests can run the real generators into a temp dir.

**Templates** (needed for the generated output to actually build/type-check)
- Name generated libs `@adopt-dont-shop/lib.<name>`.
- Modernise the generated **tsconfigs**: the lib templates now extend the ADS-988 `tsconfig.lib.base.json`, set `types: ["node"]`, and exclude `src/test-utils` (was type-checking `setup-tests.ts` and failing on `global`); the app tsconfig adds `ignoreDeprecations: "6.0"` (matches the real apps; `baseUrl` is deprecated in TS 7.0).
- Two source drifts fixed so generated apps type-check: `AuthContext` used the pre-ADS-919 `response.token` (now `response.tokens?.accessToken`), and the enterprise `FeatureFlagsContext` imported the **removed** `FeatureFlagsService` class — rewritten as a hook-based scaffold stub pointing at the lib's current `useFeatureGate` API.

**Test**
- `scripts/generators.test.mjs` — hermetic smoke tests: run the real generators into a temp root and assert correct placement, package name, and that registration never touches a root `package.json`.

## Test plan

- [x] `pnpm test:scripts` (generators.test.mjs) — 6/6 pass.
- [x] **End-to-end, all templates**: generated all three app templates (minimal/standard/enterprise) into `apps/*` and both lib types (utility/service) into `packages/lib.*`, then `pnpm install` + `pnpm exec turbo type-check --filter` for each → **16/16 tasks pass**. (Then removed the throwaway packages and restored the lockfile.)
- [x] Verified placement: apps land at `apps/<slug>`, libs at `packages/lib.<name>`; nothing created at the repo root.
- [x] Verified `registerWorkspace` is a clean no-op (logs "already covers") and leaves `pnpm-workspace.yaml` byte-identical.
- [x] `node scripts/check-workspace-consistency.mjs` passes.

## Note on scope

Fixing the generators surfaced template-source drift (the auth response shape, the removed feature-flags service class, stale tsconfigs). I fixed the minimum needed for generated output to type-check and flagged the reasoning inline. A deeper template modernization pass (e.g. moving the enterprise `FeatureFlagsContext` to real `useFeatureGate` usage rather than a stub, and the app auth demo off the localStorage-token pattern to ADS-919 cookies) is worth a follow-up but is out of scope here.

## Related

ADS-994. Follows the template-content fixes in ADS-980 (#1234).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015F6J4DXQ1Amyth4dwD5Q8P

---
_Generated by [Claude Code](https://claude.ai/code/session_015F6J4DXQ1Amyth4dwD5Q8P)_