### PR TITLE
fix(admin): neutralise CSV formula injection in export

### DIFF
--- a/apps/admin/src/services/exportService.security.test.ts
+++ b/apps/admin/src/services/exportService.security.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const mockText = vi.fn();
+const mockSetFontSize = vi.fn();
+const mockSave = vi.fn();
+const mockJsPdf = vi.fn();
+vi.mock('jspdf', () => ({
+  default: function JsPdfCtor(this: Record<string, unknown>, ...args: unknown[]) {
+    mockJsPdf(...args);
+    this.setFontSize = mockSetFontSize;
+    this.text = mockText;
+    this.save = mockSave;
+  },
+}));
+
+const mockAutoTable = vi.fn();
+vi.mock('jspdf-autotable', () => ({
+  default: (...args: unknown[]) => mockAutoTable(...args),
+}));
+
+import { exportToCSV, exportData, type ExportColumn } from './exportService';
+
+type Row = { name: string };
+
+const columns: ExportColumn<Row>[] = [{ header: 'Name', accessor: 'name' }];
+
+let capturedBlob: Blob | null = null;
+const originalCreateElement = document.createElement.bind(document);
+
+beforeEach(() => {
+  capturedBlob = null;
+
+  const createObjectURL = vi.fn((blob: Blob) => {
+    capturedBlob = blob;
+    return 'blob:url';
+  });
+  const revokeObjectURL = vi.fn();
+  Object.assign(URL, { createObjectURL, revokeObjectURL });
+
+  vi.spyOn(document, 'createElement').mockImplementation((tag: string) => {
+    const el = originalCreateElement(tag);
+    if (tag === 'a') {
+      (el as HTMLAnchorElement).click = vi.fn();
+    }
+    return el;
+  });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+const unwrapCsvField = (field: string): string =>
+  field.startsWith('"') && field.endsWith('"') ? field.slice(1, -1) : field;
+
+describe('exportToCSV formula injection protection', () => {
+  it.each(['=', '+', '-', '@'])(
+    'neutralises cells whose value begins with "%s"',
+    async dangerousChar => {
+      const rows: Row[] = [{ name: `${dangerousChar}cmd|'/c calc'!A0` }];
+
+      exportToCSV(rows, columns, 'export');
+
+      const csvText = await capturedBlob!.text();
+      const dataLine = csvText.trim().split(/\r?\n/)[1];
+      expect(unwrapCsvField(dataLine).startsWith("'")).toBe(true);
+    }
+  );
+
+  it('covers the rescues export path via exportData', async () => {
+    const rows: Row[] = [{ name: '=HYPERLINK("http://evil.example/steal","Click")' }];
+
+    exportData(rows, columns, 'rescues', 'Rescues', 'csv');
+
+    const csvText = await capturedBlob!.text();
+    const dataLine = csvText.trim().split(/\r?\n/)[1];
+    expect(unwrapCsvField(dataLine).startsWith("'=HYPERLINK")).toBe(true);
+  });
+});

--- a/apps/admin/src/services/exportService.test.ts
+++ b/apps/admin/src/services/exportService.test.ts
@@ -72,7 +72,7 @@ describe('exportToCSV', () => {
         { Name: 'Rex', Age: '3', Nick: 'Rexy' },
         { Name: 'Mittens', Age: '', Nick: '' },
       ],
-      { header: true }
+      { header: true, escapeFormulae: true }
     );
     expect(createObjectURL).toHaveBeenCalledOnce();
     expect(clickSpy).toHaveBeenCalledOnce();

--- a/apps/admin/src/services/exportService.ts
+++ b/apps/admin/src/services/exportService.ts
@@ -36,7 +36,7 @@ export const exportToCSV = <T>(data: T[], columns: ExportColumn<T>[], filename: 
     }, {})
   );
 
-  const csv = Papa.unparse(rows, { header: true });
+  const csv = Papa.unparse(rows, { header: true, escapeFormulae: true });
   const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
   triggerDownload(blob, `${filename}.csv`);
 };


### PR DESCRIPTION
## Summary

- `exportToCSV` (`apps/admin/src/services/exportService.ts`) called `Papa.unparse` without `escapeFormulae`, so user-controlled profile fields (first/last name, email, rescue name, etc.) could carry a leading `=`/`+`/`-`/`@` payload that spreadsheet apps (Excel, LibreOffice, Google Sheets) evaluate as a formula when an admin opens a CSV export.
- Since registration is public and unauthenticated, an attacker needs no existing access to plant the payload — an admin's routine **Export → CSV** action is the trigger.
- Enabled papaparse's built-in neutralisation (`escapeFormulae: true`), which prefixes any cell beginning with a dangerous character with a single quote so spreadsheet apps treat it as literal text.

## Changes

- `apps/admin/src/services/exportService.ts` — pass `escapeFormulae: true` to `Papa.unparse` in `exportToCSV`.
- `apps/admin/src/services/exportService.test.ts` — updated the existing (mocked) assertion to expect the new option.
- `apps/admin/src/services/exportService.security.test.ts` (new) — exercises the real `papaparse` implementation and asserts the CSV output is escaped for each dangerous leading character (`=`, `+`, `-`, `@`), including through the shared `exportData` path used by the Rescues export.

Note: the PDF export path (`exportToPDF`) is unaffected — jsPDF renders text and does not evaluate formulas, so no change was needed there.

## Before requesting review

- [x] Ran targeted tests/lint locally (see Test plan)
- [x] Tests for new behaviour added (TDD)
- [ ] If touching `.env` requirements, updated `.env.example`'s REQUIRED block — n/a
- [ ] If touching a `lib.*`, considered consumer impact across `app.*` and `service.backend` — n/a (app-local change)

## Test plan

- [x] `exportService` test suite passes (9/9, both the existing mocked tests and the new real-papaparse security tests)
- [x] New behaviour is covered by tests
- [ ] Tested manually — n/a (unit-tested via real `papaparse.unparse` output)
- [x] Lint passes (`eslint` on the touched files)
- [ ] No TypeScript errors (`pnpm type-check`) — not run repo-wide in this environment (shared `lib.*` packages weren't built), but `tsc --noEmit` on `app.admin` shows zero errors attributable to the touched files; all reported errors are pre-existing missing-build-output errors unrelated to this change

## Related

Linear: ADS-1005


---
_Generated by [Claude Code](https://claude.ai/code/session_011NXFkHgncYeePPKEPL7mr1)_