### PR TITLE
ci: run pnpm test:scripts in workspace-drift, wire into ci:local

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,14 +29,16 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
+      # Local composite actions can only load after the repo is checked out.
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
-        with:
-          node-version-file: '.nvmrc'
-      - name: Enable Corepack (pnpm pinned by package.json "packageManager")
-        run: corepack enable
-        env:
-          COREPACK_ENABLE_DOWNLOAD_PROMPT: '0'
+      - uses: ./.github/actions/setup-workspace
+
+      # ADS-1001: run the scripts/ guard-script test suite before the guards
+      # themselves, so a broken guard is reported as a test failure rather
+      # than a confusing guard failure.
+      - name: Run scripts/ test suite (guards the guard-scripts)
+        run: pnpm test:scripts
+
       - name: Verify workspace ↔ filesystem alignment
         run: |
           # Enumerate every workspace project pnpm-workspace.yaml resolves.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -8,6 +8,7 @@ covered by automated tests in this repository.
 | Runner   | Where it lives                                  | What it covers                                     |
 | -------- | ----------------------------------------------- | -------------------------------------------------- |
 | Vitest   | every `services/*`, `app.*`, and `lib.*`        | Behaviour-driven tests for services, components, libraries |
+| Vitest   | `scripts/` (`pnpm test:scripts`)                | The repo's own DX guard-scripts (see below) |
 | Playwright | `e2e/`                                          | Cross-app integration journeys against the docker-compose stack |
 
 Each backend service owns its own `vitest.config.ts` under
@@ -56,6 +57,18 @@ that come up most often:
   context.
 - 100% coverage of behaviour is the aspiration, but coverage thresholds
   (see `vitest.config.ts`) define the *enforced* floor.
+
+## `scripts/` test guard
+
+`scripts/` holds the repo's own enforcement — `check-workspace-consistency.mjs`,
+`check-docker-pinning.mjs`, `check-docs-freshness.mjs`, the `new-app`/`new-lib`
+generators, and their shared libs. These are tested by a dedicated Vitest
+project (`vitest.scripts.config.ts`, run via `pnpm test:scripts`) since
+`scripts/` is not a pnpm workspace and `turbo run test` never reaches it. CI
+runs it in the `workspace-drift` job before the guard-script steps, and
+`pnpm ci:local` includes it too — a regression here fails open (a guard
+silently stops catching what it was meant to catch), so it must run
+everywhere the guards do.
 
 ## `lib.*` test guard
 

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "format:check": "turbo run format:check && pnpm format:root:check",
     "format:root": "prettier --cache --write \"*.{ts,tsx,js,jsx,json,md}\" \"scripts/**/*.{ts,js,jsx,json,md}\" \"docs/**/*.md\" \".github/**/*.md\" --ignore-path .prettierignore",
     "format:root:check": "prettier --cache --check \"*.{ts,tsx,js,jsx,json,md}\" \"scripts/**/*.{ts,js,jsx,json,md}\" \"docs/**/*.md\" \".github/**/*.md\" --ignore-path .prettierignore",
-    "ci:local": "pnpm format:check && turbo run lint type-check test && pnpm check:lib-tests && pnpm check:workspaces && pnpm check:env-example && pnpm check:workflow-paths && pnpm check:docker-pinning && pnpm check:docs-index && pnpm check:docs-script-refs",
+    "ci:local": "pnpm format:check && turbo run lint type-check test && pnpm check:lib-tests && pnpm check:workspaces && pnpm check:env-example && pnpm check:workflow-paths && pnpm check:docker-pinning && pnpm check:docs-index && pnpm check:docs-script-refs && pnpm test:scripts",
     "ci:local:quick": "pnpm format:check && turbo run lint type-check",
     "clean": "turbo run clean && rm -rf node_modules",
     "prod:build": "docker compose -f docker-compose.yml -f docker-compose.prod.yml build",


### PR DESCRIPTION
## Summary

- The `scripts/` guard-script test suite (`pnpm test:scripts`, 8 files / 100 tests, ~1s) was never run by CI or any hook — a regression in a repo guard (e.g. `check-workspace-consistency.mjs`, `check-docker-pinning.mjs`) fails open instead of loudly, which is backwards given `scripts/` is exactly where the repo's enforcement lives.
- Runs it in the `workspace-drift` job in `ci.yml`, placed before the existing guard-script steps, and appends it to `ci:local` so local pre-flight matches CI.

## Changes

- `.github/workflows/ci.yml` — `workspace-drift` job: swapped the ad-hoc `actions/setup-node` + `corepack enable` steps for the shared `./.github/actions/setup-workspace` composite action (needed so `node_modules`/`vitest` are actually installed in that job — it previously ran zero JS dependencies), then added a `pnpm test:scripts` step before the guard-script steps.
- `package.json` — appended `pnpm test:scripts` to the `ci:local` script.
- `docs/testing.md` — added a `scripts/` row to the test-runner table and a short section explaining the suite and why it must run everywhere the guards do.

## Before requesting review

- [x] Ran `pnpm ci:local:quick` locally is N/A here (root config only) — ran the specific affected commands instead (see Test plan)
- [x] Tests for new behaviour added — N/A, this wires up an *existing* test suite rather than adding new tests
- [ ] If touching `.env` requirements, updated `.env.example`'s REQUIRED block — N/A
- [ ] If touching a `lib.*`, considered consumer impact — N/A

## Test plan

- [x] `pnpm test:scripts` — 8 files / 100 tests pass
- [x] `node scripts/check-workspace-consistency.mjs` — passes (composite-action swap didn't break workspace alignment)
- [x] `node scripts/check-workflow-paths.mjs` — passes (workflow path filters still match canonical source)
- [x] `node scripts/check-docs-index.mjs` — passes (new `docs/testing.md` section still linked from `docs/README.md`)
- [x] `node scripts/check-docs-script-references.mjs` — passes (documented `pnpm test:scripts` resolves to a real script)
- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"` — valid YAML
- [x] Confirmed via diff of prettier-formatted output that this PR introduces no *new* formatting issues in `ci.yml` — the file already fails `prettier --check` on `main` today (pre-existing, unrelated `# comment` spacing on 5 other lines; tracked separately by ADS-1028)

## Related

Linear: ADS-1001 — `pnpm test:scripts` (100 tests guarding the repo's DX guard-scripts) is never run by CI or any hook


---
_Generated by [Claude Code](https://claude.ai/code/session_01E796o1QX4h1kvKppgqfvxC)_