### PR TITLE
fix(security): rate-limit unauthenticated socket.io handshakes at the gateway (ADS-962)

### DIFF
--- a/services/gateway/src/ws/socket-server.test.ts
+++ b/services/gateway/src/ws/socket-server.test.ts
@@ -14,6 +14,7 @@ import type { AuthClient } from '../grpc-clients/auth-client.js';
 import { SocketRegistry } from './socket-registry.js';
 import {
   attachSocketServer,
+  createHandshakeRateLimiter,
   emitToUser,
   type AttachSocketServerOptions,
   type RedisAdapterClient,
@@ -513,5 +514,76 @@ describe('per-user connection cap (ADS-888)', () => {
 
     expect(flood.every(c => c.connected)).toBe(true);
     expect(registry.socketsFor('usr-at-cap')).toHaveLength(10);
+  });
+});
+
+describe('createHandshakeRateLimiter (ADS-962)', () => {
+  it('allows handshakes up to the cap within a window, then rejects', () => {
+    const limiter = createHandshakeRateLimiter({ max: 3, windowMs: 1000, now: () => 0 });
+
+    expect(limiter.tryConsume('1.2.3.4')).toBe(true);
+    expect(limiter.tryConsume('1.2.3.4')).toBe(true);
+    expect(limiter.tryConsume('1.2.3.4')).toBe(true);
+    expect(limiter.tryConsume('1.2.3.4')).toBe(false);
+  });
+
+  it('meters each IP independently', () => {
+    const limiter = createHandshakeRateLimiter({ max: 1, windowMs: 1000, now: () => 0 });
+
+    expect(limiter.tryConsume('1.1.1.1')).toBe(true);
+    expect(limiter.tryConsume('2.2.2.2')).toBe(true);
+    expect(limiter.tryConsume('1.1.1.1')).toBe(false);
+  });
+
+  it('replenishes the allowance once the window rolls over', () => {
+    let clock = 0;
+    const limiter = createHandshakeRateLimiter({ max: 1, windowMs: 1000, now: () => clock });
+
+    expect(limiter.tryConsume('1.2.3.4')).toBe(true);
+    expect(limiter.tryConsume('1.2.3.4')).toBe(false);
+
+    clock = 1000;
+    expect(limiter.tryConsume('1.2.3.4')).toBe(true);
+  });
+});
+
+describe('handshake rate limiting — pre-auth per-IP cap (ADS-962)', () => {
+  it('rejects handshakes from one IP once the per-window cap is exceeded', async () => {
+    const validateMock = vi.fn().mockResolvedValue(VALID_RES);
+    const { url } = await startServer({
+      logger: quietLogger(),
+      authClient: makeAuthClient(validateMock),
+      handshakeRateLimit: { max: 2, windowMs: 60_000 },
+    });
+
+    // All three clients share the loopback source IP, so they draw from the
+    // same bucket. The first two are admitted; the third trips the cap.
+    const first = connectClient(url, { auth: { token: 'good.jwt' } });
+    expect(await awaitConnectOutcome(first)).toBe(true);
+    const second = connectClient(url, { auth: { token: 'good.jwt' } });
+    expect(await awaitConnectOutcome(second)).toBe(true);
+
+    const third = connectClient(url, { auth: { token: 'good.jwt' } });
+    expect(await awaitConnectOutcome(third)).toBe(false);
+  });
+
+  it('runs before token validation — a rate-limited handshake never hits the auth service', async () => {
+    const validateMock = vi.fn().mockResolvedValue(VALID_RES);
+    const { url } = await startServer({
+      logger: quietLogger(),
+      authClient: makeAuthClient(validateMock),
+      handshakeRateLimit: { max: 2, windowMs: 60_000 },
+    });
+
+    const first = connectClient(url, { auth: { token: 'good.jwt' } });
+    expect(await awaitConnectOutcome(first)).toBe(true);
+    const second = connectClient(url, { auth: { token: 'good.jwt' } });
+    expect(await awaitConnectOutcome(second)).toBe(true);
+    const third = connectClient(url, { auth: { token: 'good.jwt' } });
+    expect(await awaitConnectOutcome(third)).toBe(false);
+
+    // The two admitted handshakes each validate their token; the rejected
+    // third is short-circuited by the limiter before the auth round-trip.
+    expect(validateMock).toHaveBeenCalledTimes(2);
   });
 });

--- a/services/gateway/src/ws/socket-server.ts
+++ b/services/gateway/src/ws/socket-server.ts
@@ -43,7 +43,9 @@
 import type { Server as HttpServer } from 'node:http';
 
 import { Metadata } from '@grpc/grpc-js';
+import { getMetricsRegistry } from '@adopt-dont-shop/observability';
 import { createAdapter } from '@socket.io/redis-adapter';
+import { Counter } from 'prom-client';
 import { Server as IOServer, type Socket } from 'socket.io';
 import type { Logger } from 'winston';
 
@@ -66,6 +68,99 @@ type SocketAuthClient = Pick<AuthClient, 'validateToken'>;
 // comment on SocketRegistry for why a cross-replica Redis-backed cap isn't
 // worth the added complexity here.
 const MAX_SOCKETS_PER_USER = 10;
+
+// Pre-auth per-IP handshake rate limit (ADS-962). nginx already caps
+// /socket.io/ handshakes at the edge (deploy/gateway/nginx.conf, `socketio`
+// zone: 2 r/s, burst 10), but the gateway can be reached directly (internal
+// LB, a debug run without nginx), so this is defence-in-depth — the same
+// posture as the origin allowlist and per-user cap in this file. It runs
+// BEFORE the origin and auth checks so an unauthenticated flood is dropped
+// before it costs a gRPC ValidateToken round-trip. Fixed window, in process
+// (per replica) — consistent with the per-user cap's per-replica philosophy;
+// nginx is the cross-instance layer. 30 per 10 s mirrors nginx's effective
+// ceiling (2 r/s + burst 10) while leaving generous headroom for legitimate
+// reconnect storms (multiple tabs re-handshaking after a network blip).
+const MAX_HANDSHAKES_PER_WINDOW = 30;
+const HANDSHAKE_WINDOW_MS = 10_000;
+
+// Trip counter for the handshake rate limit, mirroring the sibling limiters'
+// trip counters in server.ts (login, invitation-accept). Lazily created and
+// registry-change-aware so repeated attachSocketServer/createServer calls in
+// Vitest suites don't throw "metric already registered".
+let _handshakeRejectEntry: { registryRef: object; counter: Counter } | null = null;
+
+const getOrCreateHandshakeRejectCounter = (): Counter => {
+  const reg = getMetricsRegistry();
+  if (_handshakeRejectEntry && _handshakeRejectEntry.registryRef === reg) {
+    return _handshakeRejectEntry.counter;
+  }
+  const counter = new Counter({
+    name: 'gateway_ws_handshake_ratelimit_rejects_total',
+    help: 'Total Socket.IO handshakes rejected by the per-IP pre-auth rate limit (ADS-962).',
+    registers: [reg],
+  });
+  _handshakeRejectEntry = { registryRef: reg, counter };
+  return counter;
+};
+
+export type HandshakeRateLimiter = { tryConsume: (ip: string) => boolean };
+
+// Fixed-window per-IP handshake limiter (ADS-962). Pure and in-process; one
+// instance lives per attachSocketServer call so there's no cross-replica or
+// cross-test shared state. `now` is injectable for deterministic tests.
+// Returns false once an IP has exhausted its allowance for the current window.
+export const createHandshakeRateLimiter = (opts: {
+  max: number;
+  windowMs: number;
+  now?: () => number;
+}): HandshakeRateLimiter => {
+  const { max, windowMs, now = Date.now } = opts;
+  const buckets = new Map<string, { count: number; resetAt: number }>();
+
+  const tryConsume = (ip: string): boolean => {
+    const t = now();
+    const bucket = buckets.get(ip);
+    if (!bucket || t >= bucket.resetAt) {
+      // Opportunistic sweep keeps the map bounded by the IPs active within a
+      // window, not all-time. A completed TCP+WS handshake means a real source
+      // IP, so the working set is small — this is a safety net, not hot path.
+      if (buckets.size > 10_000) {
+        for (const [key, b] of buckets) {
+          if (t >= b.resetAt) {
+            buckets.delete(key);
+          }
+        }
+      }
+      buckets.set(ip, { count: 1, resetAt: t + windowMs });
+      return true;
+    }
+    if (bucket.count >= max) {
+      return false;
+    }
+    bucket.count += 1;
+    return true;
+  };
+
+  return { tryConsume };
+};
+
+// The client IP for handshake rate-limit keying. nginx overwrites
+// X-Forwarded-For with the real connecting IP ($remote_addr, ADS-915), so
+// when the header is present the RIGHTMOST entry is the trustworthy hop —
+// mirroring the HTTP path's trustProxy:1. A client-prepended XFF is discarded
+// by nginx, and taking the rightmost entry also resists spoofing on a
+// direct-to-gateway path. Falls back to the raw socket address when there's
+// no proxy header (a direct connection).
+const handshakeClientIp = (socket: Socket): string => {
+  const xff = socket.handshake.headers['x-forwarded-for'];
+  if (typeof xff === 'string' && xff.length > 0) {
+    const last = xff.split(',').pop()?.trim();
+    if (last) {
+      return last;
+    }
+  }
+  return socket.handshake.address;
+};
 
 // The slim Redis pub/sub surface the @socket.io/redis-adapter broadcast path
 // uses. Parameters are intentionally widened (ioredis' publish/subscribe carry
@@ -105,6 +200,10 @@ export type AttachSocketServerOptions = {
   // replica that user is connected to. When omitted (single-replica dev /
   // tests) the server runs with the default in-process adapter.
   redisAdapter?: { pubClient: RedisAdapterClient; subClient: RedisAdapterClient };
+  // Pre-auth handshake rate-limit tuning (ADS-962). Defaults to the module
+  // constants; overridden in tests to exercise the rejection path without a
+  // real flood. A per-IP fixed-window cap — see MAX_HANDSHAKES_PER_WINDOW.
+  handshakeRateLimit?: { max: number; windowMs: number };
 };
 
 export const attachSocketServer = (opts: AttachSocketServerOptions): IOServer => {
@@ -146,6 +245,32 @@ export const attachSocketServer = (opts: AttachSocketServerOptions): IOServer =>
   if (opts.redisAdapter) {
     io.adapter(createAdapter(opts.redisAdapter.pubClient, opts.redisAdapter.subClient));
   }
+
+  // Pre-auth per-IP handshake rate limit (ADS-962). Runs as the FIRST
+  // handshake middleware — before the origin allowlist and token validation —
+  // so a flood is rejected before it costs a gRPC ValidateToken round-trip.
+  // State is scoped to this attachSocketServer call (fresh per replica / per
+  // test), never module-global.
+  const { max: handshakeMax, windowMs: handshakeWindowMs } = opts.handshakeRateLimit ?? {
+    max: MAX_HANDSHAKES_PER_WINDOW,
+    windowMs: HANDSHAKE_WINDOW_MS,
+  };
+  const handshakeLimiter = createHandshakeRateLimiter({
+    max: handshakeMax,
+    windowMs: handshakeWindowMs,
+  });
+  const handshakeRejectsTotal = getOrCreateHandshakeRejectCounter();
+
+  io.use((socket, next) => {
+    const ip = handshakeClientIp(socket);
+    if (!handshakeLimiter.tryConsume(ip)) {
+      handshakeRejectsTotal.inc();
+      logger.warn('socket handshake rate limit exceeded', { ip });
+      next(new Error('rate limit exceeded'));
+      return;
+    }
+    next();
+  });
 
   io.use((socket, next) => {
     // Origin allowlist (ADS-843). A browser always sends an Origin on the WS


### PR DESCRIPTION
## Summary

- Adds a **pre-auth, per-IP fixed-window rate limiter** as the first Socket.IO handshake middleware in the gateway, so an unauthenticated handshake flood is dropped **before** it costs a gRPC `ValidateToken` round-trip.
- Completes the gateway half of ADS-962 — the nginx edge half (`socketio` `limit_req` zone) landed earlier in `deploy/gateway/nginx.conf`.

## Changes

- `services/gateway/src/ws/socket-server.ts`
  - New exported pure `createHandshakeRateLimiter({ max, windowMs, now? })` — in-process fixed-window counter, one instance per `attachSocketServer` call (no module-global / cross-test state).
  - New first `io.use()` middleware that keys on the client IP and rejects with `rate limit exceeded` once the per-IP window cap is hit. Runs **before** the origin allowlist and token validation.
  - IP keying uses the **rightmost** `X-Forwarded-For` entry (nginx overwrites XFF with the real connecting IP per ADS-915), mirroring the HTTP path's `trustProxy: 1`, falling back to `socket.handshake.address` on a direct connection.
  - `gateway_ws_handshake_ratelimit_rejects_total` Prometheus counter, following the same lazily-created / registry-change-aware singleton pattern as the sibling limiters' trip counters in `server.ts`.
  - Optional `handshakeRateLimit?: { max, windowMs }` on `AttachSocketServerOptions` (defaults to the module constants `30 / 10s`) — a tuning/test seam, same idiom as the file's existing `allowUnauthenticated` / `redisAdapter` options.
- `services/gateway/src/ws/socket-server.test.ts` — TDD coverage.

### Design note

Consistent with this module's stated per-replica philosophy (see the per-user cap comment), the limiter is **in-process**, not Redis-backed. nginx remains the cross-instance layer; this is defence-in-depth for direct-to-gateway paths (internal LB, debug runs without nginx) — the same posture as the existing origin allowlist and per-user connection cap. The `30 / 10s` default mirrors nginx's effective ceiling (2 r/s + burst 10) with headroom for legitimate reconnect storms.

## Before requesting review

- [x] Tests for new behaviour added (TDD)
- [ ] If touching `.env` requirements, updated `.env.example`'s REQUIRED block — n/a
- [x] If touching a `lib.*`, considered consumer impact — n/a (gateway service only)

## Test plan

- [x] Existing tests pass (`pnpm exec turbo test --filter=@adopt-dont-shop/service.gateway` — 1051 passed)
- [x] New behaviour is covered by tests (5 new tests: limiter counting/window/per-IP isolation; over-cap handshake rejected; limiter runs before token validation)
- [x] No TypeScript errors (`type-check` clean)
- [x] Lint passes (`lint` clean)

## Related

- Linear: ADS-962
- Builds on the nginx `socketio` `limit_req` zone (edge half) and the existing gateway handshake defences (ADS-843 origin allowlist, ADS-888 per-user cap, ADS-887 buffer cap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015F6J4DXQ1Amyth4dwD5Q8P)_