### PR TITLE
fix(deps): override fast-uri and @opentelemetry/propagator-jaeger to patched versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -124,7 +124,9 @@
     "js-yaml": "Force js-yaml >=4.3.0 to patch the quadratic-CPU DoS via YAML merge-key chains (GHSA-52cp-r559-cp3m); the 4.x line is vulnerable below 4.3.0. Kept on 4.3.0 (not the 5.x latest) to stay API-compatible for transitive consumers. Do not downgrade below 4.3.0.",
     "shell-quote": "Force shell-quote >=1.9.0 to patch the quadratic-complexity DoS in parse() (GHSA-395f-4hp3-45gv, CWE-407); everything <=1.8.4 is vulnerable and 1.9.0 is the first published release above the range. Dev/build-chain transitive dependency. Do not downgrade below 1.9.0.",
     "protobufjs": "Force protobufjs >=7.6.5 to patch the infinite-loop DoS in .proto option parsing (GHSA-j3f2-48v5-ccww); the 7.5.0-7.6.4 range is vulnerable. Kept on the 7.6.5 patch (not the 8.x latest) to avoid a runtime major bump for @grpc/proto-loader / packages/proto consumers. Do not downgrade below 7.6.5.",
-    "dompurify": "Force dompurify >=3.4.11 to patch the permanent ALLOWED_ATTR pollution via setConfig() (GHSA-cmwh-pvxp-8882); <=3.4.10 is vulnerable. dompurify sanitises chat-attachment previews (lib.chat), so keeping it patched is defence-relevant, not just an audit-gate fix. Do not downgrade below 3.4.11."
+    "dompurify": "Force dompurify >=3.4.11 to patch the permanent ALLOWED_ATTR pollution via setConfig() (GHSA-cmwh-pvxp-8882); <=3.4.10 is vulnerable. dompurify sanitises chat-attachment previews (lib.chat), so keeping it patched is defence-relevant, not just an audit-gate fix. Do not downgrade below 3.4.11.",
+    "fast-uri": "Force fast-uri >=3.1.3 to patch the host-confusion via failed IDN canonicalization (GHSA-4c8g-83qw-93j6); the 3.0.0-3.1.2 range is vulnerable and 3.1.3 is the first patched 3.x release. fast-uri is a transitive dependency (fastify/ajv URI validation in the gateway + service toolchains), so the root-level override reaches the nested copies pnpm audit flags. Kept on the 3.1.3 patch (not the 4.x latest) to avoid a transitive major bump. Do not downgrade below 3.1.3.",
+    "@opentelemetry/propagator-jaeger": "Force @opentelemetry/propagator-jaeger >=2.9.0 to patch the JaegerPropagator DoS via unhandled exception on a malformed header (GHSA-45rx-2jwx-cxfr); everything <2.9.0 is vulnerable. Transitive via the @opentelemetry auto-instrumentations bundle used by @adopt-dont-shop/observability. Do not downgrade below 2.9.0."
   },
   "pnpm": {
     "onlyBuiltDependencies": [
@@ -157,7 +159,9 @@
       "js-yaml@>=4.0.0 <4.3.0": "4.3.0",
       "shell-quote@<1.9.0": "1.9.0",
       "protobufjs@>=7.5.0 <7.6.5": "7.6.5",
-      "dompurify@<3.4.11": "3.4.11"
+      "dompurify@<3.4.11": "3.4.11",
+      "fast-uri@>=3.0.0 <3.1.3": "3.1.3",
+      "@opentelemetry/propagator-jaeger@<2.9.0": "2.9.0"
     }
   },
   "engines": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,8 @@ overrides:
   shell-quote@<1.9.0: 1.9.0
   protobufjs@>=7.5.0 <7.6.5: 7.6.5
   dompurify@<3.4.11: 3.4.11
+  fast-uri@>=3.0.0 <3.1.3: 3.1.3
+  '@opentelemetry/propagator-jaeger@<2.9.0': 2.9.0
 
 importers:
 
@@ -1532,7 +1534,7 @@ importers:
         version: 1.9.1
       '@opentelemetry/auto-instrumentations-node':
         specifier: ^0.77.0
-        version: 0.77.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))
+        version: 0.77.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))
       '@opentelemetry/exporter-trace-otlp-http':
         specifier: ^0.219.0
         version: 0.219.0(@opentelemetry/api@1.9.1)
@@ -3951,6 +3953,12 @@ packages:
     peerDependencies:
       '@opentelemetry/api': '>=1.0.0 <1.10.0'
 
+  '@opentelemetry/core@2.9.0':
+    resolution: {integrity: sha512-m2nckMT80NnmjTYSPjJQObBJ+8dgkoajEOUbznL8AHZ3T3yHRk2P7gI1PhEBc1+lOnrYE9UWrWHqJDsmqjmNbw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
   '@opentelemetry/exporter-logs-otlp-grpc@0.219.0':
     resolution: {integrity: sha512-7SvzDCIclHWAcCwZ1MTOLcwn4BVNPGI3QxS/DJraPNe1TTL+4TvUBq5zeQV8tsnYvtDN7wKW2qocVmaCP2l7sQ==}
     engines: {node: ^18.19.0 || >=20.6.0}
@@ -4305,8 +4313,8 @@ packages:
     peerDependencies:
       '@opentelemetry/api': '>=1.0.0 <1.10.0'
 
-  '@opentelemetry/propagator-jaeger@2.8.0':
-    resolution: {integrity: sha512-Xnz9zZvvQzUw+9DrOn0MomR7BxFCkA2pcfXBQuHC28ndJpSbjLs7knzYb05kw5SyCjSsEWombkZMgGcJSk8JVg==}
+  '@opentelemetry/propagator-jaeger@2.9.0':
+    resolution: {integrity: sha512-4mYGty27rYvSM0jtp1ZUOqd3LfVRCYg9H5G9OFzSx5HViYToU21MFhWfco7x1HwXr7ER8yGOiCIHZUwjPksc0Q==}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': '>=1.0.0 <1.10.0'
@@ -7422,8 +7430,8 @@ packages:
   fast-string-width@3.0.2:
     resolution: {integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==}
 
-  fast-uri@3.1.2:
-    resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
+  fast-uri@3.1.3:
+    resolution: {integrity: sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==}
 
   fast-wrap-ansi@0.2.2:
     resolution: {integrity: sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==}
@@ -11891,7 +11899,7 @@ snapshots:
     dependencies:
       ajv: 8.20.0
       ajv-formats: 3.0.1(ajv@8.20.0)
-      fast-uri: 3.1.2
+      fast-uri: 3.1.3
 
   '@fastify/busboy@3.2.0': {}
 
@@ -12372,10 +12380,10 @@ snapshots:
 
   '@opentelemetry/api@1.9.1': {}
 
-  '@opentelemetry/auto-instrumentations-node@0.77.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))':
+  '@opentelemetry/auto-instrumentations-node@0.77.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))':
     dependencies:
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/core': 2.9.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/instrumentation': 0.219.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/instrumentation-amqplib': 0.66.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/instrumentation-aws-lambda': 0.71.0(@opentelemetry/api@1.9.1)
@@ -12439,6 +12447,11 @@ snapshots:
       '@opentelemetry/api': 1.9.1
 
   '@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/semantic-conventions': 1.41.1
+
+  '@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/semantic-conventions': 1.41.1
@@ -12951,10 +12964,10 @@ snapshots:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.1)
 
-  '@opentelemetry/propagator-jaeger@2.8.0(@opentelemetry/api@1.9.1)':
+  '@opentelemetry/propagator-jaeger@2.9.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/core': 2.9.0(@opentelemetry/api@1.9.1)
 
   '@opentelemetry/redis-common@0.38.3': {}
 
@@ -13035,7 +13048,7 @@ snapshots:
       '@opentelemetry/otlp-exporter-base': 0.219.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/otlp-grpc-exporter-base': 0.219.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/propagator-b3': 2.8.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/propagator-jaeger': 2.8.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/propagator-jaeger': 2.9.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/resources': 2.8.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-logs': 0.219.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-metrics': 2.8.0(@opentelemetry/api@1.9.1)
@@ -15022,7 +15035,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.2
+      fast-uri: 3.1.3
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -16297,7 +16310,7 @@ snapshots:
       '@fastify/merge-json-schemas': 0.2.1
       ajv: 8.20.0
       ajv-formats: 3.0.1(ajv@8.20.0)
-      fast-uri: 3.1.2
+      fast-uri: 3.1.3
       json-schema-ref-resolver: 3.0.0
       rfdc: 1.4.1
 
@@ -16323,7 +16336,7 @@ snapshots:
     dependencies:
       fast-string-truncated-width: 3.0.3
 
-  fast-uri@3.1.2: {}
+  fast-uri@3.1.3: {}
 
   fast-wrap-ansi@0.2.2:
     dependencies:
@@ -17093,7 +17106,7 @@ snapshots:
   json-schema-resolver@3.0.0:
     dependencies:
       debug: 4.4.3
-      fast-uri: 3.1.2
+      fast-uri: 3.1.3
       rfdc: 1.4.1
     transitivePeerDependencies:
       - supports-color


### PR DESCRIPTION
## Summary

- Two newly-published high-severity advisories against **transitive** dependencies are failing the Dependency Audit on `main` and every open PR (the audit hits the live npm advisory endpoint, so it flags the tree regardless of a PR's own diff — this is the same class of failure #1241 fixed).
- Adds root-level `pnpm.overrides` pinning both to their nearest patched release.

## Changes

- `package.json` — two new `pnpm.overrides` (+ matching `overridesDocumentation` entries):
  - `fast-uri@>=3.0.0 <3.1.3` → `3.1.3` — host confusion via failed IDN canonicalization ([GHSA-4c8g-83qw-93j6](https://github.com/advisories/GHSA-4c8g-83qw-93j6)). Transitive via fastify/ajv URI validation.
  - `@opentelemetry/propagator-jaeger@<2.9.0` → `2.9.0` — `JaegerPropagator` DoS via unhandled exception on a malformed header ([GHSA-45rx-2jwx-cxfr](https://github.com/advisories/GHSA-45rx-2jwx-cxfr)). Transitive via the OpenTelemetry auto-instrumentations bundle.
- `pnpm-lock.yaml` — regenerated (`pnpm install --lockfile-only`); the vulnerable `fast-uri@3.1.2` and `@opentelemetry/propagator-jaeger@2.8.0` are gone.

Both pinned to the nearest patched line (not the `4.x` / `2.10` latest) to avoid a transitive major bump, following the existing convention in this file.

## Test plan

- [x] `node scripts/audit-bulk.mjs` → `No advisories match the installed dependency versions`, exit 0 (was 2 high matches)
- [x] Confirmed the lockfile resolves `fast-uri` → `3.1.3` and `@opentelemetry/propagator-jaeger` → `2.9.0`, with no vulnerable versions remaining
- [x] `pnpm install --lockfile-only` succeeds (pre-existing peer warnings only)

## Related

- Unblocks the Dependency Audit on `main` and all open PRs (incl. #1247). Same pattern as #1241.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015F6J4DXQ1Amyth4dwD5Q8P)_