### PR TITLE
fix: stop turbo type-check from claiming dist/ build outputs

### DIFF
--- a/scripts/check-workspace-consistency.mjs
+++ b/scripts/check-workspace-consistency.mjs
@@ -665,12 +665,37 @@ function checkToolVersions(rootPkg) {
   return checkToolVersionsDrift(nvmrc, rootPkg.packageManager, toolVersions);
 }
 
+// ADS-1000: a Turbo task whose script body is `tsc --noEmit` produces no
+// build artefacts. Declaring dist/** outputs for it lets Turbo restore a
+// stale/partial dist/ snapshot on a cache hit — silently corrupting a
+// package's build (type declarations with no matching JS). Guards against
+// that regression reappearing in turbo.json.
+export function checkNoEmitTaskOutputs(turboConfig) {
+  const failures = [];
+  const tasks = turboConfig.tasks || {};
+  for (const [name, bodies] of Object.entries(EXPECTED_SCRIPT_BODIES)) {
+    if (!bodies.some(body => body.includes('--noEmit'))) continue;
+    const task = tasks[name];
+    if (!task) continue;
+    const distOutputs = (task.outputs || []).filter(o => o.includes('dist/'));
+    if (distOutputs.length > 0) {
+      failures.push(
+        `[turbo.json] '${name}' task declares dist/ output(s) (${distOutputs.join(', ')}) but its script is ` +
+          `'${bodies.join(' | ')}' — --noEmit produces no build artefacts, so a cache hit restores a ` +
+          `stale/partial dist/ snapshot over a real build (ADS-1000).`
+      );
+    }
+  }
+  return failures;
+}
+
 function main() {
   const libs = listLibs();
   const apps = listApps();
   const services = listServices();
   const packages = listAllPackages();
   const rootPkg = JSON.parse(readFileSync(join(ROOT, 'package.json'), 'utf8'));
+  const turboConfig = JSON.parse(readFileSync(join(ROOT, 'turbo.json'), 'utf8'));
 
   const failures = [];
   const warnings = [];
@@ -797,6 +822,9 @@ function main() {
 
   // 12. Every service vitest.config.ts must import the shared helper (ADS-985)
   failures.push(...checkServiceVitestConfig(services));
+
+  // 13. No --noEmit task may declare dist/ outputs in turbo.json (ADS-1000)
+  failures.push(...checkNoEmitTaskOutputs(turboConfig));
 
   if (warnings.length > 0) {
     console.warn('Warnings (non-fatal — script body drift):');

--- a/scripts/check-workspace-consistency.test.mjs
+++ b/scripts/check-workspace-consistency.test.mjs
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import {
+  checkNoEmitTaskOutputs,
   checkTemplateDepDrift,
   checkToolVersionsDrift,
   computeExpectedDevVolumeMounts,
@@ -107,6 +108,37 @@ describe('checkTemplateDepDrift (ADS-980)', () => {
   it('ignores dependencies the root does not track at all', () => {
     const templatePkg = { dependencies: { 'left-pad': '^1.0.0' } };
     expect(checkTemplateDepDrift('scripts/templates/lib/utility/package.json', templatePkg, rootPkg)).toEqual([]);
+  });
+});
+
+describe('checkNoEmitTaskOutputs (ADS-1000)', () => {
+  it('flags a --noEmit task that declares dist/ outputs', () => {
+    const turboConfig = {
+      tasks: {
+        'type-check': { dependsOn: ['^build'], outputs: ['**/.tsbuildinfo', 'dist/**/*.d.ts'] },
+      },
+    };
+    const failures = checkNoEmitTaskOutputs(turboConfig);
+    expect(failures).toHaveLength(1);
+    expect(failures[0]).toContain("'type-check' task declares dist/ output(s)");
+  });
+
+  it('passes when the --noEmit task declares no dist/ outputs', () => {
+    const turboConfig = {
+      tasks: {
+        'type-check': { dependsOn: ['^build'], outputs: [] },
+      },
+    };
+    expect(checkNoEmitTaskOutputs(turboConfig)).toEqual([]);
+  });
+
+  it('ignores a task with no configured outputs at all', () => {
+    const turboConfig = { tasks: { 'type-check': { dependsOn: ['^build'] } } };
+    expect(checkNoEmitTaskOutputs(turboConfig)).toEqual([]);
+  });
+
+  it('ignores tasks not present in turbo.json', () => {
+    expect(checkNoEmitTaskOutputs({ tasks: {} })).toEqual([]);
   });
 });
 

--- a/turbo.json
+++ b/turbo.json
@@ -65,7 +65,17 @@
     },
     "type-check": {
       "dependsOn": ["^build"],
-      "outputs": ["**/.tsbuildinfo", "dist/**/*.d.ts"]
+      "outputs": [],
+      "inputs": [
+        "src/**",
+        "test/**",
+        "tsconfig*.json",
+        "package.json",
+        "$TURBO_ROOT$/tsconfig.base.json",
+        "$TURBO_ROOT$/tsconfig.lib.base.json",
+        "$TURBO_ROOT$/tsconfig.service.base.json",
+        "$TURBO_ROOT$/tsconfig.cjs.base.json"
+      ]
     },
     "clean": {
       "cache": false


### PR DESCRIPTION
## Summary

- `turbo.json`'s `type-check` task declared `**/.tsbuildinfo` and `dist/**/*.d.ts` as outputs, even though every workspace runs `type-check` as `tsc --noEmit`, which emits neither.
- A cached `type-check` run therefore restored whatever partial `dist/` snapshot happened to exist at cache-write time — including onto a tree where `dist/` was absent or stale — leaving a package with type declarations but no matching JavaScript and no error anywhere in the log.
- Fixes ADS-1000.

## Changes

- `turbo.json`: `type-check` now declares `outputs: []` and an explicit `inputs` list (source, tests, tsconfigs, and the four shared root `tsconfig.*.base.json` files), so `tsc --noEmit`'s cache reflects only what actually determines its result.
- `scripts/check-workspace-consistency.mjs`: added `checkNoEmitTaskOutputs`, a regression guard that fails if any Turbo task whose script body is `tsc --noEmit` reclaims `dist/` outputs.
- `scripts/check-workspace-consistency.test.mjs`: unit tests for the new guard.

## Before requesting review

- [x] Ran `pnpm ci:local:quick` locally (or installed the pre-push hook — see CONTRIBUTING.md)
- [x] Tests for new behaviour added (TDD)
- [ ] If touching `.env` requirements, updated `.env.example`'s REQUIRED block — n/a
- [ ] If touching a `lib.*`, considered consumer impact across `app.*` and `service.backend` — n/a, this is a build-tooling config change

## Test plan

- [x] Existing tests pass (`pnpm test:scripts` — `check-workspace-consistency.test.mjs`, 18/18 passed)
- [x] New behaviour is covered by tests (`checkNoEmitTaskOutputs`)
- [x] Tested manually — reproduced the ticket's exact repro against `packages/lib.utils`:
  1. `pnpm exec turbo run type-check --filter=@adopt-dont-shop/lib.utils --force`
  2. `rm -rf packages/lib.utils/dist`
  3. `pnpm exec turbo run type-check --filter=@adopt-dont-shop/lib.utils` → cache hit, and `dist/` correctly stays absent (previously restored 16 stale files)
  4. `pnpm build --filter=@adopt-dont-shop/lib.utils` from that state emits real `.js` files, including `dist/index.js`
- [x] No TypeScript errors — n/a (`.mjs`/JSON only)
- [ ] Lint passes (`pnpm lint`) — not run for this config-only change; `node scripts/check-workspace-consistency.mjs` passes

## Related

Linear: ADS-1000


---
_Generated by [Claude Code](https://claude.ai/code/session_01XpbEAfesn2cbKHdpbVD18u)_