### PR TITLE
docs(readmes): backfill undocumented workspaces + enforce README template on strict set (ADS-946)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,6 +94,13 @@ jobs:
       - name: Verify docs reference only real pnpm scripts
         run: node scripts/check-docs-script-references.mjs
 
+      # ADS-946: workspace READMEs must carry the canonical template sections
+      # (docs/templates/README.{app,service,lib}.md). Warn-only for packages
+      # not yet backfilled; a hard failure for those in the guard's
+      # STRICT_PACKAGES set, so an enforced README can't regress.
+      - name: Verify workspace READMEs match the template
+        run: node scripts/check-readmes.mjs
+
   # ============================================================================
   # CHANGE DETECTION — gate all downstream jobs on relevant path changes
   # ============================================================================

--- a/apps/client/README.md
+++ b/apps/client/README.md
@@ -1,10 +1,19 @@
 # @adopt-dont-shop/app.client
 
-Public adoption portal for pet adopters.
+## Purpose
 
-See the full product spec: [docs/frontend/app-client-prd.md](../../docs/frontend/app-client-prd.md).
+The public adoption portal — where adopters browse pets, submit adoption
+applications, and chat with rescues. The unauthenticated entry point to the
+platform.
 
-## Quick Start
+## Location in the architecture
+
+Full product spec: [docs/frontend/app-client-prd.md](../../docs/frontend/app-client-prd.md).
+Shares the app-shell pattern (routing, state, styling) described in
+[docs/frontend/technical-architecture.md](../../docs/frontend/technical-architecture.md)
+with `app.admin` and `app.rescue`. Talks to the backend exclusively through
+`service.gateway` (port 4000) — see the root
+[README Access table](../../README.md#access) for local URLs.
 
 From the repo root:
 
@@ -28,3 +37,25 @@ Or from this directory: `pnpm dev` — Vite serves on http://localhost:3000.
 - `pnpm test` — Vitest (run mode)
 - `pnpm lint` / `lint:fix` — ESLint
 - `pnpm type-check` — TypeScript type check
+
+## Public surface
+
+Route tree lives under `src/pages/` (pet browse/detail, application flow,
+chat, account). See `src/App.tsx` for the router configuration.
+
+## Environment variables consumed
+
+Shares the common frontend vars (`VITE_API_BASE_URL`, `VITE_WS_BASE_URL`)
+documented in [docs/env-reference.md](../../docs/env-reference.md) — this
+app defines no vars of its own beyond those.
+
+## Testing notes
+
+Vitest + React Testing Library, jsdom environment (repo-wide convention —
+see [CONTRIBUTING.md](../../CONTRIBUTING.md#test-dom-environment)). Tests
+are co-located next to source (`Component.tsx` + `Component.test.tsx`).
+
+## Ownership
+
+See [.github/CODEOWNERS](../../.github/CODEOWNERS) for the current owner
+of `/apps/`.

--- a/apps/rescue/README.md
+++ b/apps/rescue/README.md
@@ -1,19 +1,20 @@
 # @adopt-dont-shop/app.rescue
 
-Rescue organization portal for the Adopt Don't Shop platform.
+## Purpose
 
-See the full product spec: [docs/frontend/app-rescue-prd.md](../../docs/frontend/app-rescue-prd.md).
+The rescue organization portal — where rescue staff manage their pet
+listings, review and progress adoption applications, coordinate foster
+placements, and chat with adopters.
 
-## Stack
+## Location in the architecture
 
-- React 19 + TypeScript (strict)
-- Vite
-- vanilla-extract for styling (`*.css.ts` files)
-- Vitest + React Testing Library
-- ESLint + Prettier
-- Docker (multi-stage build for dev and prod)
-
-## Quick Start
+Full product spec: [docs/frontend/app-rescue-prd.md](../../docs/frontend/app-rescue-prd.md).
+Shares the app-shell pattern (routing, state, styling) described in
+[docs/frontend/technical-architecture.md](../../docs/frontend/technical-architecture.md)
+with `app.admin` and `app.client`. Built on React 19 + TypeScript (strict),
+Vite, and vanilla-extract styling (`*.css.ts`). Talks to the backend
+exclusively through `service.gateway` (port 4000) — see the root
+[README Access table](../../README.md#access) for local URLs.
 
 From the repo root:
 
@@ -28,7 +29,10 @@ pnpm dev:apps
 pnpm exec turbo dev --filter=@adopt-dont-shop/app.rescue
 ```
 
-Or from this directory: `pnpm dev` — Vite serves on http://localhost:3000 (container internal port; Docker maps it to 3002 externally).
+Or from this directory: `pnpm dev` — Vite serves on http://localhost:3000
+(container internal port; Docker maps it to 3002 externally). The root
+`docker-compose.yml` wires this app up automatically — no per-app commands
+needed.
 
 ## Scripts
 
@@ -41,22 +45,25 @@ Or from this directory: `pnpm dev` — Vite serves on http://localhost:3000 (con
 - `pnpm lint` / `lint:fix` — ESLint
 - `pnpm type-check` — TypeScript type check
 
-## Project Structure
+## Public surface
 
-```
-src/
-├── components/     Reusable UI components
-├── contexts/       React contexts (Chat, Statsig)
-├── pages/          Route-level components
-├── hooks/          Custom React hooks
-├── services/       API clients and external services
-├── utils/          Utility helpers
-├── types/          TypeScript type definitions
-├── App.tsx         Main App component
-├── main.tsx        Application entry point
-└── index.css       Global styles
-```
+Route tree lives under `src/pages/` (pet management, applications, foster,
+chat, settings), with `src/contexts/` holding the Chat and Statsig providers.
+See `src/App.tsx` for the router configuration.
 
-## Docker
+## Environment variables consumed
 
-The root `docker-compose.yml` wires this app up automatically — no per-app commands needed. The app container exposes port 3000 internally and is mapped to 3002 on the host.
+Shares the common frontend vars (`VITE_API_BASE_URL`, `VITE_WS_BASE_URL`)
+documented in [docs/env-reference.md](../../docs/env-reference.md) — this
+app defines no vars of its own beyond those.
+
+## Testing notes
+
+Vitest + React Testing Library, jsdom environment (repo-wide convention —
+see [CONTRIBUTING.md](../../CONTRIBUTING.md#test-dom-environment)). Tests
+are co-located next to source (`Component.tsx` + `Component.test.tsx`).
+
+## Ownership
+
+See [.github/CODEOWNERS](../../.github/CODEOWNERS) for the current owner
+of `/apps/`.

--- a/packages/config-secrets/README.md
+++ b/packages/config-secrets/README.md
@@ -1,0 +1,63 @@
+# @adopt-dont-shop/config-secrets
+
+## Purpose
+
+Boot-time secret loader shared by the backend microservices. It reads a
+credential from a file-mounted Docker secret (`NAME_FILE` pointing at a file
+whose contents are the value) when present, and otherwise falls back to a
+plain environment variable (`NAME`). This mirrors the `readSecretOrEnv()`
+helper the deleted `service.backend` monolith used, so any extracted service
+can opt onto file-mounted secrets without changing its config contract.
+
+This is a service-only shared package (not a `lib.*`) — it is imported by
+`services/*` config loaders, never by the React apps. See the decision tree
+in [`CONTRIBUTING.md`](../../CONTRIBUTING.md#where-does-my-code-go).
+
+## Location in the architecture
+
+Sits below every service's `config.ts` in the boot path — see
+[`docs/README.md`](../../docs/README.md#libraries) for where the shared
+backend packages fit relative to the services that consume them. Pairs with
+[`@adopt-dont-shop/observability`](../observability/README.md) and
+[`@adopt-dont-shop/service-bootstrap`](../service-bootstrap/README.md) as the
+common boot substrate.
+
+## Scripts
+
+```bash
+pnpm build        # tsc build
+pnpm dev          # tsc --watch
+pnpm test         # Vitest (run mode)
+pnpm lint         # ESLint
+pnpm type-check   # TypeScript type-check
+```
+
+## Public API / exports
+
+The canonical list lives in [`src/index.ts`](src/index.ts):
+
+- `readSecret(name)` — value from `NAME_FILE` (file contents) or `NAME`, or
+  `undefined`.
+- `requireSecret(name)` — same, but throws when neither source is set.
+- `requireHexSecret(name)` — `requireSecret` plus a hex-format assertion (for
+  signing keys).
+- `parsePort(raw, fallback, name)` — validated numeric-port parse.
+
+## Environment variables consumed
+
+This package does not read fixed env var names of its own — it resolves
+whatever `NAME` / `NAME_FILE` pair a caller asks for. The full list of the
+secrets services request through it lives in
+[`docs/env-reference.md`](../../docs/env-reference.md).
+
+## Testing notes
+
+Behaviour is covered in [`src/index.test.ts`](src/index.test.ts) against
+temp files for the `_FILE` path. Nothing service-specific — see
+[`docs/backend/testing.md`](../../docs/backend/testing.md) for shared
+conventions.
+
+## Ownership
+
+See [`.github/CODEOWNERS`](../../.github/CODEOWNERS) for the current owner of
+`/packages/`.

--- a/packages/eslint-config-base/README.md
+++ b/packages/eslint-config-base/README.md
@@ -1,0 +1,54 @@
+# @adopt-dont-shop/eslint-config-base
+
+## Purpose
+
+The shared base ESLint flat config for TypeScript packages in the monorepo:
+`typescript-eslint` recommended rules plus Prettier integration
+(`eslint-plugin-prettier` + `eslint-config-prettier`). The Node and React
+config packages extend this one, so a rule change here propagates everywhere.
+
+This is a service-only shared tooling package (not a `lib.*`) — it ships
+config, not runtime code. See the decision tree in
+[`CONTRIBUTING.md`](../../CONTRIBUTING.md#where-does-my-code-go).
+
+## Location in the architecture
+
+The root of the lint-config hierarchy —
+[`@adopt-dont-shop/eslint-config-node`](../eslint-config-node/README.md) and
+[`@adopt-dont-shop/eslint-config-react`](../eslint-config-react/README.md)
+both spread this config first. Consumed by each workspace's `eslint.config.js`.
+See [`docs/README.md`](../../docs/README.md#libraries) for where the shared
+packages sit.
+
+## Scripts
+
+None — this is a config-only package with no build, test, or dev step. It is
+consumed directly as a flat-config module. Lint the whole workspace from the
+repo root with `pnpm lint`.
+
+## Public API / exports
+
+Default export ([`index.js`](index.js)): a `typescript-eslint` flat-config
+array. Consume it in a workspace `eslint.config.js`:
+
+```js
+import base from '@adopt-dont-shop/eslint-config-base';
+export default [...base /* , local overrides */];
+```
+
+`eslint`, `typescript-eslint`, `eslint-config-prettier`, and
+`eslint-plugin-prettier` are peer dependencies.
+
+## Environment variables consumed
+
+None.
+
+## Testing notes
+
+No test suite — the config is exercised by every package's `pnpm lint` run in
+CI (`quality.yml`). A rule change is validated by linting the whole workspace.
+
+## Ownership
+
+See [`.github/CODEOWNERS`](../../.github/CODEOWNERS) for the current owner of
+`/packages/`.

--- a/packages/eslint-config-node/README.md
+++ b/packages/eslint-config-node/README.md
@@ -1,0 +1,54 @@
+# @adopt-dont-shop/eslint-config-node
+
+## Purpose
+
+The shared ESLint flat config for the Node.js backend services. Extends
+[`@adopt-dont-shop/eslint-config-base`](../eslint-config-base/README.md) and
+layers on backend-stricter rules (`no-console: error`,
+`no-process-exit: error`), with a more lenient block for test files.
+
+This is a service-only shared tooling package (not a `lib.*`) — it ships
+config, not runtime code. See the decision tree in
+[`CONTRIBUTING.md`](../../CONTRIBUTING.md#where-does-my-code-go).
+
+## Location in the architecture
+
+Consumed by each `services/*` workspace's `eslint.config.js`. Builds on the
+base config — see
+[`@adopt-dont-shop/eslint-config-base`](../eslint-config-base/README.md) — and
+sits alongside
+[`@adopt-dont-shop/eslint-config-react`](../eslint-config-react/README.md) for
+the frontend. See [`docs/README.md`](../../docs/README.md#libraries) for where
+the shared packages sit.
+
+## Scripts
+
+None — config-only package with no build, test, or dev step. Lint the
+workspace from the repo root with `pnpm lint`.
+
+## Public API / exports
+
+Default export ([`index.js`](index.js)): the base flat-config array plus the
+backend rule overrides. Consume it in a service's `eslint.config.js`:
+
+```js
+import node from '@adopt-dont-shop/eslint-config-node';
+export default [...node /* , local overrides */];
+```
+
+Peer dependencies match the base config (`eslint`, `typescript-eslint`,
+`eslint-config-prettier`, `eslint-plugin-prettier`).
+
+## Environment variables consumed
+
+None.
+
+## Testing notes
+
+No test suite — validated by every service's `pnpm lint` run in CI
+(`quality.yml`).
+
+## Ownership
+
+See [`.github/CODEOWNERS`](../../.github/CODEOWNERS) for the current owner of
+`/packages/`.

--- a/packages/eslint-config-react/README.md
+++ b/packages/eslint-config-react/README.md
@@ -1,0 +1,56 @@
+# @adopt-dont-shop/eslint-config-react
+
+## Purpose
+
+The shared ESLint flat config for the React applications. Extends
+[`@adopt-dont-shop/eslint-config-base`](../eslint-config-base/README.md) and
+layers on the React plugins (`eslint-plugin-react`, `react-hooks`,
+`react-refresh`) with the flat `react.recommended` ruleset.
+
+This is a service-only shared tooling package (not a `lib.*`) — it ships
+config, not runtime code. See the decision tree in
+[`CONTRIBUTING.md`](../../CONTRIBUTING.md#where-does-my-code-go).
+
+## Location in the architecture
+
+Consumed by each `apps/*` workspace's `eslint.config.js`. Builds on the base
+config — see
+[`@adopt-dont-shop/eslint-config-base`](../eslint-config-base/README.md) — and
+is the frontend counterpart to
+[`@adopt-dont-shop/eslint-config-node`](../eslint-config-node/README.md). See
+[`docs/README.md`](../../docs/README.md#libraries) for where the shared
+packages sit.
+
+## Scripts
+
+None — config-only package with no build, test, or dev step. Lint the
+workspace from the repo root with `pnpm lint`.
+
+## Public API / exports
+
+Default export ([`index.js`](index.js)): the base flat-config array plus the
+React plugin config. Consume it in an app's `eslint.config.js`:
+
+```js
+import react from '@adopt-dont-shop/eslint-config-react';
+export default [...react /* , local overrides */];
+```
+
+React version detection is pinned rather than `'detect'` — see the comment in
+[`index.js`](index.js) for the `eslint-plugin-react` / ESLint 10 compatibility
+reason. `eslint-plugin-react`, `eslint-plugin-react-hooks`, and
+`eslint-plugin-react-refresh` are peer dependencies on top of the base set.
+
+## Environment variables consumed
+
+None.
+
+## Testing notes
+
+No test suite — validated by every app's `pnpm lint` run in CI
+(`quality.yml`).
+
+## Ownership
+
+See [`.github/CODEOWNERS`](../../.github/CODEOWNERS) for the current owner of
+`/packages/`.

--- a/packages/seed-faker/README.md
+++ b/packages/seed-faker/README.md
@@ -1,0 +1,62 @@
+# @adopt-dont-shop/seed-faker
+
+## Purpose
+
+Dev-only bulk-data ("spam") seeding toolkit: an env guard, a seeded UK-locale
+Faker, and a batched bulk-insert helper. Shared by each service's `db:spam`
+script to flood a development database with prod-shaped volume. It is **never**
+imported by runtime code — it exists purely for local load/shape testing.
+
+This is a service-only shared package (not a `lib.*`). See the decision tree
+in [`CONTRIBUTING.md`](../../CONTRIBUTING.md#where-does-my-code-go).
+
+## Location in the architecture
+
+Consumed only by the `db:spam` scripts in `services/*` that own a schema — see
+[`docs/README.md`](../../docs/README.md#libraries) for where the shared
+packages sit. Pairs with [`@adopt-dont-shop/db`](../db/README.md) (the
+Postgres client the bulk inserts run through).
+
+## Scripts
+
+```bash
+pnpm build        # tsc build
+pnpm dev          # tsc --watch
+pnpm test         # Vitest (run mode)
+pnpm lint         # ESLint
+pnpm type-check   # TypeScript type-check
+```
+
+## Public API / exports
+
+The canonical list lives in [`src/index.ts`](src/index.ts):
+
+- `assertSpamAllowed()` — throws unless the spam env guard is satisfied (see
+  below), so `db:spam` can never run against a non-dev database.
+- `createSpamFaker()` / `DEFAULT_FAKER_SEED` — a UK-locale Faker seeded for
+  reproducible runs.
+- `bulkInsert(...)` (`BulkInsertDeps`, `QueryFn`) — batched multi-row insert.
+- `spamCount()` — resolves how many rows to generate.
+
+## Environment variables consumed
+
+| Variable | Purpose | Required |
+| --- | --- | --- |
+| `ALLOW_SPAM` | Must be truthy for `assertSpamAllowed()` to pass — the safety interlock. | Yes (to run `db:spam`) |
+| `NODE_ENV` | Guard refuses to run under `production`. | — |
+| `FAKER_SEED` | Overrides `DEFAULT_FAKER_SEED` for reproducible data. | No |
+| `SPAM_PETS` | Row-count override read by `spamCount()`. | No |
+
+See [`docs/env-reference.md`](../../docs/env-reference.md) for the full list.
+
+## Testing notes
+
+Each unit has a sibling `*.test.ts` (env-guard, faker-rng, bulk-insert,
+counts). The env guard is the security-relevant path — its tests assert it
+fails closed. See [`docs/backend/testing.md`](../../docs/backend/testing.md)
+for shared conventions.
+
+## Ownership
+
+See [`.github/CODEOWNERS`](../../.github/CODEOWNERS) for the current owner of
+`/packages/`.

--- a/packages/service-bootstrap/README.md
+++ b/packages/service-bootstrap/README.md
@@ -1,0 +1,67 @@
+# @adopt-dont-shop/service-bootstrap
+
+## Purpose
+
+Shared boot mechanics for the gRPC microservices — a Fastify health server,
+a gRPC bind/shutdown wrapper, the gRPC adapter (`adapt` / `adaptUnauth`), a
+principal extractor + signer, `HandlerError`, and a shutdown sequencer.
+Extracted from the ~200 lines of near-identical boot code that all ten
+services were copy-pasting, so a new service stands up its servers and its
+graceful-shutdown path with one call.
+
+This is a service-only shared package (not a `lib.*`) — imported by
+`services/*` entry points only. See the decision tree in
+[`CONTRIBUTING.md`](../../CONTRIBUTING.md#where-does-my-code-go).
+
+## Location in the architecture
+
+The common entry-point substrate every extracted service boots through — see
+[`docs/infrastructure/MICROSERVICES-STANDARDS.md`](../../docs/infrastructure/MICROSERVICES-STANDARDS.md)
+for the service boundary/ownership model and
+[`docs/README.md`](../../docs/README.md#libraries) for where the shared
+backend packages sit. Pairs with
+[`@adopt-dont-shop/config-secrets`](../config-secrets/README.md) and
+[`@adopt-dont-shop/observability`](../observability/README.md).
+
+## Scripts
+
+```bash
+pnpm build        # tsc build
+pnpm dev          # tsc --watch
+pnpm test         # Vitest (run mode)
+pnpm lint         # ESLint
+pnpm type-check   # TypeScript type-check
+```
+
+## Public API / exports
+
+The canonical list lives in [`src/index.ts`](src/index.ts):
+
+- `createMicroserviceServer(...)` — Fastify health server (`/health/simple`).
+- `startGrpcServer(...)` — bind + graceful-close a gRPC server.
+- `adapt` / `adaptUnauth` / `HandlerError` — the gRPC handler adapter that
+  maps thrown errors to gRPC status codes (unauth variant skips the principal
+  check).
+- Principal extraction + signing helpers (`PrincipalVerification`,
+  `PrincipalSigning`).
+- `runServiceShutdown(...)` — ordered shutdown sequencer (`ShutdownDeps`).
+
+## Environment variables consumed
+
+This package takes config via function arguments rather than reading env vars
+directly; callers pass in the values their own `config.ts` resolved (e.g.
+`PRINCIPAL_SIGNING_KEY`). See
+[`docs/env-reference.md`](../../docs/env-reference.md) for the shared list.
+
+## Testing notes
+
+Each unit is covered by a sibling `*.test.ts` (adapter, principal, server,
+shutdown). Downstream services stub the gRPC transport with
+[`@adopt-dont-shop/test-utils`](../test-utils/README.md). See
+[`docs/backend/testing.md`](../../docs/backend/testing.md) for shared
+conventions.
+
+## Ownership
+
+See [`.github/CODEOWNERS`](../../.github/CODEOWNERS) for the current owner of
+`/packages/`.

--- a/packages/test-utils/README.md
+++ b/packages/test-utils/README.md
@@ -1,0 +1,56 @@
+# @adopt-dont-shop/test-utils
+
+## Purpose
+
+Shared test utilities for the gRPC microservices: a stub gRPC server harness,
+principal/metadata builders, and NATS/JetStream test doubles. Dev-only — it
+is a `devDependency` of the services and is never bundled into a service
+image.
+
+This is a service-only shared package (not a `lib.*`). See the decision tree
+in [`CONTRIBUTING.md`](../../CONTRIBUTING.md#where-does-my-code-go).
+
+## Location in the architecture
+
+Test-time only — consumed by `services/*` Vitest suites, alongside
+[`@adopt-dont-shop/service-bootstrap`](../service-bootstrap/README.md) (whose
+gRPC adapter and principal helpers these doubles exercise). See
+[`docs/README.md`](../../docs/README.md#libraries) for where the shared
+packages sit.
+
+## Scripts
+
+```bash
+pnpm test         # Vitest (run mode)
+pnpm lint         # ESLint
+pnpm type-check   # TypeScript type-check
+```
+
+This package ships its `src/` directly (no build step) — consumers import it
+over the workspace alias.
+
+## Public API / exports
+
+The canonical list lives in [`src/index.ts`](src/index.ts):
+
+- `startStubGrpcServer(...)` → `StubGrpcServer` — stand up an in-process gRPC
+  server backed by handler stubs.
+- `testPrincipal(overrides)` / `metadataFor(...)` — build a principal and the
+  gRPC metadata a handler expects.
+- `makeNatsDouble()` → `NatsDouble` — an in-memory NATS/JetStream double that
+  records `NatsPublishCall`s.
+
+## Environment variables consumed
+
+None — the harness is configured entirely through function arguments.
+
+## Testing notes
+
+The utilities are themselves covered by sibling `*.test.ts` files. See
+[`docs/backend/testing.md`](../../docs/backend/testing.md) for how services
+wire these doubles into their suites.
+
+## Ownership
+
+See [`.github/CODEOWNERS`](../../.github/CODEOWNERS) for the current owner of
+`/packages/`.

--- a/scripts/check-readmes.mjs
+++ b/scripts/check-readmes.mjs
@@ -6,10 +6,12 @@
  * canonical section headings defined in docs/templates/README.{app,service,lib}.md
  * and reports which are missing.
  *
- * Informational / warn-only: always exits 0. The intent (per ADS-946) is
- * to surface drift without blocking existing packages that haven't been
- * backfilled yet — flip a package to strict enforcement by adding it to
- * STRICT_PACKAGES below once its README has been brought up to the template.
+ * Mixed mode (per ADS-946): a workspace listed in STRICT_PACKAGES is a hard
+ * failure (exit 1) if its README drifts from the template; every other
+ * workspace is warn-only so existing packages that haven't been backfilled
+ * yet don't block CI. Bring a README up to the template, then add its dir to
+ * STRICT_PACKAGES to enforce it going forward. This guard runs in CI's
+ * workspace-drift job, so a strict regression fails the build.
  *
  * Mirrors the no-dependency single-file style of scripts/check-*.mjs.
  */
@@ -36,10 +38,24 @@ const FAMILY_HEADINGS = {
   packages: [...SHARED_HEADINGS, '## Public API / exports'],
 };
 
-// Packages that have been backfilled to the template and should be treated
-// as a hard failure (not just a warning) if they regress. Empty today —
-// ADS-946 ships the template + guard; enforcement is opt-in per package.
-const STRICT_PACKAGES = [];
+// Workspaces backfilled to the template and enforced as a hard failure if
+// they regress. Enforcement is opt-in per package (see the module comment):
+// this first strict set is the three React apps plus the previously
+// undocumented shared packages. The remaining services + libs stay warn-only
+// until their (substantial, hand-written) READMEs are restructured to the
+// canonical headings in follow-ups.
+const STRICT_PACKAGES = [
+  'apps/admin',
+  'apps/client',
+  'apps/rescue',
+  'packages/config-secrets',
+  'packages/eslint-config-base',
+  'packages/eslint-config-node',
+  'packages/eslint-config-react',
+  'packages/seed-faker',
+  'packages/service-bootstrap',
+  'packages/test-utils',
+];
 
 function listPackageDirs(family) {
   const familyDir = join(ROOT, family);


### PR DESCRIPTION
## Summary

- Backfills the workspaces furthest from the canonical README template and flips `check:readmes` from purely warn-only to **enforcing a first strict set**, so drift in an enforced README now fails CI.
- Completes the remaining half of ADS-946 (the template + warn-only guard already shipped) using the guard's own intended opt-in path, without destroying the substantial hand-written READMEs the services/libs already have.

## Changes

- **7 new READMEs** for previously-undocumented shared packages — `config-secrets`, `eslint-config-base`, `eslint-config-node`, `eslint-config-react`, `seed-faker`, `service-bootstrap`, `test-utils` — each written from real `package.json` metadata, `src/index.ts` exports, and env usage.
- **Restructured `apps/client` and `apps/rescue`** to the canonical section headings, preserving their existing content (`apps/admin` was already compliant and served as the exemplar).
- **`scripts/check-readmes.mjs`**: populated `STRICT_PACKAGES` with the 3 apps + 7 backfilled packages (hard failure on drift); updated the module comment to describe the mixed warn/strict mode.
- **`.github/workflows/ci.yml`**: added `node scripts/check-readmes.mjs` to the `workspace-drift` job, alongside the sibling drift guards, so a strict regression fails the build.

### Scope note

The ~13 services and ~26 content-bearing `lib.*` packages stay **warn-only** for incremental follow-up. Their READMEs are 60–350 lines of genuine, accurate documentation that simply use non-canonical heading names — restructuring them is per-file editorial work, not a wholesale rewrite (which would discard real docs and violate the repo's surgical-change guideline). The guard was explicitly designed for this per-package opt-in, and its warning output continues to track the remaining set.

## Before requesting review

- [x] Tests for new behaviour added (TDD) — n/a; verified the guard's fail-on-drift path exits 1 when a strict README drops a heading, and exits 0 on the committed tree
- [x] If touching `.env` requirements, updated `.env.example`'s REQUIRED block — n/a
- [x] If touching a `lib.*`, considered consumer impact — n/a (docs + tooling only)

## Test plan

- [x] `node scripts/check-readmes.mjs` exits 0 on the committed tree (0 strict failures, 40 warnings for the not-yet-backfilled set)
- [x] Proved fail-on-drift: dropping `## Ownership` from a strict README makes the guard exit 1
- [x] `ci.yml` validated as well-formed YAML
- [x] Lint/format pass (prettier ran via lint-staged on the new markdown)

## Related

- Linear: ADS-946
- Builds on the template + warn-only guard (`docs/templates/README.{app,service,lib}.md`, `scripts/check-readmes.mjs`) shipped earlier for ADS-946.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015F6J4DXQ1Amyth4dwD5Q8P)_