### PR TITLE
fix(gateway): add per-route rate limits to chat, broadcast and matching endpoints

### DIFF
--- a/services/gateway/src/routes/broadcast.test.ts
+++ b/services/gateway/src/routes/broadcast.test.ts
@@ -295,3 +295,30 @@ describe('GET /api/v1/notifications/broadcast/preview', () => {
     expect(broadcast).not.toHaveBeenCalled();
   });
 });
+
+describe('broadcast rate limiting (ADS-997)', () => {
+  it('caps the broadcast fan-out at 5/min and 429s once the ceiling is exceeded', async () => {
+    const app = Fastify({ logger: false });
+    const { client, broadcast } = makeClient();
+    broadcast.mockResolvedValue({ targeted: 0, delivered: 0, suppressed: 0, failed: 0 });
+    await registerBroadcastRoutes(app, { client });
+    try {
+      const fire = () =>
+        app.inject({
+          method: 'POST',
+          url: '/api/v1/notifications/broadcast',
+          headers: ADMIN_HEADERS,
+          payload: { cohort: {}, title: 't', message: 'm' },
+        });
+      const statuses: number[] = [];
+      for (let i = 0; i < 6; i += 1) {
+        statuses.push((await fire()).statusCode);
+      }
+      // The first 5 (the cap) pass; the 6th trips the per-route limit.
+      expect(statuses.slice(0, 5)).toEqual([200, 200, 200, 200, 200]);
+      expect(statuses[5]).toBe(429);
+    } finally {
+      await app.close();
+    }
+  });
+});

--- a/services/gateway/src/routes/broadcast.ts
+++ b/services/gateway/src/routes/broadcast.ts
@@ -11,6 +11,7 @@
 // audiences onto the same BroadcastCohort shape the explicit `cohort`
 // object uses, so both forms are accepted side by side.
 
+import rateLimit from '@fastify/rate-limit';
 import type { FastifyInstance } from 'fastify';
 
 import {
@@ -28,6 +29,18 @@ export type BroadcastRoutesOptions = {
   client: NotificationsClient;
 };
 
+// Per-route rate limits (ADS-997). The broadcast fan-out queues thousands of
+// notification rows + outbound emails per call, so even one compromised admin
+// account could fire ~100 broadcasts/min under the gateway-wide cap. A tight
+// 5/min ceiling has negligible UX impact on what is an occasional admin action.
+// Preview is a cheap dry-run cohort count but still admin-only, so a modest
+// read cap is plenty. Registering @fastify/rate-limit with { global: false }
+// below means an unconfigured route is UNcapped, so both routes set one.
+const BROADCAST_RATE_LIMITS = {
+  broadcast: { max: 5, timeWindow: '1 minute' },
+  preview: { max: 60, timeWindow: '1 minute' },
+} as const;
+
 const AUDIENCE_COHORT: Record<string, BroadcastCohort> = {
   all: { userTypes: [], statuses: [] },
   'all-rescues': { userTypes: ['rescue_staff'], statuses: [] },
@@ -41,9 +54,12 @@ export const registerBroadcastRoutes = async (
 ): Promise<void> => {
   const { client } = opts;
 
+  await app.register(rateLimit, { global: false });
+
   app.post(
     '/api/v1/notifications/broadcast',
     {
+      config: { rateLimit: BROADCAST_RATE_LIMITS.broadcast },
       schema: {
         tags: ['notifications', 'admin'],
         summary: 'Broadcast a notification to a cohort of users',
@@ -140,6 +156,7 @@ export const registerBroadcastRoutes = async (
   app.get(
     '/api/v1/notifications/broadcast/preview',
     {
+      config: { rateLimit: BROADCAST_RATE_LIMITS.preview },
       schema: {
         tags: ['notifications', 'admin'],
         summary: 'Preview the recipient count for a named broadcast audience',

--- a/services/gateway/src/routes/chat.test.ts
+++ b/services/gateway/src/routes/chat.test.ts
@@ -872,3 +872,29 @@ describe('DELETE /api/v1/chats/:chatId', () => {
     expect(client.deleteChatMock).toHaveBeenCalledTimes(1);
   });
 });
+
+describe('chat rate limiting (ADS-996)', () => {
+  it('caps open-chat at 10/min and 429s once the ceiling is exceeded', async () => {
+    const client = makeClient();
+    client.openChatMock.mockResolvedValue({ chat: CHAT_FIXTURE, created: false });
+    const app = await buildApp(client);
+    try {
+      const fire = () =>
+        app.inject({
+          method: 'POST',
+          url: '/api/v1/chats',
+          headers: { 'x-user-id': 'usr-1', 'x-user-roles': 'adopter' },
+          payload: { otherUserId: 'usr-2' },
+        });
+      const statuses: number[] = [];
+      for (let i = 0; i < 11; i += 1) {
+        statuses.push((await fire()).statusCode);
+      }
+      // The first 10 (the cap) pass; the 11th trips the per-route limit.
+      expect(statuses.slice(0, 10).every(s => s === 200)).toBe(true);
+      expect(statuses[10]).toBe(429);
+    } finally {
+      await app.close();
+    }
+  });
+});

--- a/services/gateway/src/routes/chat.ts
+++ b/services/gateway/src/routes/chat.ts
@@ -10,6 +10,7 @@
 // `x-user-permissions` / `x-rescue-id` headers from the client become
 // the gRPC metadata the chat handlers' principal extractor reads.
 
+import rateLimit from '@fastify/rate-limit';
 import type { FastifyInstance } from 'fastify';
 
 import {
@@ -39,6 +40,22 @@ export type ChatRoutesOptions = {
 // prefixes via this list.
 const CHAT_PREFIXES = ['/api/v1/chats', '/api/v1/conversations'] as const;
 
+// Per-route rate limits (ADS-996). Before this the only cap on the chat
+// surface was the gateway-wide 100 req/min/IP limit — per-IP, so a rotating
+// proxy bypassed it, and far too loose for POST message flooding. Reads sit
+// at 120/min (same house sizing as moderation.ts); the chatty writes get
+// their own ceilings, and open-chat is tightened to curb chat-spam creation.
+// Registering @fastify/rate-limit with { global: false } below means a route
+// without a config.rateLimit block is UNcapped, so every route below sets one.
+const CHAT_RATE_LIMITS = {
+  read: { max: 120, timeWindow: '1 minute' },
+  openChat: { max: 10, timeWindow: '1 minute' },
+  sendMessage: { max: 60, timeWindow: '1 minute' },
+  markRead: { max: 60, timeWindow: '1 minute' },
+  react: { max: 30, timeWindow: '1 minute' },
+  delete: { max: 30, timeWindow: '1 minute' },
+} as const;
+
 // Envelope normalization: the proto Message carries its text under `body`
 // (the POST maps the SPA's `content` onto it). But the SPA chat client
 // (ChatContext) and the e2e helpers READ `content`, so without this the text
@@ -64,6 +81,8 @@ export const registerChatRoutes = async (
 ): Promise<void> => {
   const { client } = opts;
 
+  await app.register(rateLimit, { global: false });
+
   for (const prefix of CHAT_PREFIXES) {
     registerChatRoutesForPrefix(app, client, prefix);
   }
@@ -74,6 +93,7 @@ export const registerChatRoutes = async (
   app.post<{ Params: { messageId: string } }>(
     '/api/v1/messages/:messageId/reactions',
     {
+      config: { rateLimit: CHAT_RATE_LIMITS.react },
       schema: {
         tags: ['chat'],
         summary: 'Add or remove a reaction on a message',
@@ -120,6 +140,7 @@ const registerChatRoutesForPrefix = (
   app.get(
     prefix,
     {
+      config: { rateLimit: CHAT_RATE_LIMITS.read },
       schema: {
         tags: ['chat'],
         summary: 'List chats for the calling user',
@@ -163,6 +184,7 @@ const registerChatRoutesForPrefix = (
   app.post(
     prefix,
     {
+      config: { rateLimit: CHAT_RATE_LIMITS.openChat },
       schema: {
         tags: ['chat'],
         summary: 'Open or create a chat',
@@ -214,6 +236,7 @@ const registerChatRoutesForPrefix = (
   app.get(
     `${prefix}/search`,
     {
+      config: { rateLimit: CHAT_RATE_LIMITS.read },
       schema: {
         tags: ['chat'],
         summary: 'Search chats',
@@ -289,6 +312,7 @@ const registerChatRoutesForPrefix = (
   app.get<{ Params: { chatId: string } }>(
     `${prefix}/:chatId/unread-count`,
     {
+      config: { rateLimit: CHAT_RATE_LIMITS.read },
       schema: {
         tags: ['chat'],
         summary: 'Get unread message count for a chat',
@@ -330,6 +354,7 @@ const registerChatRoutesForPrefix = (
   app.get<{ Params: { chatId: string } }>(
     `${prefix}/:chatId`,
     {
+      config: { rateLimit: CHAT_RATE_LIMITS.read },
       schema: {
         tags: ['chat'],
         summary: 'Get a single chat by ID',
@@ -375,6 +400,7 @@ const registerChatRoutesForPrefix = (
   app.delete<{ Params: { chatId: string }; Body?: { reason?: string } }>(
     `${prefix}/:chatId`,
     {
+      config: { rateLimit: CHAT_RATE_LIMITS.delete },
       schema: {
         tags: ['chat'],
         summary: 'Delete (archive) a chat',
@@ -418,6 +444,7 @@ const registerChatRoutesForPrefix = (
   app.get<{ Params: { chatId: string } }>(
     `${prefix}/:chatId/messages`,
     {
+      config: { rateLimit: CHAT_RATE_LIMITS.read },
       schema: {
         tags: ['chat'],
         summary: 'List messages in a chat',
@@ -466,6 +493,7 @@ const registerChatRoutesForPrefix = (
   app.delete<{ Params: { chatId: string; messageId: string }; Body?: { reason?: string } }>(
     `${prefix}/:chatId/messages/:messageId`,
     {
+      config: { rateLimit: CHAT_RATE_LIMITS.delete },
       schema: {
         tags: ['chat'],
         summary: 'Delete a message',
@@ -509,6 +537,7 @@ const registerChatRoutesForPrefix = (
   app.post<{ Params: { chatId: string } }>(
     `${prefix}/:chatId/messages`,
     {
+      config: { rateLimit: CHAT_RATE_LIMITS.sendMessage },
       schema: {
         tags: ['chat'],
         summary: 'Send a message to a chat',
@@ -553,6 +582,7 @@ const registerChatRoutesForPrefix = (
   app.post<{ Params: { chatId: string } }>(
     `${prefix}/:chatId/read`,
     {
+      config: { rateLimit: CHAT_RATE_LIMITS.markRead },
       schema: {
         tags: ['chat'],
         summary: 'Mark messages in a chat as read',

--- a/services/gateway/src/routes/matching.test.ts
+++ b/services/gateway/src/routes/matching.test.ts
@@ -734,3 +734,45 @@ describe('GET /api/v1/match/top-picks (GetTopPicks)', () => {
     }
   });
 });
+
+describe('match profile rate limiting (ADS-998)', () => {
+  it('caps the match-profile upsert at 30/min and 429s once the ceiling is exceeded', async () => {
+    const m = makeClient();
+    m.upsertMatchProfileMock.mockResolvedValue({
+      profile: {
+        userId: 'usr-1',
+        preferredTypesJson: '',
+        preferredSizesJson: '',
+        preferredAgeGroupsJson: '',
+        preferredEnergyJson: '',
+        preferredTemperamentJson: '',
+        lifestyleJson: '{}',
+        openToSpecialNeeds: false,
+        notifyNewMatches: false,
+        minNotificationScore: 0,
+        inferredPrefsJson: '{}',
+        createdAt: '2026-06-01T00:00:00Z',
+        updatedAt: '2026-06-01T00:00:00Z',
+      },
+    });
+    const app = await makeApp(m.client);
+    try {
+      const fire = () =>
+        app.inject({
+          method: 'PUT',
+          url: '/api/v1/match/profile',
+          headers: ADOPTER_HEADERS,
+          payload: { preferred_types: ['cat'] },
+        });
+      const statuses: number[] = [];
+      for (let i = 0; i < 31; i += 1) {
+        statuses.push((await fire()).statusCode);
+      }
+      // The first 30 (the cap) pass; the 31st trips the per-route limit.
+      expect(statuses.slice(0, 30).every(s => s === 200)).toBe(true);
+      expect(statuses[30]).toBe(429);
+    } finally {
+      await app.close();
+    }
+  });
+});

--- a/services/gateway/src/routes/matching.ts
+++ b/services/gateway/src/routes/matching.ts
@@ -64,6 +64,13 @@ const MATCHING_RATE_LIMITS = {
   search: { max: 120, timeWindow: '1 minute' },
   // Top picks is a curated read the SPA loads on the home + picks pages.
   topPicks: { max: 60, timeWindow: '1 minute' },
+  // Match profile: the GET is a cheap read; the PUT upserts the persistent
+  // adopter_match_profiles store (body is additionalProperties with no size
+  // constraint) so it gets the tighter write ceiling (ADS-998). Swipe
+  // stats/session are low-cost reads.
+  matchProfileRead: { max: 120, timeWindow: '1 minute' },
+  matchProfileWrite: { max: 30, timeWindow: '1 minute' },
+  swipeStats: { max: 120, timeWindow: '1 minute' },
 } as const;
 
 // userAgent / ipAddress are deliberately NOT accepted from the body:
@@ -422,6 +429,7 @@ export const registerMatchingRoutes = async (
   app.get(
     '/api/v1/match/profile',
     {
+      config: { rateLimit: MATCHING_RATE_LIMITS.matchProfileRead },
       schema: {
         tags: ['matching'],
         summary: 'Get the adopter match profile',
@@ -451,6 +459,7 @@ export const registerMatchingRoutes = async (
   app.put(
     '/api/v1/match/profile',
     {
+      config: { rateLimit: MATCHING_RATE_LIMITS.matchProfileWrite },
       schema: {
         tags: ['matching'],
         summary: 'Upsert the adopter match profile',
@@ -518,6 +527,7 @@ export const registerMatchingRoutes = async (
   app.get<{ Params: { userId: string } }>(
     '/api/v1/discovery/swipe/stats/:userId',
     {
+      config: { rateLimit: MATCHING_RATE_LIMITS.swipeStats },
       schema: {
         tags: ['discovery'],
         summary: 'Get swipe statistics for a user',
@@ -559,6 +569,7 @@ export const registerMatchingRoutes = async (
   app.get<{ Params: { sessionId: string } }>(
     '/api/v1/discovery/swipe/session/:sessionId',
     {
+      config: { rateLimit: MATCHING_RATE_LIMITS.swipeStats },
       schema: {
         tags: ['discovery'],
         summary: 'Get statistics for a swipe session',


### PR DESCRIPTION
## Summary

Reviewed the four open Linear tickets and merged the three overlapping rate-limit tickets (ADS-996, ADS-997, ADS-998) into a single change, since they all request per-route rate limits on gateway routes that today rely only on the gateway-wide 100 req/min/IP cap (per-IP, so bypassable via a rotating proxy), and all follow the same established `matching.ts` pattern.

- **ADS-996** — cap every chat route (reads 120/min, writes 30/min, open-chat 10/min, send-message & mark-read 60/min, reactions 30/min).
- **ADS-997** — cap the admin broadcast fan-out at 5/min (each call queues thousands of notification rows + emails) and the dry-run preview at 60/min.
- **ADS-998** — add the four missing caps in `matching.ts`: GET/PUT `/match/profile` and GET swipe stats/session.

The fourth ticket, **ADS-999** (IDOR on anonymous swipe sessions), was already fixed under **ADS-1020** (commit `6072114`, PR #1263) — `endSession`/`recordSwipe` now deny NULL-owner sessions to any non-super-admin caller, with tests. No code change needed; it is a duplicate to close in Linear.

## Changes

- `services/gateway/src/routes/chat.ts` — register `@fastify/rate-limit` `{ global: false }`, add `CHAT_RATE_LIMITS`, and a `config.rateLimit` block on all 11 chat routes. Because a local `{ global: false }` registration drops the gateway-wide cap for the scope, every route is given an explicit ceiling so none is left uncapped.
- `services/gateway/src/routes/broadcast.ts` — register the plugin, add `BROADCAST_RATE_LIMITS`, cap the broadcast POST (5/min) and preview GET (60/min).
- `services/gateway/src/routes/matching.ts` — add three `MATCHING_RATE_LIMITS` entries and `config.rateLimit` blocks on the four previously-uncapped routes (PUT profile gets the tighter 30/min write ceiling; reads sit at 120/min).
- `*.test.ts` — a focused regression test per file asserting the cap trips a `429` once exceeded.

## Before requesting review

- [ ] Ran `pnpm ci:local:quick` locally (or installed the pre-push hook — see CONTRIBUTING.md)
- [x] Tests for new behaviour added (TDD)
- [x] If touching `.env` requirements, updated `.env.example`'s REQUIRED block — n/a
- [x] If touching a `lib.*`, considered consumer impact across `app.*` and `service.backend` — n/a (gateway routes only)

## Test plan

- [x] Existing tests pass (`pnpm test` for `service.gateway` — 1088 tests, 76 files)
- [x] New behaviour is covered by tests (429-on-exceed for each of the three files)
- [ ] Tested manually — n/a; behaviour is fully covered by the new tests
- [x] No TypeScript errors (`turbo type-check --filter=service.gateway`)
- [x] Lint passes (`eslint` on changed files; lint-staged clean on commit)

## Related

- Linear: ADS-996, ADS-997, ADS-998
- ADS-999 — already resolved by ADS-1020 (PR #1263); close as duplicate

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PyLUww6MdfCdqbXe9V6eAE

---
_Generated by [Claude Code](https://claude.ai/code/session_01PyLUww6MdfCdqbXe9V6eAE)_