### PR TITLE
fix(ci): close pwn-request bypass in release.yml workflow_run guard

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,15 @@ name: Release
 #
 # Branch protection must require the CI workflow to pass before merging to main
 # so that by the time workflow_run fires, tests have already passed.
+#
+# workflow_run is a privileged trigger: it runs with this repo's secrets even
+# when the CI run that triggered it came from a fork PR. The `branches: [main]`
+# filter below only matches the *head branch name in the triggering run*, which
+# for a fork PR is a branch in the attacker's fork — trivially named `main`. The
+# `guard` job is what actually keeps this safe: it additionally requires the
+# triggering run's event to be `push` and its head repository to be this repo,
+# so a fork-originated `pull_request` run (however its branch is named) can
+# never reach the secret-bearing build jobs. [ADS-1013]
 on:
   workflow_run:
     workflows: [CI]
@@ -47,7 +56,10 @@ jobs:
     if: >
       github.event_name == 'push' ||
       github.event_name == 'workflow_dispatch' ||
-      (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success')
+      (github.event_name == 'workflow_run' &&
+       github.event.workflow_run.conclusion == 'success' &&
+       github.event.workflow_run.event == 'push' &&
+       github.event.workflow_run.head_repository.full_name == github.repository)
     steps:
       - name: CI passed
         run: echo "CI passed — proceeding with release"


### PR DESCRIPTION
## Summary

- Closes the fork-PR bypass in `release.yml`'s `guard` job (ADS-1013): the guard only checked `workflow_run.conclusion`, which a fork PR whose head branch is literally named `main` could satisfy — reaching Docker-publishing jobs that hold `DOCKER_USERNAME`/`DOCKER_PASSWORD`, since `workflow_run` runs with this repo's secrets regardless of where the triggering run originated.
- Adds two conditions to the guard: the triggering run's `event` must be `push`, and its `head_repository` must be this repository — so a fork-originated `pull_request` run can never pass, no matter how its branch is named.
- Updates the workflow's header comment to document why the guard is safe.

## Changes

- `.github/workflows/release.yml`: hardened `guard` job's `if:` condition; updated top-of-file rationale comment.

## Before requesting review

- [x] Ran a local YAML syntax check (`python3 -c "import yaml; yaml.safe_load(...)"`) — `pnpm ci:local:quick` not run (workflow-only YAML change, no app code affected)
- [ ] Tests for new behaviour added (TDD) — see note below
- [ ] If touching `.env` requirements, updated `.env.example`'s REQUIRED block — N/A
- [ ] If touching a `lib.*`, considered consumer impact across `app.*` and `service.backend` — N/A

## Test plan

- [x] YAML validity checked
- [ ] Existing tests pass (`pnpm test`) — N/A, workflow-only change
- [ ] Tested manually: acceptance criteria in ADS-1013 call for opening a real fork PR with head branch named `main` and confirming `Release` halts at `guard` — this requires an actual fork and cannot be exercised from this environment; needs verification against the live repo.
- [ ] No TypeScript errors (`pnpm type-check`) — N/A
- [ ] Lint passes (`pnpm lint`) — N/A

## Related

Linear: ADS-1013 (Urgent). This PR addresses the "Immediate" fix from the ticket (hardened guard condition). Follow-up work not included here, tracked as remaining scope on the ticket:
- "Preferred" fix: consider removing the `workflow_run` trigger entirely in favor of relying on branch protection, per the ticket's recommendation.
- Assert built image tags match the checked-out SHA (tags are currently derived from `github.ref`, which for `workflow_run` resolves to the default branch rather than the checked-out commit).
- Review release-build run history for any prior fork-triggered runs, and rotate `DOCKER_PASSWORD` if any are found.


---
_Generated by [Claude Code](https://claude.ai/code/session_018sDLsJsioLLWnJm9jJAymi)_