### PR TITLE
fix(ci): add GHCR_TOKEN scope guard to deploy and rollback workflows (ADS-671)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -541,11 +541,15 @@ jobs:
           GHCR_TOKEN: ${{ secrets.GHCR_TOKEN }}
         run: |
           set -euo pipefail
-          SCOPES=$(curl -fsSI \
+          # Run curl separately so a network/auth failure exits the step rather
+          # than being swallowed by || true. The || true below only applies to
+          # the grep, which legitimately returns 1 when the header is absent
+          # (fine-grained PAT).
+          RESPONSE_HEADERS=$(curl -fsSI \
             -H "Authorization: token $GHCR_TOKEN" \
             -H "User-Agent: adopt-dont-shop-deploy/1.0" \
-            https://api.github.com/ \
-            | grep -i '^x-oauth-scopes:' | sed 's/^[^:]*: *//' | tr -d '\r' || true)
+            https://api.github.com/)
+          SCOPES=$(echo "$RESPONSE_HEADERS" | grep -i '^x-oauth-scopes:' | sed 's/^[^:]*: *//' | tr -d '\r' || true)
           if [ -z "$SCOPES" ]; then
             echo "GHCR_TOKEN is a fine-grained PAT (X-OAuth-Scopes absent)."
             echo "Ensure it has Packages: read permission only (ADS-671)."

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -546,7 +546,8 @@ jobs:
           # the grep, which legitimately returns 1 when the header is absent
           # (fine-grained PAT).
           RESPONSE_HEADERS=$(curl -fsSI \
-            -H "Authorization: token $GHCR_TOKEN" \
+            -H "Authorization: Bearer $GHCR_TOKEN" \
+            -H "Accept: application/vnd.github+json" \
             -H "User-Agent: adopt-dont-shop-deploy/1.0" \
             https://api.github.com/)
           SCOPES=$(echo "$RESPONSE_HEADERS" | grep -i '^x-oauth-scopes:' | sed 's/^[^:]*: *//' | tr -d '\r' || true)

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -551,9 +551,13 @@ jobs:
             echo "Ensure it has Packages: read permission only (ADS-671)."
           else
             echo "Token scopes: $SCOPES"
+            # Split on commas and trim whitespace so each element is one scope.
+            # grep -qx requires an exact full-line match, preventing false positives
+            # from scopes that merely contain a bad name (e.g. public_repo, repo:status).
+            SCOPE_LIST=$(echo "$SCOPES" | tr ',' '\n' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
             BAD=""
             for SCOPE in "write:packages" "delete:packages" "repo"; do
-              if echo "$SCOPES" | grep -q "$SCOPE"; then
+              if echo "$SCOPE_LIST" | grep -qx "$SCOPE"; then
                 BAD="$BAD $SCOPE"
               fi
             done

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -530,6 +530,40 @@ jobs:
           target: /opt/ads/${{ github.event.inputs.environment }}
           overwrite: true
 
+      # ADS-671: Verify GHCR_TOKEN is scoped to read:packages only before
+      # shipping it to the deploy host. Classic PATs expose granted scopes via
+      # X-OAuth-Scopes; fine-grained PATs omit the header (resource-scoped) and
+      # get a logged advisory instead. Either way, write:packages / repo scope
+      # causes an immediate failure so an over-privileged token is caught here
+      # rather than silently landing on the server.
+      - name: Verify GHCR_TOKEN scope
+        env:
+          GHCR_TOKEN: ${{ secrets.GHCR_TOKEN }}
+        run: |
+          set -euo pipefail
+          SCOPES=$(curl -fsSI \
+            -H "Authorization: token $GHCR_TOKEN" \
+            -H "User-Agent: adopt-dont-shop-deploy/1.0" \
+            https://api.github.com/ \
+            | grep -i '^x-oauth-scopes:' | sed 's/^[^:]*: *//' | tr -d '\r' || true)
+          if [ -z "$SCOPES" ]; then
+            echo "GHCR_TOKEN is a fine-grained PAT (X-OAuth-Scopes absent)."
+            echo "Ensure it has Packages: read permission only (ADS-671)."
+          else
+            echo "Token scopes: $SCOPES"
+            BAD=""
+            for SCOPE in "write:packages" "delete:packages" "repo"; do
+              if echo "$SCOPES" | grep -q "$SCOPE"; then
+                BAD="$BAD $SCOPE"
+              fi
+            done
+            if [ -n "$BAD" ]; then
+              echo "::error::GHCR_TOKEN has excessive scope(s):$BAD (ADS-671). Rotate to a read:packages-only token."
+              exit 1
+            fi
+            echo "GHCR_TOKEN scope OK — no write:packages, delete:packages, or repo scope."
+          fi
+
       # ADS-670: SSH host fingerprint pinned to prevent MitM during deploy.
       # Compute on the host and store as HETZNER_HOST_FINGERPRINT secret:
       #   ssh-keyscan -t ed25519,rsa $HOST | ssh-keygen -lf - | awk '{print $2}'

--- a/.github/workflows/rollback.yml
+++ b/.github/workflows/rollback.yml
@@ -64,9 +64,13 @@ jobs:
             echo "Ensure it has Packages: read permission only (ADS-671)."
           else
             echo "Token scopes: $SCOPES"
+            # Split on commas and trim whitespace so each element is one scope.
+            # grep -qx requires an exact full-line match, preventing false positives
+            # from scopes that merely contain a bad name (e.g. public_repo, repo:status).
+            SCOPE_LIST=$(echo "$SCOPES" | tr ',' '\n' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
             BAD=""
             for SCOPE in "write:packages" "delete:packages" "repo"; do
-              if echo "$SCOPES" | grep -q "$SCOPE"; then
+              if echo "$SCOPE_LIST" | grep -qx "$SCOPE"; then
                 BAD="$BAD $SCOPE"
               fi
             done

--- a/.github/workflows/rollback.yml
+++ b/.github/workflows/rollback.yml
@@ -47,6 +47,36 @@ jobs:
           target: /opt/ads/${{ github.event.inputs.environment }}
           overwrite: true
 
+      # ADS-671: Verify GHCR_TOKEN is scoped to read:packages only before
+      # shipping it to the rollback host. See deploy.yml for rationale.
+      - name: Verify GHCR_TOKEN scope
+        env:
+          GHCR_TOKEN: ${{ secrets.GHCR_TOKEN }}
+        run: |
+          set -euo pipefail
+          SCOPES=$(curl -fsSI \
+            -H "Authorization: token $GHCR_TOKEN" \
+            -H "User-Agent: adopt-dont-shop-deploy/1.0" \
+            https://api.github.com/ \
+            | grep -i '^x-oauth-scopes:' | sed 's/^[^:]*: *//' | tr -d '\r' || true)
+          if [ -z "$SCOPES" ]; then
+            echo "GHCR_TOKEN is a fine-grained PAT (X-OAuth-Scopes absent)."
+            echo "Ensure it has Packages: read permission only (ADS-671)."
+          else
+            echo "Token scopes: $SCOPES"
+            BAD=""
+            for SCOPE in "write:packages" "delete:packages" "repo"; do
+              if echo "$SCOPES" | grep -q "$SCOPE"; then
+                BAD="$BAD $SCOPE"
+              fi
+            done
+            if [ -n "$BAD" ]; then
+              echo "::error::GHCR_TOKEN has excessive scope(s):$BAD (ADS-671). Rotate to a read:packages-only token."
+              exit 1
+            fi
+            echo "GHCR_TOKEN scope OK — no write:packages, delete:packages, or repo scope."
+          fi
+
       # ADS-670: pin SSH host fingerprint to prevent MitM.
       # ADS-671: GHCR_TOKEN must be scoped `read:packages` only — it is used
       # exclusively for `docker pull` during rollback. Passed via envs (not

--- a/.github/workflows/rollback.yml
+++ b/.github/workflows/rollback.yml
@@ -59,7 +59,8 @@ jobs:
           # the grep, which legitimately returns 1 when the header is absent
           # (fine-grained PAT).
           RESPONSE_HEADERS=$(curl -fsSI \
-            -H "Authorization: token $GHCR_TOKEN" \
+            -H "Authorization: Bearer $GHCR_TOKEN" \
+            -H "Accept: application/vnd.github+json" \
             -H "User-Agent: adopt-dont-shop-deploy/1.0" \
             https://api.github.com/)
           SCOPES=$(echo "$RESPONSE_HEADERS" | grep -i '^x-oauth-scopes:' | sed 's/^[^:]*: *//' | tr -d '\r' || true)

--- a/.github/workflows/rollback.yml
+++ b/.github/workflows/rollback.yml
@@ -54,11 +54,15 @@ jobs:
           GHCR_TOKEN: ${{ secrets.GHCR_TOKEN }}
         run: |
           set -euo pipefail
-          SCOPES=$(curl -fsSI \
+          # Run curl separately so a network/auth failure exits the step rather
+          # than being swallowed by || true. The || true below only applies to
+          # the grep, which legitimately returns 1 when the header is absent
+          # (fine-grained PAT).
+          RESPONSE_HEADERS=$(curl -fsSI \
             -H "Authorization: token $GHCR_TOKEN" \
             -H "User-Agent: adopt-dont-shop-deploy/1.0" \
-            https://api.github.com/ \
-            | grep -i '^x-oauth-scopes:' | sed 's/^[^:]*: *//' | tr -d '\r' || true)
+            https://api.github.com/)
+          SCOPES=$(echo "$RESPONSE_HEADERS" | grep -i '^x-oauth-scopes:' | sed 's/^[^:]*: *//' | tr -d '\r' || true)
           if [ -z "$SCOPES" ]; then
             echo "GHCR_TOKEN is a fine-grained PAT (X-OAuth-Scopes absent)."
             echo "Ensure it has Packages: read permission only (ADS-671)."


### PR DESCRIPTION
## Summary

- Adds a "Verify GHCR_TOKEN scope" step to both `deploy.yml` and `rollback.yml` that runs before any secrets are shipped to the deploy host
- The step calls the GitHub API and inspects the `X-OAuth-Scopes` response header; it fails loudly if `write:packages`, `delete:packages`, or `repo` scope is present
- Fine-grained PATs (which omit `X-OAuth-Scopes`) log an advisory instead of failing, since their permissions are resource-scoped rather than scope-named

## Changes

- `.github/workflows/deploy.yml` — new "Verify GHCR_TOKEN scope" step inserted before "Deploy to server"
- `.github/workflows/rollback.yml` — same step inserted before "Rollback on server"

## Before requesting review

- [ ] Ran `pnpm ci:local:quick` locally (or installed the pre-push hook — see CONTRIBUTING.md)
- [ ] Tests for new behaviour added (TDD)
- [ ] If touching `.env` requirements, updated `.env.example`'s REQUIRED block
- [ ] If touching a `lib.*`, considered consumer impact across `app.*` and `service.backend`

## Test plan

- [x] No TypeScript errors — workflow-only change, no TS files touched
- [x] No new dependencies introduced
- [ ] Verify with a classic PAT that has only `read:packages`: step should log "GHCR_TOKEN scope OK"
- [ ] Verify with a classic PAT that has `write:packages`: step should fail with `::error::` annotation
- [ ] Verify that a fine-grained PAT logs the advisory and does not fail

> **Note:** The primary remediation (rotating the actual `GHCR_TOKEN` secret to a `read:packages`-only PAT) requires a manual GitHub admin action by the repo owner. This PR automates the ongoing enforcement so any future token creep is caught at the workflow layer on the next deploy or rollback run.

## Screenshots / recordings

N/A — workflow-only change.

## Related

- Linear: https://linear.app/ideasquared/issue/ADS-671/ghcr-deploy-token-has-excessive-permissions-should-be-readpackages

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rp5zxqH7hiKKZQBHQdVkAX)_