### PR TITLE
docs(rescue): document the service.applications gRPC dependency

### DIFF
--- a/docs/env-reference.md
+++ b/docs/env-reference.md
@@ -135,6 +135,24 @@ instead of direct gateway access):
 # VITE_WS_BASE_URL=ws://api.localhost
 ```
 
+## Internal service gRPC URLs
+
+Every gRPC client defaults to the in-cluster Docker Compose service name
+(`service-<name>:<grpcPort>`) — override only when reaching a service on a
+different host/port (e.g. native dev without Docker):
+
+```env
+# service.pets — service.rescue's CreateFosterPlacement and
+# service.applications' StartDraft both resolve pet -> rescue ownership
+# via this before committing.
+PETS_GRPC_URL=service-pets:6003
+
+# service.applications — service.rescue's GetEventAnalytics calls
+# CountAdoptedAdopters here to compute registered-then-adopted
+# attribution (ADS-941).
+APPLICATIONS_GRPC_URL=service-applications:6005
+```
+
 ## Email
 
 `.env.example` sets `EMAIL_PROVIDER=console` (prints to stdout — no

--- a/docs/env-reference.md
+++ b/docs/env-reference.md
@@ -137,9 +137,12 @@ instead of direct gateway access):
 
 ## Internal service gRPC URLs
 
-Every gRPC client defaults to the in-cluster Docker Compose service name
-(`service-<name>:<grpcPort>`) — override only when reaching a service on a
-different host/port (e.g. native dev without Docker):
+Required gRPC clients like these two on service.rescue default to the
+in-cluster Docker Compose service name (`service-<name>:<grpcPort>`) — override
+only when reaching a service on a different host/port (e.g. native dev without
+Docker). Some clients are optional instead and default to `undefined` when
+unset (e.g. service.notifications' `AUTH_GRPC_URL` / `PETS_GRPC_URL` /
+`RESCUE_GRPC_URL`):
 
 ```env
 # service.pets — service.rescue's CreateFosterPlacement and

--- a/services/rescue/README.md
+++ b/services/rescue/README.md
@@ -14,10 +14,12 @@ transitions).
 See [`docs/infrastructure/MICROSERVICES-STANDARDS.md`](../../docs/infrastructure/MICROSERVICES-STANDARDS.md)
 for the shared service boundaries / ownership model. Cross-service gRPC: calls
 **service.pets** (`PETS_GRPC_URL`) in `CreateFosterPlacement` to validate pet
-ownership. Read over gRPC by **service.notifications** (`ListStaffMembers` /
-`Get`) for rescue fan-out. Depends on the shared backend packages
-`@adopt-dont-shop/{authz, config-secrets, db, events, lib.types, observability,
-proto, service-bootstrap}`.
+ownership, and **service.applications** (`APPLICATIONS_GRPC_URL`) in
+`GetEventAnalytics` → `CountAdoptedAdopters` to compute registered-then-adopted
+attribution (ADS-941). Read over gRPC by **service.notifications**
+(`ListStaffMembers` / `Get`) for rescue fan-out. Depends on the shared backend
+packages `@adopt-dont-shop/{authz, config-secrets, db, events, lib.types,
+observability, proto, service-bootstrap}`.
 
 ## Scripts
 
@@ -70,16 +72,17 @@ denormalisation.
 
 `DATABASE_URL` is **required** (boot fails fast without it). `RESCUE_PORT`
 (5004), `RESCUE_GRPC_PORT` (6004), `RESCUE_HOST`, `RESCUE_SCHEMA` (`rescue`),
-`PETS_GRPC_URL`, and `NATS_URL` have dev defaults, plus the standard
-`@adopt-dont-shop/observability` vars. See
+`PETS_GRPC_URL`, `APPLICATIONS_GRPC_URL`, and `NATS_URL` have dev defaults,
+plus the standard `@adopt-dont-shop/observability` vars. See
 [`docs/env-reference.md`](../../docs/env-reference.md) for the full list.
 
 ## Testing notes
 
 Vitest. The verification state machine is a pure, I/O-free transition table
-tested directly; handlers are tested with pool + NATS (+ a stub pets client)
-injected — assert each permission/scope path, one-time invitation-token
-behaviour, foster-placement validation against the pets client, and
+tested directly; handlers are tested with pool + NATS (+ a stub pets client
+and a stub applications client) injected — assert each permission/scope path,
+one-time invitation-token behaviour, foster-placement validation against the
+pets client, event-analytics attribution against the applications client, and
 publish-after-commit ordering. See
 [`docs/backend/testing.md`](../../docs/backend/testing.md) for shared
 conventions.


### PR DESCRIPTION
## Summary

- `services/rescue/README.md` documented only the `service.pets` (`PETS_GRPC_URL`) outbound gRPC dependency, but ADS-941 added a second one: `service.applications` (`APPLICATIONS_GRPC_URL`), used by `GetEventAnalytics` → `CountAdoptedAdopters` for registered-then-adopted attribution.
- `docs/env-reference.md` had no entry at all for either gRPC URL var.

## Changes

- `services/rescue/README.md`: updated the "Location in the architecture" paragraph to name `service.applications`/`APPLICATIONS_GRPC_URL`/`GetEventAnalytics` → `CountAdoptedAdopters`; added `APPLICATIONS_GRPC_URL` to the "Environment variables consumed" list; updated "Testing notes" to mention the stub applications client injected alongside the stub pets client (verified against `services/rescue/src/grpc/server.ts` and `server.test.ts`/`event-handlers.test.ts`).
- `docs/env-reference.md`: added a new "Internal service gRPC URLs" section documenting `PETS_GRPC_URL` (default `service-pets:6003`) and `APPLICATIONS_GRPC_URL` (default `service-applications:6005`), confirmed against `services/rescue/src/config.ts` and `services/applications/src/config.ts`.

## Before requesting review

- [x] Ran `pnpm ci:local:quick` locally (or installed the pre-push hook — see CONTRIBUTING.md) — ran `check:readmes`, `check:docs-freshness --strict`, and `check:docs-index` directly (docs-only change, all pass)
- [ ] Tests for new behaviour added (TDD) — n/a, docs-only
- [ ] If touching `.env` requirements, updated `.env.example`'s REQUIRED block — n/a, both vars already have dev-safe defaults, not required
- [ ] If touching a `lib.*`, considered consumer impact across `app.*` and `service.backend` — n/a

## Test plan

- [x] `node scripts/check-readmes.mjs` — 0 warnings, 0 failures
- [x] `node scripts/check-docs-freshness.mjs --strict` — 0 broken internal links
- [x] `node scripts/check-docs-index.mjs` — every docs/*.md still linked from docs/README.md
- [ ] Tested manually (describe how) — n/a, docs-only
- [ ] No TypeScript errors (`pnpm type-check`) — n/a, no code changed
- [ ] Lint passes (`pnpm lint`) — n/a, no code changed

## Screenshots / recordings

N/A — docs-only change.

## Related

Linear: ADS-1026

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PyLUww6MdfCdqbXe9V6eAE


---
_Generated by [Claude Code](https://claude.ai/code/session_01PyLUww6MdfCdqbXe9V6eAE)_