### PR TITLE
feat: rescue-scope, bound, and correct adoption attribution counting (ADS-1023/1024/1025)

### DIFF
--- a/packages/proto/proto/adopt_dont_shop/applications/v1/application.proto
+++ b/packages/proto/proto/adopt_dont_shop/applications/v1/application.proto
@@ -102,9 +102,11 @@ service ApplicationService {
   // rescue (ADS-1023). Deliberately narrow: the caller already knows
   // the adopter_ids (it resolved them itself); the response reveals
   // only the count, never which ids matched or which rescue/pet was
-  // involved. Caller MUST hold applications.read. adopter_ids is
-  // capped at 10,000 entries (ADS-1024) — rejected with
-  // INVALID_ARGUMENT above that.
+  // involved. Caller MUST hold ANALYTICS_VIEW (admin.reports) — an
+  // admin-only reporting permission, NOT applications.read, which
+  // every adopter is seeded (ADS-1006). adopter_ids is capped at
+  // 10,000 entries (ADS-1024) — rejected with INVALID_ARGUMENT above
+  // that.
   rpc CountAdoptedAdopters(CountAdoptedAdoptersRequest) returns (CountAdoptedAdoptersResponse);
 
   // Document metadata — append a row referencing an already-stored

--- a/packages/proto/proto/adopt_dont_shop/applications/v1/application.proto
+++ b/packages/proto/proto/adopt_dont_shop/applications/v1/application.proto
@@ -96,11 +96,15 @@ service ApplicationService {
   // caller-supplied set of adopter user ids (e.g. an event's
   // registrants, resolved by the calling service), returns how many of
   // them have at least one application that reached APPROVED or
-  // ADOPTED status with created_at inside [created_after,
-  // created_before]. Deliberately narrow: the caller already knows the
-  // adopter_ids (it resolved them itself); the response reveals only
-  // the count, never which ids matched or which rescue/pet was
-  // involved. Caller MUST hold applications.read.
+  // ADOPTED status with actioned_at (ADS-1025 — when the application
+  // reached that status, not when it was created) inside
+  // [actioned_after, actioned_before], optionally narrowed to one
+  // rescue (ADS-1023). Deliberately narrow: the caller already knows
+  // the adopter_ids (it resolved them itself); the response reveals
+  // only the count, never which ids matched or which rescue/pet was
+  // involved. Caller MUST hold applications.read. adopter_ids is
+  // capped at 10,000 entries (ADS-1024) — rejected with
+  // INVALID_ARGUMENT above that.
   rpc CountAdoptedAdopters(CountAdoptedAdoptersRequest) returns (CountAdoptedAdoptersResponse);
 
   // Document metadata — append a row referencing an already-stored
@@ -406,19 +410,34 @@ message GetStatsResponse {
 
 message CountAdoptedAdoptersRequest {
   // Candidate adopter user ids to check — e.g. an event's registrant
-  // list, resolved by the calling service. No filter/scope semantics;
-  // the caller decides which ids are in play.
+  // list, resolved by the calling service. No filter/scope semantics
+  // beyond the optional rescue_id below; the caller decides which ids
+  // are in play. Capped at 10,000 entries (ADS-1024) — the handler
+  // rejects anything above that with INVALID_ARGUMENT before querying.
   repeated string adopter_ids = 1;
-  // Inclusive lower bound (RFC3339) on the application's created_at.
-  string created_after = 2;
-  // Inclusive upper bound (RFC3339) on the application's created_at.
-  string created_before = 3;
+  // Inclusive lower bound (RFC3339) on the application's actioned_at —
+  // when it reached APPROVED/ADOPTED status (ADS-1025). Renamed from
+  // created_after: the documented attribution rule was always "reached
+  // APPROVED/ADOPTED within the window", not "created within the
+  // window". Required; must parse as a valid date and must not be
+  // after actioned_before.
+  string actioned_after = 2;
+  // Inclusive upper bound (RFC3339) on actioned_at. See actioned_after.
+  string actioned_before = 3;
+  // Optional rescue scope (ADS-1023). When set, only applications
+  // owned by this rescue count towards the distinct-adopter total —
+  // e.g. an event's attribution count should only reflect adoptions at
+  // the rescue that ran the event. Omit for an unscoped, cross-rescue
+  // count.
+  optional string rescue_id = 4;
 }
 
 message CountAdoptedAdoptersResponse {
   // Distinct count of adopter_ids (from the request) with at least one
-  // non-deleted application whose status is APPROVED or ADOPTED and
-  // whose created_at falls in [created_after, created_before].
+  // non-deleted application whose status is APPROVED or ADOPTED, whose
+  // actioned_at (when it reached that status) falls in
+  // [actioned_after, actioned_before], and — when rescue_id was
+  // supplied — that belongs to that rescue.
   uint32 count = 1;
 }
 

--- a/packages/proto/src/generated/proto/adopt_dont_shop/applications/v1/application.ts
+++ b/packages/proto/src/generated/proto/adopt_dont_shop/applications/v1/application.ts
@@ -386,21 +386,40 @@ export interface GetStatsResponse {
 export interface CountAdoptedAdoptersRequest {
   /**
    * Candidate adopter user ids to check — e.g. an event's registrant
-   * list, resolved by the calling service. No filter/scope semantics;
-   * the caller decides which ids are in play.
+   * list, resolved by the calling service. No filter/scope semantics
+   * beyond the optional rescue_id below; the caller decides which ids
+   * are in play. Capped at 10,000 entries (ADS-1024) — the handler
+   * rejects anything above that with INVALID_ARGUMENT before querying.
    */
   adopterIds: string[];
-  /** Inclusive lower bound (RFC3339) on the application's created_at. */
-  createdAfter: string;
-  /** Inclusive upper bound (RFC3339) on the application's created_at. */
-  createdBefore: string;
+  /**
+   * Inclusive lower bound (RFC3339) on the application's actioned_at —
+   * when it reached APPROVED/ADOPTED status (ADS-1025). Renamed from
+   * created_after: the documented attribution rule was always "reached
+   * APPROVED/ADOPTED within the window", not "created within the
+   * window". Required; must parse as a valid date and must not be
+   * after actioned_before.
+   */
+  actionedAfter: string;
+  /** Inclusive upper bound (RFC3339) on actioned_at. See actioned_after. */
+  actionedBefore: string;
+  /**
+   * Optional rescue scope (ADS-1023). When set, only applications
+   * owned by this rescue count towards the distinct-adopter total —
+   * e.g. an event's attribution count should only reflect adoptions at
+   * the rescue that ran the event. Omit for an unscoped, cross-rescue
+   * count.
+   */
+  rescueId?: string | undefined;
 }
 
 export interface CountAdoptedAdoptersResponse {
   /**
    * Distinct count of adopter_ids (from the request) with at least one
-   * non-deleted application whose status is APPROVED or ADOPTED and
-   * whose created_at falls in [created_after, created_before].
+   * non-deleted application whose status is APPROVED or ADOPTED, whose
+   * actioned_at (when it reached that status) falls in
+   * [actioned_after, actioned_before], and — when rescue_id was
+   * supplied — that belongs to that rescue.
    */
   count: number;
 }
@@ -3386,7 +3405,7 @@ export const GetStatsResponse: MessageFns<GetStatsResponse> = {
 };
 
 function createBaseCountAdoptedAdoptersRequest(): CountAdoptedAdoptersRequest {
-  return { adopterIds: [], createdAfter: "", createdBefore: "" };
+  return { adopterIds: [], actionedAfter: "", actionedBefore: "", rescueId: undefined };
 }
 
 export const CountAdoptedAdoptersRequest: MessageFns<CountAdoptedAdoptersRequest> = {
@@ -3394,11 +3413,14 @@ export const CountAdoptedAdoptersRequest: MessageFns<CountAdoptedAdoptersRequest
     for (const v of message.adopterIds) {
       writer.uint32(10).string(v!);
     }
-    if (message.createdAfter !== "") {
-      writer.uint32(18).string(message.createdAfter);
+    if (message.actionedAfter !== "") {
+      writer.uint32(18).string(message.actionedAfter);
     }
-    if (message.createdBefore !== "") {
-      writer.uint32(26).string(message.createdBefore);
+    if (message.actionedBefore !== "") {
+      writer.uint32(26).string(message.actionedBefore);
+    }
+    if (message.rescueId !== undefined) {
+      writer.uint32(34).string(message.rescueId);
     }
     return writer;
   },
@@ -3423,7 +3445,7 @@ export const CountAdoptedAdoptersRequest: MessageFns<CountAdoptedAdoptersRequest
             break;
           }
 
-          message.createdAfter = reader.string();
+          message.actionedAfter = reader.string();
           continue;
         }
         case 3: {
@@ -3431,7 +3453,15 @@ export const CountAdoptedAdoptersRequest: MessageFns<CountAdoptedAdoptersRequest
             break;
           }
 
-          message.createdBefore = reader.string();
+          message.actionedBefore = reader.string();
+          continue;
+        }
+        case 4: {
+          if (tag !== 34) {
+            break;
+          }
+
+          message.rescueId = reader.string();
           continue;
         }
       }
@@ -3450,16 +3480,21 @@ export const CountAdoptedAdoptersRequest: MessageFns<CountAdoptedAdoptersRequest
         : globalThis.Array.isArray(object?.adopter_ids)
         ? object.adopter_ids.map((e: any) => globalThis.String(e))
         : [],
-      createdAfter: isSet(object.createdAfter)
-        ? globalThis.String(object.createdAfter)
-        : isSet(object.created_after)
-        ? globalThis.String(object.created_after)
+      actionedAfter: isSet(object.actionedAfter)
+        ? globalThis.String(object.actionedAfter)
+        : isSet(object.actioned_after)
+        ? globalThis.String(object.actioned_after)
         : "",
-      createdBefore: isSet(object.createdBefore)
-        ? globalThis.String(object.createdBefore)
-        : isSet(object.created_before)
-        ? globalThis.String(object.created_before)
+      actionedBefore: isSet(object.actionedBefore)
+        ? globalThis.String(object.actionedBefore)
+        : isSet(object.actioned_before)
+        ? globalThis.String(object.actioned_before)
         : "",
+      rescueId: isSet(object.rescueId)
+        ? globalThis.String(object.rescueId)
+        : isSet(object.rescue_id)
+        ? globalThis.String(object.rescue_id)
+        : undefined,
     };
   },
 
@@ -3468,11 +3503,14 @@ export const CountAdoptedAdoptersRequest: MessageFns<CountAdoptedAdoptersRequest
     if (message.adopterIds?.length) {
       obj.adopterIds = message.adopterIds;
     }
-    if (message.createdAfter !== "") {
-      obj.createdAfter = message.createdAfter;
+    if (message.actionedAfter !== "") {
+      obj.actionedAfter = message.actionedAfter;
     }
-    if (message.createdBefore !== "") {
-      obj.createdBefore = message.createdBefore;
+    if (message.actionedBefore !== "") {
+      obj.actionedBefore = message.actionedBefore;
+    }
+    if (message.rescueId !== undefined) {
+      obj.rescueId = message.rescueId;
     }
     return obj;
   },
@@ -3483,8 +3521,9 @@ export const CountAdoptedAdoptersRequest: MessageFns<CountAdoptedAdoptersRequest
   fromPartial<I extends Exact<DeepPartial<CountAdoptedAdoptersRequest>, I>>(object: I): CountAdoptedAdoptersRequest {
     const message = createBaseCountAdoptedAdoptersRequest();
     message.adopterIds = object.adopterIds?.map((e) => e) || [];
-    message.createdAfter = object.createdAfter ?? "";
-    message.createdBefore = object.createdBefore ?? "";
+    message.actionedAfter = object.actionedAfter ?? "";
+    message.actionedBefore = object.actionedBefore ?? "";
+    message.rescueId = object.rescueId ?? undefined;
     return message;
   },
 };
@@ -5156,11 +5195,15 @@ export const ApplicationServiceService = {
    * caller-supplied set of adopter user ids (e.g. an event's
    * registrants, resolved by the calling service), returns how many of
    * them have at least one application that reached APPROVED or
-   * ADOPTED status with created_at inside [created_after,
-   * created_before]. Deliberately narrow: the caller already knows the
-   * adopter_ids (it resolved them itself); the response reveals only
-   * the count, never which ids matched or which rescue/pet was
-   * involved. Caller MUST hold applications.read.
+   * ADOPTED status with actioned_at (ADS-1025 — when the application
+   * reached that status, not when it was created) inside
+   * [actioned_after, actioned_before], optionally narrowed to one
+   * rescue (ADS-1023). Deliberately narrow: the caller already knows
+   * the adopter_ids (it resolved them itself); the response reveals
+   * only the count, never which ids matched or which rescue/pet was
+   * involved. Caller MUST hold applications.read. adopter_ids is
+   * capped at 10,000 entries (ADS-1024) — rejected with
+   * INVALID_ARGUMENT above that.
    */
   countAdoptedAdopters: {
     path: "/adopt_dont_shop.applications.v1.ApplicationService/CountAdoptedAdopters" as const,
@@ -5393,11 +5436,15 @@ export interface ApplicationServiceServer extends UntypedServiceImplementation {
    * caller-supplied set of adopter user ids (e.g. an event's
    * registrants, resolved by the calling service), returns how many of
    * them have at least one application that reached APPROVED or
-   * ADOPTED status with created_at inside [created_after,
-   * created_before]. Deliberately narrow: the caller already knows the
-   * adopter_ids (it resolved them itself); the response reveals only
-   * the count, never which ids matched or which rescue/pet was
-   * involved. Caller MUST hold applications.read.
+   * ADOPTED status with actioned_at (ADS-1025 — when the application
+   * reached that status, not when it was created) inside
+   * [actioned_after, actioned_before], optionally narrowed to one
+   * rescue (ADS-1023). Deliberately narrow: the caller already knows
+   * the adopter_ids (it resolved them itself); the response reveals
+   * only the count, never which ids matched or which rescue/pet was
+   * involved. Caller MUST hold applications.read. adopter_ids is
+   * capped at 10,000 entries (ADS-1024) — rejected with
+   * INVALID_ARGUMENT above that.
    */
   countAdoptedAdopters: handleUnaryCall<CountAdoptedAdoptersRequest, CountAdoptedAdoptersResponse>;
   /**
@@ -5721,11 +5768,15 @@ export interface ApplicationServiceClient extends Client {
    * caller-supplied set of adopter user ids (e.g. an event's
    * registrants, resolved by the calling service), returns how many of
    * them have at least one application that reached APPROVED or
-   * ADOPTED status with created_at inside [created_after,
-   * created_before]. Deliberately narrow: the caller already knows the
-   * adopter_ids (it resolved them itself); the response reveals only
-   * the count, never which ids matched or which rescue/pet was
-   * involved. Caller MUST hold applications.read.
+   * ADOPTED status with actioned_at (ADS-1025 — when the application
+   * reached that status, not when it was created) inside
+   * [actioned_after, actioned_before], optionally narrowed to one
+   * rescue (ADS-1023). Deliberately narrow: the caller already knows
+   * the adopter_ids (it resolved them itself); the response reveals
+   * only the count, never which ids matched or which rescue/pet was
+   * involved. Caller MUST hold applications.read. adopter_ids is
+   * capped at 10,000 entries (ADS-1024) — rejected with
+   * INVALID_ARGUMENT above that.
    */
   countAdoptedAdopters(
     request: CountAdoptedAdoptersRequest,

--- a/packages/proto/src/generated/proto/adopt_dont_shop/applications/v1/application.ts
+++ b/packages/proto/src/generated/proto/adopt_dont_shop/applications/v1/application.ts
@@ -5201,9 +5201,11 @@ export const ApplicationServiceService = {
    * rescue (ADS-1023). Deliberately narrow: the caller already knows
    * the adopter_ids (it resolved them itself); the response reveals
    * only the count, never which ids matched or which rescue/pet was
-   * involved. Caller MUST hold applications.read. adopter_ids is
-   * capped at 10,000 entries (ADS-1024) — rejected with
-   * INVALID_ARGUMENT above that.
+   * involved. Caller MUST hold ANALYTICS_VIEW (admin.reports) — an
+   * admin-only reporting permission, NOT applications.read, which
+   * every adopter is seeded (ADS-1006). adopter_ids is capped at
+   * 10,000 entries (ADS-1024) — rejected with INVALID_ARGUMENT above
+   * that.
    */
   countAdoptedAdopters: {
     path: "/adopt_dont_shop.applications.v1.ApplicationService/CountAdoptedAdopters" as const,
@@ -5442,9 +5444,11 @@ export interface ApplicationServiceServer extends UntypedServiceImplementation {
    * rescue (ADS-1023). Deliberately narrow: the caller already knows
    * the adopter_ids (it resolved them itself); the response reveals
    * only the count, never which ids matched or which rescue/pet was
-   * involved. Caller MUST hold applications.read. adopter_ids is
-   * capped at 10,000 entries (ADS-1024) — rejected with
-   * INVALID_ARGUMENT above that.
+   * involved. Caller MUST hold ANALYTICS_VIEW (admin.reports) — an
+   * admin-only reporting permission, NOT applications.read, which
+   * every adopter is seeded (ADS-1006). adopter_ids is capped at
+   * 10,000 entries (ADS-1024) — rejected with INVALID_ARGUMENT above
+   * that.
    */
   countAdoptedAdopters: handleUnaryCall<CountAdoptedAdoptersRequest, CountAdoptedAdoptersResponse>;
   /**
@@ -5774,9 +5778,11 @@ export interface ApplicationServiceClient extends Client {
    * rescue (ADS-1023). Deliberately narrow: the caller already knows
    * the adopter_ids (it resolved them itself); the response reveals
    * only the count, never which ids matched or which rescue/pet was
-   * involved. Caller MUST hold applications.read. adopter_ids is
-   * capped at 10,000 entries (ADS-1024) — rejected with
-   * INVALID_ARGUMENT above that.
+   * involved. Caller MUST hold ANALYTICS_VIEW (admin.reports) — an
+   * admin-only reporting permission, NOT applications.read, which
+   * every adopter is seeded (ADS-1006). adopter_ids is capped at
+   * 10,000 entries (ADS-1024) — rejected with INVALID_ARGUMENT above
+   * that.
    */
   countAdoptedAdopters(
     request: CountAdoptedAdoptersRequest,

--- a/services/applications/src/grpc/attribution-handlers.test.ts
+++ b/services/applications/src/grpc/attribution-handlers.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 
 import { HandlerError, type HandlerDeps } from './adapter.js';
-import { countAdoptedAdopters, MIN_COHORT_SIZE } from './attribution-handlers.js';
+import { countAdoptedAdopters, MAX_ADOPTER_IDS, MIN_COHORT_SIZE } from './attribution-handlers.js';
 
 function makePrincipal(
   overrides: Partial<{
@@ -31,8 +31,8 @@ const cohortIds = Array.from({ length: MIN_COHORT_SIZE }, (_, i) => `usr-adopter
 
 const baseReq = {
   adopterIds: cohortIds,
-  createdAfter: '2026-07-01T10:00:00.000Z',
-  createdBefore: '2026-09-29T10:00:00.000Z',
+  actionedAfter: '2026-07-01T10:00:00.000Z',
+  actionedBefore: '2026-09-29T10:00:00.000Z',
 };
 
 describe('countAdoptedAdopters', () => {
@@ -54,18 +54,82 @@ describe('countAdoptedAdopters', () => {
     ).rejects.toBeInstanceOf(HandlerError);
   });
 
-  it('throws INVALID_ARGUMENT when created_after is missing', async () => {
+  it('throws INVALID_ARGUMENT when actioned_after is missing', async () => {
     const { deps } = makeDeps();
     await expect(
-      countAdoptedAdopters(deps, makePrincipal(), { ...baseReq, createdAfter: '' })
+      countAdoptedAdopters(deps, makePrincipal(), { ...baseReq, actionedAfter: '' })
     ).rejects.toMatchObject({ code: 'INVALID_ARGUMENT' });
   });
 
-  it('throws INVALID_ARGUMENT when created_before is missing', async () => {
+  it('throws INVALID_ARGUMENT when actioned_before is missing', async () => {
     const { deps } = makeDeps();
     await expect(
-      countAdoptedAdopters(deps, makePrincipal(), { ...baseReq, createdBefore: '' })
+      countAdoptedAdopters(deps, makePrincipal(), { ...baseReq, actionedBefore: '' })
     ).rejects.toMatchObject({ code: 'INVALID_ARGUMENT' });
+  });
+
+  // ── ADS-1024 — input bounds ─────────────────────────────────────────
+
+  it('rejects adopter_ids above the documented cap with INVALID_ARGUMENT, before any query', async () => {
+    const { deps, query } = makeDeps();
+    const tooMany = Array.from({ length: MAX_ADOPTER_IDS + 1 }, (_, i) => `usr-${i}`);
+    await expect(
+      countAdoptedAdopters(deps, makePrincipal(), { ...baseReq, adopterIds: tooMany })
+    ).rejects.toMatchObject({ code: 'INVALID_ARGUMENT' });
+    expect(query).not.toHaveBeenCalled();
+  });
+
+  it('accepts adopter_ids exactly at the cap', async () => {
+    const { deps, query } = makeDeps();
+    query.mockResolvedValueOnce({ rows: [{ count: '0' }] });
+    const atCap = Array.from({ length: MAX_ADOPTER_IDS }, (_, i) => `usr-${i}`);
+    await expect(
+      countAdoptedAdopters(deps, makePrincipal(), { ...baseReq, adopterIds: atCap })
+    ).resolves.toEqual({ count: 0 });
+  });
+
+  it('rejects a non-parseable actioned_after with INVALID_ARGUMENT, before any query', async () => {
+    const { deps, query } = makeDeps();
+    await expect(
+      countAdoptedAdopters(deps, makePrincipal(), { ...baseReq, actionedAfter: 'not-a-date' })
+    ).rejects.toMatchObject({ code: 'INVALID_ARGUMENT' });
+    expect(query).not.toHaveBeenCalled();
+  });
+
+  it('rejects a non-parseable actioned_before with INVALID_ARGUMENT, before any query', async () => {
+    const { deps, query } = makeDeps();
+    await expect(
+      countAdoptedAdopters(deps, makePrincipal(), { ...baseReq, actionedBefore: 'not-a-date' })
+    ).rejects.toMatchObject({ code: 'INVALID_ARGUMENT' });
+    expect(query).not.toHaveBeenCalled();
+  });
+
+  it('rejects actioned_after after actioned_before with INVALID_ARGUMENT, not a silent zero', async () => {
+    const { deps, query } = makeDeps();
+    await expect(
+      countAdoptedAdopters(deps, makePrincipal(), {
+        ...baseReq,
+        actionedAfter: '2026-09-29T10:00:00.000Z',
+        actionedBefore: '2026-07-01T10:00:00.000Z',
+      })
+    ).rejects.toMatchObject({ code: 'INVALID_ARGUMENT' });
+    expect(query).not.toHaveBeenCalled();
+  });
+
+  // Boundary: an equal after/before window (a single instant) is the edge
+  // of the "after must not be after before" rule and must NOT be rejected.
+  it('accepts actioned_after equal to actioned_before (boundary of the range check)', async () => {
+    const { deps, query } = makeDeps();
+    query.mockResolvedValueOnce({ rows: [{ count: '0' }] });
+    const instant = '2026-08-01T00:00:00.000Z';
+    await expect(
+      countAdoptedAdopters(deps, makePrincipal(), {
+        ...baseReq,
+        actionedAfter: instant,
+        actionedBefore: instant,
+      })
+    ).resolves.toEqual({ count: 0 });
+    expect(query).toHaveBeenCalledTimes(1);
   });
 
   it('rejects a cohort below the k-anonymity floor with INVALID_ARGUMENT', async () => {
@@ -112,7 +176,7 @@ describe('countAdoptedAdopters', () => {
     expect(params[0]).toEqual(cohortIds);
   });
 
-  it('scopes to APPROVED/ADOPTED status, the candidate ids, and the created_at window', async () => {
+  it('scopes to APPROVED/ADOPTED status, the candidate ids, and the actioned_at window', async () => {
     const { deps, query } = makeDeps();
     query.mockResolvedValueOnce({ rows: [{ count: '2' }] });
 
@@ -121,10 +185,10 @@ describe('countAdoptedAdopters', () => {
     const [sql, params] = query.mock.calls[0] as [string, unknown[]];
     expect(sql).toContain("status IN ('approved', 'adopted')");
     expect(sql).toContain('user_id = ANY($1)');
-    expect(sql).toContain('created_at >= $2');
-    expect(sql).toContain('created_at <= $3');
+    expect(sql).toContain('actioned_at >= $2');
+    expect(sql).toContain('actioned_at <= $3');
     expect(sql).toContain('COUNT(DISTINCT user_id)');
-    expect(params).toEqual([baseReq.adopterIds, baseReq.createdAfter, baseReq.createdBefore]);
+    expect(params).toEqual([baseReq.adopterIds, baseReq.actionedAfter, baseReq.actionedBefore]);
   });
 
   it('returns the distinct count from the query for a legitimate admin caller', async () => {
@@ -156,5 +220,42 @@ describe('countAdoptedAdopters', () => {
         baseReq
       )
     ).resolves.toEqual({ count: 0 });
+  });
+
+  // ── ADS-1023 — rescue scoping ────────────────────────────────────────
+
+  it('omits the rescue filter when rescue_id is not supplied (unscoped, cross-rescue count)', async () => {
+    const { deps, query } = makeDeps();
+    query.mockResolvedValueOnce({ rows: [{ count: '2' }] });
+
+    await countAdoptedAdopters(deps, makePrincipal(), baseReq);
+
+    const [sql, params] = query.mock.calls[0] as [string, unknown[]];
+    expect(sql).not.toContain('rescue_id');
+    expect(params).toEqual([baseReq.adopterIds, baseReq.actionedAfter, baseReq.actionedBefore]);
+  });
+
+  it('excludes an adopter whose only qualifying application is at a different rescue when scoped', async () => {
+    const { deps, query } = makeDeps();
+    // Simulates the DB: of the cohort, only adopters with a qualifying
+    // application AT rsc-target count; an adopter whose sole approved
+    // application belongs to a different rescue does not, so the
+    // rescue-scoped query returns fewer matches than an unscoped one would.
+    query.mockResolvedValueOnce({ rows: [{ count: '0' }] });
+
+    const res = await countAdoptedAdopters(deps, makePrincipal(), {
+      ...baseReq,
+      rescueId: 'rsc-target',
+    });
+
+    const [sql, params] = query.mock.calls[0] as [string, unknown[]];
+    expect(sql).toContain('AND rescue_id = $4');
+    expect(params).toEqual([
+      baseReq.adopterIds,
+      baseReq.actionedAfter,
+      baseReq.actionedBefore,
+      'rsc-target',
+    ]);
+    expect(res).toEqual({ count: 0 });
   });
 });

--- a/services/applications/src/grpc/attribution-handlers.ts
+++ b/services/applications/src/grpc/attribution-handlers.ts
@@ -1,26 +1,40 @@
-// gRPC handler — CountAdoptedAdopters (ADS-941, hardened in ADS-1006).
+// gRPC handler — CountAdoptedAdopters (ADS-941, hardened in ADS-1006,
+// rescue-scoped + input-bounded in ADS-1023/ADS-1024, actioned_at in
+// ADS-1025).
 //
 // Cross-service attribution primitive: given a caller-supplied set of
 // adopter user ids (e.g. service.rescue resolves an event's registrant
 // list from rescue.event_attendees), returns how many of them have at
 // least one non-deleted application that reached APPROVED or ADOPTED
-// status with created_at inside [created_after, created_before].
+// status with actioned_at — when it REACHED that status, stamped by
+// event-store.ts's projectReadModel off the triggering event's
+// occurred_at, not when the application was first created — inside
+// [actioned_after, actioned_before]. Optionally narrowed to a single
+// rescue via rescue_id.
 //
 // The response is a single distinct-adopter count. That "the caller never
 // learns which ids matched" is only privacy-preserving when the id set is
 // large enough that the count cannot be attributed to one person — with a
 // single id the count ∈ {0,1} is a direct yes/no about that user, and a
-// caller-controlled created window turns that boolean into a timeline
-// (ADS-1006). Two preconditions therefore hold the safety property:
+// caller-controlled actioned window turns that boolean into a timeline
+// (ADS-1006). These preconditions hold the safety property:
 //
 //   1. Gated on ANALYTICS_VIEW (admin.reports), an admin-only reporting
 //      permission — NOT applications.read, which every adopter is seeded.
 //   2. A k-anonymity cohort floor (MIN_COHORT_SIZE): the request is
 //      rejected below it, so the response can never be a per-user answer.
+//   3. adopter_ids is capped at MAX_ADOPTER_IDS (ADS-1024) so one request
+//      can't smuggle an unbounded query past the two guards above.
 //
 // Reads straight off the `applications` read-model row (no event-fold
-// needed — status + created_at are both real columns).
-
+// needed — status / actioned_at / rescue_id are all real columns). Query
+// shape is user_id = ANY(ids) + status IN (...) + actioned_at range,
+// optionally + rescue_id — the existing
+// applications_rescue_status_created_idx compound index is on
+// (rescue_id, status, created_at), not actioned_at, so the rescue-scoped
+// path here doesn't get full index coverage; a matching
+// (rescue_id, status, actioned_at) index is a worthwhile follow-up but is
+// deliberately left out of this change (see PR description).
 import { requirePermission, type Principal } from '@adopt-dont-shop/authz';
 import { ANALYTICS_VIEW } from '@adopt-dont-shop/lib.types';
 import type {
@@ -39,6 +53,10 @@ type CountRow = { count: string };
 // 0 count rather than an error.
 export const MIN_COHORT_SIZE = 20;
 
+// Upper bound on adopter_ids per request (ADS-1024) — documented on the
+// proto field. Rejected with INVALID_ARGUMENT before any query runs.
+export const MAX_ADOPTER_IDS = 10_000;
+
 export async function countAdoptedAdopters(
   deps: HandlerDeps,
   principal: Principal,
@@ -47,11 +65,27 @@ export async function countAdoptedAdopters(
   if (!requirePermission(principal, ANALYTICS_VIEW)) {
     throw new HandlerError('PERMISSION_DENIED', `'${ANALYTICS_VIEW}' required`);
   }
-  if (!req.createdAfter) {
-    throw new HandlerError('INVALID_ARGUMENT', 'created_after is required');
+
+  if (req.adopterIds.length > MAX_ADOPTER_IDS) {
+    throw new HandlerError('INVALID_ARGUMENT', `adopter_ids exceeds the ${MAX_ADOPTER_IDS} cap`);
   }
-  if (!req.createdBefore) {
-    throw new HandlerError('INVALID_ARGUMENT', 'created_before is required');
+  if (!req.actionedAfter) {
+    throw new HandlerError('INVALID_ARGUMENT', 'actioned_after is required');
+  }
+  if (!req.actionedBefore) {
+    throw new HandlerError('INVALID_ARGUMENT', 'actioned_before is required');
+  }
+
+  const actionedAfterMs = Date.parse(req.actionedAfter);
+  if (Number.isNaN(actionedAfterMs)) {
+    throw new HandlerError('INVALID_ARGUMENT', 'actioned_after is not a valid date');
+  }
+  const actionedBeforeMs = Date.parse(req.actionedBefore);
+  if (Number.isNaN(actionedBeforeMs)) {
+    throw new HandlerError('INVALID_ARGUMENT', 'actioned_before is not a valid date');
+  }
+  if (actionedAfterMs > actionedBeforeMs) {
+    throw new HandlerError('INVALID_ARGUMENT', 'actioned_after must not be after actioned_before');
   }
 
   const adopterIds = [...new Set(req.adopterIds.filter(id => id !== ''))];
@@ -62,15 +96,25 @@ export async function countAdoptedAdopters(
     );
   }
 
+  const params: unknown[] = [adopterIds, req.actionedAfter, req.actionedBefore];
+  let p = params.length;
+  // Optional rescue scope (ADS-1023) — e.g. an event's attribution count
+  // should only reflect adoptions at the rescue that ran the event.
+  let rescueFilter = '';
+  if (req.rescueId !== undefined && req.rescueId !== '') {
+    params.push(req.rescueId);
+    rescueFilter = ` AND rescue_id = $${++p}`;
+  }
+
   const { rows } = await deps.pool.query<CountRow>(
     `SELECT COUNT(DISTINCT user_id) AS count
        FROM applications
       WHERE deleted_at IS NULL
         AND status IN ('approved', 'adopted')
         AND user_id = ANY($1)
-        AND created_at >= $2
-        AND created_at <= $3`,
-    [adopterIds, req.createdAfter, req.createdBefore]
+        AND actioned_at >= $2
+        AND actioned_at <= $3${rescueFilter}`,
+    params
   );
 
   return { count: Number(rows[0]?.count ?? '0') };

--- a/services/applications/src/grpc/event-store.ts
+++ b/services/applications/src/grpc/event-store.ts
@@ -140,17 +140,33 @@ export async function appendEvents(
 // status / answers / references / version are the live-state columns;
 // everything else (timestamps stamped by specific events) is
 // projected from the state's optional fields.
+//
+// actioned_at (ADS-1025) is the CountAdoptedAdopters attribution query's
+// filter column — "when did this application reach its decision", not
+// "when was it created". It's derived from the state rather than the
+// event stream directly: decidedAt / adoptedAt are already the
+// triggering `approved` / `adopted` event's `at` (== occurred_at, see
+// appendEvents), stamped there by apply.ts. Any other status (including
+// rejected/withdrawn, which never qualify for attribution) leaves it null.
 export async function projectReadModel(client: PoolClient, state: ApplicationState): Promise<void> {
+  const actionedAt =
+    state.status === 'approved'
+      ? state.decidedAt
+      : state.status === 'adopted'
+        ? state.adoptedAt
+        : null;
+
   await client.query(
     `INSERT INTO applications (
        application_id, user_id, pet_id, rescue_id, status,
-       documents, version, created_at, updated_at
+       documents, version, actioned_at, created_at, updated_at
      )
-     VALUES ($1, $2, $3, $4, $5, $6::jsonb, $7, NOW(), NOW())
+     VALUES ($1, $2, $3, $4, $5, $6::jsonb, $7, $8, NOW(), NOW())
      ON CONFLICT (application_id) DO UPDATE SET
        status = EXCLUDED.status,
        documents = EXCLUDED.documents,
        version = EXCLUDED.version,
+       actioned_at = EXCLUDED.actioned_at,
        updated_at = NOW()`,
     [
       state.applicationId,
@@ -160,6 +176,7 @@ export async function projectReadModel(client: PoolClient, state: ApplicationSta
       state.status,
       JSON.stringify({ answers: state.answers, references: state.references }),
       state.version,
+      actionedAt,
     ]
   );
 }

--- a/services/applications/src/grpc/review-handlers.test.ts
+++ b/services/applications/src/grpc/review-handlers.test.ts
@@ -95,6 +95,16 @@ function publishOf(deps: HandlerDeps): ReturnType<typeof vi.fn> {
   return (deps as { _publish?: ReturnType<typeof vi.fn> })._publish!;
 }
 
+// The projectReadModel UPSERT is the last query call in a runCommand
+// flow. Its actioned_at param (ADS-1025) is what the query.mock.calls
+// give us to check without a real DB — see event-store.ts.
+function actionedAtParam(query: ReturnType<typeof vi.fn>): unknown {
+  const insertCall = query.mock.calls.find(([sql]) =>
+    (sql as string).includes('INSERT INTO applications')
+  );
+  return insertCall?.[1]?.[7];
+}
+
 describe('startReview', () => {
   it('throws PERMISSION_DENIED without applications.review', async () => {
     const { deps } = makeDeps(submittedStream());
@@ -216,6 +226,15 @@ describe('approve', () => {
     );
     expect(publishOf(deps).mock.calls[0][0]).toMatchObject({ type: 'applications.approved' });
   });
+
+  // ADS-1025 — the attribution query filters on actioned_at, stamped by
+  // projectReadModel when the fold reaches approved/adopted.
+  it('stamps actioned_at with the approved event’s own timestamp', async () => {
+    const { deps, query } = makeDeps(decidableStream());
+    const res = await approve(deps, makePrincipal(), { applicationId: 'app-1', notes: 'ok' });
+    expect(res.application.decidedAt).toBeTruthy();
+    expect(actionedAtParam(query)).toBe(res.application.decidedAt);
+  });
 });
 
 describe('reject', () => {
@@ -237,6 +256,14 @@ describe('reject', () => {
     );
     expect(res.application.rejectionReason).toBe('home unsuitable');
     expect(publishOf(deps).mock.calls[0][0]).toMatchObject({ type: 'applications.rejected' });
+  });
+
+  // ADS-1025 — rejected never qualifies for CountAdoptedAdopters, so
+  // actioned_at must stay unset even though the application was decided.
+  it('leaves actioned_at unset on a rejected application', async () => {
+    const { deps, query } = makeDeps(decidableStream());
+    await reject(deps, makePrincipal(), { applicationId: 'app-1', reason: 'home unsuitable' });
+    expect(actionedAtParam(query)).toBeNull();
   });
 });
 
@@ -352,5 +379,18 @@ describe('markAdopted', () => {
       ApplicationsV1.ApplicationStatus.APPLICATION_STATUS_ADOPTED
     );
     expect(publishOf(deps).mock.calls[0][0]).toMatchObject({ type: 'applications.adopted' });
+  });
+
+  // ADS-1025 — once adopted, actioned_at tracks the later `adopted` event
+  // (not the earlier `approved` one), matching "reached APPROVED/ADOPTED".
+  it('re-stamps actioned_at with the adopted event’s (later) timestamp', async () => {
+    const { deps, query } = makeDeps([
+      ...decidableStream(),
+      ev('approved', 6, { actorUserId: 'staff-1', notes: null }),
+    ]);
+    const res = await markAdopted(deps, makePrincipal(), { applicationId: 'app-1' });
+    expect(res.application.adoptedAt).toBeTruthy();
+    expect(res.application.adoptedAt).not.toBe(res.application.decidedAt);
+    expect(actionedAtParam(query)).toBe(res.application.adoptedAt);
   });
 });

--- a/services/applications/src/migrations/010_backfill_application_actioned_at.ts
+++ b/services/applications/src/migrations/010_backfill_application_actioned_at.ts
@@ -1,0 +1,52 @@
+import type { MigrationBuilder } from 'node-pg-migrate';
+
+// Backfill — applications.actioned_at (ADS-1025).
+//
+// actioned_at existed on the applications table since 002 but was never
+// written. From this change on, event-store.ts's projectReadModel stamps
+// it whenever the fold transitions to approved/adopted, so the
+// CountAdoptedAdopters attribution query can filter on "when the
+// application reached its decision" — the rule its proto comment has
+// always documented — instead of created_at.
+//
+// This migration backfills the rows that reached that decision BEFORE
+// the projector started writing the column: for every application
+// already sitting at approved/adopted with actioned_at still NULL, find
+// the event in the application_events store whose type matches the
+// application's current status (there is at most one 'approved' event
+// and at most one 'adopted' event per aggregate — the domain doesn't
+// allow re-deciding) and copy its occurred_at across.
+
+export const up = async (pgm: MigrationBuilder): Promise<void> => {
+  pgm.sql(`
+    UPDATE applications
+       SET actioned_at = latest.occurred_at
+      FROM (
+        SELECT aggregate_id, event_type, occurred_at,
+               ROW_NUMBER() OVER (
+                 PARTITION BY aggregate_id, event_type ORDER BY version DESC
+               ) AS rn
+          FROM application_events
+         WHERE event_type IN ('approved', 'adopted')
+      ) AS latest
+     WHERE applications.application_id = latest.aggregate_id
+       AND applications.status = latest.event_type
+       AND latest.rn = 1
+       AND applications.status IN ('approved', 'adopted')
+       AND applications.actioned_at IS NULL;
+  `);
+};
+
+export const down = async (pgm: MigrationBuilder): Promise<void> => {
+  // Reverses the backfill by clearing actioned_at on approved/adopted
+  // rows. Caveat: if the projector (event-store.ts) has by this point
+  // already started writing actioned_at for NEW decisions, those live
+  // values are cleared too — a column-level backfill migration can't
+  // distinguish "backfilled by this migration" from "written by the
+  // projector" after the fact.
+  pgm.sql(`
+    UPDATE applications
+       SET actioned_at = NULL
+     WHERE status IN ('approved', 'adopted');
+  `);
+};

--- a/services/applications/src/migrations/010_backfill_application_actioned_at.ts
+++ b/services/applications/src/migrations/010_backfill_application_actioned_at.ts
@@ -30,7 +30,7 @@ export const up = async (pgm: MigrationBuilder): Promise<void> => {
          WHERE event_type IN ('approved', 'adopted')
       ) AS latest
      WHERE applications.application_id = latest.aggregate_id
-       AND applications.status = latest.event_type
+       AND applications.status::text = latest.event_type
        AND latest.rn = 1
        AND applications.status IN ('approved', 'adopted')
        AND applications.actioned_at IS NULL;

--- a/services/applications/src/migrations/migrations.test.ts
+++ b/services/applications/src/migrations/migrations.test.ts
@@ -48,6 +48,7 @@ describe('applications migrations', () => {
     '007_create_application_drafts.ts',
     '008_create_application_documents.ts',
     '009_create_application_defaults.ts',
+    '010_backfill_application_actioned_at.ts',
   ])('%s exports `up` and `down` functions', async filename => {
     const mod = (await import(`./${filename}`)) as {
       up: unknown;

--- a/services/rescue/src/grpc/applications-client.test.ts
+++ b/services/rescue/src/grpc/applications-client.test.ts
@@ -44,8 +44,8 @@ const makeServiceError = (code: number, details: string): ServiceError => {
 
 const COUNT_REQUEST: CountAdoptedAdoptersRequest = {
   adopterIds: ['usr-1', 'usr-2'],
-  createdAfter: '2026-07-01T10:00:00.000Z',
-  createdBefore: '2026-09-29T10:00:00.000Z',
+  actionedAfter: '2026-07-01T10:00:00.000Z',
+  actionedBefore: '2026-09-29T10:00:00.000Z',
 };
 
 const successResponse: CountAdoptedAdoptersResponse = { count: 2 };

--- a/services/rescue/src/grpc/event-handlers.test.ts
+++ b/services/rescue/src/grpc/event-handlers.test.ts
@@ -631,6 +631,8 @@ describe('getEventAnalytics', () => {
     expect(applicationsStub.countAdoptedAdopters).toHaveBeenCalledTimes(1);
     const [req] = applicationsStub.countAdoptedAdopters.mock.calls[0];
     expect(req.adopterIds).toEqual(registrantIds);
+    // ADS-1023 — the event's own rescue scopes the attribution count.
+    expect(req.rescueId).toBe(RESCUE_ID);
   });
 
   it('skips the attribution call when the registrant cohort is below the k-anonymity floor', async () => {
@@ -659,8 +661,25 @@ describe('getEventAnalytics', () => {
     await getEventAnalytics(mocks.deps, STAFF, { eventId: EVENT_ID });
 
     const [req] = applicationsStub.countAdoptedAdopters.mock.calls[0];
-    expect(req.createdAfter).toBe('2026-07-01T10:00:00.000Z');
-    expect(req.createdBefore).toBe('2026-09-29T10:00:00.000Z'); // +90 days
+    expect(req.actionedAfter).toBe('2026-07-01T10:00:00.000Z');
+    expect(req.actionedBefore).toBe('2026-09-29T10:00:00.000Z'); // +90 days
+  });
+
+  // ── ADS-1024 — bounded attendee fetch ────────────────────────────────
+
+  it('rejects with a clear error when the event has more registrants than the attribution cap, without truncating', async () => {
+    const overCap = Array.from({ length: 10_001 }, (_, i) => ({ user_id: `usr-registrant-${i}` }));
+    mocks.poolMock.query
+      .mockResolvedValueOnce({ rows: [eventRow({ status: 'completed' })] })
+      .mockResolvedValueOnce({ rows: [{ total: '10001', checked_in: '0' }] })
+      .mockResolvedValueOnce({ rows: overCap });
+
+    await expect(getEventAnalytics(mocks.deps, STAFF, { eventId: EVENT_ID })).rejects.toMatchObject(
+      { code: 'INVALID_ARGUMENT' }
+    );
+    // No silent truncation — the whole call fails rather than attributing
+    // off a partial registrant list.
+    expect(applicationsStub.countAdoptedAdopters).not.toHaveBeenCalled();
   });
 
   it('returns zero adoptions when nobody in the registrant set has adopted', async () => {

--- a/services/rescue/src/grpc/event-handlers.ts
+++ b/services/rescue/src/grpc/event-handlers.ts
@@ -57,7 +57,9 @@ const EVENTS_DELETE: Permission = 'events.delete' as Permission;
 // adoptionsFromEvent uses a "registered → later adopted" attribution
 // model: an adoption is attributed to event X when a user who
 // REGISTERED for event X (rescue.event_attendees — every registrant,
-// not just those who checked in) later has an application that reaches
+// not just those who checked in) later has an application AT THIS EVENT'S
+// RESCUE (rescue_id is passed to CountAdoptedAdopters, ADS-1023 — an
+// adopter who adopted from a different rescue doesn't count) that reaches
 // APPROVED or ADOPTED status. Attribution is by adopter identity within
 // a bounded post-event window, not by any adoption↔event link table.
 //
@@ -69,7 +71,10 @@ const EVENTS_DELETE: Permission = 'events.delete' as Permission;
 // adopter-count reading because that's what the product decision this
 // ticket implements explicitly asked for.
 //
-// Window: 90 days after the event's start_date — a reasonable
+// Window: 90 days after the event's start_date, bounding
+// actioned_at — WHEN THE APPLICATION REACHED APPROVED/ADOPTED (ADS-1025;
+// service.applications stamps this from the deciding event, not from
+// created_at) — not the application's creation date. A reasonable
 // adoption-cycle length (submit → review → home visit → decision).
 // Single named constant so it's easy to find and retune.
 const ATTRIBUTION_WINDOW_DAYS = 90;
@@ -78,6 +83,11 @@ const MS_PER_DAY = 24 * 60 * 60 * 1000;
 // (MIN_COHORT_SIZE, ADS-1006). Kept in sync by value rather than imported —
 // services do not depend on each other's source.
 const ATTRIBUTION_MIN_COHORT = 20;
+// Mirrors service.applications' CountAdoptedAdopters adopter_ids cap
+// (MAX_ADOPTER_IDS, ADS-1024). An event with more registrants than this
+// can't be attributed in one call; countAdoptionsFromEvent fails with a
+// clear error rather than silently truncating the registrant list.
+const ATTRIBUTION_MAX_COHORT = 10_000;
 
 // grpc-js status codes service.applications can return on CountAdoptedAdopters
 // (ADS-1022). Kept as local numeric constants — same pattern as the pets
@@ -798,11 +808,20 @@ async function countAdoptionsFromEvent(
   event: EventRow,
   logger: Logger
 ): Promise<number> {
+  // Fetch one more than the cap so we can detect "more than the cap"
+  // without a separate COUNT query, and without ever silently truncating
+  // the registrant list handed to service.applications (ADS-1024).
   const attendeeRes = await deps.pool.query<{ user_id: string }>(
-    `SELECT DISTINCT user_id FROM rescue.event_attendees WHERE event_id = $1`,
-    [eventId]
+    `SELECT DISTINCT user_id FROM rescue.event_attendees WHERE event_id = $1 LIMIT $2`,
+    [eventId, ATTRIBUTION_MAX_COHORT + 1]
   );
   const adopterIds = attendeeRes.rows.map(r => r.user_id);
+  if (adopterIds.length > ATTRIBUTION_MAX_COHORT) {
+    throw new HandlerError(
+      'INVALID_ARGUMENT',
+      `event ${eventId} has more than ${ATTRIBUTION_MAX_COHORT} registrants; adoption attribution is not supported at this scale`
+    );
+  }
   // service.applications enforces a k-anonymity cohort floor on the
   // attribution count (ADS-1006) so it can never become a per-user oracle.
   // Below that floor the RPC would reject with INVALID_ARGUMENT, so skip the
@@ -811,14 +830,17 @@ async function countAdoptionsFromEvent(
     return 0;
   }
 
-  const createdAfter = event.start_date.toISOString();
-  const createdBefore = new Date(
+  const actionedAfter = event.start_date.toISOString();
+  const actionedBefore = new Date(
     event.start_date.getTime() + ATTRIBUTION_WINDOW_DAYS * MS_PER_DAY
   ).toISOString();
 
   try {
+    // rescue_id (ADS-1023) scopes the count to adoptions at THIS rescue —
+    // a registrant who adopted from a different rescue shouldn't inflate
+    // this event's attribution number.
     const res = await applicationsClient.countAdoptedAdopters(
-      { adopterIds, createdAfter, createdBefore },
+      { adopterIds, actionedAfter, actionedBefore, rescueId: event.rescue_id },
       principalToMetadata(principal)
     );
     return res.count;


### PR DESCRIPTION
## Summary

- ADS-1023: `CountAdoptedAdopters` accepts an optional `rescue_id` so an event's adoption attribution only counts adoptions at the event's own rescue.
- ADS-1024: `CountAdoptedAdopters` validates `adopter_ids` size and the date-range inputs before running any query, and `service.rescue` refuses to attribute an event with an unbounded registrant list instead of silently truncating it.
- ADS-1025: attribution now filters on a new `applications.actioned_at` column (stamped when an application reaches `approved`/`adopted`) instead of `created_at`, matching the rule the RPC's proto comment already documented.

## Changes

- `packages/proto/proto/adopt_dont_shop/applications/v1/application.proto` — `CountAdoptedAdoptersRequest`: renamed `created_after`/`created_before` → `actioned_after`/`actioned_before`, added optional `rescue_id`, documented the 10,000-entry `adopter_ids` cap. Regenerated `packages/proto/src/generated/**`. Also corrected the RPC doc comment's stated permission (was `applications.read`, actually `ANALYTICS_VIEW`/`admin.reports` — Copilot review catch).
- `services/applications/src/grpc/attribution-handlers.ts` — added the `MAX_ADOPTER_IDS` (10,000) cap check, `Date.parse` validation for both bounds, an `actioned_after > actioned_before` check, optional `rescue_id` scoping (`AND rescue_id = $N`), and switched the query to filter `actioned_at`. `MIN_COHORT_SIZE` k-anonymity floor from ADS-1006 is unchanged.
- `services/applications/src/grpc/event-store.ts` — `projectReadModel` now stamps `applications.actioned_at` from `state.decidedAt` (on `approved`) / `state.adoptedAt` (on `adopted`) — both already carry the triggering event's `occurred_at` — and leaves it `null` for every other status (rejected/withdrawn never qualify for attribution).
- `services/applications/src/migrations/010_backfill_application_actioned_at.ts` (new) — backfills `actioned_at` for existing approved/adopted rows from the `application_events` store; `up`/`down` both included. Casts `applications.status::text` when comparing to `application_events.event_type` (varchar) — Postgres rejects the bare enum = varchar comparison.
- `services/rescue/src/grpc/event-handlers.ts` — `countAdoptionsFromEvent` passes the event's own `rescue_id`, renames the date fields, and bounds the attendee fetch at `ATTRIBUTION_MAX_COHORT` (10,000, mirrors `MAX_ADOPTER_IDS` by value) — an event past that size fails the call with `INVALID_ARGUMENT` rather than silently truncating the registrant list.
- Tests updated/added in `attribution-handlers.test.ts`, `review-handlers.test.ts`, `event-handlers.test.ts`, `applications-client.test.ts`, `migrations.test.ts`.

**Not done, flagged instead of done silently:** the existing `applications_rescue_status_created_idx` index is on `(rescue_id, status, created_at)`, not `actioned_at`, so the new rescue-scoped attribution query doesn't get full index coverage from it. A matching `(rescue_id, status, actioned_at)` index looks like a reasonable follow-up but felt like scope creep for this change (attribution queries are low-volume admin/reporting calls, not a hot path) — left a code comment at the query site and flagging it here rather than adding an index quietly.

## Before requesting review

- [x] Ran the scoped verification for the touched packages: `pnpm exec turbo test type-check lint --filter=@adopt-dont-shop/service.applications --filter=@adopt-dont-shop/service.rescue --filter=@adopt-dont-shop/proto` (all green — see Test plan). Did not run the repo-wide `pnpm ci:local:quick`.
- [x] Tests for new behaviour added (TDD)
- [ ] If touching `.env` requirements, updated `.env.example`'s REQUIRED block — n/a, no new env vars
- [ ] If touching a `lib.*`, considered consumer impact across `app.*` and `service.backend` — n/a, no `lib.*` touched

## Test plan

- [x] Existing tests pass — `pnpm exec turbo test --filter=@adopt-dont-shop/service.applications --filter=@adopt-dont-shop/service.rescue --filter=@adopt-dont-shop/proto` → 308 + 256 + 66 tests passing
- [x] New behaviour is covered by tests — rescue scoping (inclusion/exclusion), cap rejection, invalid-date rejection, `actioned_after > actioned_before` rejection, the equal-bound boundary case, `actioned_at` stamped on approve/re-stamped on markAdopted/left null on reject, event-side attendee-cap rejection, `rescue_id` forwarded from `getEventAnalytics`
- [x] Tested manually — found a local Postgres 16 cluster in the sandbox, started it, and ran the actual `node-pg-migrate` runner (not just the SQL by eye) through a full up → down → up cycle against real test data (an approved row, an adopted row with both an `approved` and a later `adopted` event, and a `rejected` row): confirmed `actioned_at` is set to the correct event's `occurred_at`, `adopted` correctly wins over the earlier `approved` timestamp, `rejected` is never touched, the backfill is idempotent on re-run, and `down` clears exactly what `up` set
- [x] No TypeScript errors — `pnpm exec turbo type-check --filter=@adopt-dont-shop/service.applications --filter=@adopt-dont-shop/service.rescue --filter=@adopt-dont-shop/proto`
- [x] Lint passes — `pnpm exec turbo lint --filter=@adopt-dont-shop/service.applications --filter=@adopt-dont-shop/service.rescue --filter=@adopt-dont-shop/proto` (one pre-existing unrelated warning in `pets-client.test.ts`, not touched by this change)

## Related

- ADS-1023, ADS-1024, ADS-1025

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PyLUww6MdfCdqbXe9V6eAE
