### PR TITLE
fix(security): Group A backend authz / data-leak hardening (ADS-1006..1022)

### DIFF
--- a/packages/lib.chat/src/components/MessageBubbleComponent.test.tsx
+++ b/packages/lib.chat/src/components/MessageBubbleComponent.test.tsx
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest';
+
+import { MessageBubbleComponent } from './MessageBubbleComponent';
+import type { MessageAttachment } from '../types';
+import { buildChatContextValue, buildTestMessage, renderWithChatContext } from '../test-utils';
+
+// Mirrors apps/client's resolveFileUrl reject rules (ADS-1011): undefined
+// signals a BLOCKED url (non-http(s) scheme, protocol-relative cross-origin),
+// a string is a url safe to hand to <img src>. The component must never fall
+// back to the raw url when this returns undefined.
+const sanitizingResolveFileUrl = (url: string | undefined): string | undefined => {
+  if (!url) {
+    return undefined;
+  }
+  const trimmed = url.trim();
+  const scheme = trimmed.match(/^([a-zA-Z][a-zA-Z0-9+.-]*):/);
+  if (scheme) {
+    const s = scheme[1].toLowerCase();
+    return s === 'http' || s === 'https' ? trimmed : undefined;
+  }
+  if (trimmed.startsWith('//')) {
+    return undefined;
+  }
+  return trimmed;
+};
+
+const buildImageAttachment = (url: string): MessageAttachment => ({
+  id: 'att-1',
+  filename: 'photo.png',
+  url,
+  size: 1024,
+  mimeType: 'image/png',
+});
+
+const renderBubbleWithAttachment = (url: string) => {
+  const message = buildTestMessage({ attachments: [buildImageAttachment(url)] });
+  return renderWithChatContext(
+    <MessageBubbleComponent message={message} isOwn={false} currentUserId="user-1" />,
+    { value: buildChatContextValue({ resolveFileUrl: sanitizingResolveFileUrl }) }
+  );
+};
+
+describe('MessageBubbleComponent image attachments — sanitiser is authoritative (ADS-1011)', () => {
+  it('renders no <img> for a protocol-relative attachment url, showing a placeholder instead', () => {
+    const { container } = renderBubbleWithAttachment('//evil.example/beacon.gif?r=victim');
+    // No <img> is emitted at all — so nothing fetches from evil.example on render.
+    expect(container.querySelector('img')).toBeNull();
+    // The file-icon placeholder (filename text) stands in for the blocked image.
+    expect(container.textContent).toContain('photo.png');
+  });
+
+  it('renders no <img> for a non-http(s) scheme attachment url', () => {
+    const { container } = renderBubbleWithAttachment('data:image/png;base64,AAAA');
+    expect(container.querySelector('img')).toBeNull();
+    expect(container.textContent).toContain('photo.png');
+  });
+
+  it('renders an <img> at the resolved url for a valid absolute https attachment', () => {
+    const { container } = renderBubbleWithAttachment('https://cdn.example/photo.png');
+    const img = container.querySelector('img');
+    expect(img).not.toBeNull();
+    expect(img?.getAttribute('src')).toBe('https://cdn.example/photo.png');
+  });
+
+  it('renders an <img> for a valid relative attachment url', () => {
+    const { container } = renderBubbleWithAttachment('/uploads/photo.png');
+    const img = container.querySelector('img');
+    expect(img).not.toBeNull();
+    expect(img?.getAttribute('src')).toBe('/uploads/photo.png');
+  });
+});

--- a/packages/lib.chat/src/components/MessageBubbleComponent.tsx
+++ b/packages/lib.chat/src/components/MessageBubbleComponent.tsx
@@ -66,10 +66,22 @@ export function MessageBubbleComponent({
   const [pdfPreviewFilename, setPdfPreviewFilename] = useState('');
   const [pdfPreviewMimeType, setPdfPreviewMimeType] = useState('');
 
-  const imageAttachments = message.attachments?.filter((att) => isImageFile(att.mimeType)) || [];
+  // Only images whose URL survives sanitisation (ADS-1011). resolveFileUrl
+  // returns undefined to signal a REJECTED url (non-http(s) scheme,
+  // protocol-relative cross-origin, etc.) — those must never reach an <img src>,
+  // so they are dropped here rather than falling back to the raw url. Both the
+  // inline grid and the lightbox render from this safe set, keeping their
+  // indices aligned.
+  const imageAttachments = (message.attachments ?? []).flatMap((att) => {
+    if (!isImageFile(att.mimeType)) {
+      return [];
+    }
+    const url = resolveFileUrl(att.url);
+    return url ? [{ att, url }] : [];
+  });
 
   const handleImageClick = (attachment: NonNullable<Message['attachments']>[0]) => {
-    const imageIndex = imageAttachments.findIndex((img) => img.id === attachment.id);
+    const imageIndex = imageAttachments.findIndex((img) => img.att.id === attachment.id);
     setLightboxIndex(imageIndex >= 0 ? imageIndex : 0);
     setLightboxOpen(true);
 
@@ -131,87 +143,95 @@ export function MessageBubbleComponent({
 
           {message.attachments && message.attachments.length > 0 && (
             <div className={styles.attachmentsContainer}>
-              {message.attachments.map((attachment, index) => (
-                <div
-                  key={attachment.id || index}
-                  className={isOwn ? styles.attachmentItemOwn : styles.attachmentItemOther}
-                >
-                  {isImageFile(attachment.mimeType) ? (
-                    <div className={styles.imageWrapper}>
-                      <button
-                        type="button"
-                        className={styles.imageButtonWrapper}
-                        onClick={() => handleImageClick(attachment)}
-                        aria-label={`View ${attachment.filename}`}
-                      >
-                        <img
-                          className={styles.imageAttachment}
-                          src={resolveFileUrl(attachment.url) || attachment.url}
-                          alt={attachment.filename}
-                          loading="lazy"
-                        />
-                      </button>
-                    </div>
-                  ) : isPDFFile(attachment.mimeType) ? (
-                    <>
-                      <div className={isOwn ? styles.fileIconOwn : styles.fileIconOther}>
-                        {getFileIcon(attachment.mimeType)}
+              {message.attachments.map((attachment, index) => {
+                // undefined for non-images AND for image URLs the sanitiser
+                // rejected — both fall through to the file-icon placeholder
+                // below rather than rendering an <img> at an unsafe URL.
+                const resolvedImageUrl = isImageFile(attachment.mimeType)
+                  ? resolveFileUrl(attachment.url)
+                  : undefined;
+                return (
+                  <div
+                    key={attachment.id || index}
+                    className={isOwn ? styles.attachmentItemOwn : styles.attachmentItemOther}
+                  >
+                    {resolvedImageUrl ? (
+                      <div className={styles.imageWrapper}>
+                        <button
+                          type="button"
+                          className={styles.imageButtonWrapper}
+                          onClick={() => handleImageClick(attachment)}
+                          aria-label={`View ${attachment.filename}`}
+                        >
+                          <img
+                            className={styles.imageAttachment}
+                            src={resolvedImageUrl}
+                            alt={attachment.filename}
+                            loading="lazy"
+                          />
+                        </button>
                       </div>
-                      <div className={styles.fileInfo}>
-                        <div className={isOwn ? styles.fileNameOwn : styles.fileNameOther}>
-                          {attachment.filename}
+                    ) : isPDFFile(attachment.mimeType) ? (
+                      <>
+                        <div className={isOwn ? styles.fileIconOwn : styles.fileIconOther}>
+                          {getFileIcon(attachment.mimeType)}
                         </div>
-                        <div className={isOwn ? styles.fileSizeOwn : styles.fileSizeOther}>
-                          {formatFileSize(attachment.size)}
+                        <div className={styles.fileInfo}>
+                          <div className={isOwn ? styles.fileNameOwn : styles.fileNameOther}>
+                            {attachment.filename}
+                          </div>
+                          <div className={isOwn ? styles.fileSizeOwn : styles.fileSizeOther}>
+                            {formatFileSize(attachment.size)}
+                          </div>
                         </div>
-                      </div>
-                      <a
-                        className={isOwn ? styles.downloadButtonOwn : styles.downloadButtonOther}
-                        href="#"
-                        onClick={(e) => {
-                          e.preventDefault();
-                          handlePDFClick(attachment);
-                        }}
-                        aria-label={`Preview ${attachment.filename}`}
-                      >
-                        <MdVisibility size={16} />
-                      </a>
-                      <a
-                        className={isOwn ? styles.downloadButtonOwn : styles.downloadButtonOther}
-                        href={resolveFileUrl(attachment.url)}
-                        download={attachment.filename}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                      >
-                        <MdDownload size={16} />
-                      </a>
-                    </>
-                  ) : (
-                    <>
-                      <div className={isOwn ? styles.fileIconOwn : styles.fileIconOther}>
-                        {getFileIcon(attachment.mimeType)}
-                      </div>
-                      <div className={styles.fileInfo}>
-                        <div className={isOwn ? styles.fileNameOwn : styles.fileNameOther}>
-                          {attachment.filename}
+                        <a
+                          className={isOwn ? styles.downloadButtonOwn : styles.downloadButtonOther}
+                          href="#"
+                          onClick={(e) => {
+                            e.preventDefault();
+                            handlePDFClick(attachment);
+                          }}
+                          aria-label={`Preview ${attachment.filename}`}
+                        >
+                          <MdVisibility size={16} />
+                        </a>
+                        <a
+                          className={isOwn ? styles.downloadButtonOwn : styles.downloadButtonOther}
+                          href={resolveFileUrl(attachment.url)}
+                          download={attachment.filename}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                        >
+                          <MdDownload size={16} />
+                        </a>
+                      </>
+                    ) : (
+                      <>
+                        <div className={isOwn ? styles.fileIconOwn : styles.fileIconOther}>
+                          {getFileIcon(attachment.mimeType)}
                         </div>
-                        <div className={isOwn ? styles.fileSizeOwn : styles.fileSizeOther}>
-                          {formatFileSize(attachment.size)}
+                        <div className={styles.fileInfo}>
+                          <div className={isOwn ? styles.fileNameOwn : styles.fileNameOther}>
+                            {attachment.filename}
+                          </div>
+                          <div className={isOwn ? styles.fileSizeOwn : styles.fileSizeOther}>
+                            {formatFileSize(attachment.size)}
+                          </div>
                         </div>
-                      </div>
-                      <a
-                        className={isOwn ? styles.downloadButtonOwn : styles.downloadButtonOther}
-                        href={resolveFileUrl(attachment.url)}
-                        download={attachment.filename}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                      >
-                        <MdDownload size={16} />
-                      </a>
-                    </>
-                  )}
-                </div>
-              ))}
+                        <a
+                          className={isOwn ? styles.downloadButtonOwn : styles.downloadButtonOther}
+                          href={resolveFileUrl(attachment.url)}
+                          download={attachment.filename}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                        >
+                          <MdDownload size={16} />
+                        </a>
+                      </>
+                    )}
+                  </div>
+                );
+              })}
             </div>
           )}
         </article>
@@ -264,15 +284,12 @@ export function MessageBubbleComponent({
       )}
 
       <ImageLightbox
-        images={imageAttachments.map((att) => {
-          const resolvedUrl = resolveFileUrl(att.url);
-          return {
-            id: att.id,
-            url: resolvedUrl || att.url,
-            filename: att.filename,
-            mimeType: att.mimeType,
-          };
-        })}
+        images={imageAttachments.map(({ att, url }) => ({
+          id: att.id,
+          url,
+          filename: att.filename,
+          mimeType: att.mimeType,
+        }))}
         currentIndex={lightboxIndex}
         isOpen={lightboxOpen}
         onClose={() => setLightboxOpen(false)}

--- a/packages/service-bootstrap/src/adapter.test.ts
+++ b/packages/service-bootstrap/src/adapter.test.ts
@@ -108,6 +108,7 @@ describe('adapt — error code mapping (canonical CODE_TO_GRPC table)', () => {
     ['NOT_FOUND', status.NOT_FOUND],
     ['ALREADY_EXISTS', status.ALREADY_EXISTS],
     ['FAILED_PRECONDITION', status.FAILED_PRECONDITION],
+    ['UNAVAILABLE', status.UNAVAILABLE],
     ['INTERNAL', status.INTERNAL],
   ] as const)('HandlerError("%s") → gRPC status %i', async (code, grpcCode) => {
     const handler = vi.fn(async () => {

--- a/packages/service-bootstrap/src/adapter.ts
+++ b/packages/service-bootstrap/src/adapter.ts
@@ -9,7 +9,7 @@
 //
 // Canonical CODE_TO_GRPC table (superset across all services):
 //   INVALID_ARGUMENT, UNAUTHENTICATED, PERMISSION_DENIED,
-//   NOT_FOUND, ALREADY_EXISTS, FAILED_PRECONDITION, INTERNAL
+//   NOT_FOUND, ALREADY_EXISTS, FAILED_PRECONDITION, UNAVAILABLE, INTERNAL
 //
 // Services whose HandlerErrorCode union is a strict subset of the
 // canonical table work unchanged — TypeScript enforces that every
@@ -51,6 +51,7 @@ export type HandlerErrorCode =
   | 'NOT_FOUND'
   | 'ALREADY_EXISTS'
   | 'FAILED_PRECONDITION'
+  | 'UNAVAILABLE'
   | 'INTERNAL';
 
 export class HandlerError extends Error {
@@ -77,6 +78,7 @@ const CODE_TO_GRPC: Record<HandlerErrorCode, number> = {
   NOT_FOUND: status.NOT_FOUND,
   ALREADY_EXISTS: status.ALREADY_EXISTS,
   FAILED_PRECONDITION: status.FAILED_PRECONDITION,
+  UNAVAILABLE: status.UNAVAILABLE,
   INTERNAL: status.INTERNAL,
 };
 

--- a/packages/service-bootstrap/src/index.ts
+++ b/packages/service-bootstrap/src/index.ts
@@ -13,7 +13,7 @@
 //   HandlerErrorCode          — canonical union (INVALID_ARGUMENT,
 //                               UNAUTHENTICATED, PERMISSION_DENIED,
 //                               NOT_FOUND, ALREADY_EXISTS,
-//                               FAILED_PRECONDITION, INTERNAL).
+//                               FAILED_PRECONDITION, UNAVAILABLE, INTERNAL).
 //   HandlerDeps               — base dependency type (pool + nats).
 //   extractPrincipal          — parse x-user-* gRPC metadata headers; when a
 //                               PRINCIPAL_SIGNING_KEY is configured, requires

--- a/services/applications/src/domain/commands.ts
+++ b/services/applications/src/domain/commands.ts
@@ -67,8 +67,12 @@ export function handle(
     case 'saveDraftAnswers':
       requireAggregate(state);
       checkVersion(state, command.expectedVersion);
-      // Allowed from draft AND under_review (so rescue staff can ask
-      // follow-up questions after starting review). Rejected from
+      // Allowed from draft AND under_review. The rescue-staff allowance
+      // applies only from under_review (the follow-up-questions phase) — while
+      // still an unsubmitted draft, only the owning adopter may write. That
+      // status-dependent authorization lives in requireDraftAnswersScope
+      // (command-runner.ts, ADS-1007); the domain rule below governs which
+      // statuses the command is legal from at all. Rejected from
       // submitted / decided / withdrawn.
       if (state.status !== 'draft' && state.status !== 'under_review') {
         throw new DomainError(

--- a/services/applications/src/grpc/attribution-handlers.test.ts
+++ b/services/applications/src/grpc/attribution-handlers.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 
 import { HandlerError, type HandlerDeps } from './adapter.js';
-import { countAdoptedAdopters } from './attribution-handlers.js';
+import { countAdoptedAdopters, MIN_COHORT_SIZE } from './attribution-handlers.js';
 
 function makePrincipal(
   overrides: Partial<{
@@ -13,8 +13,9 @@ function makePrincipal(
 ) {
   return {
     userId: overrides.userId ?? 'usr-1',
-    roles: overrides.roles ?? ['rescue_staff'],
-    permissions: overrides.permissions ?? ['applications.read'],
+    roles: overrides.roles ?? ['admin'],
+    // ANALYTICS_VIEW — the admin-only reporting gate this handler now requires.
+    permissions: overrides.permissions ?? ['admin.reports'],
     ...(overrides.rescueId !== undefined ? { rescueId: overrides.rescueId } : {}),
   } as unknown as Parameters<typeof countAdoptedAdopters>[1];
 }
@@ -25,17 +26,31 @@ function makeDeps(): { deps: HandlerDeps; query: ReturnType<typeof vi.fn> } {
   return { deps: { pool, nats: {} } as unknown as HandlerDeps, query };
 }
 
+// A cohort at or above the k-anonymity floor, so the happy path is exercised.
+const cohortIds = Array.from({ length: MIN_COHORT_SIZE }, (_, i) => `usr-adopter-${i}`);
+
 const baseReq = {
-  adopterIds: ['usr-adopter-1', 'usr-adopter-2'],
+  adopterIds: cohortIds,
   createdAfter: '2026-07-01T10:00:00.000Z',
   createdBefore: '2026-09-29T10:00:00.000Z',
 };
 
 describe('countAdoptedAdopters', () => {
-  it('throws PERMISSION_DENIED without applications.read', async () => {
+  it('denies a principal holding only applications.read (an adopter)', async () => {
     const { deps } = makeDeps();
     await expect(
-      countAdoptedAdopters(deps, makePrincipal({ permissions: [] }), baseReq)
+      countAdoptedAdopters(
+        deps,
+        makePrincipal({ roles: ['adopter'], permissions: ['applications.read'] }),
+        baseReq
+      )
+    ).rejects.toMatchObject({ code: 'PERMISSION_DENIED' });
+  });
+
+  it('throws PERMISSION_DENIED without any permission', async () => {
+    const { deps } = makeDeps();
+    await expect(
+      countAdoptedAdopters(deps, makePrincipal({ roles: ['adopter'], permissions: [] }), baseReq)
     ).rejects.toBeInstanceOf(HandlerError);
   });
 
@@ -53,10 +68,34 @@ describe('countAdoptedAdopters', () => {
     ).rejects.toMatchObject({ code: 'INVALID_ARGUMENT' });
   });
 
-  it('returns zero without querying when adopter_ids is empty', async () => {
+  it('rejects a cohort below the k-anonymity floor with INVALID_ARGUMENT', async () => {
     const { deps, query } = makeDeps();
-    const res = await countAdoptedAdopters(deps, makePrincipal(), { ...baseReq, adopterIds: [] });
-    expect(res).toEqual({ count: 0 });
+    await expect(
+      countAdoptedAdopters(deps, makePrincipal(), {
+        ...baseReq,
+        adopterIds: cohortIds.slice(0, MIN_COHORT_SIZE - 1),
+      })
+    ).rejects.toMatchObject({ code: 'INVALID_ARGUMENT' });
+    expect(query).not.toHaveBeenCalled();
+  });
+
+  it('rejects a single-id request (the oracle case) with INVALID_ARGUMENT', async () => {
+    const { deps, query } = makeDeps();
+    await expect(
+      countAdoptedAdopters(deps, makePrincipal(), { ...baseReq, adopterIds: ['usr-victim'] })
+    ).rejects.toMatchObject({ code: 'INVALID_ARGUMENT' });
+    expect(query).not.toHaveBeenCalled();
+  });
+
+  it('rejects when de-duplication drops the cohort below the floor', async () => {
+    const { deps, query } = makeDeps();
+    // MIN_COHORT_SIZE raw ids that collapse to a single distinct id.
+    await expect(
+      countAdoptedAdopters(deps, makePrincipal(), {
+        ...baseReq,
+        adopterIds: Array.from({ length: MIN_COHORT_SIZE }, () => 'usr-victim'),
+      })
+    ).rejects.toMatchObject({ code: 'INVALID_ARGUMENT' });
     expect(query).not.toHaveBeenCalled();
   });
 
@@ -66,11 +105,11 @@ describe('countAdoptedAdopters', () => {
 
     await countAdoptedAdopters(deps, makePrincipal(), {
       ...baseReq,
-      adopterIds: ['usr-1', 'usr-1', 'usr-2'],
+      adopterIds: [...cohortIds, ...cohortIds],
     });
 
     const params = query.mock.calls[0][1] as unknown[];
-    expect(params[0]).toEqual(['usr-1', 'usr-2']);
+    expect(params[0]).toEqual(cohortIds);
   });
 
   it('scopes to APPROVED/ADOPTED status, the candidate ids, and the created_at window', async () => {
@@ -88,7 +127,7 @@ describe('countAdoptedAdopters', () => {
     expect(params).toEqual([baseReq.adopterIds, baseReq.createdAfter, baseReq.createdBefore]);
   });
 
-  it('returns the distinct count from the query', async () => {
+  it('returns the distinct count from the query for a legitimate admin caller', async () => {
     const { deps, query } = makeDeps();
     query.mockResolvedValueOnce({ rows: [{ count: '3' }] });
 

--- a/services/applications/src/grpc/attribution-handlers.ts
+++ b/services/applications/src/grpc/attribution-handlers.ts
@@ -1,20 +1,28 @@
-// gRPC handler — CountAdoptedAdopters (ADS-941).
+// gRPC handler — CountAdoptedAdopters (ADS-941, hardened in ADS-1006).
 //
 // Cross-service attribution primitive: given a caller-supplied set of
 // adopter user ids (e.g. service.rescue resolves an event's registrant
 // list from rescue.event_attendees), returns how many of them have at
 // least one non-deleted application that reached APPROVED or ADOPTED
-// status with created_at inside [created_after, created_before]. The
-// response is a single distinct-adopter count — the caller never
-// learns which ids matched or which rescue/pet was involved, so this
-// is safe to expose to any principal holding applications.read (the
-// same base gate List/GetStats use for their coarser reads).
+// status with created_at inside [created_after, created_before].
+//
+// The response is a single distinct-adopter count. That "the caller never
+// learns which ids matched" is only privacy-preserving when the id set is
+// large enough that the count cannot be attributed to one person — with a
+// single id the count ∈ {0,1} is a direct yes/no about that user, and a
+// caller-controlled created window turns that boolean into a timeline
+// (ADS-1006). Two preconditions therefore hold the safety property:
+//
+//   1. Gated on ANALYTICS_VIEW (admin.reports), an admin-only reporting
+//      permission — NOT applications.read, which every adopter is seeded.
+//   2. A k-anonymity cohort floor (MIN_COHORT_SIZE): the request is
+//      rejected below it, so the response can never be a per-user answer.
 //
 // Reads straight off the `applications` read-model row (no event-fold
 // needed — status + created_at are both real columns).
 
 import { requirePermission, type Principal } from '@adopt-dont-shop/authz';
-import { APPLICATIONS_VIEW } from '@adopt-dont-shop/lib.types';
+import { ANALYTICS_VIEW } from '@adopt-dont-shop/lib.types';
 import type {
   CountAdoptedAdoptersRequest,
   CountAdoptedAdoptersResponse,
@@ -24,13 +32,20 @@ import { HandlerError, type HandlerDeps } from './adapter.js';
 
 type CountRow = { count: string };
 
+// k-anonymity floor: below this many distinct candidate ids the distinct
+// count degrades to a per-user oracle, so reject rather than answer. The
+// legitimate caller (service.rescue event attribution) skips the call when
+// the registrant cohort is smaller than this, so small events degrade to a
+// 0 count rather than an error.
+export const MIN_COHORT_SIZE = 20;
+
 export async function countAdoptedAdopters(
   deps: HandlerDeps,
   principal: Principal,
   req: CountAdoptedAdoptersRequest
 ): Promise<CountAdoptedAdoptersResponse> {
-  if (!requirePermission(principal, APPLICATIONS_VIEW)) {
-    throw new HandlerError('PERMISSION_DENIED', `'${APPLICATIONS_VIEW}' required`);
+  if (!requirePermission(principal, ANALYTICS_VIEW)) {
+    throw new HandlerError('PERMISSION_DENIED', `'${ANALYTICS_VIEW}' required`);
   }
   if (!req.createdAfter) {
     throw new HandlerError('INVALID_ARGUMENT', 'created_after is required');
@@ -40,8 +55,11 @@ export async function countAdoptedAdopters(
   }
 
   const adopterIds = [...new Set(req.adopterIds.filter(id => id !== ''))];
-  if (adopterIds.length === 0) {
-    return { count: 0 };
+  if (adopterIds.length < MIN_COHORT_SIZE) {
+    throw new HandlerError(
+      'INVALID_ARGUMENT',
+      `at least ${MIN_COHORT_SIZE} distinct adopter ids required`
+    );
   }
 
   const { rows } = await deps.pool.query<CountRow>(

--- a/services/applications/src/grpc/command-runner.ts
+++ b/services/applications/src/grpc/command-runner.ts
@@ -61,6 +61,34 @@ export function requireOwnerOrRescueScope(
   }
 }
 
+// SaveDraftAnswers authorization (ADS-1007). The domain permits this command
+// from both `draft` and `under_review`, and the rescue-staff allowance exists
+// ONLY for the under_review follow-up-questions phase. Authorising it with the
+// blanket owner-OR-rescue scope let rescue staff silently rewrite an adopter's
+// answers while the application was still an unsubmitted `draft`. So the scope
+// is status-aware:
+//
+//   - draft         → owner only (the adopter's answers are theirs alone until
+//                     they submit; staff shouldn't even see them yet).
+//   - under_review  → owner OR rescue scope (the intended follow-up path).
+//
+// Any other status is unreachable — the domain rejects saveDraftAnswers
+// outside draft/under_review before this could matter — but is treated as the
+// stricter owner-only branch for safety.
+export function requireDraftAnswersScope(
+  principal: Principal,
+  permission: Permission,
+  state: ApplicationState
+): void {
+  if (state.status === 'under_review') {
+    requireOwnerOrRescueScope(principal, permission, state);
+    return;
+  }
+  if (!requirePermission(principal, permission, { userId: state.adopterId as UserId })) {
+    throw new HandlerError('PERMISSION_DENIED', `'${permission}' required`);
+  }
+}
+
 // Translate the pure domain's DomainError codes into HandlerError
 // codes. ILLEGAL_TRANSITION / INVALID_INPUT → INVALID_ARGUMENT;
 // CONCURRENCY → INTERNAL with a "CONCURRENCY:" message (the gateway

--- a/services/applications/src/grpc/handlers.test.ts
+++ b/services/applications/src/grpc/handlers.test.ts
@@ -11,13 +11,18 @@ import { makeStartDraft, saveDraftAnswers, submitDraft } from './handlers.js';
 import type { PetsClient } from './pets-client.js';
 
 function makePrincipal(
-  overrides: Partial<{ userId: string; permissions: string[]; roles: string[] }> = {}
+  overrides: Partial<{
+    userId: string;
+    permissions: string[];
+    roles: string[];
+    rescueId: string;
+  }> = {}
 ) {
   return {
     userId: overrides.userId ?? 'usr-1',
     roles: overrides.roles ?? ['adopter'],
     permissions: overrides.permissions ?? ['applications.create', 'applications.update'],
-    rescueId: undefined,
+    rescueId: overrides.rescueId,
   } as unknown as Parameters<typeof submitDraft>[1];
 }
 
@@ -60,7 +65,7 @@ vi.mock('@adopt-dont-shop/events', async () => {
 
 // A draftCreated event row for an aggregate already in 'draft' state at
 // version 1.
-function draftCreatedRow(aggregateId: string, adopterId = 'usr-1') {
+function draftCreatedRow(aggregateId: string, adopterId = 'usr-1', rescueId = '') {
   return {
     event_type: 'draftCreated',
     version: 1,
@@ -69,10 +74,36 @@ function draftCreatedRow(aggregateId: string, adopterId = 'usr-1') {
       applicationId: aggregateId,
       adopterId,
       petId: 'pet-1',
-      rescueId: '',
+      rescueId,
       at: '2026-06-01T12:00:00.000Z',
     },
   };
+}
+
+// Event rows that fold to an `under_review` aggregate (v3): draftCreated →
+// draftSubmitted → reviewStarted.
+function underReviewRows(aggregateId: string, adopterId = 'usr-1', rescueId = 'rescue-1') {
+  return [
+    draftCreatedRow(aggregateId, adopterId, rescueId),
+    {
+      event_type: 'draftSubmitted',
+      version: 2,
+      event_data: {
+        type: 'draftSubmitted',
+        applicationId: aggregateId,
+        at: '2026-06-02T12:00:00.000Z',
+      },
+    },
+    {
+      event_type: 'reviewStarted',
+      version: 3,
+      event_data: {
+        type: 'reviewStarted',
+        applicationId: aggregateId,
+        at: '2026-06-03T12:00:00.000Z',
+      },
+    },
+  ];
 }
 
 describe('saveDraftAnswers', () => {
@@ -162,6 +193,72 @@ describe('saveDraftAnswers', () => {
       saveDraftAnswers(deps, makePrincipal({ userId: 'usr-2' }), {
         applicationId: 'app-1',
         expectedVersion: 1,
+        answersPatchJson: '{"hasYard":true}',
+      } as SaveDraftAnswersRequest)
+    ).rejects.toMatchObject({ code: 'PERMISSION_DENIED' });
+  });
+
+  // ── ADS-1007: rescue staff must not rewrite an unsubmitted draft ──
+
+  const rescueStaff = () =>
+    makePrincipal({
+      userId: 'usr-staff',
+      roles: ['rescue_staff'],
+      permissions: ['applications.update'],
+      rescueId: 'rescue-1',
+    });
+
+  it('denies rescue staff editing an adopter’s unsubmitted draft', async () => {
+    // Draft owned by usr-1 and addressed to rescue-1. Under the old OR-scope
+    // the rescue-1 staff principal would have been allowed; now a `draft`
+    // is owner-only.
+    const { deps } = makeDeps([draftCreatedRow('app-1', 'usr-1', 'rescue-1')]);
+    await expect(
+      saveDraftAnswers(deps, rescueStaff(), {
+        applicationId: 'app-1',
+        expectedVersion: 1,
+        answersPatchJson: '{"hasFencedYard":false}',
+      } as SaveDraftAnswersRequest)
+    ).rejects.toMatchObject({ code: 'PERMISSION_DENIED' });
+  });
+
+  it('allows the owning adopter to edit their own draft', async () => {
+    const { deps } = makeDeps([draftCreatedRow('app-1', 'usr-1', 'rescue-1')]);
+    const res = await saveDraftAnswers(deps, makePrincipal({ userId: 'usr-1' }), {
+      applicationId: 'app-1',
+      expectedVersion: 1,
+      answersPatchJson: '{"hasYard":true}',
+    } as SaveDraftAnswersRequest);
+    expect(res.application.applicationId).toBe('app-1');
+  });
+
+  it('allows rescue staff to edit answers once the application is under_review', async () => {
+    // The intended follow-up-questions path: rescue-1 staff may amend answers
+    // after review has started.
+    const { deps } = makeDeps(underReviewRows('app-1', 'usr-1', 'rescue-1'));
+    const res = await saveDraftAnswers(deps, rescueStaff(), {
+      applicationId: 'app-1',
+      expectedVersion: 3,
+      answersPatchJson: '{"followUp":"answered"}',
+    } as SaveDraftAnswersRequest);
+    expect(res.application.applicationId).toBe('app-1');
+  });
+
+  it('denies a non-owning adopter in both draft and under_review', async () => {
+    const draftDeps = makeDeps([draftCreatedRow('app-1', 'usr-1', 'rescue-1')]);
+    await expect(
+      saveDraftAnswers(draftDeps.deps, makePrincipal({ userId: 'usr-2' }), {
+        applicationId: 'app-1',
+        expectedVersion: 1,
+        answersPatchJson: '{"hasYard":true}',
+      } as SaveDraftAnswersRequest)
+    ).rejects.toMatchObject({ code: 'PERMISSION_DENIED' });
+
+    const reviewDeps = makeDeps(underReviewRows('app-1', 'usr-1', 'rescue-1'));
+    await expect(
+      saveDraftAnswers(reviewDeps.deps, makePrincipal({ userId: 'usr-2' }), {
+        applicationId: 'app-1',
+        expectedVersion: 3,
         answersPatchJson: '{"hasYard":true}',
       } as SaveDraftAnswersRequest)
     ).rejects.toMatchObject({ code: 'PERMISSION_DENIED' });

--- a/services/applications/src/grpc/handlers.ts
+++ b/services/applications/src/grpc/handlers.ts
@@ -37,7 +37,12 @@ import type {
 import type { ApplicationCommand, Reference } from '../domain/index.js';
 
 import { HandlerError, type HandlerDeps } from './adapter.js';
-import { requireOwnerOrRescueScope, runCommand, runCreateCommand } from './command-runner.js';
+import {
+  requireDraftAnswersScope,
+  requireOwnerOrRescueScope,
+  runCommand,
+  runCreateCommand,
+} from './command-runner.js';
 import type { PetsClient } from './pets-client.js';
 import { principalToMetadata } from './principal.js';
 import { stateToProto } from './state-mapper.js';
@@ -167,7 +172,7 @@ export async function saveDraftAnswers(
       id: req.applicationId,
       payload: { applicationId: req.applicationId },
     }),
-    s => requireOwnerOrRescueScope(principal, APPLICATIONS_UPDATE, s)
+    s => requireDraftAnswersScope(principal, APPLICATIONS_UPDATE, s)
   );
 
   return { application: stateToProto(state) };

--- a/services/audit/src/grpc/reports-handlers.test.ts
+++ b/services/audit/src/grpc/reports-handlers.test.ts
@@ -14,12 +14,14 @@ import {
   upsertReportSchedule,
 } from './reports-handlers.js';
 
-function makePrincipal(over: { userId?: string; roles?: string[]; permissions?: string[] } = {}) {
+function makePrincipal(
+  over: { userId?: string; roles?: string[]; permissions?: string[]; rescueId?: string } = {}
+) {
   return {
     userId: over.userId ?? 'usr-1',
     roles: over.roles ?? ['admin'],
     permissions: over.permissions ?? ['reports.read'],
-    rescueId: undefined,
+    rescueId: over.rescueId,
   } as unknown as Parameters<typeof listSavedReports>[1];
 }
 
@@ -416,13 +418,70 @@ describe('listReportTemplates', () => {
     expect(params).toContain('adoption');
   });
 
-  it('includes system + rescue-scoped when rescueId is provided', async () => {
+  // ADS-1009 — tenant scoping is derived from the principal, not the request.
+
+  it('scopes a rescue principal to its own rescue + system on an empty request', async () => {
     const q = vi.fn().mockResolvedValue({ rows: [] });
     const { deps } = makeDeps(q);
-    await listReportTemplates(deps, makePrincipal(), { category: 0, rescueId: 'rescue-1' });
+    await listReportTemplates(deps, makePrincipal({ rescueId: 'rescue-1' }), {
+      category: 0,
+    });
     const sql = q.mock.calls[0][0] as string;
+    const params = q.mock.calls[0][1] as unknown[];
     expect(sql).toContain('rescue_id = $');
     expect(sql).toContain('OR rescue_id IS NULL');
+    // Scoped to the PRINCIPAL's rescue, regardless of any request field.
+    expect(params).toContain('rescue-1');
+  });
+
+  it('ignores a foreign rescueId from a rescue principal (no cross-tenant rows)', async () => {
+    const q = vi.fn().mockResolvedValue({ rows: [] });
+    const { deps } = makeDeps(q);
+    await listReportTemplates(deps, makePrincipal({ rescueId: 'rescue-1' }), {
+      category: 0,
+      rescueId: 'rescue-2',
+    });
+    const params = q.mock.calls[0][1] as unknown[];
+    // Only the principal's own rescue is queried; the supplied id is dropped.
+    expect(params).toContain('rescue-1');
+    expect(params).not.toContain('rescue-2');
+  });
+
+  it('falls a rescue-less non-super-admin through to system templates only', async () => {
+    const q = vi.fn().mockResolvedValue({ rows: [] });
+    const { deps } = makeDeps(q);
+    await listReportTemplates(deps, makePrincipal({ rescueId: undefined }), { category: 0 });
+    const sql = q.mock.calls[0][0] as string;
+    const params = q.mock.calls[0][1] as unknown[];
+    expect(sql).toContain('rescue_id IS NULL');
+    // No rescue predicate parameter — never the unscoped table.
+    expect(sql).not.toContain('rescue_id = $');
+    expect(params).toHaveLength(0);
+  });
+
+  it('lets super_admin (reports.read:any) enumerate across all rescues', async () => {
+    const q = vi.fn().mockResolvedValue({ rows: [] });
+    const { deps } = makeDeps(q);
+    await listReportTemplates(deps, makePrincipal({ permissions: ['reports.read:any'] }), {
+      category: 0,
+    });
+    const sql = q.mock.calls[0][0] as string;
+    const params = q.mock.calls[0][1] as unknown[];
+    // No rescue scoping predicate — the only WHERE clause is the soft-delete.
+    expect(sql).not.toContain('rescue_id = $');
+    expect(sql).not.toContain('rescue_id IS NULL');
+    expect(params).toHaveLength(0);
+  });
+
+  it('lets super_admin narrow to a specific rescue via req.rescueId', async () => {
+    const q = vi.fn().mockResolvedValue({ rows: [] });
+    const { deps } = makeDeps(q);
+    await listReportTemplates(deps, makePrincipal({ permissions: ['reports.read:any'] }), {
+      category: 0,
+      rescueId: 'rescue-2',
+    });
+    const params = q.mock.calls[0][1] as unknown[];
+    expect(params).toContain('rescue-2');
   });
 });
 

--- a/services/audit/src/grpc/reports-handlers.ts
+++ b/services/audit/src/grpc/reports-handlers.ts
@@ -417,6 +417,25 @@ export async function listReportTemplates(
   const where: string[] = ['deleted_at IS NULL'];
   const params: unknown[] = [];
 
+  // Tenant scoping FIRST, derived from the principal — never from the request
+  // (ADS-1009). Only reports.read:any (super_admin) may enumerate across
+  // rescues; a caller-supplied req.rescueId is honoured only for those callers
+  // as an optional narrowing filter. A rescue-scoped caller is always
+  // constrained to their own rescue plus system templates, and a caller with
+  // no rescue context falls through to system templates only — never the
+  // unscoped table (compare ADS-934 in rescue/src/grpc/event-handlers.ts).
+  if (hasPerm(principal, REPORTS_READ_ANY)) {
+    if (req.rescueId !== undefined && req.rescueId !== '') {
+      where.push(`(rescue_id = $${params.length + 1} OR rescue_id IS NULL)`);
+      params.push(req.rescueId);
+    }
+  } else if (principal.rescueId !== undefined && principal.rescueId !== '') {
+    where.push(`(rescue_id = $${params.length + 1} OR rescue_id IS NULL)`);
+    params.push(principal.rescueId);
+  } else {
+    where.push(`rescue_id IS NULL`);
+  }
+
   if (
     req.category !== undefined &&
     req.category !== AuditV1.ReportTemplateCategory.REPORT_TEMPLATE_CATEGORY_UNSPECIFIED
@@ -426,12 +445,6 @@ export async function listReportTemplates(
       where.push(`category = $${params.length + 1}`);
       params.push(cat);
     }
-  }
-  if (req.rescueId !== undefined && req.rescueId !== '') {
-    // Include both rescue-specific and system (rescue_id IS NULL) when
-    // a rescue is provided — the admin UI wants to see both.
-    where.push(`(rescue_id = $${params.length + 1} OR rescue_id IS NULL)`);
-    params.push(req.rescueId);
   }
   if (req.systemOnly === true) {
     where.push(`is_system = true`);

--- a/services/gateway/src/config.ts
+++ b/services/gateway/src/config.ts
@@ -110,6 +110,16 @@ export type GatewayConfig = {
   cors: {
     origins: string[];
   };
+  // Whether an X-Forwarded-For header on an inbound connection may be trusted
+  // to carry the real client IP (ADS-1021). True only when a trusted proxy
+  // (nginx) sits in front and overwrites XFF with the peer address — then the
+  // WebSocket handshake rate limiter keys per real client. False on a bare
+  // gateway reachable directly, where a client controls XFF and could rotate
+  // buckets (or pin a victim's) to defeat the limiter, so the raw socket
+  // address is used instead. Sourced from TRUST_PROXY; defaults true in
+  // production/staging (deployed behind nginx, matching the HTTP path's
+  // trustProxy:1) and false otherwise so debug/direct runs are safe by default.
+  trustProxy: boolean;
   // Rate limiting — applied at the gateway edge for every route.
   // Backed by a shared Redis store in production/staging so per-replica
   // limits don't multiply by N replicas. Falls back to an in-memory
@@ -175,9 +185,26 @@ export const loadConfig = (env: NodeJS.ProcessEnv = process.env): GatewayConfig 
     principalSigningKey: readOptionalSecret('PRINCIPAL_SIGNING_KEY', env, 32),
     testTokenPeek: buildTestTokenPeekConfig(env),
     cors: buildCorsConfig(env, environment),
+    trustProxy: buildTrustProxy(env, environment),
     rateLimit: buildRateLimitConfig(env),
   };
 };
+
+// TRUST_PROXY gates whether X-Forwarded-For is believed (ADS-1021). Explicit
+// 'true'/'false' (or '1'/'0') wins; absent, it follows the deployment posture:
+// production/staging run behind nginx (which overwrites XFF) so trust is on and
+// the WS handshake limiter buckets per real client, while every other
+// environment defaults off so a directly-reachable gateway can't be spoofed.
+function buildTrustProxy(env: NodeJS.ProcessEnv, environment: string): boolean {
+  const raw = env.TRUST_PROXY?.trim().toLowerCase();
+  if (raw === 'true' || raw === '1') {
+    return true;
+  }
+  if (raw === 'false' || raw === '0') {
+    return false;
+  }
+  return environment === 'production' || environment === 'staging';
+}
 
 // Build the CORS config block. CORS_ORIGIN is a comma-separated list
 // of allowed origins (e.g. "http://localhost:3000,http://localhost:3001").

--- a/services/gateway/src/routes/moderation.test.ts
+++ b/services/gateway/src/routes/moderation.test.ts
@@ -6,7 +6,7 @@ import { ModerationV1 } from '@adopt-dont-shop/proto';
 
 import type { ModerationClient } from '../grpc-clients/moderation-client.js';
 
-import { registerModerationRoutes } from './moderation.js';
+import { registerModerationRoutes, reportFileRateLimitKey } from './moderation.js';
 
 function makeClient(): {
   client: ModerationClient;
@@ -48,6 +48,24 @@ const HEADERS = {
   'x-user-roles': 'admin',
   'x-user-permissions': 'admin.dashboard',
 };
+
+describe('reportFileRateLimitKey (ADS-1019 per-principal report rate limit)', () => {
+  it('keys on the authenticated user id when present', () => {
+    const req = {
+      headers: { 'x-user-id': 'usr-1' },
+      ip: '10.0.0.5',
+    } as unknown as Parameters<typeof reportFileRateLimitKey>[0];
+    expect(reportFileRateLimitKey(req)).toBe('usr-1');
+  });
+
+  it('falls back to the peer IP when unauthenticated', () => {
+    const req = {
+      headers: {},
+      ip: '10.0.0.5',
+    } as unknown as Parameters<typeof reportFileRateLimitKey>[0];
+    expect(reportFileRateLimitKey(req)).toBe('10.0.0.5');
+  });
+});
 
 describe('moderation report routes', () => {
   let app: FastifyInstance;

--- a/services/gateway/src/routes/moderation.ts
+++ b/services/gateway/src/routes/moderation.ts
@@ -66,6 +66,18 @@ export type ModerationRoutesOptions = {
 const RL_WRITE = { max: 30, timeWindow: '1 minute' } as const;
 const RL_READ = { max: 120, timeWindow: '1 minute' } as const;
 
+// Report filing is open to any authenticated user, so it is rate-limited PER
+// PRINCIPAL (ADS-1019) — one account can't flood the moderator queue across
+// many entities even from rotating IPs. Falls back to the peer IP for the rare
+// unauthenticated path. Bounds the cross-entity volume the per-reporter dedup
+// (one open report per entity) doesn't cover on its own.
+export const reportFileRateLimitKey = (req: FastifyRequest): string => headerUserId(req) ?? req.ip;
+const RL_REPORT_FILE = {
+  max: 30,
+  timeWindow: '1 minute',
+  keyGenerator: reportFileRateLimitKey,
+} as const;
+
 export const registerModerationRoutes = async (
   app: FastifyInstance,
   opts: ModerationRoutesOptions
@@ -79,7 +91,7 @@ export const registerModerationRoutes = async (
   app.post(
     '/api/v1/moderation/reports',
     {
-      config: { rateLimit: RL_WRITE },
+      config: { rateLimit: RL_REPORT_FILE },
       schema: {
         tags: ['moderation'],
         summary: 'File a moderation report',

--- a/services/gateway/src/ws/socket-server.test.ts
+++ b/services/gateway/src/ws/socket-server.test.ts
@@ -6,6 +6,8 @@ import type { Server as IOServer } from 'socket.io';
 import type { Logger } from 'winston';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { getMetricsRegistry } from '@adopt-dont-shop/observability';
+
 import type { ValidateTokenResponse } from '@adopt-dont-shop/proto';
 
 import type { GatewayConfig } from '../config.js';
@@ -16,6 +18,7 @@ import {
   attachSocketServer,
   createHandshakeRateLimiter,
   emitToUser,
+  handshakeClientIp,
   type AttachSocketServerOptions,
   type RedisAdapterClient,
 } from './socket-server.js';
@@ -36,6 +39,10 @@ function devConfig(overrides?: Partial<GatewayConfig>): GatewayConfig {
   return {
     environment: 'development',
     cors: { origins: ['http://localhost:3000'] },
+    // Default: a bare gateway that does NOT trust X-Forwarded-For (ADS-1021),
+    // so the handshake limiter keys on the real socket address. Tests behind a
+    // proxy override with trustProxy: true.
+    trustProxy: false,
     ...overrides,
   } as GatewayConfig;
 }
@@ -585,5 +592,73 @@ describe('handshake rate limiting — pre-auth per-IP cap (ADS-962)', () => {
     // The two admitted handshakes each validate their token; the rejected
     // third is short-circuited by the limiter before the auth round-trip.
     expect(validateMock).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('handshakeClientIp — trusted-proxy-aware keying (ADS-1021)', () => {
+  const ADDR = '203.0.113.9';
+
+  it('ignores X-Forwarded-For entirely on an untrusted (bare-gateway) peer', () => {
+    // A directly-reachable gateway must not believe a client-supplied header —
+    // otherwise the client rotates buckets to defeat the limiter.
+    expect(handshakeClientIp({ 'x-forwarded-for': '1.1.1.1' }, ADDR, false)).toBe(ADDR);
+    expect(handshakeClientIp({ 'x-forwarded-for': '1.1.1.1, 2.2.2.2' }, ADDR, false)).toBe(ADDR);
+  });
+
+  it('falls back to the socket address when the header is absent', () => {
+    expect(handshakeClientIp({}, ADDR, false)).toBe(ADDR);
+    expect(handshakeClientIp({}, ADDR, true)).toBe(ADDR);
+  });
+
+  it('honours a single-entry X-Forwarded-For behind a trusted proxy', () => {
+    expect(handshakeClientIp({ 'x-forwarded-for': '198.51.100.7' }, ADDR, true)).toBe(
+      '198.51.100.7'
+    );
+  });
+
+  it('takes the rightmost entry of a multi-entry X-Forwarded-For behind a trusted proxy', () => {
+    // nginx appends the real peer as the last hop (ADS-915).
+    expect(handshakeClientIp({ 'x-forwarded-for': '9.9.9.9, 198.51.100.7' }, ADDR, true)).toBe(
+      '198.51.100.7'
+    );
+  });
+});
+
+describe('handshake rate limiting — XFF spoofing on an untrusted peer (ADS-1021)', () => {
+  it('trips the limiter and increments the reject counter despite a rotating spoofed XFF', async () => {
+    const rejectCounter = getMetricsRegistry().getSingleMetric(
+      'gateway_ws_handshake_ratelimit_rejects_total'
+    );
+    const readRejects = async (): Promise<number> => {
+      const snapshot = await rejectCounter?.get();
+      return snapshot?.values[0]?.value ?? 0;
+    };
+    const before = await readRejects();
+
+    // Untrusted peer (devConfig trustProxy:false); all three share the loopback
+    // socket address, so distinct spoofed XFF values must NOT split the bucket.
+    const { url } = await startServer({
+      logger: quietLogger(),
+      authClient: makeAuthClient(vi.fn().mockResolvedValue(VALID_RES)),
+      handshakeRateLimit: { max: 2, windowMs: 60_000 },
+    });
+
+    const spoof = (v: string): ClientSocket => {
+      const client = ioClient(url, {
+        path: '/socket.io',
+        transports: ['websocket'],
+        reconnection: false,
+        auth: { token: 'good.jwt' },
+        extraHeaders: { 'X-Forwarded-For': v },
+      });
+      clients.push(client);
+      return client;
+    };
+
+    expect(await awaitConnectOutcome(spoof('1.1.1.1'))).toBe(true);
+    expect(await awaitConnectOutcome(spoof('2.2.2.2'))).toBe(true);
+    expect(await awaitConnectOutcome(spoof('3.3.3.3'))).toBe(false);
+
+    expect(await readRejects()).toBe(before + 1);
   });
 });

--- a/services/gateway/src/ws/socket-server.ts
+++ b/services/gateway/src/ws/socket-server.ts
@@ -40,7 +40,7 @@
 //     join the per-user room for adapter-backed addressing.
 //   - On disconnect: unregister.
 
-import type { Server as HttpServer } from 'node:http';
+import type { IncomingHttpHeaders, Server as HttpServer } from 'node:http';
 
 import { Metadata } from '@grpc/grpc-js';
 import { getMetricsRegistry } from '@adopt-dont-shop/observability';
@@ -144,22 +144,33 @@ export const createHandshakeRateLimiter = (opts: {
   return { tryConsume };
 };
 
-// The client IP for handshake rate-limit keying. nginx overwrites
-// X-Forwarded-For with the real connecting IP ($remote_addr, ADS-915), so
-// when the header is present the RIGHTMOST entry is the trustworthy hop —
-// mirroring the HTTP path's trustProxy:1. A client-prepended XFF is discarded
-// by nginx, and taking the rightmost entry also resists spoofing on a
-// direct-to-gateway path. Falls back to the raw socket address when there's
-// no proxy header (a direct connection).
-const handshakeClientIp = (socket: Socket): string => {
-  const xff = socket.handshake.headers['x-forwarded-for'];
-  if (typeof xff === 'string' && xff.length > 0) {
-    const last = xff.split(',').pop()?.trim();
+// The client IP used to key the handshake rate limiter (ADS-1021).
+//
+// X-Forwarded-For is only meaningful when a trusted proxy set it. Behind nginx
+// (trustProxy), the header carries the real peer ($remote_addr, ADS-915), so
+// the RIGHTMOST entry is the trustworthy hop — mirroring the HTTP path's
+// trustProxy:1 — and distinct clients get distinct buckets. On a bare,
+// directly-reachable gateway (!trustProxy) the client owns the header and could
+// rotate it to get a fresh bucket every handshake — or pin a victim's IP to
+// exhaust theirs — so the header is ignored entirely and the raw socket address
+// is used. Pure and exported so the resolution rule is directly testable.
+export const handshakeClientIp = (
+  headers: IncomingHttpHeaders,
+  socketAddress: string,
+  trustProxy: boolean
+): string => {
+  if (!trustProxy) {
+    return socketAddress;
+  }
+  const xff = headers['x-forwarded-for'];
+  const raw = Array.isArray(xff) ? xff[xff.length - 1] : xff;
+  if (typeof raw === 'string' && raw.length > 0) {
+    const last = raw.split(',').pop()?.trim();
     if (last) {
       return last;
     }
   }
-  return socket.handshake.address;
+  return socketAddress;
 };
 
 // The slim Redis pub/sub surface the @socket.io/redis-adapter broadcast path
@@ -183,7 +194,7 @@ export type AttachSocketServerOptions = {
   // dev-vs-prod distinction lives in loadConfig(): dev gets localhost
   // defaults, prod must set CORS_ORIGIN or every cross-origin handshake is
   // rejected here.
-  config: Pick<GatewayConfig, 'cors'>;
+  config: Pick<GatewayConfig, 'cors' | 'trustProxy'>;
   // The auth gRPC client used to verify handshake tokens. Required in
   // production (wired in index.ts). Optional only so pure unit tests of
   // the registry/subscriber wiring don't have to stand one up.
@@ -262,7 +273,11 @@ export const attachSocketServer = (opts: AttachSocketServerOptions): IOServer =>
   const handshakeRejectsTotal = getOrCreateHandshakeRejectCounter();
 
   io.use((socket, next) => {
-    const ip = handshakeClientIp(socket);
+    const ip = handshakeClientIp(
+      socket.handshake.headers,
+      socket.handshake.address,
+      config.trustProxy
+    );
     if (!handshakeLimiter.tryConsume(ip)) {
       handshakeRejectsTotal.inc();
       logger.warn('socket handshake rate limit exceeded', { ip });

--- a/services/matching/src/gdpr/erase.ts
+++ b/services/matching/src/gdpr/erase.ts
@@ -12,11 +12,12 @@ export async function eraseMatching(
 ): Promise<number> {
   let total = 0;
   // Order matters: swipe_actions FK swipe_sessions, so drop actions first.
-  // Match on EITHER the action's own user_id OR its parent session's
-  // owner: recordSwipe lets an authenticated user swipe within a
-  // null-owner (anonymous) session, so a personal swipe row can hang off
-  // a session the user doesn't own. Deleting only via session ownership
-  // would orphan that personal data and breach erasure completeness.
+  // Match on EITHER the action's own user_id OR its parent session's owner.
+  // recordSwipe now denies an authenticated user swiping within a null-owner
+  // session (ADS-1020), but pre-existing / monolith-migrated rows may still
+  // have a personal swipe hanging off a session the user doesn't own, so the
+  // OR clause stays — deleting only via session ownership would orphan that
+  // personal data and breach erasure completeness.
   for (const sql of [
     `DELETE FROM matching.swipe_actions
        USING matching.swipe_sessions s

--- a/services/matching/src/grpc/handlers.test.ts
+++ b/services/matching/src/grpc/handlers.test.ts
@@ -220,6 +220,13 @@ describe('endSession', () => {
     });
   });
 
+  it('denies a NULL-owner (anonymous) session for a non-super-admin caller (ADS-1020)', async () => {
+    const { deps } = makeDeps([{ rows: [sessionRow({ user_id: null })] }]);
+    await expect(endSession(deps, makePrincipal(), { sessionId: 'sess-1' })).rejects.toMatchObject({
+      code: 'PERMISSION_DENIED',
+    });
+  });
+
   it('allows a super_admin to end another user session', async () => {
     const { deps } = makeDeps([
       { rows: [sessionRow({ user_id: 'someone-else' })] }, // SELECT FOR UPDATE
@@ -319,6 +326,17 @@ describe('recordSwipe', () => {
 
   it('throws PERMISSION_DENIED when principal is not the session owner', async () => {
     const { deps } = makeDeps([{ rows: [sessionRow({ user_id: 'someone-else' })] }]);
+    await expect(
+      recordSwipe(deps, makePrincipal(), {
+        sessionId: 'sess-1',
+        petId: 'pet-1',
+        action: MatchingV1.SwipeAction.SWIPE_ACTION_LIKE,
+      })
+    ).rejects.toMatchObject({ code: 'PERMISSION_DENIED' });
+  });
+
+  it('denies a NULL-owner (anonymous) session for a non-super-admin caller (ADS-1020)', async () => {
+    const { deps } = makeDeps([{ rows: [sessionRow({ user_id: null })] }]);
     await expect(
       recordSwipe(deps, makePrincipal(), {
         sessionId: 'sess-1',

--- a/services/matching/src/grpc/handlers.ts
+++ b/services/matching/src/grpc/handlers.ts
@@ -49,7 +49,7 @@ import {
   type SwipeSessionRow,
 } from './mapper.js';
 
-function ensureSwipePermission(principal: Principal): void {
+export function ensureSwipePermission(principal: Principal): void {
   if (!requirePermission(principal, PETS_VIEW)) {
     throw new HandlerError('PERMISSION_DENIED', `'${PETS_VIEW}' required`);
   }
@@ -187,12 +187,13 @@ export async function endSession(
     const row = existing.rows[0];
 
     // Ownership: only the session owner can close it. super_admin
-    // bypasses (CAD pattern) — same guard shape as recordSwipe.
-    if (
-      row.user_id !== null &&
-      row.user_id !== principal.userId &&
-      !principal.roles.includes('super_admin')
-    ) {
+    // bypasses (CAD pattern) — same guard shape as recordSwipe. A
+    // NULL-owner (anonymous) session has no authenticated owner, so an
+    // authenticated caller is never its owner — deny unless super_admin
+    // (ADS-1020). The old guard fell OPEN on user_id === null, letting any
+    // caller holding a session id close someone else's anonymous session.
+    const isOwner = row.user_id !== null && row.user_id === principal.userId;
+    if (!isOwner && !principal.roles.includes('super_admin')) {
       throw new HandlerError('PERMISSION_DENIED', 'not the session owner');
     }
 
@@ -276,12 +277,13 @@ export async function recordSwipe(
     const sessionRow = session.rows[0];
 
     // Ownership: only the session owner can record a swipe on it.
-    // super_admin bypasses (CAD pattern).
-    if (
-      sessionRow.user_id !== null &&
-      sessionRow.user_id !== principal.userId &&
-      !principal.roles.includes('super_admin')
-    ) {
+    // super_admin bypasses (CAD pattern). A NULL-owner (anonymous) session
+    // has no authenticated owner, so an authenticated caller is never its
+    // owner — deny unless super_admin (ADS-1020). The old guard fell OPEN on
+    // user_id === null, letting a personal swipe row hang off a session the
+    // caller doesn't own (see gdpr/erase.ts) and corrupt the matching signal.
+    const isOwner = sessionRow.user_id !== null && sessionRow.user_id === principal.userId;
+    if (!isOwner && !principal.roles.includes('super_admin')) {
       throw new HandlerError('PERMISSION_DENIED', 'not the session owner');
     }
 

--- a/services/matching/src/grpc/profile-stats-handlers.test.ts
+++ b/services/matching/src/grpc/profile-stats-handlers.test.ts
@@ -204,6 +204,13 @@ describe('getUserSwipeStats', () => {
 // --- GetSessionStats -------------------------------------------------
 
 describe('getSessionStats', () => {
+  it('denies a principal without the swipe (pets.read) permission (ADS-1020)', async () => {
+    const { deps } = makeDeps([]);
+    await expect(
+      getSessionStats(deps, makePrincipal({ permissions: [] }), { sessionId: 'sess-1' })
+    ).rejects.toMatchObject({ code: 'PERMISSION_DENIED' });
+  });
+
   it('rejects a missing session_id', async () => {
     const { deps } = makeDeps([]);
     await expect(getSessionStats(deps, makePrincipal(), { sessionId: '' })).rejects.toMatchObject({

--- a/services/matching/src/grpc/profile-stats-handlers.ts
+++ b/services/matching/src/grpc/profile-stats-handlers.ts
@@ -23,6 +23,7 @@ import type {
 } from '@adopt-dont-shop/proto';
 
 import { HandlerError, type HandlerDeps } from './adapter.js';
+import { ensureSwipePermission } from './handlers.js';
 
 const SWIPES_READ_ANY: Permission = 'matching.swipes.read:any' as Permission;
 
@@ -286,11 +287,20 @@ export async function getSessionStats(
   principal: Principal,
   req: GetSessionStatsRequest
 ): Promise<GetSessionStatsResponse> {
+  // Capability gate — every sibling handler runs ensureSwipePermission;
+  // getSessionStats was the only one that skipped it (ADS-1020), so a
+  // principal stripped of pets.read could still read session stats.
+  ensureSwipePermission(principal);
+
   if (!req.sessionId) {
     throw new HandlerError('INVALID_ARGUMENT', 'session_id is required');
   }
   // Resolve the session owner for the IDOR check. Anonymous sessions
-  // (user_id NULL) are readable by anyone with a valid session id.
+  // (user_id NULL) remain readable by any bearer of the session id: the id
+  // is a random UUIDv4 (StartSession: randomUUID()), so it is unguessable
+  // and functions as a bearer capability for the anonymous browsing client.
+  // Only the READ path keeps this policy — the mutating paths (recordSwipe /
+  // endSession) deny NULL-owner sessions to authenticated callers (ADS-1020).
   const owner = await deps.pool.query<{ user_id: string | null }>(
     `SELECT user_id FROM matching.swipe_sessions WHERE session_id = $1 LIMIT 1`,
     [req.sessionId]

--- a/services/moderation/src/grpc/handlers.test.ts
+++ b/services/moderation/src/grpc/handlers.test.ts
@@ -408,6 +408,31 @@ describe('listReports', () => {
     expect(sql).toContain('assigned_moderator IS NULL');
   });
 
+  // ADS-1018 — the assigned_moderator filter is redacted from the reporter
+  // projection, so a reporter-scoped caller must not be able to filter on it
+  // (the result set would recover the redacted value).
+  it('denies a reporter-scoped caller filtering on assignedModerator', async () => {
+    const { deps, query } = makeDeps([{ rows: [] }]);
+    await expect(
+      listReports(deps, makePrincipal({ userId: 'usr-1', permissions: [] }), {
+        assignedModerator: 'mod-1',
+        limit: 10,
+      } as ListReportsRequest)
+    ).rejects.toMatchObject({ code: 'PERMISSION_DENIED' });
+    expect(query).not.toHaveBeenCalled();
+  });
+
+  it('denies a reporter-scoped caller filtering on assignedModerator="" (IS NULL oracle)', async () => {
+    const { deps, query } = makeDeps([{ rows: [] }]);
+    await expect(
+      listReports(deps, makePrincipal({ userId: 'usr-1', permissions: [] }), {
+        assignedModerator: '',
+        limit: 10,
+      } as ListReportsRequest)
+    ).rejects.toMatchObject({ code: 'PERMISSION_DENIED' });
+    expect(query).not.toHaveBeenCalled();
+  });
+
   it('emits nextCursor when more rows than limit', async () => {
     const eleven = Array.from({ length: 11 }, (_, i) =>
       reportRow({ report_id: `r-${i}`, created_at: new Date(2026, 5, 1, 12, 0, 0, i) })

--- a/services/moderation/src/grpc/handlers.test.ts
+++ b/services/moderation/src/grpc/handlers.test.ts
@@ -184,6 +184,41 @@ describe('fileReport', () => {
       payload: { reportId: 'persisted-rpt' },
     });
   });
+
+  // ADS-1019 — per-reporter dedup for user reports; SYSTEM path unchanged.
+  it('dedups a user report per-reporter (one OPEN report per reporter+entity)', async () => {
+    const { deps, query } = makeDeps([{ rows: [reportRow()] }]);
+    await fileReport(deps, makePrincipal({ userId: 'usr-1' }), VALID_FILE_REQ);
+    const sql = String(query.mock.calls[0][0]);
+    expect(sql).toMatch(/ON CONFLICT \(reporter_id, reported_entity_type, reported_entity_id\)/);
+    // Scoped to open statuses so a reporter may re-file once resolved/dismissed.
+    expect(sql).toMatch(/status IN \('pending', 'under_review', 'escalated'\)/);
+  });
+
+  it('a repeat user report against the same entity collapses to a no-op (no duplicate)', async () => {
+    // ON CONFLICT DO UPDATE returns the existing row with was_inserted=false.
+    const { deps } = makeDeps([
+      { rows: [reportRow({ report_id: 'first-rpt', was_inserted: false })] },
+    ]);
+    const res = await fileReport(deps, makePrincipal({ userId: 'usr-1' }), VALID_FILE_REQ);
+    const publish = (deps as { _publish?: ReturnType<typeof vi.fn> })._publish!;
+    expect(publish).not.toHaveBeenCalled();
+    expect(res.report.reportId).toBe('first-rpt');
+  });
+
+  it('SYSTEM auto-reports keep the entity-scoped arbiter (no regression)', async () => {
+    const { deps, query } = makeDeps([{ rows: [reportRow()] }]);
+    await fileReport(
+      deps,
+      makePrincipal({ userId: '00000000-0000-0000-0000-000000000000' }),
+      VALID_FILE_REQ
+    );
+    const sql = String(query.mock.calls[0][0]);
+    expect(sql).toMatch(/ON CONFLICT \(reported_entity_type, reported_entity_id\)/);
+    expect(sql).toMatch(/WHERE reporter_id = '00000000-0000-0000-0000-000000000000'/);
+    // Not the per-reporter arbiter.
+    expect(sql).not.toMatch(/ON CONFLICT \(reporter_id,/);
+  });
 });
 
 describe('getReport', () => {

--- a/services/moderation/src/grpc/handlers.ts
+++ b/services/moderation/src/grpc/handlers.ts
@@ -98,12 +98,28 @@ export async function fileReport(
   const severityDb = severityToDb(req.severity);
   const metadataJson = parseMetadataJson(req.metadataJson);
 
+  // Dedup arbiter (ADS-1019). SYSTEM auto-reports dedup on the entity alone
+  // (JetStream may redeliver the same event). A real user's reports dedup
+  // per-reporter: one OPEN report per (reporter, entity), so a single account
+  // can't flood the moderator queue with duplicate rows against one target.
+  // Both paths DO UPDATE (a no-op that returns the existing row with
+  // was_inserted = false), so the caller gets the canonical report either way.
+  const isSystemReporter = principal.userId === SYSTEM_USER_ID;
+  const conflictClause = isSystemReporter
+    ? `ON CONFLICT (reported_entity_type, reported_entity_id)
+         WHERE reporter_id = '${SYSTEM_USER_ID}'
+         DO UPDATE SET updated_at = reports.updated_at`
+    : `ON CONFLICT (reporter_id, reported_entity_type, reported_entity_id)
+         WHERE reporter_id <> '${SYSTEM_USER_ID}'
+           AND status IN ('pending', 'under_review', 'escalated')
+         DO UPDATE SET updated_at = reports.updated_at`;
+
   return withTransaction(deps, async ({ client, publish }) => {
     const reportId = randomUUID();
     // `was_inserted` (xmax = 0) distinguishes a fresh insert from the
     // ON CONFLICT no-op so JetStream redelivery of a SYSTEM auto-report
-    // doesn't re-publish. The persisted report_id (not the throwaway
-    // `reportId`) is the canonical id on the conflict path.
+    // (or a repeat user report) doesn't re-publish. The persisted report_id
+    // (not the throwaway `reportId`) is the canonical id on the conflict path.
     const inserted = await client.query<ReportRow & { was_inserted: boolean }>(
       `INSERT INTO reports (
          report_id, reporter_id, reported_entity_type, reported_entity_id,
@@ -111,9 +127,7 @@ export async function fileReport(
          metadata
        )
        VALUES ($1, $2, $3, $4, $5, $6, $7, 'pending', $8, $9, $10::jsonb)
-       ON CONFLICT (reported_entity_type, reported_entity_id)
-         WHERE reporter_id = '${SYSTEM_USER_ID}'
-         DO UPDATE SET updated_at = reports.updated_at
+       ${conflictClause}
        RETURNING report_id, reporter_id, reported_entity_type, reported_entity_id,
                  reported_user_id, category, severity, status, title, description,
                  metadata, assigned_moderator, assigned_at, resolved_by, resolved_at,

--- a/services/moderation/src/grpc/handlers.ts
+++ b/services/moderation/src/grpc/handlers.ts
@@ -254,6 +254,18 @@ export async function listReports(
     params.push(categoryToDb(req.category));
   }
   if (req.assignedModerator !== undefined) {
+    // assigned_moderator is redacted from the reporter-safe projection
+    // (reportRowToProto forReporter=true), so it must not be filterable by a
+    // caller who can't see it — otherwise the result set is an oracle that
+    // recovers the redacted value (ADS-1018). '' → IS NULL is the same leak
+    // (assigned-vs-unassigned). Reject rather than silently ignore: a caller
+    // filtering on a field they can't see is confused or probing.
+    if (!canViewInternal) {
+      throw new HandlerError(
+        'PERMISSION_DENIED',
+        `'${MODERATION_REPORTS_VIEW}' required to filter on assigned_moderator`
+      );
+    }
     if (req.assignedModerator === '') {
       where.push(`assigned_moderator IS NULL`);
     } else {

--- a/services/moderation/src/grpc/mapper.ts
+++ b/services/moderation/src/grpc/mapper.ts
@@ -84,6 +84,12 @@ export function reportRowToProto(row: ReportRow, forReporter = false): Report {
   }
 
   // Internal moderation-workflow fields — moderators only.
+  //
+  // COUPLING (ADS-1018): every field redacted below must also be non-filterable
+  // by a reporter-scoped caller in listReports — allowing a filter on a
+  // redacted field turns the result set into an oracle that recovers the value.
+  // Keep this redaction list and listReports' filter gating in sync: today only
+  // assigned_moderator is filterable, and it is gated on MODERATION_REPORTS_VIEW.
   if (row.assigned_moderator !== null) {
     report.assignedModerator = row.assigned_moderator;
   }

--- a/services/moderation/src/grpc/ticket-handlers.test.ts
+++ b/services/moderation/src/grpc/ticket-handlers.test.ts
@@ -9,7 +9,7 @@ import {
   type RespondToTicketRequest,
 } from '@adopt-dont-shop/proto';
 
-import { HandlerError, type HandlerDeps } from './adapter.js';
+import { type HandlerDeps } from './adapter.js';
 import {
   assignSupportTicket,
   getSupportTicket,
@@ -139,6 +139,55 @@ describe('openSupportTicket', () => {
     await expect(
       openSupportTicket(deps, makePrincipal(), req as OpenSupportTicketRequest)
     ).rejects.toMatchObject({ code: 'INVALID_ARGUMENT' });
+  });
+
+  // ADS-1017 — user_email / user_name field validation.
+  it('rejects a user_email containing CR/LF (header-injection payload)', async () => {
+    const { deps, query } = makeDeps([]);
+    await expect(
+      openSupportTicket(deps, makePrincipal(), {
+        ...VALID_OPEN,
+        userEmail: 'user@example.com\r\nBcc: victim@example.com',
+      })
+    ).rejects.toMatchObject({ code: 'INVALID_ARGUMENT' });
+    expect(query).not.toHaveBeenCalled();
+  });
+
+  it('rejects a malformed user_email', async () => {
+    const { deps } = makeDeps([]);
+    await expect(
+      openSupportTicket(deps, makePrincipal(), { ...VALID_OPEN, userEmail: 'not-an-email' })
+    ).rejects.toMatchObject({ code: 'INVALID_ARGUMENT' });
+  });
+
+  it('rejects a user_email over the length bound', async () => {
+    const { deps } = makeDeps([]);
+    const longLocal = 'a'.repeat(250);
+    await expect(
+      openSupportTicket(deps, makePrincipal(), {
+        ...VALID_OPEN,
+        userEmail: `${longLocal}@example.com`,
+      })
+    ).rejects.toMatchObject({ code: 'INVALID_ARGUMENT' });
+  });
+
+  it('rejects a user_name containing control characters', async () => {
+    const { deps } = makeDeps([]);
+    await expect(
+      openSupportTicket(deps, makePrincipal(), {
+        ...VALID_OPEN,
+        userName: 'Platform Security\r\nX-Injected: 1',
+      })
+    ).rejects.toMatchObject({ code: 'INVALID_ARGUMENT' });
+  });
+
+  it('accepts a valid user_email + user_name', async () => {
+    const { deps } = makeDeps([{ rows: [ticketRow()] }]);
+    const res = await openSupportTicket(deps, makePrincipal(), {
+      ...VALID_OPEN,
+      userName: 'Jane Doe',
+    });
+    expect(res.ticket.ticketId).toBe('tkt-1');
   });
 
   it('falls back to principal.userId when request user_id is absent', async () => {

--- a/services/moderation/src/grpc/ticket-handlers.ts
+++ b/services/moderation/src/grpc/ticket-handlers.ts
@@ -66,6 +66,44 @@ function clampLimit(raw: number): number {
   return Math.min(Math.trunc(raw), MAX_LIMIT);
 }
 
+// Ticket identity-field validation (ADS-1017). user_email / user_name are
+// written verbatim into the support_tickets row, the moderation.ticketOpened
+// event, and the staff inbox, so they must not carry a CRLF / control-char
+// header-injection payload, and user_email must be a plausibly-real, bounded
+// address rather than arbitrary attacker text.
+const MAX_EMAIL_LENGTH = 254; // RFC 5321 forward-path limit.
+const MAX_NAME_LENGTH = 200;
+// C0 controls (incl. CR U+000D / LF U+000A), DEL, and C1 controls — reject so a
+// CRLF header-injection payload can't ride through into anything that later
+// composes headers from these fields.
+const CONTROL_CHARS = /[\u0000-\u001f\u007f-\u009f]/;
+// Pragmatic single-line email shape: non-space/@ local, @, dotted domain.
+const EMAIL_SHAPE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+function validateTicketEmail(email: string): void {
+  if (email.length > MAX_EMAIL_LENGTH) {
+    throw new HandlerError('INVALID_ARGUMENT', 'user_email exceeds the maximum length');
+  }
+  if (CONTROL_CHARS.test(email)) {
+    throw new HandlerError('INVALID_ARGUMENT', 'user_email contains control characters');
+  }
+  if (!EMAIL_SHAPE.test(email)) {
+    throw new HandlerError('INVALID_ARGUMENT', 'user_email is not a valid email address');
+  }
+}
+
+function validateTicketName(name: string | undefined): void {
+  if (name === undefined || name === '') {
+    return;
+  }
+  if (name.length > MAX_NAME_LENGTH) {
+    throw new HandlerError('INVALID_ARGUMENT', 'user_name exceeds the maximum length');
+  }
+  if (CONTROL_CHARS.test(name)) {
+    throw new HandlerError('INVALID_ARGUMENT', 'user_name contains control characters');
+  }
+}
+
 // --- OpenSupportTicket -----------------------------------------------
 
 export async function openSupportTicket(
@@ -91,18 +129,27 @@ export async function openSupportTicket(
     throw new HandlerError('INVALID_ARGUMENT', 'category is required');
   }
 
+  // Reject a malformed / control-char-bearing user_email or user_name before
+  // it reaches the row, the ticketOpened event, or the staff inbox (ADS-1017).
+  validateTicketEmail(req.userEmail);
+  validateTicketName(req.userName);
+
   const priorityDb = ticketPriorityToDb(req.priority);
   const categoryDb = ticketCategoryToDb(req.category);
-  // Identity is always derived from the authenticated principal — a
-  // caller-supplied user_id is trusted ONLY when the caller holds
-  // MODERATION_TICKETS_MANAGE (staff opening a ticket on a user's
-  // behalf during support-agent-assisted intake). Anyone else passing
-  // a user_id that doesn't match their own is rejected outright rather
-  // than silently overridden, so the caller finds out immediately
-  // instead of assuming the impersonation succeeded. (ADS-917: a
-  // caller-supplied user_id previously won unconditionally, letting
-  // any authenticated user forge another user's identity onto the
-  // ticket row and the moderation.ticketOpened audit event.)
+  // user_id is derived from the authenticated principal: a caller-supplied
+  // user_id is trusted ONLY when the caller holds MODERATION_TICKETS_MANAGE
+  // (staff opening a ticket on a user's behalf during support-agent-assisted
+  // intake). Anyone else passing a user_id that doesn't match their own is
+  // rejected outright rather than silently overridden. (ADS-917: a
+  // caller-supplied user_id previously won unconditionally.)
+  //
+  // user_email / user_name are NOT yet identity-bound (ADS-1017): they are
+  // validated above but still taken from the request, because binding them to
+  // the principal's verified account requires resolving the principal's email
+  // of record via the auth service — moderation has no auth client wired, the
+  // same gap ADS-1008 hit. Until that shared capability exists, a support
+  // agent must treat user_email as claimed, not verified. See the ticket for
+  // the deferred identity-binding follow-up.
   const canProxy = requirePermission(principal, MODERATION_TICKETS_MANAGE);
   if (
     !canProxy &&

--- a/services/moderation/src/migrations/012_add_reporter_open_report_unique_index.ts
+++ b/services/moderation/src/migrations/012_add_reporter_open_report_unique_index.ts
@@ -1,0 +1,53 @@
+import type { MigrationBuilder } from 'node-pg-migrate';
+
+// Per-reporter dedup for user-filed reports (ADS-1019).
+//
+// 009 added a SYSTEM-scoped unique arbiter so redelivered auto-reports don't
+// duplicate, but deliberately left user reports un-deduped — which let one
+// account insert unbounded reports against the same entity, flooding the
+// moderator queue and manufacturing an apparent repeat-offender pattern.
+//
+// This adds the mirror constraint for real users: at most one OPEN report per
+// (reporter_id, reported_entity_type, reported_entity_id). Scoped to open
+// statuses (pending / under_review / escalated) so a reporter may file again
+// once their earlier report is resolved or dismissed. FileReport's ON CONFLICT
+// targets exactly this partial index.
+
+const SYSTEM_USER_ID = '00000000-0000-0000-0000-000000000000';
+const OPEN_STATUSES = "('pending', 'under_review', 'escalated')";
+const REPORTER_OPEN_UNIQUE = 'reports_reporter_open_report_uniq';
+
+export const up = async (pgm: MigrationBuilder): Promise<void> => {
+  // Dedupe pre-existing open duplicates so the unique index can be built:
+  // keep the earliest-created open report per (reporter, entity) and delete
+  // the rest. report_status_transitions cascade on delete (002).
+  pgm.sql(`
+    DELETE FROM reports r
+    WHERE r.reporter_id <> '${SYSTEM_USER_ID}'
+      AND r.status IN ${OPEN_STATUSES}
+      AND EXISTS (
+        SELECT 1 FROM reports keep
+        WHERE keep.reporter_id = r.reporter_id
+          AND keep.reported_entity_type = r.reported_entity_type
+          AND keep.reported_entity_id = r.reported_entity_id
+          AND keep.reporter_id <> '${SYSTEM_USER_ID}'
+          AND keep.status IN ${OPEN_STATUSES}
+          AND (
+            keep.created_at < r.created_at
+            OR (keep.created_at = r.created_at AND keep.report_id < r.report_id)
+          )
+      )
+  `);
+
+  pgm.createIndex('reports', ['reporter_id', 'reported_entity_type', 'reported_entity_id'], {
+    name: REPORTER_OPEN_UNIQUE,
+    unique: true,
+    where: `reporter_id <> '${SYSTEM_USER_ID}' AND status IN ${OPEN_STATUSES}`,
+  });
+};
+
+export const down = async (pgm: MigrationBuilder): Promise<void> => {
+  pgm.dropIndex('reports', ['reporter_id', 'reported_entity_type', 'reported_entity_id'], {
+    name: REPORTER_OPEN_UNIQUE,
+  });
+};

--- a/services/notifications/src/grpc/device-token-handlers.test.ts
+++ b/services/notifications/src/grpc/device-token-handlers.test.ts
@@ -80,7 +80,12 @@ const tokenRowFixture = (overrides: Record<string, unknown> = {}) => ({
 const makeMocks = () => {
   const poolScript: Array<{ rows: unknown[] }> = [];
   const pool = {
-    query: vi.fn(async () => {
+    query: vi.fn(async (sql?: unknown) => {
+      // The per-token advisory lock is bookkeeping, not a scripted read — don't
+      // let it consume a scripted response.
+      if (typeof sql === 'string' && sql.includes('pg_advisory_xact_lock')) {
+        return { rows: [] };
+      }
       const next = poolScript.shift();
       return next ?? { rows: [] };
     }),
@@ -213,9 +218,9 @@ describe('registerDeviceTokenHandler', () => {
     // A takeover is a fresh mapping, not a refresh of the other user's row.
     expect(res.alreadyRegistered).toBe(false);
     expect(res.token?.userId).toBe('usr-adopter');
-    // Three queries ran (lookup, soft-delete, insert) — the prior row was
-    // unregistered rather than left as a second active mapping.
-    expect(mocks.poolMock.query).toHaveBeenCalledTimes(3);
+    // Four queries ran (advisory lock, lookup, soft-delete, insert) — the
+    // prior row was unregistered rather than left as a second active mapping.
+    expect(mocks.poolMock.query).toHaveBeenCalledTimes(4);
     // The transfer is audited at warn with both user ids (not the raw token).
     expect(mocks.logger.warn).toHaveBeenCalledWith(
       'device token reassigned to a different user',

--- a/services/notifications/src/grpc/device-token-handlers.test.ts
+++ b/services/notifications/src/grpc/device-token-handlers.test.ts
@@ -16,6 +16,23 @@ import {
   unregisterDeviceTokenHandler,
 } from './device-token-handlers.js';
 
+// RegisterDeviceToken runs registerDeviceToken inside withTransaction; the mock
+// runs the callback against a client whose query is the scripted pool mock.
+vi.mock('@adopt-dont-shop/events', async () => {
+  const actual =
+    await vi.importActual<typeof import('@adopt-dont-shop/events')>('@adopt-dont-shop/events');
+  return {
+    ...actual,
+    withTransaction: async (
+      deps: { pool: { query: ReturnType<typeof vi.fn> } },
+      fn: (scope: {
+        client: { query: ReturnType<typeof vi.fn> };
+        publish: ReturnType<typeof vi.fn>;
+      }) => Promise<unknown>
+    ) => fn({ client: { query: deps.pool.query }, publish: vi.fn() }),
+  };
+});
+
 // --- Fixtures + mocks ------------------------------------------------
 
 const ADOPTER_PRINCIPAL: Principal = {
@@ -69,13 +86,16 @@ const makeMocks = () => {
     }),
     connect: vi.fn(),
   };
+  const logger = { warn: vi.fn(), info: vi.fn(), error: vi.fn() };
   return {
     pool: pool as unknown as Pool,
     poolMock: pool,
     poolScript,
+    logger,
     deps: {
       pool: pool as unknown as Pool,
       nats: {} as unknown as NatsConnection,
+      logger: logger as unknown as import('winston').Logger,
     },
   };
 };
@@ -175,6 +195,42 @@ describe('registerDeviceTokenHandler', () => {
     });
 
     expect(res.token?.userId).toBe('usr-target');
+  });
+
+  it('transfers a token already active under another user instead of duplicating it', async () => {
+    // Sequence: SELECT by device_token → the token is active under usr-other →
+    // soft-delete that row (UPDATE) → INSERT the new mapping under usr-adopter.
+    mocks.poolScript.push({
+      rows: [tokenRowFixture({ token_id: 'dt-old', user_id: 'usr-other' })],
+    });
+    mocks.poolScript.push({ rows: [] }); // soft-delete UPDATE
+    mocks.poolScript.push({
+      rows: [tokenRowFixture({ token_id: 'dt-new', user_id: 'usr-adopter' })],
+    });
+
+    const res = await registerDeviceTokenHandler(mocks.deps, ADOPTER_PRINCIPAL, BASE_REGISTER);
+
+    // A takeover is a fresh mapping, not a refresh of the other user's row.
+    expect(res.alreadyRegistered).toBe(false);
+    expect(res.token?.userId).toBe('usr-adopter');
+    // Three queries ran (lookup, soft-delete, insert) — the prior row was
+    // unregistered rather than left as a second active mapping.
+    expect(mocks.poolMock.query).toHaveBeenCalledTimes(3);
+    // The transfer is audited at warn with both user ids (not the raw token).
+    expect(mocks.logger.warn).toHaveBeenCalledWith(
+      'device token reassigned to a different user',
+      expect.objectContaining({ previousUserId: 'usr-other', newUserId: 'usr-adopter' })
+    );
+  });
+
+  it('does not log a takeover on the normal same-user refresh path', async () => {
+    mocks.poolScript.push({ rows: [tokenRowFixture()] }); // SELECT (usr-adopter)
+    mocks.poolScript.push({ rows: [tokenRowFixture()] }); // UPDATE refresh
+
+    const res = await registerDeviceTokenHandler(mocks.deps, ADOPTER_PRINCIPAL, BASE_REGISTER);
+
+    expect(res.alreadyRegistered).toBe(true);
+    expect(mocks.logger.warn).not.toHaveBeenCalled();
   });
 });
 

--- a/services/notifications/src/grpc/device-token-handlers.ts
+++ b/services/notifications/src/grpc/device-token-handlers.ts
@@ -6,8 +6,10 @@
 // `notifications.device_token.registered` so analytics can count
 // active push installs.
 
+import type { Logger } from 'winston';
+
 import { hasPermission, type Principal } from '@adopt-dont-shop/authz';
-import type { WithTransactionDeps } from '@adopt-dont-shop/events';
+import { withTransaction, type WithTransactionDeps } from '@adopt-dont-shop/events';
 import type { Permission } from '@adopt-dont-shop/lib.types';
 import {
   NotificationsV1,
@@ -111,7 +113,9 @@ const resolveTargetUserId = (
   return target;
 };
 
-export type DeviceTokenDeps = WithTransactionDeps;
+// Optional logger so the RegisterDeviceToken handler can audit a device-token
+// takeover (ADS-1010) with both user ids. Injected by the server wiring.
+export type DeviceTokenDeps = WithTransactionDeps & { logger?: Logger };
 
 // --- RegisterDeviceToken ---------------------------------------------
 
@@ -149,13 +153,28 @@ export async function registerDeviceTokenHandler(
     }
   }
 
-  const { row, alreadyRegistered } = await registerDeviceToken(deps.pool, {
-    userId,
-    deviceToken: req.deviceToken,
-    platform: protoToPlatform[req.platform],
-    appVersion: req.appVersion ?? null,
-    deviceInfo,
-  });
+  // Run in a transaction: a takeover (soft-delete of the prior owner's row +
+  // insert of the new mapping) must be atomic.
+  const { row, alreadyRegistered, replacedUserId } = await withTransaction(deps, ({ client }) =>
+    registerDeviceToken(client, {
+      userId,
+      deviceToken: req.deviceToken,
+      platform: protoToPlatform[req.platform],
+      appVersion: req.appVersion ?? null,
+      deviceInfo,
+    })
+  );
+
+  if (replacedUserId !== undefined) {
+    // Audit the transfer — a device token moving between users is exactly the
+    // hijack vector ADS-1010 hardens. Log the user ids, not the raw token.
+    deps.logger?.warn('device token reassigned to a different user', {
+      tokenId: row.token_id,
+      previousUserId: replacedUserId,
+      newUserId: userId,
+      platform: row.platform,
+    });
+  }
 
   return { token: rowToProto(row), alreadyRegistered };
 }

--- a/services/notifications/src/grpc/email-handlers.test.ts
+++ b/services/notifications/src/grpc/email-handlers.test.ts
@@ -146,6 +146,13 @@ describe('sendEmail', () => {
 
   beforeEach(() => {
     mocks = makeMocks();
+    // Default wiring: an auth client whose record for the caller-supplied
+    // user_id matches BASE_SEND_REQ.toEmail, so the ADS-1008 binding passes on
+    // the happy path. Tests exercising the bypass override deps.authClient.
+    mocks.deps = {
+      ...mocks.deps,
+      authClient: { adminGetUser: vi.fn(async () => ({ user: { email: 'jane@example.com' } })) },
+    } as unknown as typeof mocks.deps;
   });
 
   afterEach(() => {
@@ -242,13 +249,29 @@ describe('sendEmail', () => {
     expect(realClientQueries(mocks)).toEqual(['INSERT']);
   });
 
-  it('skips the binding check when no auth client is configured (dev/test)', async () => {
-    // mocks.deps has no authClient — the send proceeds without the check.
-    mocks.clientScript.push({ rows: [{ email_id: 'queued-noauth' }] }); // INSERT
-    const res = await sendEmail(mocks.deps, SYSTEM_PRINCIPAL, {
+  it('fails closed when a user_id is supplied but no auth client is wired', async () => {
+    // Security control must not depend on optional wiring: a misconfigured
+    // deploy that can't verify the binding refuses the send rather than
+    // reopening the bypass.
+    const deps = { pool: mocks.poolMock, nats: mocks.natsMock } as unknown as typeof mocks.deps;
+    await expect(
+      sendEmail(deps, SYSTEM_PRINCIPAL, {
+        ...BASE_SEND_REQ,
+        toEmail: 'jane@example.com',
+        userId: 'usr-adopter',
+      })
+    ).rejects.toMatchObject({ code: 'INTERNAL' });
+  });
+
+  it('needs no auth client when the send carries no user_id', async () => {
+    // Nothing to bind — a user_id-less transactional send proceeds. (Marketing
+    // still requires a user_id via the check above.)
+    const deps = { pool: mocks.poolMock, nats: mocks.natsMock } as unknown as typeof mocks.deps;
+    mocks.clientScript.push({ rows: [{ email_id: 'queued-nouser' }] }); // INSERT
+    const res = await sendEmail(deps, SYSTEM_PRINCIPAL, {
       ...BASE_SEND_REQ,
       toEmail: 'jane@example.com',
-      userId: 'usr-adopter',
+      userId: '',
     });
     expect(res.alreadyQueued).toBe(false);
   });

--- a/services/notifications/src/grpc/email-handlers.test.ts
+++ b/services/notifications/src/grpc/email-handlers.test.ts
@@ -195,6 +195,64 @@ describe('sendEmail', () => {
     expect(res.alreadyQueued).toBe(false);
   });
 
+  // ── ADS-1008: bind user_id to to_email so suppression can't be bypassed ──
+
+  const authClientReturning = (email: string | undefined) => ({
+    adminGetUser: vi.fn(async () => ({ user: email === undefined ? undefined : { email } })),
+  });
+
+  it('rejects when the supplied user_id does not own to_email (suppression bypass)', async () => {
+    // user_id names a different, non-suppressed user than the recipient
+    // address — exactly the vector that let an opted-out / blacklisted
+    // address be reached.
+    const authClient = authClientReturning('someone-else@example.com');
+    const deps = { ...mocks.deps, authClient } as unknown as typeof mocks.deps;
+    await expect(
+      sendEmail(deps, SYSTEM_PRINCIPAL, {
+        ...BASE_SEND_REQ,
+        toEmail: 'jane@example.com',
+        userId: 'usr-adopter',
+      })
+    ).rejects.toMatchObject({ code: 'PERMISSION_DENIED' });
+    expect(authClient.adminGetUser).toHaveBeenCalledWith({ userId: 'usr-adopter' });
+  });
+
+  it('rejects when the named user_id is unknown to auth', async () => {
+    const authClient = authClientReturning(undefined);
+    const deps = { ...mocks.deps, authClient } as unknown as typeof mocks.deps;
+    await expect(
+      sendEmail(deps, SYSTEM_PRINCIPAL, {
+        ...BASE_SEND_REQ,
+        toEmail: 'jane@example.com',
+        userId: 'usr-ghost',
+      })
+    ).rejects.toMatchObject({ code: 'PERMISSION_DENIED' });
+  });
+
+  it('dispatches when the user_id owns to_email (case-insensitive match)', async () => {
+    const authClient = authClientReturning('Jane@Example.com');
+    const deps = { ...mocks.deps, authClient } as unknown as typeof mocks.deps;
+    mocks.clientScript.push({ rows: [{ email_id: 'queued-bound' }] }); // INSERT
+    const res = await sendEmail(deps, SYSTEM_PRINCIPAL, {
+      ...BASE_SEND_REQ,
+      toEmail: 'jane@example.com',
+      userId: 'usr-adopter',
+    });
+    expect(res.alreadyQueued).toBe(false);
+    expect(realClientQueries(mocks)).toEqual(['INSERT']);
+  });
+
+  it('skips the binding check when no auth client is configured (dev/test)', async () => {
+    // mocks.deps has no authClient — the send proceeds without the check.
+    mocks.clientScript.push({ rows: [{ email_id: 'queued-noauth' }] }); // INSERT
+    const res = await sendEmail(mocks.deps, SYSTEM_PRINCIPAL, {
+      ...BASE_SEND_REQ,
+      toEmail: 'jane@example.com',
+      userId: 'usr-adopter',
+    });
+    expect(res.alreadyQueued).toBe(false);
+  });
+
   it('rejects when template_data_json is not a JSON object', async () => {
     await expect(
       sendEmail(mocks.deps, SYSTEM_PRINCIPAL, {

--- a/services/notifications/src/grpc/email-handlers.ts
+++ b/services/notifications/src/grpc/email-handlers.ts
@@ -32,7 +32,8 @@ import { renderEmailTemplate } from '../email/renderer.js';
 import { findActiveTemplate, incrementTemplateUsage } from '../email/templates.js';
 import type { EmailPriority, EmailType } from '../email/types.js';
 
-import { HandlerError } from './handlers.js';
+import type { AuthUserClient } from './auth-client.js';
+import { HandlerError, type HandlerDeps } from './handlers.js';
 
 // --- Defaults --------------------------------------------------------
 
@@ -137,7 +138,33 @@ const stripHeaderOpt = (s: string | undefined): string | undefined =>
 
 // --- SendEmail -------------------------------------------------------
 
-export type SendEmailDeps = WithTransactionDeps;
+// Reuses HandlerDeps so the shared adapt() wiring passes the same deps object.
+// deps.authClient?.adminGetUser binds the recipient identity to the address
+// being mailed (ADS-1008); when unwired (dev/test) the check is skipped.
+export type SendEmailDeps = HandlerDeps;
+
+// Normalise an address for comparison — trim + lowercase. Enough to bind a
+// caller-supplied user_id to to_email without importing a full RFC-5321
+// normaliser; the auth record and the request are both raw addresses.
+const normaliseAddress = (email: string): string => email.trim().toLowerCase();
+
+// Rejects unless `userId`'s email of record equals `toEmail`. Throws
+// PERMISSION_DENIED — the caller has named a user that does not own the
+// address, which is exactly the suppression-bypass ADS-1008 closes.
+const assertUserOwnsAddress = async (
+  adminGetUser: AuthUserClient['adminGetUser'],
+  userId: string,
+  toEmail: string
+): Promise<void> => {
+  const { user } = await adminGetUser({ userId });
+  const ofRecord = user?.email ? normaliseAddress(user.email) : undefined;
+  if (ofRecord === undefined || ofRecord !== normaliseAddress(toEmail)) {
+    throw new HandlerError(
+      'PERMISSION_DENIED',
+      'user_id does not match to_email; suppression cannot be bound to the recipient'
+    );
+  }
+};
 
 const parseJson = (input: string | undefined, fallback: object): Record<string, unknown> => {
   if (!input) {
@@ -194,6 +221,17 @@ export async function sendEmail(
       'INVALID_ARGUMENT',
       "user_id is required for 'marketing' email so recipient opt-outs are honoured"
     );
+  }
+
+  // Bind the recipient identity to the address actually being mailed
+  // (ADS-1008). The worker's opt-out / blacklist suppression keys off user_id,
+  // not to_email, so a user_id that does NOT own to_email would let a caller
+  // reach an opted-out or bounce-blacklisted address by naming an unrelated,
+  // non-suppressed user. Require the supplied user_id's email of record to
+  // equal to_email; skip only when no auth client is configured (dev/test).
+  const adminGetUser = deps.authClient?.adminGetUser;
+  if (req.userId && adminGetUser) {
+    await assertUserOwnsAddress(adminGetUser, req.userId, req.toEmail);
   }
 
   // Resolve subject / html / text — template wins when present.

--- a/services/notifications/src/grpc/email-handlers.ts
+++ b/services/notifications/src/grpc/email-handlers.ts
@@ -140,7 +140,9 @@ const stripHeaderOpt = (s: string | undefined): string | undefined =>
 
 // Reuses HandlerDeps so the shared adapt() wiring passes the same deps object.
 // deps.authClient?.adminGetUser binds the recipient identity to the address
-// being mailed (ADS-1008); when unwired (dev/test) the check is skipped.
+// being mailed (ADS-1008). A send that carries a user_id but reaches a
+// deployment with no auth client wired fails closed (INTERNAL) rather than
+// skipping the binding.
 export type SendEmailDeps = HandlerDeps;
 
 // Normalise an address for comparison — trim + lowercase. Enough to bind a
@@ -228,9 +230,17 @@ export async function sendEmail(
   // not to_email, so a user_id that does NOT own to_email would let a caller
   // reach an opted-out or bounce-blacklisted address by naming an unrelated,
   // non-suppressed user. Require the supplied user_id's email of record to
-  // equal to_email; skip only when no auth client is configured (dev/test).
-  const adminGetUser = deps.authClient?.adminGetUser;
-  if (req.userId && adminGetUser) {
+  // equal to_email. This is a security control, so it fails CLOSED: if a
+  // user_id is supplied but no auth client is wired to verify it, refuse the
+  // send rather than let a misconfigured deploy reopen the bypass.
+  if (req.userId) {
+    const adminGetUser = deps.authClient?.adminGetUser;
+    if (!adminGetUser) {
+      throw new HandlerError(
+        'INTERNAL',
+        'cannot verify recipient identity: auth client unavailable'
+      );
+    }
     await assertUserOwnsAddress(adminGetUser, req.userId, req.toEmail);
   }
 

--- a/services/notifications/src/grpc/handlers.ts
+++ b/services/notifications/src/grpc/handlers.ts
@@ -66,9 +66,12 @@ export type AuthCohortClient = {
 };
 
 export type HandlerDeps = WithTransactionDeps & {
-  // Optional — only broadcast-handlers reads it. Other handlers (Create,
-  // List, Dismiss, etc.) work fine without a cross-service client wired.
-  authClient?: AuthCohortClient;
+  // Optional cross-service client. Broadcast reads listUserIdsByCohort;
+  // SendEmail reads adminGetUser to bind user_id → to_email (ADS-1008). The
+  // adminGetUser slice is Partial so a cohort-only mock (broadcast tests) is
+  // still assignable; the production client (createAuthCohortClient) carries
+  // both. Handlers that read neither work without it wired at all.
+  authClient?: AuthCohortClient & Partial<import('./auth-client.js').AuthUserClient>;
   // Optional — only broadcast-handlers reads it (per-recipient failure
   // warns). Other handlers log via the adapt() wrapper's logger.
   logger?: Logger;

--- a/services/notifications/src/grpc/server.ts
+++ b/services/notifications/src/grpc/server.ts
@@ -49,11 +49,12 @@ export type CreateGrpcServerOptions = {
   pool: Pool;
   nats: NatsConnection;
   logger: Logger;
-  // Optional cross-service client for cohort lookups. Only the Broadcast
-  // RPC reads it; wiring it in production happens from index.ts. Smoke
-  // tests + unit tests can omit it — Broadcast will return INTERNAL when
-  // the wiring is missing, which is the correct signal.
-  authClient?: import('./handlers.js').AuthCohortClient;
+  // Optional cross-service client. Broadcast reads listUserIdsByCohort;
+  // SendEmail reads adminGetUser to bind user_id → to_email (ADS-1008).
+  // Wiring it in production happens from index.ts. Smoke tests + unit tests
+  // can omit it — Broadcast returns INTERNAL when the wiring is missing, and
+  // SendEmail skips the binding check.
+  authClient?: import('./handlers.js').AuthCohortClient & import('./auth-client.js').AuthUserClient;
 };
 
 export type { RunningGrpcServer };
@@ -87,7 +88,7 @@ export const createGrpcServer = (opts: CreateGrpcServerOptions): Server => {
       deps: { pool, nats },
       logger,
     }),
-    sendEmail: adapt(sendEmail, { deps: { pool, nats }, logger }),
+    sendEmail: adapt(sendEmail, { deps: { pool, nats, authClient }, logger }),
     getEmailPreferences: adapt(getEmailPreferences, { deps: { pool, nats }, logger }),
     updateEmailPreferences: adapt(updateEmailPreferences, { deps: { pool, nats }, logger }),
     registerDeviceToken: adapt(registerDeviceTokenHandler, { deps: { pool, nats }, logger }),

--- a/services/notifications/src/grpc/server.ts
+++ b/services/notifications/src/grpc/server.ts
@@ -91,7 +91,10 @@ export const createGrpcServer = (opts: CreateGrpcServerOptions): Server => {
     sendEmail: adapt(sendEmail, { deps: { pool, nats, authClient }, logger }),
     getEmailPreferences: adapt(getEmailPreferences, { deps: { pool, nats }, logger }),
     updateEmailPreferences: adapt(updateEmailPreferences, { deps: { pool, nats }, logger }),
-    registerDeviceToken: adapt(registerDeviceTokenHandler, { deps: { pool, nats }, logger }),
+    registerDeviceToken: adapt(registerDeviceTokenHandler, {
+      deps: { pool, nats, logger },
+      logger,
+    }),
     unregisterDeviceToken: adapt(unregisterDeviceTokenHandler, { deps: { pool, nats }, logger }),
     listDeviceTokens: adapt(listDeviceTokensHandler, { deps: { pool, nats }, logger }),
     listEmailTemplates: adapt(listEmailTemplates, { deps: { pool, nats }, logger }),

--- a/services/notifications/src/grpc/server.ts
+++ b/services/notifications/src/grpc/server.ts
@@ -53,7 +53,8 @@ export type CreateGrpcServerOptions = {
   // SendEmail reads adminGetUser to bind user_id → to_email (ADS-1008).
   // Wiring it in production happens from index.ts. Smoke tests + unit tests
   // can omit it — Broadcast returns INTERNAL when the wiring is missing, and
-  // SendEmail skips the binding check.
+  // SendEmail fails closed (INTERNAL) for any send carrying a user_id it then
+  // cannot verify (user_id-less sends still proceed).
   authClient?: import('./handlers.js').AuthCohortClient & import('./auth-client.js').AuthUserClient;
 };
 

--- a/services/notifications/src/migrations/009_device_token_global_unique.ts
+++ b/services/notifications/src/migrations/009_device_token_global_unique.ts
@@ -1,0 +1,53 @@
+import type { MigrationBuilder } from 'node-pg-migrate';
+
+// Enforce that a device token maps to at most one ACTIVE user (ADS-1010).
+//
+// Registration previously keyed uniqueness on (user_id, device_token), so the
+// same physical device token could be active under two users at once — one
+// user's notifications would then reach another user's device, and the mapping
+// survived the prior owner's GDPR erasure. registerDeviceToken now transfers a
+// token between users instead of duplicating it; this migration backs that with
+// a database-level invariant.
+//
+// 1. Dedupe any pre-existing active duplicates: for each device_token with
+//    more than one active (deleted_at IS NULL) row, keep the most recently
+//    created row and soft-delete the rest, so the unique index can be built.
+// 2. Add a partial unique index on device_token WHERE deleted_at IS NULL.
+//    (The older (user_id, device_token) partial unique index is left in place —
+//    it is subsumed by this stricter one but harmless.)
+
+const ACTIVE_TOKEN_UNIQUE_INDEX = 'device_tokens_active_token_unique';
+
+export const up = async (pgm: MigrationBuilder): Promise<void> => {
+  // Soft-delete every active duplicate except the newest per device_token.
+  // Tie-break on token_id so the choice is deterministic when created_at ties.
+  pgm.sql(`
+    UPDATE device_tokens dt
+    SET status     = 'inactive',
+        deleted_at = now(),
+        updated_at = now()
+    WHERE dt.deleted_at IS NULL
+      AND EXISTS (
+        SELECT 1
+        FROM device_tokens newer
+        WHERE newer.device_token = dt.device_token
+          AND newer.deleted_at IS NULL
+          AND (
+            newer.created_at > dt.created_at
+            OR (newer.created_at = dt.created_at AND newer.token_id > dt.token_id)
+          )
+      )
+  `);
+
+  pgm.createIndex('device_tokens', 'device_token', {
+    name: ACTIVE_TOKEN_UNIQUE_INDEX,
+    unique: true,
+    where: 'deleted_at IS NULL',
+  });
+};
+
+export const down = async (pgm: MigrationBuilder): Promise<void> => {
+  // Drop only the index — the dedupe soft-deletes are not reversible (and
+  // reinstating duplicate active mappings would be a regression, not a fix).
+  pgm.dropIndex('device_tokens', 'device_token', { name: ACTIVE_TOKEN_UNIQUE_INDEX });
+};

--- a/services/notifications/src/push/device-tokens.ts
+++ b/services/notifications/src/push/device-tokens.ts
@@ -50,6 +50,14 @@ export const registerDeviceToken = async (
   conn: DbConn,
   input: RegisterDeviceTokenInput
 ): Promise<{ row: DeviceTokenRow; alreadyRegistered: boolean; replacedUserId?: string }> => {
+  // Serialise concurrent registrations of the SAME token so the
+  // lookup → (soft-delete) → insert sequence can't race two callers into a
+  // unique-violation against device_tokens_active_token_unique. Transaction-
+  // scoped, so the lock releases on commit/rollback; keyed on a hash of the
+  // token so it only contends per device_token, not globally. Requires the
+  // caller to run this inside a transaction (registerDeviceTokenHandler does).
+  await conn.query(`SELECT pg_advisory_xact_lock(hashtext($1)::bigint)`, [input.deviceToken]);
+
   // Look up by device_token alone so a token owned by another user is seen.
   const existing = await conn.query<DeviceTokenRow>(
     `

--- a/services/notifications/src/push/device-tokens.ts
+++ b/services/notifications/src/push/device-tokens.ts
@@ -31,27 +31,39 @@ export type RegisterDeviceTokenInput = {
   deviceInfo?: Record<string, unknown>;
 };
 
-// Upsert by (user_id, device_token). The partial unique index
-// `device_tokens_user_token_unique` enforces the uniqueness while
-// permitting historical soft-deleted rows.
+// Register a device token under `input.userId`, treating the token as
+// globally unique to a single active mapping (ADS-1010).
 //
-// Returns the row + a flag indicating whether the registration was
-// new (false → call refreshed an existing row's last_used_at).
+// The lookup keys on `device_token` alone, not `(user_id, device_token)`, so a
+// token already active under a DIFFERENT user is detected. A device genuinely
+// changing hands is the common legitimate case, so the prior mapping is
+// soft-deleted (transferred) rather than left to duplicate — a duplicate would
+// let one physical device receive two users' notifications and survive the
+// prior owner's GDPR erasure. `device_tokens_active_token_unique` enforces the
+// single-active-mapping invariant at the database level.
+//
+// Returns the row, an `alreadyRegistered` flag (true → the same user's row was
+// refreshed in place), and `replacedUserId` when a different user's mapping was
+// taken over (so the caller can audit the transfer). Run inside a transaction:
+// the takeover is a soft-delete followed by an insert.
 export const registerDeviceToken = async (
   conn: DbConn,
   input: RegisterDeviceTokenInput
-): Promise<{ row: DeviceTokenRow; alreadyRegistered: boolean }> => {
-  // Look up first so we can report alreadyRegistered accurately.
+): Promise<{ row: DeviceTokenRow; alreadyRegistered: boolean; replacedUserId?: string }> => {
+  // Look up by device_token alone so a token owned by another user is seen.
   const existing = await conn.query<DeviceTokenRow>(
     `
     SELECT * FROM device_tokens
-    WHERE user_id = $1 AND device_token = $2 AND deleted_at IS NULL
+    WHERE device_token = $1 AND deleted_at IS NULL
     LIMIT 1
     `,
-    [input.userId, input.deviceToken]
+    [input.deviceToken]
   );
+  const current = existing.rows[0];
 
-  if (existing.rows[0]) {
+  // Same user re-registering their own token → refresh in place (normal path,
+  // unchanged behaviour, alreadyRegistered = true).
+  if (current && current.user_id === input.userId) {
     const refreshed = await conn.query<DeviceTokenRow>(
       `
       UPDATE device_tokens
@@ -65,13 +77,30 @@ export const registerDeviceToken = async (
       RETURNING *
       `,
       [
-        existing.rows[0].token_id,
+        current.token_id,
         input.appVersion ?? null,
         input.deviceInfo ? JSON.stringify(input.deviceInfo) : null,
         input.platform,
       ]
     );
     return { row: refreshed.rows[0], alreadyRegistered: true };
+  }
+
+  // Token currently mapped to a DIFFERENT user → transfer it: soft-delete the
+  // prior mapping so at most one active row per device_token survives.
+  let replacedUserId: string | undefined;
+  if (current) {
+    await conn.query(
+      `
+      UPDATE device_tokens
+      SET status     = 'inactive',
+          deleted_at = COALESCE(deleted_at, now()),
+          updated_at = now()
+      WHERE token_id = $1
+      `,
+      [current.token_id]
+    );
+    replacedUserId = current.user_id;
   }
 
   const inserted = await conn.query<DeviceTokenRow>(
@@ -97,7 +126,7 @@ export const registerDeviceToken = async (
       JSON.stringify(input.deviceInfo ?? {}),
     ]
   );
-  return { row: inserted.rows[0], alreadyRegistered: false };
+  return { row: inserted.rows[0], alreadyRegistered: false, replacedUserId };
 };
 
 // Soft-delete by token_id. Idempotent — a second call returns the

--- a/services/notifications/src/push/device-tokens.ts
+++ b/services/notifications/src/push/device-tokens.ts
@@ -4,6 +4,8 @@
 
 import { randomUUID } from 'node:crypto';
 
+import type { PoolClient } from 'pg';
+
 import type { DbConn } from '../email/queue.js';
 
 import type { DevicePlatform, DeviceTokenStatus } from './types.js';
@@ -44,10 +46,16 @@ export type RegisterDeviceTokenInput = {
 //
 // Returns the row, an `alreadyRegistered` flag (true → the same user's row was
 // refreshed in place), and `replacedUserId` when a different user's mapping was
-// taken over (so the caller can audit the transfer). Run inside a transaction:
-// the takeover is a soft-delete followed by an insert.
+// taken over (so the caller can audit the transfer).
+//
+// Takes a PoolClient, not a Pool: the pg_advisory_xact_lock below only holds for
+// the duration of a transaction, and on a bare Pool each query runs on its own
+// implicit-transaction connection — the lock would release immediately and the
+// lookup → soft-delete → insert sequence could still race into the partial
+// unique index. Requiring a PoolClient makes "call inside a transaction"
+// type-enforced (registerDeviceTokenHandler passes withTransaction's client).
 export const registerDeviceToken = async (
-  conn: DbConn,
+  conn: PoolClient,
   input: RegisterDeviceTokenInput
 ): Promise<{ row: DeviceTokenRow; alreadyRegistered: boolean; replacedUserId?: string }> => {
   // Serialise concurrent registrations of the SAME token so the

--- a/services/rescue/src/grpc/event-handlers.test.ts
+++ b/services/rescue/src/grpc/event-handlers.test.ts
@@ -540,7 +540,15 @@ describe('getEventAnalytics', () => {
       countAdoptedAdopters: vi.fn(async () => ({ count: 0 })),
       close: vi.fn(),
     };
-    getEventAnalytics = makeGetEventAnalytics(applicationsStub as unknown as ApplicationsClient);
+    const logger = {
+      warn: vi.fn(),
+      info: vi.fn(),
+      error: vi.fn(),
+    } as unknown as Parameters<typeof makeGetEventAnalytics>[1];
+    getEventAnalytics = makeGetEventAnalytics(
+      applicationsStub as unknown as ApplicationsClient,
+      logger
+    );
   });
 
   it('rejects callers without events.read', async () => {

--- a/services/rescue/src/grpc/event-handlers.test.ts
+++ b/services/rescue/src/grpc/event-handlers.test.ts
@@ -601,15 +601,20 @@ describe('getEventAnalytics', () => {
 
   // ── adoptionsFromEvent — registered-then-adopted attribution (ADS-941) ──
 
+  // A registrant cohort at/above the k-anonymity floor service.applications
+  // enforces (ADS-1006), so the attribution call is actually made.
+  const registrantRows = Array.from({ length: 20 }, (_, i) => ({
+    user_id: `usr-registrant-${i}`,
+  }));
+  const registrantIds = registrantRows.map(r => r.user_id);
+
   it('resolves the registrant ids (not just checked-in attendees) and reports the adopted count', async () => {
     mocks.poolMock.query
       .mockResolvedValueOnce({
         rows: [eventRow({ status: 'completed', start_date: new Date('2026-07-01T10:00:00Z') })],
       })
-      .mockResolvedValueOnce({ rows: [{ total: '2', checked_in: '1' }] })
-      .mockResolvedValueOnce({
-        rows: [{ user_id: 'usr-registrant-1' }, { user_id: 'usr-registrant-2' }],
-      });
+      .mockResolvedValueOnce({ rows: [{ total: '20', checked_in: '1' }] })
+      .mockResolvedValueOnce({ rows: registrantRows });
     applicationsStub.countAdoptedAdopters.mockResolvedValueOnce({ count: 2 });
 
     const res = await getEventAnalytics(mocks.deps, STAFF, { eventId: EVENT_ID });
@@ -617,7 +622,22 @@ describe('getEventAnalytics', () => {
     expect(res.analytics?.adoptionsFromEvent).toBe(2);
     expect(applicationsStub.countAdoptedAdopters).toHaveBeenCalledTimes(1);
     const [req] = applicationsStub.countAdoptedAdopters.mock.calls[0];
-    expect(req.adopterIds).toEqual(['usr-registrant-1', 'usr-registrant-2']);
+    expect(req.adopterIds).toEqual(registrantIds);
+  });
+
+  it('skips the attribution call when the registrant cohort is below the k-anonymity floor', async () => {
+    mocks.poolMock.query
+      .mockResolvedValueOnce({ rows: [eventRow({ status: 'completed' })] })
+      .mockResolvedValueOnce({ rows: [{ total: '2', checked_in: '1' }] })
+      .mockResolvedValueOnce({
+        rows: [{ user_id: 'usr-registrant-1' }, { user_id: 'usr-registrant-2' }],
+      });
+
+    const res = await getEventAnalytics(mocks.deps, STAFF, { eventId: EVENT_ID });
+
+    // Degrades to a 0 count rather than erroring on the rejected RPC.
+    expect(res.analytics?.adoptionsFromEvent).toBe(0);
+    expect(applicationsStub.countAdoptedAdopters).not.toHaveBeenCalled();
   });
 
   it('queries a 90-day post-event window anchored on the event start date', async () => {
@@ -625,8 +645,8 @@ describe('getEventAnalytics', () => {
       .mockResolvedValueOnce({
         rows: [eventRow({ status: 'completed', start_date: new Date('2026-07-01T10:00:00Z') })],
       })
-      .mockResolvedValueOnce({ rows: [{ total: '1', checked_in: '0' }] })
-      .mockResolvedValueOnce({ rows: [{ user_id: 'usr-registrant-1' }] });
+      .mockResolvedValueOnce({ rows: [{ total: '20', checked_in: '0' }] })
+      .mockResolvedValueOnce({ rows: registrantRows });
 
     await getEventAnalytics(mocks.deps, STAFF, { eventId: EVENT_ID });
 
@@ -638,8 +658,8 @@ describe('getEventAnalytics', () => {
   it('returns zero adoptions when nobody in the registrant set has adopted', async () => {
     mocks.poolMock.query
       .mockResolvedValueOnce({ rows: [eventRow({ status: 'completed' })] })
-      .mockResolvedValueOnce({ rows: [{ total: '1', checked_in: '0' }] })
-      .mockResolvedValueOnce({ rows: [{ user_id: 'usr-registrant-1' }] });
+      .mockResolvedValueOnce({ rows: [{ total: '20', checked_in: '0' }] })
+      .mockResolvedValueOnce({ rows: registrantRows });
     applicationsStub.countAdoptedAdopters.mockResolvedValueOnce({ count: 0 });
 
     const res = await getEventAnalytics(mocks.deps, STAFF, { eventId: EVENT_ID });
@@ -650,8 +670,8 @@ describe('getEventAnalytics', () => {
   it('surfaces a downstream attribution failure as INTERNAL rather than silently reporting zero', async () => {
     mocks.poolMock.query
       .mockResolvedValueOnce({ rows: [eventRow({ status: 'completed' })] })
-      .mockResolvedValueOnce({ rows: [{ total: '1', checked_in: '0' }] })
-      .mockResolvedValueOnce({ rows: [{ user_id: 'usr-registrant-1' }] });
+      .mockResolvedValueOnce({ rows: [{ total: '20', checked_in: '0' }] })
+      .mockResolvedValueOnce({ rows: registrantRows });
     applicationsStub.countAdoptedAdopters.mockRejectedValueOnce({ code: 14 });
 
     await expect(getEventAnalytics(mocks.deps, STAFF, { eventId: EVENT_ID })).rejects.toMatchObject(

--- a/services/rescue/src/grpc/event-handlers.test.ts
+++ b/services/rescue/src/grpc/event-handlers.test.ts
@@ -667,12 +667,51 @@ describe('getEventAnalytics', () => {
     expect(res.analytics?.adoptionsFromEvent).toBe(0);
   });
 
-  it('surfaces a downstream attribution failure as INTERNAL rather than silently reporting zero', async () => {
+  it('maps a transient downstream failure (UNAVAILABLE) to a retryable status, not INTERNAL', async () => {
     mocks.poolMock.query
       .mockResolvedValueOnce({ rows: [eventRow({ status: 'completed' })] })
       .mockResolvedValueOnce({ rows: [{ total: '20', checked_in: '0' }] })
       .mockResolvedValueOnce({ rows: registrantRows });
-    applicationsStub.countAdoptedAdopters.mockRejectedValueOnce({ code: 14 });
+    applicationsStub.countAdoptedAdopters.mockRejectedValueOnce({ code: 14 }); // UNAVAILABLE
+
+    await expect(getEventAnalytics(mocks.deps, STAFF, { eventId: EVENT_ID })).rejects.toMatchObject(
+      { code: 'UNAVAILABLE' }
+    );
+  });
+
+  it('maps a downstream DEADLINE_EXCEEDED to the same retryable status', async () => {
+    mocks.poolMock.query
+      .mockResolvedValueOnce({ rows: [eventRow({ status: 'completed' })] })
+      .mockResolvedValueOnce({ rows: [{ total: '20', checked_in: '0' }] })
+      .mockResolvedValueOnce({ rows: registrantRows });
+    applicationsStub.countAdoptedAdopters.mockRejectedValueOnce({ code: 4 }); // DEADLINE_EXCEEDED
+
+    await expect(getEventAnalytics(mocks.deps, STAFF, { eventId: EVENT_ID })).rejects.toMatchObject(
+      { code: 'UNAVAILABLE' }
+    );
+  });
+
+  it('degrades attribution to 0 when the caller lacks the analytics permission (PERMISSION_DENIED)', async () => {
+    mocks.poolMock.query
+      .mockResolvedValueOnce({ rows: [eventRow({ status: 'completed' })] })
+      .mockResolvedValueOnce({ rows: [{ total: '20', checked_in: '5' }] })
+      .mockResolvedValueOnce({ rows: registrantRows });
+    applicationsStub.countAdoptedAdopters.mockRejectedValueOnce({ code: 7 }); // PERMISSION_DENIED
+
+    const res = await getEventAnalytics(mocks.deps, STAFF, { eventId: EVENT_ID });
+
+    // The rest of the analytics (which only needs events.read) still returns.
+    expect(res.analytics?.adoptionsFromEvent).toBe(0);
+    expect(res.analytics?.totalRegistrations).toBe(20);
+    expect(res.analytics?.actualAttendance).toBe(5);
+  });
+
+  it('maps an INVALID_ARGUMENT (our request bug) to INTERNAL, not a permission or retry status', async () => {
+    mocks.poolMock.query
+      .mockResolvedValueOnce({ rows: [eventRow({ status: 'completed' })] })
+      .mockResolvedValueOnce({ rows: [{ total: '20', checked_in: '0' }] })
+      .mockResolvedValueOnce({ rows: registrantRows });
+    applicationsStub.countAdoptedAdopters.mockRejectedValueOnce({ code: 3 }); // INVALID_ARGUMENT
 
     await expect(getEventAnalytics(mocks.deps, STAFF, { eventId: EVENT_ID })).rejects.toMatchObject(
       { code: 'INTERNAL' }

--- a/services/rescue/src/grpc/event-handlers.ts
+++ b/services/rescue/src/grpc/event-handlers.ts
@@ -72,6 +72,10 @@ const EVENTS_DELETE: Permission = 'events.delete' as Permission;
 // Single named constant so it's easy to find and retune.
 const ATTRIBUTION_WINDOW_DAYS = 90;
 const MS_PER_DAY = 24 * 60 * 60 * 1000;
+// Mirrors service.applications' CountAdoptedAdopters k-anonymity floor
+// (MIN_COHORT_SIZE, ADS-1006). Kept in sync by value rather than imported —
+// services do not depend on each other's source.
+const ATTRIBUTION_MIN_COHORT = 20;
 
 // ── DB row types ────────────────────────────────────────────────────────
 
@@ -772,7 +776,11 @@ async function countAdoptionsFromEvent(
     [eventId]
   );
   const adopterIds = attendeeRes.rows.map(r => r.user_id);
-  if (adopterIds.length === 0) {
+  // service.applications enforces a k-anonymity cohort floor on the
+  // attribution count (ADS-1006) so it can never become a per-user oracle.
+  // Below that floor the RPC would reject with INVALID_ARGUMENT, so skip the
+  // call: small events degrade to a 0 attribution count rather than failing.
+  if (adopterIds.length < ATTRIBUTION_MIN_COHORT) {
     return 0;
   }
 

--- a/services/rescue/src/grpc/event-handlers.ts
+++ b/services/rescue/src/grpc/event-handlers.ts
@@ -11,10 +11,11 @@
 
 import { randomUUID } from 'node:crypto';
 
+import type { Logger } from 'winston';
+
 import { hasPermission, type Principal } from '@adopt-dont-shop/authz';
 import { withTransaction } from '@adopt-dont-shop/events';
 import type { Permission } from '@adopt-dont-shop/lib.types';
-import { createLogger } from '@adopt-dont-shop/observability';
 import {
   RescueV1,
   type AddEventAttendeeRequest,
@@ -85,8 +86,6 @@ const ATTRIBUTION_MIN_COHORT = 20;
 const GRPC_DEADLINE_EXCEEDED = 4;
 const GRPC_PERMISSION_DENIED = 7;
 const GRPC_UNAVAILABLE = 14;
-
-const logger = createLogger({ serviceName: 'service.rescue' });
 
 // ── DB row types ────────────────────────────────────────────────────────
 
@@ -721,7 +720,8 @@ export async function checkInAttendee(
 // "Adoption attribution (ADS-941)" above for the counting rule. Direct port
 // of staff-foster-handlers.ts's makeCreateFosterPlacement pattern.
 export function makeGetEventAnalytics(
-  applicationsClient: ApplicationsClient
+  applicationsClient: ApplicationsClient,
+  logger: Logger
 ): (
   deps: HandlerDeps,
   principal: Principal,
@@ -755,7 +755,14 @@ export function makeGetEventAnalytics(
 
     const adoptionsFromEvent =
       totalRegistrations > 0
-        ? await countAdoptionsFromEvent(deps, applicationsClient, principal, req.eventId, row)
+        ? await countAdoptionsFromEvent(
+            deps,
+            applicationsClient,
+            principal,
+            req.eventId,
+            row,
+            logger
+          )
         : 0;
 
     const analytics: RescueEventAnalytics = {
@@ -788,7 +795,8 @@ async function countAdoptionsFromEvent(
   applicationsClient: ApplicationsClient,
   principal: Principal,
   eventId: string,
-  event: EventRow
+  event: EventRow,
+  logger: Logger
 ): Promise<number> {
   const attendeeRes = await deps.pool.query<{ user_id: string }>(
     `SELECT DISTINCT user_id FROM rescue.event_attendees WHERE event_id = $1`,

--- a/services/rescue/src/grpc/event-handlers.ts
+++ b/services/rescue/src/grpc/event-handlers.ts
@@ -14,6 +14,7 @@ import { randomUUID } from 'node:crypto';
 import { hasPermission, type Principal } from '@adopt-dont-shop/authz';
 import { withTransaction } from '@adopt-dont-shop/events';
 import type { Permission } from '@adopt-dont-shop/lib.types';
+import { createLogger } from '@adopt-dont-shop/observability';
 import {
   RescueV1,
   type AddEventAttendeeRequest,
@@ -76,6 +77,16 @@ const MS_PER_DAY = 24 * 60 * 60 * 1000;
 // (MIN_COHORT_SIZE, ADS-1006). Kept in sync by value rather than imported —
 // services do not depend on each other's source.
 const ATTRIBUTION_MIN_COHORT = 20;
+
+// grpc-js status codes service.applications can return on CountAdoptedAdopters
+// (ADS-1022). Kept as local numeric constants — same pattern as the pets
+// client mapping in staff-foster-handlers.ts. INVALID_ARGUMENT and any
+// unmapped status fall through to INTERNAL, so only the mapped ones are named.
+const GRPC_DEADLINE_EXCEEDED = 4;
+const GRPC_PERMISSION_DENIED = 7;
+const GRPC_UNAVAILABLE = 14;
+
+const logger = createLogger({ serviceName: 'service.rescue' });
 
 // ── DB row types ────────────────────────────────────────────────────────
 
@@ -763,7 +774,15 @@ export function makeGetEventAnalytics(
 // checked in — the attribution model is "registered → later adopted") and
 // asks service.applications how many of them have since adopted within the
 // window. Forwards the caller's identity so applications runs its own
-// applications.read gate.
+// ANALYTICS_VIEW gate (ADS-1006).
+//
+// Downstream failures are mapped by gRPC status rather than flattened to
+// INTERNAL (ADS-1022): a caller lacking the analytics permission gets the
+// attribution field degraded to 0 (the rest of the analytics — which only
+// needs events.read — still returns), transient failures surface as a
+// retryable UNAVAILABLE, and everything else is our INTERNAL. Every failure
+// path logs exactly one line with the downstream code and event id, and no
+// downstream message text is forwarded to the client (ADS-977).
 async function countAdoptionsFromEvent(
   deps: HandlerDeps,
   applicationsClient: ApplicationsClient,
@@ -795,7 +814,32 @@ async function countAdoptionsFromEvent(
       principalToMetadata(principal)
     );
     return res.count;
-  } catch {
+  } catch (err) {
+    const code = (err as { code?: number }).code;
+    logger.warn('event adoption attribution failed', {
+      eventId,
+      grpcCode: code,
+      adopterIdCount: adopterIds.length,
+    });
+
+    // Caller lacks the admin-only analytics permission the attribution count
+    // requires (ADS-1006). Degrade this one field to 0 rather than failing
+    // the whole analytics call — registrations/attendance only need
+    // events.read, which the caller already holds.
+    if (code === GRPC_PERMISSION_DENIED) {
+      return 0;
+    }
+
+    // Transient downstream conditions — surface as a retryable status
+    // distinct from INTERNAL so the caller/SPA can distinguish "try again"
+    // from "server fault".
+    if (code === GRPC_UNAVAILABLE || code === GRPC_DEADLINE_EXCEEDED) {
+      throw new HandlerError('UNAVAILABLE', 'adoption attribution temporarily unavailable');
+    }
+
+    // INVALID_ARGUMENT is our request-construction bug, not the caller's;
+    // it and any unmapped status are an INTERNAL fault. Message stays generic
+    // so no downstream internals leak (ADS-977).
     throw new HandlerError('INTERNAL', 'failed to resolve adoption attribution');
   }
 }

--- a/services/rescue/src/grpc/handlers.ts
+++ b/services/rescue/src/grpc/handlers.ts
@@ -69,6 +69,10 @@ export type HandlerErrorCode =
   | 'NOT_FOUND'
   | 'ALREADY_EXISTS'
   | 'FAILED_PRECONDITION'
+  // Retryable downstream failure (e.g. service.applications UNAVAILABLE /
+  // DEADLINE_EXCEEDED on event attribution — ADS-1022). Mapped to
+  // grpc.status.UNAVAILABLE by the shared CODE_TO_GRPC table.
+  | 'UNAVAILABLE'
   | 'INTERNAL';
 
 export class HandlerError extends Error {

--- a/services/rescue/src/grpc/server.ts
+++ b/services/rescue/src/grpc/server.ts
@@ -122,7 +122,7 @@ export const createGrpcServer = (opts: CreateGrpcServerOptions): Server => {
     getEventAttendees: adapt(getEventAttendees, { deps, logger }),
     addEventAttendee: adapt(addEventAttendee, { deps, logger }),
     checkInAttendee: adapt(checkInAttendee, { deps, logger }),
-    getEventAnalytics: adapt(makeGetEventAnalytics(applicationsClient), { deps, logger }),
+    getEventAnalytics: adapt(makeGetEventAnalytics(applicationsClient, logger), { deps, logger }),
   });
 
   logger.info('gRPC RescueService registered', {


### PR DESCRIPTION
## Summary

Group A of the security-review backlog — backend authorisation and data-leak hardening. Twelve Linear tickets, each a self-contained TDD commit (tests + type-check green per commit); a few follow-up commits address PR-review feedback. Closes cross-adopter / cross-tenant leaks and authorisation gaps across `applications`, `rescue`, `notifications`, `moderation`, `audit`, `matching`, `chat`, and the `gateway` WebSocket path.

A recurring theme: several fixes want to bind an identity (a reporter, a ticket's email, an emailed recipient) to its owning account, but the owning service has **no auth/cross-service client wired**. Where that's the case the commit ships the bounded fix the ticket scoped and records the identity-binding as an explicit follow-up (ADS-1008 / 1017 / 1019 share this gap).

## Changes

### applications
- **ADS-1006** (High) — `CountAdoptedAdopters` was gated on `applications.read` (seeded to every adopter) and rejected only an empty id list, so a single-id request was a per-user "was this person ever approved/adopted?" oracle with a caller-controlled date window. Now gated on admin-only `ANALYTICS_VIEW` (`admin.reports`) with a k-anonymity cohort floor (`MIN_COHORT_SIZE = 20`); the rescue attribution caller skips below the floor so small events degrade to 0.
- **ADS-1007** — `saveDraftAnswers` used the blanket owner-OR-rescue scope, so rescue staff could rewrite an adopter's answers while the application was still an unsubmitted `draft`. New `requireDraftAnswersScope`: `draft` is owner-only, `under_review` keeps owner-OR-rescue (the intended follow-up-questions path).

### rescue
- **ADS-1022** (High) — `countAdoptionsFromEvent` swallowed every downstream gRPC status into a bare `INTERNAL` with nothing logged. Now maps by status (`PERMISSION_DENIED` → degrade attribution to 0; `UNAVAILABLE`/`DEADLINE_EXCEEDED` → retryable `UNAVAILABLE`; else `INTERNAL`) with one log line per failure. Adds `UNAVAILABLE` to the canonical `HandlerErrorCode` table.

### notifications
- **ADS-1008** — the email worker's opt-out/blacklist suppression keyed off caller-supplied `user_id`, never `to_email`, so a caller could name a non-suppressed `user_id` while mailing a victim's opted-out address. `sendEmail` now resolves the `user_id`'s email of record via `auth.adminGetUser` and requires it to equal `to_email`; **fails closed** (`INTERNAL`) when a `user_id`-carrying send can't be verified because auth is unwired.
- **ADS-1010** — `registerDeviceToken` scoped uniqueness to `(user_id, device_token)`, so one physical device could map to two users and receive another user's push PII (and survive the prior owner's GDPR erasure). Now keys on `device_token` alone, transfers on change-of-owner (soft-delete + insert), serialises per-token with a transaction-scoped advisory lock, and migration 009 adds a partial unique index. Follow-up commit narrows the param to `PoolClient` so the "inside a transaction" requirement the lock depends on is type-enforced.

### moderation
- **ADS-1017** — `openSupportTicket` wrote `user_email` / `user_name` verbatim (CRLF/control-char/length unchecked) into the row, event, and staff inbox. Both fields are now format/length/control-char validated.
- **ADS-1018** — `listReports` applied the `assignedModerator` filter unconditionally even though the reporter projection redacts `assigned_moderator`, giving a reporter-scoped caller a presence/absence oracle over moderator anonymity. Filtering on `assignedModerator` (id or the `''`/IS NULL path) without `MODERATION_REPORTS_VIEW` is now rejected.
- **ADS-1019** — `fileReport`'s dedup arbiter covered only SYSTEM auto-reports, so one account could flood the queue against a target and manufacture a repeat-offender pattern. Adds per-reporter dedup (open-status-scoped partial unique index + migration 012) and a per-principal gateway rate limit on report filing.

### audit
- **ADS-1009** — `listReportTemplates` built its WHERE clause purely from optional request fields: an empty request dumped every rescue's templates (+ custom config JSON) and a supplied `rescueId` was trusted verbatim (IDOR). Tenant scoping is now derived from the principal before any optional filter — `reports.read:any` enumerates across rescues, a rescue principal is pinned to own+system, a rescue-less caller falls through to system-only.

### gateway (WebSocket)
- **ADS-1021** (High) — the pre-auth handshake rate limiter's `handshakeClientIp` trusted `X-Forwarded-For` unconditionally, so on the direct-to-gateway path it protects, a client could rotate the header for a fresh bucket (or pin a victim's IP). It's now a pure, exported `(headers, address, trustProxy)` function that consults XFF only behind a trusted proxy; `trustProxy` comes from config (`TRUST_PROXY`), defaulting true in prod/staging (behind nginx) and false on a bare gateway.

### chat (frontend)
- **ADS-1011** — both attachment sites undid `resolveFileUrl`'s rejection with `resolveFileUrl(x) || x`, handing a `//evil.example/beacon.gif` attachment straight to `<img src>` (silent tracking pixel in a private thread). Rejected image URLs now render the file-icon placeholder instead of fetching.

### matching
- **ADS-1020** — the NULL-owner ownership guards in `recordSwipe`/`endSession` failed open (any caller holding an anonymous session's id could mutate it), and `getSessionStats` skipped the capability check every sibling runs. Guards now deny NULL-owner mutation unless super_admin; `getSessionStats` runs `ensureSwipePermission`. The read path keeps bearer access to anonymous sessions (random UUIDv4 ids), documented inline.

## Before requesting review

- [x] Tests for new behaviour added (TDD)
- [x] Full `pnpm test` / `type-check` / `lint` sweep — CI green on the current head

## Test plan

- [x] New behaviour covered by tests (per-commit)
- [x] Touched services type-check clean
- [x] Full-suite green in CI (Library / Service / Frontend / Package / Contract all passing)

## Related

Linear: ADS-1006, ADS-1007, ADS-1008, ADS-1009, ADS-1010, ADS-1011, ADS-1017, ADS-1018, ADS-1019, ADS-1020, ADS-1021, ADS-1022

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HXfco46xnVEa3Cs8sRoe1i

---
_Generated by [Claude Code](https://claude.ai/code/session_01HXfco46xnVEa3Cs8sRoe1i)_