### PR TITLE
fix(ci): scope TURBO_TOKEN to turbo-invoking steps, enable cache signing (ADS-1014)

### DIFF
--- a/.github/actions/run-package-tests/action.yml
+++ b/.github/actions/run-package-tests/action.yml
@@ -49,6 +49,17 @@ inputs:
       tests. Leave unset to skip (e.g. test-contracts has no coverage).
     required: false
     default: ''
+  turbo-token:
+    description: >-
+      ADS-1014: Turbo remote cache token, computed and gated by the calling
+      workflow (composite actions can't reference the `secrets` context
+      directly). Pass '' to run without remote cache.
+    required: false
+    default: ''
+  turbo-team:
+    description: 'Turbo remote cache team, passed through from the caller.'
+    required: false
+    default: ''
 runs:
   using: 'composite'
   steps:
@@ -61,12 +72,12 @@ runs:
       shell: bash
       # ADS-1014: TURBO_TOKEN is scoped to only this step (not job-level env)
       # so it's never in scope for the pnpm install / build steps above that
-      # run PR-supplied lifecycle scripts and config. Withheld entirely on
-      # pull_request — PR runs pay full cache misses rather than exposing a
-      # write-capable token to untrusted code.
+      # run PR-supplied lifecycle scripts and config. The caller workflow
+      # gates it to '' on pull_request before passing it in — composite
+      # actions can't reference `secrets` directly.
       env:
-        TURBO_TOKEN: ${{ github.event_name == 'pull_request' && '' || secrets.TURBO_TOKEN }}
-        TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
+        TURBO_TOKEN: ${{ inputs.turbo-token }}
+        TURBO_TEAM: ${{ inputs.turbo-team }}
       run: |
         pnpm exec turbo run lint ${{ inputs.run-coverage == 'true' && 'test:coverage' || 'test' }} type-check --filter='${{ inputs.filter }}'
 
@@ -74,8 +85,8 @@ runs:
       if: inputs.working-directory != ''
       shell: bash
       env:
-        TURBO_TOKEN: ${{ github.event_name == 'pull_request' && '' || secrets.TURBO_TOKEN }}
-        TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
+        TURBO_TOKEN: ${{ inputs.turbo-token }}
+        TURBO_TEAM: ${{ inputs.turbo-team }}
       run: pnpm exec turbo run lint --filter='${{ inputs.filter }}'
 
     - name: Test (with coverage thresholds)
@@ -88,8 +99,8 @@ runs:
       if: inputs.working-directory != ''
       shell: bash
       env:
-        TURBO_TOKEN: ${{ github.event_name == 'pull_request' && '' || secrets.TURBO_TOKEN }}
-        TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
+        TURBO_TOKEN: ${{ inputs.turbo-token }}
+        TURBO_TEAM: ${{ inputs.turbo-team }}
       run: pnpm exec turbo run type-check --filter='${{ inputs.filter }}'
 
     - name: Build

--- a/.github/actions/run-package-tests/action.yml
+++ b/.github/actions/run-package-tests/action.yml
@@ -59,12 +59,23 @@ runs:
     - name: Lint, test and type-check
       if: inputs.working-directory == ''
       shell: bash
+      # ADS-1014: TURBO_TOKEN is scoped to only this step (not job-level env)
+      # so it's never in scope for the pnpm install / build steps above that
+      # run PR-supplied lifecycle scripts and config. Withheld entirely on
+      # pull_request — PR runs pay full cache misses rather than exposing a
+      # write-capable token to untrusted code.
+      env:
+        TURBO_TOKEN: ${{ github.event_name == 'pull_request' && '' || secrets.TURBO_TOKEN }}
+        TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
       run: |
         pnpm exec turbo run lint ${{ inputs.run-coverage == 'true' && 'test:coverage' || 'test' }} type-check --filter='${{ inputs.filter }}'
 
     - name: Lint
       if: inputs.working-directory != ''
       shell: bash
+      env:
+        TURBO_TOKEN: ${{ github.event_name == 'pull_request' && '' || secrets.TURBO_TOKEN }}
+        TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
       run: pnpm exec turbo run lint --filter='${{ inputs.filter }}'
 
     - name: Test (with coverage thresholds)
@@ -76,6 +87,9 @@ runs:
     - name: Type check
       if: inputs.working-directory != ''
       shell: bash
+      env:
+        TURBO_TOKEN: ${{ github.event_name == 'pull_request' && '' || secrets.TURBO_TOKEN }}
+        TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
       run: pnpm exec turbo run type-check --filter='${{ inputs.filter }}'
 
     - name: Build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,7 +187,7 @@ jobs:
         # this job (via checkout-and-setup) never had it in scope, and this
         # step itself can't leak a write-capable token to a PR build.
         env:
-          TURBO_TOKEN: ${{ github.event_name == 'pull_request' && '' || secrets.TURBO_TOKEN }}
+          TURBO_TOKEN: ${{ github.event_name != 'pull_request' && secrets.TURBO_TOKEN || '' }}
           TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
         run: pnpm build:libs
       # ADS-909: downstream jobs restore this same actions/cache entry
@@ -220,7 +220,7 @@ jobs:
           coverage-cache-key: 'coverage-current-${{ github.run_id }}-${{ matrix.app }}'
           # ADS-1014: gated here, not inside the composite — composite
           # actions can't reference `secrets` directly.
-          turbo-token: ${{ github.event_name == 'pull_request' && '' || secrets.TURBO_TOKEN }}
+          turbo-token: ${{ github.event_name != 'pull_request' && secrets.TURBO_TOKEN || '' }}
           turbo-team: ${{ secrets.TURBO_TEAM }}
 
   # ============================================================================
@@ -244,7 +244,7 @@ jobs:
           filter: '@adopt-dont-shop/lib.*'
           upload-artifact-name: 'test-results-libs'
           coverage-cache-key: 'coverage-current-${{ github.run_id }}-libs'
-          turbo-token: ${{ github.event_name == 'pull_request' && '' || secrets.TURBO_TOKEN }}
+          turbo-token: ${{ github.event_name != 'pull_request' && secrets.TURBO_TOKEN || '' }}
           turbo-team: ${{ secrets.TURBO_TEAM }}
 
   # ============================================================================
@@ -273,7 +273,7 @@ jobs:
           filter: '@adopt-dont-shop/service.*'
           upload-artifact-name: 'test-results-services'
           coverage-cache-key: 'coverage-current-${{ github.run_id }}-services'
-          turbo-token: ${{ github.event_name == 'pull_request' && '' || secrets.TURBO_TOKEN }}
+          turbo-token: ${{ github.event_name != 'pull_request' && secrets.TURBO_TOKEN || '' }}
           turbo-team: ${{ secrets.TURBO_TEAM }}
 
   # ============================================================================

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,10 +160,6 @@ jobs:
       # ADS-947: surfaced as a CI-health signal on the coverage-report comment.
       lib-dist-cache-hit: ${{ steps.cache-lib-dist.outputs.cache-hit }}
 
-    env:
-      TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-      TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
-
     steps:
       # Local composite actions can only load after the repo is checked out.
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -185,6 +181,14 @@ jobs:
 
       - name: Build shared libraries
         if: steps.cache-lib-dist.outputs.cache-hit != 'true'
+        # ADS-1014: step-scoped, not job-level env — this is the only step in
+        # the job that invokes turbo. Withheld entirely on pull_request so a
+        # PR-supplied vitest.config.ts / postinstall script run earlier in
+        # this job (via checkout-and-setup) never had it in scope, and this
+        # step itself can't leak a write-capable token to a PR build.
+        env:
+          TURBO_TOKEN: ${{ github.event_name == 'pull_request' && '' || secrets.TURBO_TOKEN }}
+          TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
         run: pnpm build:libs
       # ADS-909: downstream jobs restore this same actions/cache entry
       # (see .github/actions/checkout-and-setup) rather than downloading an
@@ -198,10 +202,6 @@ jobs:
     if: needs.changes.outputs.frontend == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 30
-
-    env:
-      TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-      TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
 
     strategy:
       fail-fast: false
@@ -232,10 +232,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
 
-    env:
-      TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-      TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
-
     steps:
       # Local composite actions can only load after the repo is checked out.
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -262,10 +258,6 @@ jobs:
     if: needs.changes.outputs.backend == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 30
-
-    env:
-      TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-      TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
 
     steps:
       # Local composite actions can only load after the repo is checked out.
@@ -294,9 +286,10 @@ jobs:
     timeout-minutes: 15
 
     env:
-      TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-      TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
       # Suppress Pact telemetry in CI.
+      # ADS-1014: no TURBO_TOKEN here — this job's steps below call vitest
+      # directly (test:contracts:consumer/provider), never `turbo run`, so
+      # the token served no purpose and was pure unnecessary exposure.
       PACT_DO_NOT_TRACK: 'true'
 
     steps:
@@ -365,12 +358,14 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
 
+    # ADS-1014: no TURBO_TOKEN here — this job's steps build/run via docker
+    # compose and `pnpm test:e2e` directly, never `turbo run`, so the token
+    # served no purpose and was pure unnecessary exposure to the compose
+    # build (which executes PR-supplied Dockerfiles and install scripts).
     env:
       CI: true
       DOCKER_BUILDKIT: 1
       COMPOSE_DOCKER_CLI_BUILD: 1
-      TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-      TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
       E2E_RUN_ID: ${{ github.run_id }}-${{ github.run_attempt }}
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -218,6 +218,10 @@ jobs:
           run-build: 'true'
           upload-artifact-name: 'test-results-${{ matrix.app }}'
           coverage-cache-key: 'coverage-current-${{ github.run_id }}-${{ matrix.app }}'
+          # ADS-1014: gated here, not inside the composite — composite
+          # actions can't reference `secrets` directly.
+          turbo-token: ${{ github.event_name == 'pull_request' && '' || secrets.TURBO_TOKEN }}
+          turbo-team: ${{ secrets.TURBO_TEAM }}
 
   # ============================================================================
   # SHARED LIBRARIES — lint/test/type-check the libs themselves
@@ -240,6 +244,8 @@ jobs:
           filter: '@adopt-dont-shop/lib.*'
           upload-artifact-name: 'test-results-libs'
           coverage-cache-key: 'coverage-current-${{ github.run_id }}-libs'
+          turbo-token: ${{ github.event_name == 'pull_request' && '' || secrets.TURBO_TOKEN }}
+          turbo-team: ${{ secrets.TURBO_TEAM }}
 
   # ============================================================================
   # SERVICE TESTS — lint/test:coverage/type-check all service.* packages
@@ -267,6 +273,8 @@ jobs:
           filter: '@adopt-dont-shop/service.*'
           upload-artifact-name: 'test-results-services'
           coverage-cache-key: 'coverage-current-${{ github.run_id }}-services'
+          turbo-token: ${{ github.event_name == 'pull_request' && '' || secrets.TURBO_TOKEN }}
+          turbo-team: ${{ secrets.TURBO_TEAM }}
 
   # ============================================================================
   # CONTRACT TESTS — consumer-driven Pact verification matrix (ADS-816).

--- a/turbo.json
+++ b/turbo.json
@@ -1,7 +1,8 @@
 {
   "$schema": "https://turbo.build/schema.json",
   "remoteCache": {
-    "enabled": true
+    "enabled": true,
+    "signature": true
   },
   "globalDependencies": ["**/.env.*local", ".prettierrc", ".prettierignore", ".editorconfig"],
   "globalEnv": ["NODE_ENV", "CI", "DOCKER"],


### PR DESCRIPTION
## Summary

- `TURBO_TOKEN`/`TURBO_TEAM` were declared as **job-level** `env` on six `ci.yml` jobs, making them visible to every step in the job — including `pnpm install` (runs dependency lifecycle scripts) and PR-supplied `vitest.config.ts`/test code. Any of those could exfiltrate the token.
- Combined with `turbo.json`'s remote cache having no artifact signing, a leaked write-capable token could poison a cache entry a `main` build would later restore — landing backdoored `dist/` in production images with no trace in source review.
- This addresses both halves of the proposed fix in [ADS-1014](https://linear.app/ideasquared/issue/ADS-1014).

## Changes

- `.github/workflows/ci.yml`: removed job-level `TURBO_TOKEN`/`TURBO_TEAM` env from `build-libs`, `test-frontend`, `test-libs`, `test-services`, `test-contracts`, `test-e2e`.
  - `build-libs`: token moved to step-level env on the single `pnpm build:libs` step, withheld on `pull_request`.
  - `test-contracts`/`test-e2e`: token removed entirely — neither job's steps ever invoke `turbo` (contracts run `vitest` directly; e2e runs `docker compose` + `pnpm test:e2e` directly), so it served no purpose there beyond exposure.
- `.github/actions/run-package-tests/action.yml` (shared by `test-frontend`/`test-libs`/`test-services`): token moved to step-level env on only the `Lint`, `Type check`, and combined `Lint, test and type-check` steps — the only steps that call `pnpm exec turbo run ...`. Withheld on `pull_request`.
- `turbo.json`: `remoteCache.signature` set to `true`.

## Before requesting review

- [x] Ran a YAML/JSON parse check on all three changed files locally
- [ ] Tests for new behaviour added (TDD) — N/A, this is CI/build config with no unit-testable behaviour
- [ ] If touching `.env` requirements, updated `.env.example`'s REQUIRED block — N/A, `TURBO_REMOTE_CACHE_SIGNATURE_KEY` is a CI-only secret, not an app runtime var
- [ ] If touching a `lib.*`, considered consumer impact — N/A

## Test plan

- [ ] This PR's own CI run is the test: confirms the token-scoping change doesn't break `build-libs`/`test-frontend`/`test-libs`/`test-services`, and that `turbo.json`'s `signature: true` doesn't break builds before the signature key secret exists (turbo is expected to degrade to cache-miss, not hard-fail, when the key is absent — worth double-checking against this run's logs)
- [ ] Manual check confirms an unsigned/tampered cache artifact is rejected on restore (blocked on the signature key existing — see below)

## Related

Linear: [ADS-1014](https://linear.app/ideasquared/issue/ADS-1014/security-urgent-turbo-token-exposed-to-every-ci-job-that-runs-pr-code) (Urgent)

### Not done in this PR — needs repo secrets access

The following acceptance criteria require actions outside a code diff:

- [ ] Provision `TURBO_REMOTE_CACHE_SIGNATURE_KEY` as a GitHub Actions secret so signing actually takes effect
- [ ] Rotate `TURBO_TOKEN` and revoke the old value (it's been readable by PR-supplied code for as long as the prior config was in place — treat as disclosed)
- [ ] Review or flush existing remote-cache contents, since prior entries were written without signature verification

---
_Generated by [Claude Code](https://claude.ai/code/session_01FN2jeNNsCLqXYciFmE1JsS)_