### PR TITLE
chore(deps): remove stale pnpm overrides and audit exemptions post-migration (ADS-995)

### DIFF
--- a/package.json
+++ b/package.json
@@ -130,7 +130,6 @@
     "postcss": "Force postcss >=8.5.18 to patch the path traversal via sourceMappingURL auto-loading (GHSA-r28c-9q8g-f849); <=8.5.17 is vulnerable. postcss is a transitive build-time dependency of every Vite-based app and lib. Do not downgrade below 8.5.18.",
     "find-my-way": "Force find-my-way >=9.7.0 to patch the HTTP/2 DDoS via algorithmic complexity (GHSA-c96f-x56v-gq3h); <=9.6.0 is vulnerable. find-my-way is a transitive dependency of fastify (used in all microservices). The override is a patch-level bump within the 9.x line. Do not downgrade below 9.7.0.",
     "@fastify/static": "Force @fastify/static >=10.1.2 to patch the route-guard-bypass path traversal (GHSA-83w8-p2f5-377r) and the non-canonical-URL authorization bypass (GHSA-8pvw-jcv7-9cmj); everything <=10.1.0 is vulnerable and there is NO patched 9.x, so the fix requires the 10.x major. It is transitive via @fastify/swagger-ui (which declares @fastify/static ^9.1.2); v10 needs fastify 5, which the gateway already runs (^5.8.5), and swagger-ui only uses it to serve its own fixed-prefix bundled assets, so the override is verified against the gateway's openapi/swagger tests. Do not downgrade below 10.1.2.",
-    "react-router": "Force react-router >=7.18.1 as a backstop for any transitive copy still on the 7.x line (patches GHSA-chx6-hx7r-mcp5 DDoS, GHSA-337j-9hxr-rhxg constructor injection, GHSA-h8fp-f39c-q6mh XSS, GHSA-wrjc-x8rr-h8h6 open redirect, all fixed in 7.18.0). The apps + lib.components now depend on react-router ^8.3.0 directly (react-router-dom removed), which resolves outside this override's range and fully fixes GHSA-qwww-vcr4-c8h2 (RSC CSRF) too. Do not downgrade below 7.18.1.",
     "@opentelemetry/propagator-jaeger": "Force @opentelemetry/propagator-jaeger >=2.9.0 to patch the JaegerPropagator DoS via unhandled exception on a malformed header (GHSA-45rx-2jwx-cxfr); everything <2.9.0 is vulnerable. Transitive via the @opentelemetry auto-instrumentations bundle used by @adopt-dont-shop/observability. Do not downgrade below 2.9.0."
   },
   "pnpm": {
@@ -169,7 +168,6 @@
       "postcss@<=8.5.17": "8.5.23",
       "find-my-way@<=9.6.0": "9.7.0",
       "brace-expansion@>=3.0.0 <5.0.8": "5.0.8",
-      "react-router@>=6.0.0 <7.18.1": "7.18.1",
       "@fastify/static@<10.1.2": "10.1.2",
       "@opentelemetry/propagator-jaeger@<2.9.0": "2.9.0"
     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,7 +30,6 @@ overrides:
   postcss@<=8.5.17: 8.5.23
   find-my-way@<=9.6.0: 9.7.0
   brace-expansion@>=3.0.0 <5.0.8: 5.0.8
-  react-router@>=6.0.0 <7.18.1: 7.18.1
   '@fastify/static@<10.1.2': 10.1.2
   '@opentelemetry/propagator-jaeger@<2.9.0': 2.9.0
 

--- a/scripts/audit-bulk.mjs
+++ b/scripts/audit-bulk.mjs
@@ -43,14 +43,9 @@ const MAX_RETRIES = 3;
 //     there is no 9.x patch available. Unblock when @fastify/swagger-ui releases
 //     a version compatible with @fastify/static 10.x.
 //
-//   GHSA-qwww-vcr4-c8h2  react-router RSC CSRF — advisory range >=7.12.0 <8.3.0.
-//     This project uses Vite SPA + BrowserRouter with no React Server Components,
-//     so the RSC code path is never executed. Unblock when the apps are migrated
-//     to react-router 8.x.
 const EXEMPTED_GHSA_IDS = new Set([
   'ghsa-mh99-v99m-4gvg',
   'ghsa-83w8-p2f5-377r',
-  'ghsa-qwww-vcr4-c8h2',
 ]);
 
 const ghsaIdFromUrl = (url) => {

--- a/scripts/audit-bulk.mjs
+++ b/scripts/audit-bulk.mjs
@@ -38,14 +38,8 @@ const MAX_RETRIES = 3;
 //     (minimatch@3, minimatch@5/9) cannot be safely force-bumped to 5.x without
 //     API compatibility audit. Unblock when upstream ships 1.1.17 / 2.1.3.
 //
-//   GHSA-83w8-p2f5-377r  @fastify/static route-guard bypass — patched only in
-//     10.1.2 (major version from 9.x). @fastify/swagger-ui@6.x pins ^9.1.2, so
-//     there is no 9.x patch available. Unblock when @fastify/swagger-ui releases
-//     a version compatible with @fastify/static 10.x.
-//
 const EXEMPTED_GHSA_IDS = new Set([
   'ghsa-mh99-v99m-4gvg',
-  'ghsa-83w8-p2f5-377r',
 ]);
 
 const ghsaIdFromUrl = (url) => {


### PR DESCRIPTION
## Summary

Two rounds of cleanup for stopgaps that were explicitly marked "remove once fixed" in their comments:

### 1. react-router v7 override + GHSA-qwww-vcr4-c8h2 exemption

Commit `cb7a4dd` (PR #1252) completed the v7→v8 migration: all three apps and `lib.components` now declare `react-router ^8.3.0`. Two stopgaps from commit `eb94649` were never removed:

- **`package.json`** — removes `"react-router@>=6.0.0 <7.18.1": "7.18.1"` from `pnpm.overrides` and its `overridesDocumentation` entry. No transitive 7.x consumer exists in the workspace.
- **`scripts/audit-bulk.mjs`** — removes `GHSA-qwww-vcr4-c8h2` (react-router RSC CSRF, range `>=7.12.0 <8.3.0`) from `EXEMPTED_GHSA_IDS`. Installed version 8.3.0 is outside that range; the CI gate naturally passes without the exemption.

### 2. @fastify/static GHSA-83w8-p2f5-377r exemption

The existing `"@fastify/static@<10.1.2": "10.1.2"` pnpm override already forces every transitive copy to the patched release. `pnpm-lock.yaml` confirms only `@fastify/static@10.1.2` is installed. The advisory's vulnerable range is `<10.1.2`, so `semver.satisfies('10.1.2', '<10.1.2')` is false — the CI gate passes without the exemption. Per the script's own rule (*"Remove an entry the moment a fixable patched version exists"*), the exemption and its comment block are removed. The override itself remains (still needed to force @fastify/swagger-ui's 9.x peer dep to 10.x).

### Lockfile

`pnpm-lock.yaml` regenerated — the stale `react-router@>=6.0.0 <7.18.1` resolution entry is gone.

Closes ADS-995.