### PR TITLE
fix(gateway): require an authenticated principal on upload routes (ADS-1035)

### DIFF
--- a/services/gateway/src/routes/application-documents.test.ts
+++ b/services/gateway/src/routes/application-documents.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, rmSync } from 'node:fs';
+import { existsSync, mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -225,6 +225,25 @@ describe('application document routes', () => {
     });
     expect(res.statusCode).toBe(400);
     expect(mocks.addDocument).not.toHaveBeenCalled();
+  });
+
+  it('POST rejects an anonymous request with 401 and never writes bytes (ADS-1035)', async () => {
+    const boundary = 'b-anon';
+    const body = multipartBody(
+      boundary,
+      Buffer.from('%PDF-1.4 hello'),
+      'aaa.pdf',
+      'id_verification'
+    );
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/v1/applications/app-1/documents',
+      headers: { 'content-type': `multipart/form-data; boundary=${boundary}` },
+      payload: body,
+    });
+    expect(res.statusCode).toBe(401);
+    expect(mocks.addDocument).not.toHaveBeenCalled();
+    expect(existsSync(join(tmp, 'documents'))).toBe(false);
   });
 
   it('GET /:id/documents returns { data: view[] } with a freshly-signed URL per document', async () => {

--- a/services/gateway/src/routes/application-documents.ts
+++ b/services/gateway/src/routes/application-documents.ts
@@ -321,10 +321,11 @@ export const registerApplicationDocumentsRoutes = async (
 // --- Helpers ---------------------------------------------------------
 
 // x-user-id is stamped by the authenticate middleware after a validated
-// ValidateToken call (never client-supplied — see middleware/authenticate.ts's
-// SPOOFABLE_HEADERS strip). Its absence means the request carried no valid
-// principal, so the route must reject before writing bytes to storage
-// (ADS-1035).
+// ValidateToken call, which strips any client-supplied value first (see
+// middleware/authenticate.ts's SPOOFABLE_HEADERS strip) — provided that
+// middleware runs in front of this route. Its absence means the request
+// carried no valid principal, so the route must reject before writing
+// bytes to storage (ADS-1035).
 function principalUserId(req: FastifyRequest): string | null {
   const raw = (req.headers as Record<string, string | string[] | undefined>)['x-user-id'];
   return typeof raw === 'string' && raw.length > 0 ? raw : null;

--- a/services/gateway/src/routes/application-documents.ts
+++ b/services/gateway/src/routes/application-documents.ts
@@ -327,7 +327,8 @@ export const registerApplicationDocumentsRoutes = async (
 // carried no valid principal, so the route must reject before writing
 // bytes to storage (ADS-1035).
 function principalUserId(req: FastifyRequest): string | null {
-  const raw = (req.headers as Record<string, string | string[] | undefined>)['x-user-id'];
+  const headers = req.headers as Record<string, string | string[] | undefined>;
+  const raw = headers['x-user-id'];
   return typeof raw === 'string' && raw.length > 0 ? raw : null;
 }
 

--- a/services/gateway/src/routes/application-documents.ts
+++ b/services/gateway/src/routes/application-documents.ts
@@ -40,7 +40,7 @@
 
 import { extname } from 'node:path';
 
-import type { FastifyInstance } from 'fastify';
+import type { FastifyInstance, FastifyRequest } from 'fastify';
 
 import { createStorageProvider, type StorageConfig } from '@adopt-dont-shop/storage';
 
@@ -130,12 +130,17 @@ export const registerApplicationDocumentsRoutes = async (
             properties: { data: { type: 'object', additionalProperties: true } },
           },
           400: { type: 'object', properties: { error: { type: 'string' } } },
+          401: { type: 'object', properties: { error: { type: 'string' } } },
           500: { type: 'object', properties: { error: { type: 'string' } } },
           503: { type: 'object', properties: { error: { type: 'string' } } },
         },
       },
     },
     async (req, reply) => {
+      if (!principalUserId(req)) {
+        return reply.code(401).send({ error: 'unauthenticated' });
+      }
+
       if (typeof (req as { isMultipart?: () => boolean }).isMultipart !== 'function') {
         return reply.code(500).send({ error: 'multipart support not registered' });
       }
@@ -314,6 +319,16 @@ export const registerApplicationDocumentsRoutes = async (
 };
 
 // --- Helpers ---------------------------------------------------------
+
+// x-user-id is stamped by the authenticate middleware after a validated
+// ValidateToken call (never client-supplied — see middleware/authenticate.ts's
+// SPOOFABLE_HEADERS strip). Its absence means the request carried no valid
+// principal, so the route must reject before writing bytes to storage
+// (ADS-1035).
+function principalUserId(req: FastifyRequest): string | null {
+  const raw = (req.headers as Record<string, string | string[] | undefined>)['x-user-id'];
+  return typeof raw === 'string' && raw.length > 0 ? raw : null;
+}
 
 // Thin multipart-part shape — kept loose so this module doesn't take a
 // hard dep on @fastify/multipart's own types at the type level. The

--- a/services/gateway/src/routes/uploads.test.ts
+++ b/services/gateway/src/routes/uploads.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from 'node:fs';
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync, existsSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -69,7 +69,10 @@ describe('POST /api/v1/uploads/images', () => {
     const res = await app.inject({
       method: 'POST',
       url: '/api/v1/uploads/images',
-      headers: { 'content-type': `multipart/form-data; boundary=${boundary}` },
+      headers: {
+        'x-user-id': 'usr-1',
+        'content-type': `multipart/form-data; boundary=${boundary}`,
+      },
       payload: body,
     });
 
@@ -89,7 +92,10 @@ describe('POST /api/v1/uploads/images', () => {
     const res = await app.inject({
       method: 'POST',
       url: '/api/v1/uploads/images',
-      headers: { 'content-type': `multipart/form-data; boundary=${boundary}` },
+      headers: {
+        'x-user-id': 'usr-1',
+        'content-type': `multipart/form-data; boundary=${boundary}`,
+      },
       payload: body,
     });
 
@@ -105,7 +111,10 @@ describe('POST /api/v1/uploads/images', () => {
     const res = await app.inject({
       method: 'POST',
       url: '/api/v1/uploads/images',
-      headers: { 'content-type': `multipart/form-data; boundary=${boundary}` },
+      headers: {
+        'x-user-id': 'usr-1',
+        'content-type': `multipart/form-data; boundary=${boundary}`,
+      },
       payload: body,
     });
 
@@ -120,7 +129,10 @@ describe('POST /api/v1/uploads/images', () => {
     const res = await app.inject({
       method: 'POST',
       url: '/api/v1/uploads/images',
-      headers: { 'content-type': `multipart/form-data; boundary=${boundary}` },
+      headers: {
+        'x-user-id': 'usr-1',
+        'content-type': `multipart/form-data; boundary=${boundary}`,
+      },
       payload: body,
     });
 
@@ -140,7 +152,10 @@ describe('POST /api/v1/uploads/images', () => {
     const res = await app.inject({
       method: 'POST',
       url: '/api/v1/uploads/images',
-      headers: { 'content-type': `multipart/form-data; boundary=${boundary}` },
+      headers: {
+        'x-user-id': 'usr-1',
+        'content-type': `multipart/form-data; boundary=${boundary}`,
+      },
       payload: body,
     });
 
@@ -157,7 +172,10 @@ describe('POST /api/v1/uploads/images', () => {
     const res = await app.inject({
       method: 'POST',
       url: '/api/v1/uploads/images',
-      headers: { 'content-type': `multipart/form-data; boundary=${boundary}` },
+      headers: {
+        'x-user-id': 'usr-1',
+        'content-type': `multipart/form-data; boundary=${boundary}`,
+      },
       payload: body,
     });
 
@@ -176,12 +194,30 @@ describe('POST /api/v1/uploads/images', () => {
     const res = await app.inject({
       method: 'POST',
       url: '/api/v1/uploads/images',
-      headers: { 'content-type': `multipart/form-data; boundary=${boundary}` },
+      headers: {
+        'x-user-id': 'usr-1',
+        'content-type': `multipart/form-data; boundary=${boundary}`,
+      },
       payload: body,
     });
 
     expect(res.statusCode).toBe(400);
     expect((res.json() as { error: string }).error).toMatch(/dimensions/i);
+  });
+
+  it('rejects an anonymous request with 401 and writes nothing to storage (ADS-1035)', async () => {
+    const boundary = 'b7';
+    const body = multipartBody(boundary, await makeJpeg(), 'cat.jpg', 'image/jpeg');
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/v1/uploads/images',
+      headers: { 'content-type': `multipart/form-data; boundary=${boundary}` },
+      payload: body,
+    });
+
+    expect(res.statusCode).toBe(401);
+    expect(existsSync(join(tmp, 'pets'))).toBe(false);
   });
 });
 

--- a/services/gateway/src/routes/uploads.ts
+++ b/services/gateway/src/routes/uploads.ts
@@ -22,7 +22,7 @@ import crypto from 'node:crypto';
 import * as fs from 'node:fs';
 import path from 'node:path';
 
-import type { FastifyInstance, FastifyReply } from 'fastify';
+import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
 
 import {
   createStorageProvider,
@@ -111,11 +111,16 @@ export const registerUploadsRoutes = async (
             },
           },
           400: { type: 'object', properties: { error: { type: 'string' } } },
+          401: { type: 'object', properties: { error: { type: 'string' } } },
           500: { type: 'object', properties: { error: { type: 'string' } } },
         },
       },
     },
     async (req, reply) => {
+      if (!principalUserId(req)) {
+        return reply.code(401).send({ error: 'unauthenticated' });
+      }
+
       if (typeof (req as { isMultipart?: () => boolean }).isMultipart !== 'function') {
         return reply.code(500).send({ error: 'multipart support not registered' });
       }
@@ -233,6 +238,15 @@ export const registerUploadsRoutes = async (
 };
 
 // --- Helpers ---------------------------------------------------------
+
+// x-user-id is stamped by the authenticate middleware after a validated
+// ValidateToken call (never client-supplied — see middleware/authenticate.ts's
+// SPOOFABLE_HEADERS strip). Its absence means the request carried no valid
+// principal, so the route must reject before touching storage (ADS-1035).
+function principalUserId(req: FastifyRequest): string | null {
+  const raw = (req.headers as Record<string, string | string[] | undefined>)['x-user-id'];
+  return typeof raw === 'string' && raw.length > 0 ? raw : null;
+}
 
 type MultipartPart = {
   type: 'file' | 'field';

--- a/services/gateway/src/routes/uploads.ts
+++ b/services/gateway/src/routes/uploads.ts
@@ -246,7 +246,8 @@ export const registerUploadsRoutes = async (
 // carried no valid principal, so the route must reject before touching
 // storage (ADS-1035).
 function principalUserId(req: FastifyRequest): string | null {
-  const raw = (req.headers as Record<string, string | string[] | undefined>)['x-user-id'];
+  const headers = req.headers as Record<string, string | string[] | undefined>;
+  const raw = headers['x-user-id'];
   return typeof raw === 'string' && raw.length > 0 ? raw : null;
 }
 

--- a/services/gateway/src/routes/uploads.ts
+++ b/services/gateway/src/routes/uploads.ts
@@ -240,9 +240,11 @@ export const registerUploadsRoutes = async (
 // --- Helpers ---------------------------------------------------------
 
 // x-user-id is stamped by the authenticate middleware after a validated
-// ValidateToken call (never client-supplied — see middleware/authenticate.ts's
-// SPOOFABLE_HEADERS strip). Its absence means the request carried no valid
-// principal, so the route must reject before touching storage (ADS-1035).
+// ValidateToken call, which strips any client-supplied value first (see
+// middleware/authenticate.ts's SPOOFABLE_HEADERS strip) — provided that
+// middleware runs in front of this route. Its absence means the request
+// carried no valid principal, so the route must reject before touching
+// storage (ADS-1035).
 function principalUserId(req: FastifyRequest): string | null {
   const raw = (req.headers as Record<string, string | string[] | undefined>)['x-user-id'];
   return typeof raw === 'string' && raw.length > 0 ? raw : null;


### PR DESCRIPTION
## Summary

- `POST /api/v1/uploads/images` and `POST /api/v1/applications/:id/documents` wrote bytes to the storage backend with no authentication check anywhere in either route — an anonymous caller could write to the shared storage volume with no account and no forensic trail.
- Adds the "minimal, surgical fix" called out in ADS-1035: reject with `401` before parsing multipart or touching storage when the authenticate middleware did not stamp a validated `x-user-id` header onto the request.

## Changes

- `services/gateway/src/routes/uploads.ts` — guard `POST /api/v1/uploads/images` on a validated principal (`principalUserId` helper, same pattern already used in `routes/gdpr.ts`); adds a `401` response schema entry.
- `services/gateway/src/routes/application-documents.ts` — same guard on `POST /api/v1/applications/:id/documents`.
- `services/gateway/src/routes/uploads.test.ts` / `application-documents.test.ts` — updated happy-path tests to supply a principal header, added a new case per route asserting an anonymous request gets `401` and writes nothing to storage.

## Before requesting review

- [x] Ran the gateway test suite locally
- [x] Tests for new behaviour added (TDD)
- [ ] If touching `.env` requirements, updated `.env.example`'s REQUIRED block — n/a
- [ ] If touching a `lib.*`, considered consumer impact — n/a (gateway-only)

## Test plan

- [x] `pnpm --filter @adopt-dont-shop/service.gateway exec vitest run src/routes/uploads.test.ts src/routes/application-documents.test.ts` — 34 passed
- [x] `pnpm --filter @adopt-dont-shop/service.gateway exec tsc --noEmit -p .` — clean
- [x] `pnpm --filter @adopt-dont-shop/service.gateway exec eslint` on changed files — clean
- [ ] Tested manually — n/a (no local stack available in this session)

## Related

Linear: ADS-1035

This is a partial fix — first logical step of the ticket. Remaining acceptance criteria (tracked as follow-up, not in this PR):
- Reorder `application-documents.ts` so the storage write happens only after a successful ownership check (currently bytes are written before `AddDocument` authorizes anything).
- Emit an audit event on successful upload — there's currently no "write an audit event from the gateway" mechanism in this repo (audit emission today is producer→consumer over NATS `*.actionTaken`, and no gateway route publishes one yet); this needs its own plumbing (thread `nats` into the route options, define the event payload) rather than a one-line addition.
- Correct/resolve the stale strangler-fig comment in `middleware/authenticate.ts` (`if (!token) { return; }`) — left alone here since flipping it to fail-closed globally affects every other route on the gateway, not just these two, and needs its own audit of what currently relies on that fail-open behaviour.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EBUJicFhfUGQqSoqN3bhFk)_