### PR TITLE
fix(reliability): crash-safe pools, process handlers, /health/ready, bounded gateway shutdown

### DIFF
--- a/packages/db/src/client.test.ts
+++ b/packages/db/src/client.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { createDbClient } from './client.js';
 
 describe('createDbClient', () => {
@@ -86,6 +86,42 @@ describe('createDbClient', () => {
 
       void pool.end();
     }, 3_000); // Test-level timeout: well above the pool timeout, below the default 5s
+  });
+
+  describe('idle client error handling (ADS-1040)', () => {
+    it('attaches a persistent pool error listener so an idle-client error does not crash the process', () => {
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+      const pool = createDbClient({
+        schema: 'test',
+        connectionString: 'postgres://localhost/test',
+      });
+
+      try {
+        // Without a listener, an EventEmitter 'error' is re-thrown by Node and
+        // terminates the process; the persistent listener delivers it instead.
+        expect(pool.listenerCount('error')).toBeGreaterThan(0);
+        expect(() => pool.emit('error', new Error('idle client terminated'))).not.toThrow();
+        expect(errorSpy).toHaveBeenCalled();
+      } finally {
+        errorSpy.mockRestore();
+        void pool.end();
+      }
+    });
+
+    it('attaches the error listener to the read pool too when a replica is configured', () => {
+      const pool = createDbClient({
+        schema: 'pets',
+        connectionString: 'postgres://localhost/primary',
+        readUrl: 'postgres://replica.example.com/pets',
+      });
+
+      try {
+        expect(pool.read.listenerCount('error')).toBeGreaterThan(0);
+      } finally {
+        void pool.read.end();
+        void pool.end();
+      }
+    });
   });
 
   describe('read-replica routing (ADS-815)', () => {

--- a/packages/db/src/client.ts
+++ b/packages/db/src/client.ts
@@ -46,6 +46,19 @@ const SAFE_SCHEMA = /^[A-Za-z_][A-Za-z0-9_]*$/;
 function buildPool(schema: string, config: PoolConfig): Pool {
   const pool = new Pool({ ...TIMEOUT_DEFAULTS, ...config });
 
+  // pg emits 'error' on an *idle* pooled client whenever its backend
+  // connection drops — Postgres failover/restart/idle-reap or a brief network
+  // partition, all routine in production. With NO listener, Node re-throws it
+  // as an unhandled 'error' and the process terminates → crash-loop under
+  // `restart: always`, with no logged cause. A persistent listener keeps the
+  // process alive and surfaces it; the query/transaction paths still observe
+  // their own failures through the returned promise. Logged to stderr (not a
+  // logger) because this low-level package can't assume one is configured —
+  // same reason as the search_path fallback below.
+  pool.on('error', (err: Error) => {
+    console.error(`db: pool error (schema "${schema}"):`, err);
+  });
+
   pool.on('connect', client => {
     // A connection that fails to set its search_path would silently resolve
     // unqualified table refs to `public` (wrong rows / "relation does not

--- a/packages/service-bootstrap/src/index.ts
+++ b/packages/service-bootstrap/src/index.ts
@@ -70,5 +70,11 @@ export type {
   SignPrincipalTokenOptions,
 } from './principal-token.js';
 
-export { runServiceShutdown } from './shutdown.js';
-export type { ShutdownDeps } from './shutdown.js';
+export { runServiceShutdown, withShutdownDeadline } from './shutdown.js';
+export type { ShutdownDeps, ShutdownDeadlineOptions } from './shutdown.js';
+
+export { installProcessErrorHandlers } from './process-handlers.js';
+export type { ProcessErrorHandlerDeps } from './process-handlers.js';
+
+export { checkReadiness, registerReadinessRoute } from './readiness.js';
+export type { ReadinessDeps, ReadinessResult, RegisterReadinessRouteOptions } from './readiness.js';

--- a/packages/service-bootstrap/src/process-handlers.test.ts
+++ b/packages/service-bootstrap/src/process-handlers.test.ts
@@ -1,0 +1,119 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { installProcessErrorHandlers } from './process-handlers.js';
+
+const makeLogger = () => {
+  const errorCalls: Array<[string, unknown]> = [];
+  const logger = {
+    info: () => undefined,
+    error: (msg: string, meta?: unknown) => errorCalls.push([msg, meta]),
+    warn: () => undefined,
+    debug: () => undefined,
+    silly: () => undefined,
+  } as unknown as ReturnType<typeof import('@adopt-dont-shop/observability').createLogger>;
+  return Object.assign(logger, { errorCalls });
+};
+
+// Flush the microtask + immediate queue so the handler's async teardown IIFE
+// runs to completion (teardown → exit).
+const flush = (): Promise<void> => new Promise<void>(resolve => setImmediate(resolve));
+
+// Capture the listeners installProcessErrorHandlers registers WITHOUT letting
+// them attach to the real process (mockReturnValue replaces the impl, so no
+// call-through and nothing to leak between tests).
+const captureRegistration = () => {
+  const onSpy = vi.spyOn(process, 'on').mockReturnValue(process);
+  const handlerFor = (event: string): ((arg: unknown) => void) | undefined => {
+    const call = onSpy.mock.calls.find(([registeredEvent]) => registeredEvent === event);
+    return call?.[1];
+  };
+  return { handlerFor };
+};
+
+describe('installProcessErrorHandlers', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('registers both uncaughtException and unhandledRejection handlers', () => {
+    const { handlerFor } = captureRegistration();
+
+    installProcessErrorHandlers({
+      logger: makeLogger(),
+      onFatal: async () => undefined,
+      exit: vi.fn(),
+    });
+
+    expect(typeof handlerFor('uncaughtException')).toBe('function');
+    expect(typeof handlerFor('unhandledRejection')).toBe('function');
+  });
+
+  it('on uncaughtException: logs the cause, drains, then exits non-zero', async () => {
+    const { handlerFor } = captureRegistration();
+    const logger = makeLogger();
+    const onFatal = vi.fn(async () => undefined);
+    const exit = vi.fn();
+
+    installProcessErrorHandlers({ logger, onFatal, exit });
+    handlerFor('uncaughtException')?.(new Error('idle client error'));
+    await flush();
+
+    expect(onFatal).toHaveBeenCalledTimes(1);
+    expect(exit).toHaveBeenCalledWith(1);
+    expect(logger.errorCalls.some(([msg]) => msg.includes('uncaughtException'))).toBe(true);
+  });
+
+  it('on unhandledRejection: logs the cause, drains, then exits non-zero', async () => {
+    const { handlerFor } = captureRegistration();
+    const logger = makeLogger();
+    const onFatal = vi.fn(async () => undefined);
+    const exit = vi.fn();
+
+    installProcessErrorHandlers({ logger, onFatal, exit });
+    handlerFor('unhandledRejection')?.(new Error('boom'));
+    await flush();
+
+    expect(onFatal).toHaveBeenCalledTimes(1);
+    expect(exit).toHaveBeenCalledWith(1);
+    expect(logger.errorCalls.some(([msg]) => msg.includes('unhandledRejection'))).toBe(true);
+  });
+
+  it('still exits non-zero when the teardown itself throws', async () => {
+    const { handlerFor } = captureRegistration();
+    const logger = makeLogger();
+    const onFatal = vi.fn(async () => {
+      throw new Error('drain failed');
+    });
+    const exit = vi.fn();
+
+    installProcessErrorHandlers({ logger, onFatal, exit });
+    handlerFor('uncaughtException')?.(new Error('boom'));
+    await flush();
+
+    expect(exit).toHaveBeenCalledWith(1);
+    expect(
+      logger.errorCalls.some(([msg]) => msg.includes('teardown during fatal handler failed'))
+    ).toBe(true);
+  });
+
+  it('does not re-enter teardown when a second fatal event fires mid-drain', async () => {
+    const { handlerFor } = captureRegistration();
+    let resolveTeardown: (() => void) | undefined;
+    const onFatal = vi.fn(
+      () =>
+        new Promise<void>(resolve => {
+          resolveTeardown = resolve;
+        })
+    );
+    const exit = vi.fn();
+
+    installProcessErrorHandlers({ logger: makeLogger(), onFatal, exit });
+    handlerFor('uncaughtException')?.(new Error('first')); // starts teardown (pending)
+    handlerFor('unhandledRejection')?.(new Error('second')); // must be ignored while draining
+    resolveTeardown?.();
+    await flush();
+
+    expect(onFatal).toHaveBeenCalledTimes(1);
+    expect(exit).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/service-bootstrap/src/process-handlers.ts
+++ b/packages/service-bootstrap/src/process-handlers.ts
@@ -1,0 +1,59 @@
+// Last-resort handlers for errors that escape every try/catch.
+//
+// Without these, a `pg.Pool` idle-client 'error' event (emitted on Postgres
+// failover/restart/idle-reap or a brief network partition — all routine in
+// production) is re-thrown by Node as an unhandled 'error', and an absent
+// `uncaughtException` handler terminates the process with no drain and no
+// logged cause. Under `restart: always` that becomes a crash-loop on every
+// Postgres blip. The same is true for any stray `unhandledRejection`.
+//
+// installProcessErrorHandlers logs the cause, runs the same teardown a
+// signal-driven shutdown would, and exits non-zero so the orchestrator
+// restarts a *drained* process rather than a mid-flight one.
+
+import type { createLogger } from '@adopt-dont-shop/observability';
+
+type Logger = ReturnType<typeof createLogger>;
+
+export type ProcessErrorHandlerDeps = {
+  logger: Logger;
+  // Best-effort teardown run before exiting. Should resolve; any throw is
+  // logged and swallowed so the process still exits. Typically the same
+  // `runServiceShutdown` call used on SIGTERM/SIGINT.
+  onFatal: () => Promise<void>;
+  // Injectable for tests; defaults to process.exit. Typed to return void
+  // (process.exit's `never` is assignable to it) so a test can pass a plain
+  // spy without an assertion.
+  exit?: (code: number) => void;
+};
+
+export const installProcessErrorHandlers = (deps: ProcessErrorHandlerDeps): void => {
+  // Wrap rather than alias process.exit so we neither trip the unbound-method
+  // lint rule nor lose the `this` binding.
+  const exit = deps.exit ?? ((code: number) => process.exit(code));
+
+  // A teardown that itself throws (or a second fatal event fired while we are
+  // already draining) must not re-enter and loop.
+  let handling = false;
+
+  const handle =
+    (kind: 'uncaughtException' | 'unhandledRejection') =>
+    (err: unknown): void => {
+      if (handling) {
+        return;
+      }
+      handling = true;
+      deps.logger.error(`fatal ${kind} — draining and exiting`, { err });
+      void (async () => {
+        try {
+          await deps.onFatal();
+        } catch (teardownErr) {
+          deps.logger.error('teardown during fatal handler failed', { err: teardownErr });
+        }
+        exit(1);
+      })();
+    };
+
+  process.on('uncaughtException', handle('uncaughtException'));
+  process.on('unhandledRejection', handle('unhandledRejection'));
+};

--- a/packages/service-bootstrap/src/readiness.test.ts
+++ b/packages/service-bootstrap/src/readiness.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { checkReadiness } from './readiness.js';
+
+describe('checkReadiness', () => {
+  it('is ready with no checks when no dependencies are configured', async () => {
+    const result = await checkReadiness({});
+    expect(result).toEqual({ ok: true, checks: {} });
+  });
+
+  it('probes the database with SELECT 1 and reports ok', async () => {
+    const query = vi.fn(async () => ({ rows: [] }));
+    const result = await checkReadiness({ pool: { query } });
+
+    expect(query).toHaveBeenCalledWith('SELECT 1');
+    expect(result).toEqual({ ok: true, checks: { database: 'ok' } });
+  });
+
+  it('reports the database not ready when the query rejects', async () => {
+    const query = vi.fn(async () => {
+      throw new Error('connection terminated');
+    });
+    const result = await checkReadiness({ pool: { query } });
+
+    expect(result.ok).toBe(false);
+    expect(result.checks.database).toBe('error');
+  });
+
+  it('reports nats not ready when the connection is closed', async () => {
+    const result = await checkReadiness({ nats: { isClosed: () => true } });
+    expect(result).toEqual({ ok: false, checks: { nats: 'error' } });
+  });
+
+  it('reports nats ready when the connection is open', async () => {
+    const result = await checkReadiness({ nats: { isClosed: () => false } });
+    expect(result).toEqual({ ok: true, checks: { nats: 'ok' } });
+  });
+
+  it('probes redis with PING and reports ok', async () => {
+    const ping = vi.fn(async () => 'PONG');
+    const result = await checkReadiness({ redis: { ping } });
+
+    expect(ping).toHaveBeenCalled();
+    expect(result).toEqual({ ok: true, checks: { redis: 'ok' } });
+  });
+
+  it('is not ready overall when any single dependency fails', async () => {
+    const result = await checkReadiness({
+      pool: { query: vi.fn(async () => ({ rows: [] })) },
+      nats: { isClosed: () => false },
+      redis: {
+        ping: vi.fn(async () => {
+          throw new Error('LOADING Redis is loading the dataset in memory');
+        }),
+      },
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.checks).toEqual({ database: 'ok', nats: 'ok', redis: 'error' });
+  });
+
+  it('treats a probe that never resolves as a failure (bounded by the timeout)', async () => {
+    vi.useFakeTimers();
+    try {
+      const promise = checkReadiness(
+        { pool: { query: vi.fn(() => new Promise<never>(() => undefined)) } },
+        { timeoutMs: 1_000 }
+      );
+      await vi.advanceTimersByTimeAsync(1_001);
+      const result = await promise;
+
+      expect(result.ok).toBe(false);
+      expect(result.checks.database).toBe('error');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('logs a warning naming the failed dependency', async () => {
+    const warn = vi.fn();
+    const logger = {
+      info: () => undefined,
+      error: () => undefined,
+      warn,
+      debug: () => undefined,
+      silly: () => undefined,
+    } as unknown as ReturnType<typeof import('@adopt-dont-shop/observability').createLogger>;
+
+    await checkReadiness({ nats: { isClosed: () => true } }, { logger });
+
+    expect(warn).toHaveBeenCalledWith(
+      'readiness probe failed',
+      expect.objectContaining({ check: 'nats' })
+    );
+  });
+});

--- a/packages/service-bootstrap/src/readiness.ts
+++ b/packages/service-bootstrap/src/readiness.ts
@@ -1,0 +1,143 @@
+// Dependency-aware readiness probe shared by every gRPC microservice and the
+// gateway.
+//
+// /health/simple is pure liveness — it answers 200 as soon as the process is
+// up and (for microservices) the gRPC server has bound. It deliberately does
+// NOT reflect downstream health, so a service that has lost its DB pool, NATS
+// or Redis still reports 200 there and keeps taking traffic.
+//
+// /health/ready closes that gap: it actively probes the backing services a
+// process depends on (Postgres `SELECT 1`, NATS connection state, Redis PING)
+// and answers 503 when any of them is unreachable, so an orchestrator or load
+// balancer can stop routing to (or restart) a service that can't serve.
+
+import type { FastifyInstance } from 'fastify';
+
+import type { createLogger } from '@adopt-dont-shop/observability';
+
+type Logger = ReturnType<typeof createLogger>;
+
+// Dependency handles a service hands to the readiness probe. Every field is
+// optional — a service wires only the backing services it actually uses, and
+// an omitted dependency is simply not probed. Structural (rather than the
+// concrete pg/nats/ioredis types) so this stays dependency-light and trivially
+// fakeable in tests; a real pg Pool, NatsConnection and ioredis client each
+// satisfy the shape.
+export type ReadinessDeps = {
+  // Postgres primary pool — probed with `SELECT 1`.
+  pool?: { query: (text: string) => Promise<unknown> };
+  // NATS connection — reported not-ready once the connection has closed.
+  nats?: { isClosed: () => boolean };
+  // Redis client (ioredis / node-redis both expose this shape) — probed with PING.
+  redis?: { ping: () => Promise<unknown> };
+};
+
+export type ReadinessResult = {
+  ok: boolean;
+  checks: Record<string, 'ok' | 'error'>;
+};
+
+// A single probe gets this long to answer before it is treated as a failure —
+// a hung dependency must never hang the readiness endpoint itself.
+const DEFAULT_CHECK_TIMEOUT_MS = 2_000;
+
+const withTimeout = async (
+  label: string,
+  work: Promise<unknown>,
+  timeoutMs: number
+): Promise<void> => {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(
+      () => reject(new Error(`${label} readiness probe timed out after ${timeoutMs}ms`)),
+      timeoutMs
+    );
+  });
+  try {
+    await Promise.race([work, timeout]);
+  } finally {
+    if (timer) {
+      clearTimeout(timer);
+    }
+  }
+};
+
+// Probe every configured dependency concurrently. Each probe is individually
+// try/caught so one failing dependency yields `error` for that check rather
+// than throwing out of the whole readiness evaluation.
+export const checkReadiness = async (
+  deps: ReadinessDeps,
+  opts: { timeoutMs?: number; logger?: Logger } = {}
+): Promise<ReadinessResult> => {
+  const timeoutMs = opts.timeoutMs ?? DEFAULT_CHECK_TIMEOUT_MS;
+
+  const probes: Array<{ name: string; run: () => Promise<void> }> = [];
+
+  if (deps.pool) {
+    const { pool } = deps;
+    probes.push({
+      name: 'database',
+      run: () => withTimeout('database', pool.query('SELECT 1'), timeoutMs),
+    });
+  }
+  if (deps.nats) {
+    const { nats } = deps;
+    probes.push({
+      name: 'nats',
+      run: async () => {
+        if (nats.isClosed()) {
+          throw new Error('nats connection is closed');
+        }
+      },
+    });
+  }
+  if (deps.redis) {
+    const { redis } = deps;
+    probes.push({ name: 'redis', run: () => withTimeout('redis', redis.ping(), timeoutMs) });
+  }
+
+  const entries = await Promise.all(
+    probes.map(async ({ name, run }): Promise<readonly [string, 'ok' | 'error']> => {
+      try {
+        await run();
+        return [name, 'ok'] as const;
+      } catch (err) {
+        opts.logger?.warn('readiness probe failed', { check: name, err });
+        return [name, 'error'] as const;
+      }
+    })
+  );
+
+  const checks: Record<string, 'ok' | 'error'> = Object.fromEntries(entries);
+  const ok = entries.every(([, status]) => status === 'ok');
+  return { ok, checks };
+};
+
+export type RegisterReadinessRouteOptions = {
+  serviceName: string;
+  environment: string;
+  deps: ReadinessDeps;
+  logger?: Logger;
+  timeoutMs?: number;
+};
+
+// Register GET /health/ready on a Fastify instance. Answers 200 when every
+// probed dependency is reachable, 503 {status:'degraded'} otherwise, with a
+// per-dependency breakdown so an operator can see which one is down.
+export const registerReadinessRoute = (
+  server: FastifyInstance,
+  opts: RegisterReadinessRouteOptions
+): void => {
+  server.get('/health/ready', async (_req, reply) => {
+    const result = await checkReadiness(opts.deps, {
+      timeoutMs: opts.timeoutMs,
+      logger: opts.logger,
+    });
+    return reply.status(result.ok ? 200 : 503).send({
+      status: result.ok ? 'ok' : 'degraded',
+      service: opts.serviceName,
+      environment: opts.environment,
+      checks: result.checks,
+    });
+  });
+};

--- a/packages/service-bootstrap/src/server.test.ts
+++ b/packages/service-bootstrap/src/server.test.ts
@@ -113,6 +113,68 @@ describe('createMicroserviceServer — readiness probe (isReady gate)', () => {
   });
 });
 
+describe('createMicroserviceServer — /health/ready dependency probe', () => {
+  it('returns 200 with no checks when no readiness deps are configured', async () => {
+    const server = createMicroserviceServer({
+      serviceName: 'service.test',
+      config: baseConfig,
+      logger: quietLogger,
+    });
+    try {
+      const res = await server.inject({ method: 'GET', url: '/health/ready' });
+      expect(res.statusCode).toBe(200);
+      expect(res.json()).toMatchObject({ status: 'ok', service: 'service.test', checks: {} });
+    } finally {
+      await server.close();
+    }
+  });
+
+  it('returns 200 when every configured dependency is healthy', async () => {
+    const server = createMicroserviceServer({
+      serviceName: 'service.test',
+      config: baseConfig,
+      logger: quietLogger,
+      readiness: {
+        pool: { query: async () => ({ rows: [] }) },
+        nats: { isClosed: () => false },
+      },
+    });
+    try {
+      const res = await server.inject({ method: 'GET', url: '/health/ready' });
+      expect(res.statusCode).toBe(200);
+      expect(res.json()).toMatchObject({ status: 'ok', checks: { database: 'ok', nats: 'ok' } });
+    } finally {
+      await server.close();
+    }
+  });
+
+  it('returns 503 degraded when a dependency is unreachable', async () => {
+    const server = createMicroserviceServer({
+      serviceName: 'service.test',
+      config: baseConfig,
+      logger: quietLogger,
+      readiness: {
+        pool: {
+          query: async () => {
+            throw new Error('connection terminated unexpectedly');
+          },
+        },
+        nats: { isClosed: () => false },
+      },
+    });
+    try {
+      const res = await server.inject({ method: 'GET', url: '/health/ready' });
+      expect(res.statusCode).toBe(503);
+      expect(res.json()).toMatchObject({
+        status: 'degraded',
+        checks: { database: 'error', nats: 'ok' },
+      });
+    } finally {
+      await server.close();
+    }
+  });
+});
+
 describe('createMicroserviceServer — /metrics endpoint', () => {
   it('exposes Prometheus metrics including http_request_duration_seconds', async () => {
     const server = createMicroserviceServer({

--- a/packages/service-bootstrap/src/server.ts
+++ b/packages/service-bootstrap/src/server.ts
@@ -10,6 +10,8 @@
 import { createLogger, registerMetrics, registerRequestId } from '@adopt-dont-shop/observability';
 import Fastify, { type FastifyInstance } from 'fastify';
 
+import { registerReadinessRoute, type ReadinessDeps } from './readiness.js';
+
 export type CreateServerConfig = {
   environment: string;
 };
@@ -18,10 +20,14 @@ export type CreateServerOptions = {
   serviceName: string;
   config: CreateServerConfig;
   logger?: ReturnType<typeof createLogger>;
-  // Readiness probe — /health/simple returns 503 until this returns
-  // true. Defaults to () => true so call-sites that don't gate on gRPC
-  // readiness compile unchanged.
+  // Liveness gate — /health/simple returns 503 until this returns true.
+  // Defaults to () => true so call-sites that don't gate on gRPC readiness
+  // compile unchanged.
   isReady?: () => boolean;
+  // Downstream dependencies probed by /health/ready (DB/NATS/Redis). Omitted
+  // dependencies are not probed; omitting the whole object leaves /health/ready
+  // answering 200 with no checks (liveness-equivalent).
+  readiness?: ReadinessDeps;
 };
 
 export const createMicroserviceServer = (opts: CreateServerOptions): FastifyInstance => {
@@ -53,13 +59,23 @@ export const createMicroserviceServer = (opts: CreateServerOptions): FastifyInst
   // Prometheus /metrics + http_request_duration_seconds onResponse hook.
   registerMetrics(server);
 
-  // Health endpoint — returns 503 until the gRPC server has bound
-  // (isReady probe), then the normal 200 payload.
+  // Liveness — returns 503 until the gRPC server has bound (isReady probe),
+  // then the normal 200 payload. Deliberately does NOT reflect downstream
+  // health; that is /health/ready's job.
   server.get('/health/simple', async (_req, reply) => {
     if (!isReady()) {
       return reply.status(503).send({ status: 'starting' });
     }
     return { status: 'ok', service: serviceName, environment: config.environment };
+  });
+
+  // Readiness — actively probes DB/NATS/Redis and returns 503 when any
+  // configured dependency is unreachable.
+  registerReadinessRoute(server, {
+    serviceName,
+    environment: config.environment,
+    deps: opts.readiness ?? {},
+    logger,
   });
 
   return server;

--- a/packages/service-bootstrap/src/shutdown.test.ts
+++ b/packages/service-bootstrap/src/shutdown.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { runServiceShutdown } from './shutdown.js';
+import { runServiceShutdown, withShutdownDeadline } from './shutdown.js';
 
 describe('runServiceShutdown — shutdown sequencing', () => {
   it('calls close → grpc shutdown → nats drain → pool end in order', async () => {
@@ -252,5 +252,45 @@ describe('runServiceShutdown — overall deadline (timeoutMs)', () => {
     await p;
 
     expect(order).toEqual(['http', 'grpc', 'nats', 'pool']);
+  });
+});
+
+// --- withShutdownDeadline (shared bounded-shutdown primitive) --------
+
+describe('withShutdownDeadline', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('runs the sequence and returns without exiting on normal completion', async () => {
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => undefined as never);
+    const sequence = vi.fn(async () => undefined);
+
+    await withShutdownDeadline(sequence, { logger: makeLogger() });
+
+    expect(sequence).toHaveBeenCalledTimes(1);
+    expect(exitSpy).not.toHaveBeenCalled();
+  });
+
+  it('exits 1 and names the in-flight step when the sequence hangs past the deadline', async () => {
+    vi.useFakeTimers();
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => undefined as never);
+    const logger = makeLogger();
+
+    const p = withShutdownDeadline(() => new Promise<void>(() => undefined), {
+      logger,
+      timeoutMs: 10_000,
+      currentStep: () => 'redis',
+    });
+    await vi.advanceTimersByTimeAsync(10_001);
+    await Promise.resolve();
+
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    expect(
+      logger.errorCalls.some(([msg]) => typeof msg === 'string' && msg.includes('redis'))
+    ).toBe(true);
+
+    p.catch(() => undefined);
   });
 });

--- a/packages/service-bootstrap/src/shutdown.ts
+++ b/packages/service-bootstrap/src/shutdown.ts
@@ -27,12 +27,56 @@ export type ShutdownDeps = {
 
 const DEFAULT_TIMEOUT_MS = 25_000;
 
+export type ShutdownDeadlineOptions = {
+  logger: Logger;
+  /** Overall deadline in ms. Default 25 000. */
+  timeoutMs?: number;
+  /** Names the step in flight for the deadline log line (evaluated when the
+   *  deadline fires, so it reflects the step reached, not the step at call
+   *  time). */
+  currentStep?: () => string;
+};
+
+// withShutdownDeadline — race an arbitrary teardown `sequence` against an
+// overall deadline. On timeout it logs the step in flight and calls
+// process.exit(1); on normal completion it clears the timer and returns.
+// Extracted so both runServiceShutdown (fixed HTTP→gRPC→NATS→pool order) and
+// bespoke teardowns (the gateway's io/redis/http/nats/grpc-clients sequence)
+// share one bounded-shutdown guarantee.
+export const withShutdownDeadline = async (
+  sequence: () => Promise<void>,
+  opts: ShutdownDeadlineOptions
+): Promise<void> => {
+  const timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const deadline = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => {
+      const step = opts.currentStep?.();
+      reject(new Error(`shutdown deadline exceeded${step ? ` in step: ${step}` : ''}`));
+    }, timeoutMs);
+  });
+
+  try {
+    await Promise.race([sequence(), deadline]);
+  } catch (err) {
+    const step = opts.currentStep?.();
+    opts.logger.error(`shutdown deadline exceeded${step ? ` — step in flight: ${step}` : ''}`, {
+      err,
+    });
+    process.exit(1);
+  } finally {
+    if (timer) {
+      clearTimeout(timer);
+    }
+  }
+};
+
 // runServiceShutdown — execute the four-step teardown sequence.
 // Each step is individually try/caught so a failure in one step
 // does not skip the remaining steps.
 export const runServiceShutdown = async (deps: ShutdownDeps): Promise<void> => {
   const { httpServer, grpc, nats, pool, logger } = deps;
-  const timeoutMs = deps.timeoutMs ?? DEFAULT_TIMEOUT_MS;
 
   let currentStep = 'http';
 
@@ -66,16 +110,9 @@ export const runServiceShutdown = async (deps: ShutdownDeps): Promise<void> => {
     }
   };
 
-  const deadline = new Promise<never>((_, reject) =>
-    setTimeout(() => {
-      reject(new Error(`shutdown deadline exceeded in step: ${currentStep}`));
-    }, timeoutMs)
-  );
-
-  try {
-    await Promise.race([sequence(), deadline]);
-  } catch (err) {
-    logger.error(`shutdown deadline exceeded — step in flight: ${currentStep}`, { err });
-    process.exit(1);
-  }
+  await withShutdownDeadline(sequence, {
+    logger,
+    timeoutMs: deps.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+    currentStep: () => currentStep,
+  });
 };

--- a/services/applications/src/index.ts
+++ b/services/applications/src/index.ts
@@ -2,7 +2,10 @@ import { connect, type NatsConnection } from 'nats';
 
 import { createDbClient } from '@adopt-dont-shop/db';
 import { createLogger } from '@adopt-dont-shop/observability';
-import { runServiceShutdown } from '@adopt-dont-shop/service-bootstrap';
+import {
+  installProcessErrorHandlers,
+  runServiceShutdown,
+} from '@adopt-dont-shop/service-bootstrap';
 
 import { loadConfig } from './config.js';
 import { startGrpcServer, type RunningGrpcServer } from './grpc/server.js';
@@ -48,7 +51,12 @@ const main = async (): Promise<void> => {
       onError: (err, subject) => logger.error('gdpr erasure subscriber error', { subject, err }),
     });
 
-    const httpServer = createServer({ config, logger, isReady: () => grpcReady });
+    const httpServer = createServer({
+      config,
+      logger,
+      isReady: () => grpcReady,
+      readiness: { pool, nats },
+    });
     await httpServer.listen({ port: config.port, host: config.host });
 
     logger.info('service.applications running', {
@@ -59,14 +67,22 @@ const main = async (): Promise<void> => {
       environment: config.environment,
     });
 
+    const teardown = (): Promise<void> =>
+      runServiceShutdown({ httpServer, grpc, nats, pool, logger });
+
     const shutdown = async (signal: string): Promise<void> => {
       logger.info('service.applications shutting down', { signal });
-      await runServiceShutdown({ httpServer, grpc, nats, pool, logger });
+      await teardown();
       process.exit(0);
     };
 
     process.once('SIGTERM', () => void shutdown('SIGTERM'));
     process.once('SIGINT', () => void shutdown('SIGINT'));
+
+    // ADS-1040: last-resort handlers so an idle DB-pool 'error' event (or
+    // any stray rejection) drains via the same teardown and exits non-zero,
+    // instead of crashing the process undrained under `restart: always`.
+    installProcessErrorHandlers({ logger, onFatal: teardown });
   } catch (err) {
     logger.error('service.applications failed to start', { err });
     try {

--- a/services/applications/src/server.ts
+++ b/services/applications/src/server.ts
@@ -1,4 +1,4 @@
-import { createMicroserviceServer } from '@adopt-dont-shop/service-bootstrap';
+import { createMicroserviceServer, type ReadinessDeps } from '@adopt-dont-shop/service-bootstrap';
 import type { FastifyInstance } from 'fastify';
 
 import type { createLogger } from '@adopt-dont-shop/observability';
@@ -9,6 +9,7 @@ export type CreateServerOptions = {
   config: ApplicationsConfig;
   logger?: ReturnType<typeof createLogger>;
   isReady?: () => boolean;
+  readiness?: ReadinessDeps;
 };
 
 export const createServer = (opts: CreateServerOptions): FastifyInstance => {
@@ -17,6 +18,7 @@ export const createServer = (opts: CreateServerOptions): FastifyInstance => {
     config: opts.config,
     logger: opts.logger,
     isReady: opts.isReady,
+    readiness: opts.readiness,
   });
 };
 

--- a/services/audit/src/index.ts
+++ b/services/audit/src/index.ts
@@ -3,7 +3,10 @@ import { connect, type NatsConnection } from 'nats';
 import { createDbClient } from '@adopt-dont-shop/db';
 import { type SubscriptionHandle } from '@adopt-dont-shop/events';
 import { createLogger } from '@adopt-dont-shop/observability';
-import { runServiceShutdown } from '@adopt-dont-shop/service-bootstrap';
+import {
+  installProcessErrorHandlers,
+  runServiceShutdown,
+} from '@adopt-dont-shop/service-bootstrap';
 
 import { loadConfig } from './config.js';
 import { startGrpcServer, type RunningGrpcServer } from './grpc/server.js';
@@ -92,7 +95,12 @@ const main = async (): Promise<void> => {
       { logger }
     );
 
-    const httpServer = createServer({ config, logger, isReady: () => grpcReady });
+    const httpServer = createServer({
+      config,
+      logger,
+      isReady: () => grpcReady,
+      readiness: { pool, nats },
+    });
     await httpServer.listen({ port: config.port, host: config.host });
 
     logger.info('service.audit running', {
@@ -104,6 +112,9 @@ const main = async (): Promise<void> => {
       environment: config.environment,
     });
 
+    const teardown = (): Promise<void> =>
+      runServiceShutdown({ httpServer, grpc, nats, pool, logger });
+
     const shutdown = async (signal: string): Promise<void> => {
       logger.info('service.audit shutting down', { signal });
       try {
@@ -111,12 +122,17 @@ const main = async (): Promise<void> => {
       } catch (err) {
         logger.error('scheduler stop error', { err });
       }
-      await runServiceShutdown({ httpServer, grpc, nats, pool, logger });
+      await teardown();
       process.exit(0);
     };
 
     process.once('SIGTERM', () => void shutdown('SIGTERM'));
     process.once('SIGINT', () => void shutdown('SIGINT'));
+
+    // ADS-1040: last-resort handlers so an idle DB-pool 'error' event (or
+    // any stray rejection) drains via the same teardown and exits non-zero,
+    // instead of crashing the process undrained under `restart: always`.
+    installProcessErrorHandlers({ logger, onFatal: teardown });
   } catch (err) {
     logger.error('service.audit failed to start', { err });
     try {

--- a/services/audit/src/server.ts
+++ b/services/audit/src/server.ts
@@ -1,4 +1,4 @@
-import { createMicroserviceServer } from '@adopt-dont-shop/service-bootstrap';
+import { createMicroserviceServer, type ReadinessDeps } from '@adopt-dont-shop/service-bootstrap';
 import type { FastifyInstance } from 'fastify';
 
 import type { createLogger } from '@adopt-dont-shop/observability';
@@ -9,6 +9,7 @@ export type CreateServerOptions = {
   config: AuditConfig;
   logger?: ReturnType<typeof createLogger>;
   isReady?: () => boolean;
+  readiness?: ReadinessDeps;
 };
 
 export const createServer = (opts: CreateServerOptions): FastifyInstance => {
@@ -17,6 +18,7 @@ export const createServer = (opts: CreateServerOptions): FastifyInstance => {
     config: opts.config,
     logger: opts.logger,
     isReady: opts.isReady,
+    readiness: opts.readiness,
   });
 };
 

--- a/services/auth/src/index.ts
+++ b/services/auth/src/index.ts
@@ -2,7 +2,10 @@ import { connect, type NatsConnection } from 'nats';
 
 import { createDbClient } from '@adopt-dont-shop/db';
 import { createLogger } from '@adopt-dont-shop/observability';
-import { runServiceShutdown } from '@adopt-dont-shop/service-bootstrap';
+import {
+  installProcessErrorHandlers,
+  runServiceShutdown,
+} from '@adopt-dont-shop/service-bootstrap';
 
 import { loadConfig } from './config.js';
 import { createBcryptPasswordHasher } from './grpc/password-hasher.js';
@@ -63,7 +66,12 @@ const main = async (): Promise<void> => {
       onError: (err, subject) => logger.error('gdpr erasure subscriber error', { subject, err }),
     });
 
-    const httpServer = createServer({ config, logger, isReady: () => grpcReady });
+    const httpServer = createServer({
+      config,
+      logger,
+      isReady: () => grpcReady,
+      readiness: { pool, nats },
+    });
     await httpServer.listen({ port: config.port, host: config.host });
 
     logger.info('service.auth running', {
@@ -74,14 +82,22 @@ const main = async (): Promise<void> => {
       environment: config.environment,
     });
 
+    const teardown = (): Promise<void> =>
+      runServiceShutdown({ httpServer, grpc, nats, pool, logger });
+
     const shutdown = async (signal: string): Promise<void> => {
       logger.info('service.auth shutting down', { signal });
-      await runServiceShutdown({ httpServer, grpc, nats, pool, logger });
+      await teardown();
       process.exit(0);
     };
 
     process.once('SIGTERM', () => void shutdown('SIGTERM'));
     process.once('SIGINT', () => void shutdown('SIGINT'));
+
+    // ADS-1040: last-resort handlers so an idle DB-pool 'error' event (or
+    // any stray rejection) drains via the same teardown and exits non-zero,
+    // instead of crashing the process undrained under `restart: always`.
+    installProcessErrorHandlers({ logger, onFatal: teardown });
   } catch (err) {
     logger.error('service.auth failed to start', { err });
     try {

--- a/services/auth/src/server.ts
+++ b/services/auth/src/server.ts
@@ -1,4 +1,4 @@
-import { createMicroserviceServer } from '@adopt-dont-shop/service-bootstrap';
+import { createMicroserviceServer, type ReadinessDeps } from '@adopt-dont-shop/service-bootstrap';
 import type { FastifyInstance } from 'fastify';
 
 import type { createLogger } from '@adopt-dont-shop/observability';
@@ -9,6 +9,7 @@ export type CreateServerOptions = {
   config: AuthConfig;
   logger?: ReturnType<typeof createLogger>;
   isReady?: () => boolean;
+  readiness?: ReadinessDeps;
 };
 
 export const createServer = (opts: CreateServerOptions): FastifyInstance => {
@@ -17,6 +18,7 @@ export const createServer = (opts: CreateServerOptions): FastifyInstance => {
     config: opts.config,
     logger: opts.logger,
     isReady: opts.isReady,
+    readiness: opts.readiness,
   });
 };
 

--- a/services/chat/src/index.ts
+++ b/services/chat/src/index.ts
@@ -2,7 +2,10 @@ import { connect, type NatsConnection } from 'nats';
 
 import { createDbClient } from '@adopt-dont-shop/db';
 import { createLogger } from '@adopt-dont-shop/observability';
-import { runServiceShutdown } from '@adopt-dont-shop/service-bootstrap';
+import {
+  installProcessErrorHandlers,
+  runServiceShutdown,
+} from '@adopt-dont-shop/service-bootstrap';
 
 import { loadConfig } from './config.js';
 import { startGrpcServer, type RunningGrpcServer } from './grpc/server.js';
@@ -45,7 +48,12 @@ const main = async (): Promise<void> => {
       onError: (err, subject) => logger.error('gdpr erasure subscriber error', { subject, err }),
     });
 
-    const httpServer = createServer({ config, logger, isReady: () => grpcReady });
+    const httpServer = createServer({
+      config,
+      logger,
+      isReady: () => grpcReady,
+      readiness: { pool, nats },
+    });
     await httpServer.listen({ port: config.port, host: config.host });
 
     logger.info('service.chat running', {
@@ -56,14 +64,22 @@ const main = async (): Promise<void> => {
       environment: config.environment,
     });
 
+    const teardown = (): Promise<void> =>
+      runServiceShutdown({ httpServer, grpc, nats, pool, logger });
+
     const shutdown = async (signal: string): Promise<void> => {
       logger.info('service.chat shutting down', { signal });
-      await runServiceShutdown({ httpServer, grpc, nats, pool, logger });
+      await teardown();
       process.exit(0);
     };
 
     process.once('SIGTERM', () => void shutdown('SIGTERM'));
     process.once('SIGINT', () => void shutdown('SIGINT'));
+
+    // ADS-1040: last-resort handlers so an idle DB-pool 'error' event (or
+    // any stray rejection) drains via the same teardown and exits non-zero,
+    // instead of crashing the process undrained under `restart: always`.
+    installProcessErrorHandlers({ logger, onFatal: teardown });
   } catch (err) {
     logger.error('service.chat failed to start', { err });
     try {

--- a/services/chat/src/server.ts
+++ b/services/chat/src/server.ts
@@ -2,7 +2,7 @@
 // with the service name bound.
 
 import { createLogger } from '@adopt-dont-shop/observability';
-import { createMicroserviceServer } from '@adopt-dont-shop/service-bootstrap';
+import { createMicroserviceServer, type ReadinessDeps } from '@adopt-dont-shop/service-bootstrap';
 import type { FastifyInstance } from 'fastify';
 
 import type { ChatConfig } from './config.js';
@@ -18,6 +18,7 @@ export type CreateServerOptions = {
   // true. Defaults to () => true so existing call-sites compile
   // unchanged. index.ts flips a local boolean after gRPC binds.
   isReady?: () => boolean;
+  readiness?: ReadinessDeps;
 };
 
 export const createServer = (opts: CreateServerOptions): FastifyInstance => {
@@ -26,6 +27,7 @@ export const createServer = (opts: CreateServerOptions): FastifyInstance => {
     config: { environment: opts.config.environment },
     logger: opts.logger,
     isReady: opts.isReady,
+    readiness: opts.readiness,
   });
 };
 

--- a/services/cms/src/index.ts
+++ b/services/cms/src/index.ts
@@ -2,7 +2,10 @@ import { connect, type NatsConnection } from 'nats';
 
 import { createDbClient } from '@adopt-dont-shop/db';
 import { createLogger } from '@adopt-dont-shop/observability';
-import { runServiceShutdown } from '@adopt-dont-shop/service-bootstrap';
+import {
+  installProcessErrorHandlers,
+  runServiceShutdown,
+} from '@adopt-dont-shop/service-bootstrap';
 
 import { loadConfig } from './config.js';
 import { startGrpcServer, type RunningGrpcServer } from './grpc/server.js';
@@ -40,7 +43,12 @@ const main = async (): Promise<void> => {
       onError: (err, subject) => logger.error('gdpr erasure subscriber error', { subject, err }),
     });
 
-    const httpServer = createServer({ config, logger, isReady: () => grpcReady });
+    const httpServer = createServer({
+      config,
+      logger,
+      isReady: () => grpcReady,
+      readiness: { pool, nats },
+    });
     await httpServer.listen({ port: config.port, host: config.host });
 
     logger.info('service.cms running', {
@@ -51,14 +59,22 @@ const main = async (): Promise<void> => {
       environment: config.environment,
     });
 
+    const teardown = (): Promise<void> =>
+      runServiceShutdown({ httpServer, grpc, nats, pool, logger });
+
     const shutdown = async (signal: string): Promise<void> => {
       logger.info('service.cms shutting down', { signal });
-      await runServiceShutdown({ httpServer, grpc, nats, pool, logger });
+      await teardown();
       process.exit(0);
     };
 
     process.once('SIGTERM', () => void shutdown('SIGTERM'));
     process.once('SIGINT', () => void shutdown('SIGINT'));
+
+    // ADS-1040: last-resort handlers so an idle DB-pool 'error' event (or
+    // any stray rejection) drains via the same teardown and exits non-zero,
+    // instead of crashing the process undrained under `restart: always`.
+    installProcessErrorHandlers({ logger, onFatal: teardown });
   } catch (err) {
     logger.error('service.cms failed to start', { err });
     try {

--- a/services/cms/src/server.ts
+++ b/services/cms/src/server.ts
@@ -1,4 +1,4 @@
-import { createMicroserviceServer } from '@adopt-dont-shop/service-bootstrap';
+import { createMicroserviceServer, type ReadinessDeps } from '@adopt-dont-shop/service-bootstrap';
 import type { FastifyInstance } from 'fastify';
 
 import type { createLogger } from '@adopt-dont-shop/observability';
@@ -9,6 +9,7 @@ export type CreateServerOptions = {
   config: CmsConfig;
   logger?: ReturnType<typeof createLogger>;
   isReady?: () => boolean;
+  readiness?: ReadinessDeps;
 };
 
 export const createServer = (opts: CreateServerOptions): FastifyInstance => {
@@ -17,5 +18,6 @@ export const createServer = (opts: CreateServerOptions): FastifyInstance => {
     config: opts.config,
     logger: opts.logger,
     isReady: opts.isReady,
+    readiness: opts.readiness,
   });
 };

--- a/services/gateway/src/index.ts
+++ b/services/gateway/src/index.ts
@@ -3,7 +3,11 @@ import { connect, type NatsConnection } from 'nats';
 import type { Server as IOServer } from 'socket.io';
 
 import { createLogger } from '@adopt-dont-shop/observability';
-import { assertPrincipalVerificationConfig } from '@adopt-dont-shop/service-bootstrap';
+import {
+  assertPrincipalVerificationConfig,
+  installProcessErrorHandlers,
+  withShutdownDeadline,
+} from '@adopt-dont-shop/service-bootstrap';
 
 import { loadConfig } from './config.js';
 import { createApplicationsClient } from './grpc-clients/applications-client.js';
@@ -163,37 +167,55 @@ const main = async (): Promise<void> => {
       environment: config.environment,
     });
 
+    // ADS-1051: the gateway is the one process serving public HTTP *and*
+    // long-lived WebSockets, so io.close()/server.close() can block
+    // indefinitely. Race the whole teardown against runServiceShutdown's 25s
+    // deadline (→ process.exit(1)) so a rollout can't hang until SIGKILL,
+    // dropping connections, instead of draining.
+    const teardown = (): Promise<void> =>
+      withShutdownDeadline(
+        async () => {
+          try {
+            if (io) {
+              await new Promise<void>(resolve => io!.close(() => resolve()));
+            }
+          } catch (err) {
+            logger.error('socket.io close error', { err });
+          }
+          try {
+            socketAdapterPub?.disconnect();
+            socketAdapterSub?.disconnect();
+          } catch (err) {
+            logger.error('socket adapter redis close error', { err });
+          }
+          try {
+            await server.close();
+          } catch (err) {
+            logger.error('http close error', { err });
+          }
+          try {
+            await nats?.drain();
+          } catch (err) {
+            logger.error('nats drain error', { err });
+          }
+          closeGrpcClients(true);
+        },
+        { logger }
+      );
+
     const shutdown = async (signal: string): Promise<void> => {
       logger.info('service.gateway shutting down', { signal });
-      try {
-        if (io) {
-          await new Promise<void>(resolve => io!.close(() => resolve()));
-        }
-      } catch (err) {
-        logger.error('socket.io close error', { err });
-      }
-      try {
-        socketAdapterPub?.disconnect();
-        socketAdapterSub?.disconnect();
-      } catch (err) {
-        logger.error('socket adapter redis close error', { err });
-      }
-      try {
-        await server.close();
-      } catch (err) {
-        logger.error('http close error', { err });
-      }
-      try {
-        await nats?.drain();
-      } catch (err) {
-        logger.error('nats drain error', { err });
-      }
-      closeGrpcClients(true);
+      await teardown();
       process.exit(0);
     };
 
     process.once('SIGTERM', () => void shutdown('SIGTERM'));
     process.once('SIGINT', () => void shutdown('SIGINT'));
+
+    // ADS-1040: last-resort handlers so an idle DB-pool 'error' event (or any
+    // stray rejection) drains via the same teardown and exits non-zero,
+    // instead of crashing the process undrained under `restart: always`.
+    installProcessErrorHandlers({ logger, onFatal: teardown });
   } catch (err) {
     // Error's message/stack are non-enumerable — logging { err } serializes
     // to {} and hides the cause.

--- a/services/gateway/src/server.test.ts
+++ b/services/gateway/src/server.test.ts
@@ -70,6 +70,43 @@ describe('createServer — health endpoint', () => {
   });
 });
 
+describe('createServer — /health/ready readiness probe', () => {
+  it('is ready with no checks when NATS is not wired (tests / degraded boot)', async () => {
+    const server = await createServer({ config: baseConfig, logger: quietLogger });
+    try {
+      const res = await server.inject({ method: 'GET', url: '/health/ready' });
+      expect(res.statusCode).toBe(200);
+      expect(res.json()).toMatchObject({ status: 'ok', service: 'service.gateway', checks: {} });
+    } finally {
+      await server.close();
+    }
+  });
+
+  it('is ready when the NATS connection is open', async () => {
+    const nats = { isClosed: () => false } as unknown as import('nats').NatsConnection;
+    const server = await createServer({ config: baseConfig, logger: quietLogger, nats });
+    try {
+      const res = await server.inject({ method: 'GET', url: '/health/ready' });
+      expect(res.statusCode).toBe(200);
+      expect(res.json()).toMatchObject({ status: 'ok', checks: { nats: 'ok' } });
+    } finally {
+      await server.close();
+    }
+  });
+
+  it('returns 503 degraded when the NATS connection has closed', async () => {
+    const nats = { isClosed: () => true } as unknown as import('nats').NatsConnection;
+    const server = await createServer({ config: baseConfig, logger: quietLogger, nats });
+    try {
+      const res = await server.inject({ method: 'GET', url: '/health/ready' });
+      expect(res.statusCode).toBe(503);
+      expect(res.json()).toMatchObject({ status: 'degraded', checks: { nats: 'error' } });
+    } finally {
+      await server.close();
+    }
+  });
+});
+
 // Phase 11: the residual service.backend monolith is gone. Anything
 // under /api/* that isn't owned by an extracted service must 404 — no
 // silent fallthrough to a backend that doesn't exist.

--- a/services/gateway/src/server.ts
+++ b/services/gateway/src/server.ts
@@ -30,6 +30,7 @@ import {
   registerMetrics,
   registerRequestId,
 } from '@adopt-dont-shop/observability';
+import { registerReadinessRoute } from '@adopt-dont-shop/service-bootstrap';
 import cookie from '@fastify/cookie';
 import cors from '@fastify/cors';
 import helmet from '@fastify/helmet';
@@ -430,6 +431,17 @@ export const createServer = async (opts: CreateServerOptions): Promise<FastifyIn
     service: 'service.gateway',
     environment: config.environment,
   }));
+
+  // ADS-1046: dependency-aware readiness. NATS is the gateway's hard
+  // dependency (WebSocket fan-out to clients + GDPR erasure publish); the
+  // rate-limit Redis is deliberately degraded-tolerant (in-memory fallback),
+  // so its loss must NOT pull the gateway out of rotation and is excluded here.
+  registerReadinessRoute(server, {
+    serviceName: 'service.gateway',
+    environment: config.environment,
+    deps: { nats: opts.nats },
+    logger,
+  });
 
   // Authentication middleware runs as an onRequest hook on EVERY
   // request, BEFORE any route or the catch-all proxy. The order

--- a/services/matching/src/index.ts
+++ b/services/matching/src/index.ts
@@ -2,7 +2,10 @@ import { connect, type NatsConnection } from 'nats';
 
 import { createDbClient } from '@adopt-dont-shop/db';
 import { createLogger } from '@adopt-dont-shop/observability';
-import { runServiceShutdown } from '@adopt-dont-shop/service-bootstrap';
+import {
+  installProcessErrorHandlers,
+  runServiceShutdown,
+} from '@adopt-dont-shop/service-bootstrap';
 
 import { loadConfig } from './config.js';
 import { startGrpcServer, type RunningGrpcServer } from './grpc/server.js';
@@ -48,7 +51,12 @@ const main = async (): Promise<void> => {
       onError: (err, subject) => logger.error('gdpr erasure subscriber error', { subject, err }),
     });
 
-    const httpServer = createServer({ config, logger, isReady: () => grpcReady });
+    const httpServer = createServer({
+      config,
+      logger,
+      isReady: () => grpcReady,
+      readiness: { pool, nats },
+    });
     await httpServer.listen({ port: config.port, host: config.host });
 
     logger.info('service.matching running', {
@@ -59,14 +67,22 @@ const main = async (): Promise<void> => {
       environment: config.environment,
     });
 
+    const teardown = (): Promise<void> =>
+      runServiceShutdown({ httpServer, grpc, nats, pool, logger });
+
     const shutdown = async (signal: string): Promise<void> => {
       logger.info('service.matching shutting down', { signal });
-      await runServiceShutdown({ httpServer, grpc, nats, pool, logger });
+      await teardown();
       process.exit(0);
     };
 
     process.once('SIGTERM', () => void shutdown('SIGTERM'));
     process.once('SIGINT', () => void shutdown('SIGINT'));
+
+    // ADS-1040: last-resort handlers so an idle DB-pool 'error' event (or
+    // any stray rejection) drains via the same teardown and exits non-zero,
+    // instead of crashing the process undrained under `restart: always`.
+    installProcessErrorHandlers({ logger, onFatal: teardown });
   } catch (err) {
     logger.error('service.matching failed to start', { err });
     try {

--- a/services/matching/src/server.ts
+++ b/services/matching/src/server.ts
@@ -1,4 +1,4 @@
-import { createMicroserviceServer } from '@adopt-dont-shop/service-bootstrap';
+import { createMicroserviceServer, type ReadinessDeps } from '@adopt-dont-shop/service-bootstrap';
 import type { FastifyInstance } from 'fastify';
 
 import type { createLogger } from '@adopt-dont-shop/observability';
@@ -9,6 +9,7 @@ export type CreateServerOptions = {
   config: MatchingConfig;
   logger?: ReturnType<typeof createLogger>;
   isReady?: () => boolean;
+  readiness?: ReadinessDeps;
 };
 
 export const createServer = (opts: CreateServerOptions): FastifyInstance => {
@@ -17,6 +18,7 @@ export const createServer = (opts: CreateServerOptions): FastifyInstance => {
     config: opts.config,
     logger: opts.logger,
     isReady: opts.isReady,
+    readiness: opts.readiness,
   });
 };
 

--- a/services/moderation/src/index.ts
+++ b/services/moderation/src/index.ts
@@ -2,7 +2,10 @@ import { connect, type NatsConnection } from 'nats';
 
 import { createDbClient } from '@adopt-dont-shop/db';
 import { createLogger } from '@adopt-dont-shop/observability';
-import { runServiceShutdown } from '@adopt-dont-shop/service-bootstrap';
+import {
+  installProcessErrorHandlers,
+  runServiceShutdown,
+} from '@adopt-dont-shop/service-bootstrap';
 
 import { loadConfig } from './config.js';
 import { startGrpcServer, type RunningGrpcServer } from './grpc/server.js';
@@ -55,7 +58,12 @@ const main = async (): Promise<void> => {
     // connection on shutdown.
     registerSubscribers({ nats, deps: { pool, nats }, logger });
 
-    const httpServer = createServer({ config, logger, isReady: () => grpcReady });
+    const httpServer = createServer({
+      config,
+      logger,
+      isReady: () => grpcReady,
+      readiness: { pool, nats },
+    });
     await httpServer.listen({ port: config.port, host: config.host });
 
     logger.info('service.moderation running', {
@@ -66,14 +74,22 @@ const main = async (): Promise<void> => {
       environment: config.environment,
     });
 
+    const teardown = (): Promise<void> =>
+      runServiceShutdown({ httpServer, grpc, nats, pool, logger });
+
     const shutdown = async (signal: string): Promise<void> => {
       logger.info('service.moderation shutting down', { signal });
-      await runServiceShutdown({ httpServer, grpc, nats, pool, logger });
+      await teardown();
       process.exit(0);
     };
 
     process.once('SIGTERM', () => void shutdown('SIGTERM'));
     process.once('SIGINT', () => void shutdown('SIGINT'));
+
+    // ADS-1040: last-resort handlers so an idle DB-pool 'error' event (or
+    // any stray rejection) drains via the same teardown and exits non-zero,
+    // instead of crashing the process undrained under `restart: always`.
+    installProcessErrorHandlers({ logger, onFatal: teardown });
   } catch (err) {
     logger.error('service.moderation failed to start', { err });
     try {

--- a/services/moderation/src/server.ts
+++ b/services/moderation/src/server.ts
@@ -1,4 +1,4 @@
-import { createMicroserviceServer } from '@adopt-dont-shop/service-bootstrap';
+import { createMicroserviceServer, type ReadinessDeps } from '@adopt-dont-shop/service-bootstrap';
 import type { FastifyInstance } from 'fastify';
 
 import type { createLogger } from '@adopt-dont-shop/observability';
@@ -9,6 +9,7 @@ export type CreateServerOptions = {
   config: ModerationConfig;
   logger?: ReturnType<typeof createLogger>;
   isReady?: () => boolean;
+  readiness?: ReadinessDeps;
 };
 
 export const createServer = (opts: CreateServerOptions): FastifyInstance => {
@@ -17,6 +18,7 @@ export const createServer = (opts: CreateServerOptions): FastifyInstance => {
     config: opts.config,
     logger: opts.logger,
     isReady: opts.isReady,
+    readiness: opts.readiness,
   });
 };
 

--- a/services/notifications/src/index.ts
+++ b/services/notifications/src/index.ts
@@ -2,7 +2,10 @@ import { connect, type NatsConnection } from 'nats';
 
 import { createDbClient } from '@adopt-dont-shop/db';
 import { createLogger } from '@adopt-dont-shop/observability';
-import { runServiceShutdown } from '@adopt-dont-shop/service-bootstrap';
+import {
+  installProcessErrorHandlers,
+  runServiceShutdown,
+} from '@adopt-dont-shop/service-bootstrap';
 
 import { loadConfig } from './config.js';
 import { createAuthCohortClient } from './grpc/auth-client.js';
@@ -185,7 +188,12 @@ const main = async (): Promise<void> => {
         { logger }
       );
     }
-    const httpServer = createServer({ config, logger, isReady: () => grpcReady });
+    const httpServer = createServer({
+      config,
+      logger,
+      isReady: () => grpcReady,
+      readiness: { pool, nats },
+    });
     await httpServer.listen({ port: config.port, host: config.host });
 
     logger.info('service.notifications running', {
@@ -195,6 +203,9 @@ const main = async (): Promise<void> => {
       natsUrl: config.natsUrl,
       environment: config.environment,
     });
+
+    const teardown = (): Promise<void> =>
+      runServiceShutdown({ httpServer, grpc, nats, pool, logger });
 
     const shutdown = async (signal: string): Promise<void> => {
       logger.info('service.notifications shutting down', { signal });
@@ -219,12 +230,17 @@ const main = async (): Promise<void> => {
       } catch (err) {
         logger.error('scheduler stop error', { err });
       }
-      await runServiceShutdown({ httpServer, grpc, nats, pool, logger });
+      await teardown();
       process.exit(0);
     };
 
     process.once('SIGTERM', () => void shutdown('SIGTERM'));
     process.once('SIGINT', () => void shutdown('SIGINT'));
+
+    // ADS-1040: last-resort handlers so an idle DB-pool 'error' event (or
+    // any stray rejection) drains via the same teardown and exits non-zero,
+    // instead of crashing the process undrained under `restart: always`.
+    installProcessErrorHandlers({ logger, onFatal: teardown });
   } catch (err) {
     logger.error('service.notifications failed to start', { err });
     try {

--- a/services/notifications/src/server.ts
+++ b/services/notifications/src/server.ts
@@ -1,4 +1,4 @@
-import { createMicroserviceServer } from '@adopt-dont-shop/service-bootstrap';
+import { createMicroserviceServer, type ReadinessDeps } from '@adopt-dont-shop/service-bootstrap';
 import type { FastifyInstance } from 'fastify';
 
 import type { createLogger } from '@adopt-dont-shop/observability';
@@ -9,6 +9,7 @@ export type CreateServerOptions = {
   config: NotificationsConfig;
   logger?: ReturnType<typeof createLogger>;
   isReady?: () => boolean;
+  readiness?: ReadinessDeps;
 };
 
 export const createServer = (opts: CreateServerOptions): FastifyInstance => {
@@ -17,6 +18,7 @@ export const createServer = (opts: CreateServerOptions): FastifyInstance => {
     config: opts.config,
     logger: opts.logger,
     isReady: opts.isReady,
+    readiness: opts.readiness,
   });
 };
 

--- a/services/pets/src/index.ts
+++ b/services/pets/src/index.ts
@@ -2,7 +2,10 @@ import { connect, type NatsConnection } from 'nats';
 
 import { createDbClient } from '@adopt-dont-shop/db';
 import { createLogger } from '@adopt-dont-shop/observability';
-import { runServiceShutdown } from '@adopt-dont-shop/service-bootstrap';
+import {
+  installProcessErrorHandlers,
+  runServiceShutdown,
+} from '@adopt-dont-shop/service-bootstrap';
 
 import { loadConfig } from './config.js';
 import { startGrpcServer, type RunningGrpcServer } from './grpc/server.js';
@@ -47,7 +50,12 @@ const main = async (): Promise<void> => {
       onError: (err, subject) => logger.error('gdpr erasure subscriber error', { subject, err }),
     });
 
-    const httpServer = createServer({ config, logger, isReady: () => grpcReady });
+    const httpServer = createServer({
+      config,
+      logger,
+      isReady: () => grpcReady,
+      readiness: { pool, nats },
+    });
     await httpServer.listen({ port: config.port, host: config.host });
 
     logger.info('service.pets running', {
@@ -58,14 +66,22 @@ const main = async (): Promise<void> => {
       environment: config.environment,
     });
 
+    const teardown = (): Promise<void> =>
+      runServiceShutdown({ httpServer, grpc, nats, pool, logger });
+
     const shutdown = async (signal: string): Promise<void> => {
       logger.info('service.pets shutting down', { signal });
-      await runServiceShutdown({ httpServer, grpc, nats, pool, logger });
+      await teardown();
       process.exit(0);
     };
 
     process.once('SIGTERM', () => void shutdown('SIGTERM'));
     process.once('SIGINT', () => void shutdown('SIGINT'));
+
+    // ADS-1040: last-resort handlers so an idle DB-pool 'error' event (or
+    // any stray rejection) drains via the same teardown and exits non-zero,
+    // instead of crashing the process undrained under `restart: always`.
+    installProcessErrorHandlers({ logger, onFatal: teardown });
   } catch (err) {
     logger.error('service.pets failed to start', { err });
     try {

--- a/services/pets/src/server.ts
+++ b/services/pets/src/server.ts
@@ -1,4 +1,4 @@
-import { createMicroserviceServer } from '@adopt-dont-shop/service-bootstrap';
+import { createMicroserviceServer, type ReadinessDeps } from '@adopt-dont-shop/service-bootstrap';
 import type { FastifyInstance } from 'fastify';
 
 import type { createLogger } from '@adopt-dont-shop/observability';
@@ -9,6 +9,7 @@ export type CreateServerOptions = {
   config: PetsConfig;
   logger?: ReturnType<typeof createLogger>;
   isReady?: () => boolean;
+  readiness?: ReadinessDeps;
 };
 
 export const createServer = (opts: CreateServerOptions): FastifyInstance => {
@@ -17,6 +18,7 @@ export const createServer = (opts: CreateServerOptions): FastifyInstance => {
     config: opts.config,
     logger: opts.logger,
     isReady: opts.isReady,
+    readiness: opts.readiness,
   });
 };
 

--- a/services/rescue/src/index.ts
+++ b/services/rescue/src/index.ts
@@ -2,7 +2,10 @@ import { connect, type NatsConnection } from 'nats';
 
 import { createDbClient } from '@adopt-dont-shop/db';
 import { createLogger } from '@adopt-dont-shop/observability';
-import { runServiceShutdown } from '@adopt-dont-shop/service-bootstrap';
+import {
+  installProcessErrorHandlers,
+  runServiceShutdown,
+} from '@adopt-dont-shop/service-bootstrap';
 
 import { loadConfig } from './config.js';
 import { startGrpcServer, type RunningGrpcServer } from './grpc/server.js';
@@ -47,7 +50,12 @@ const main = async (): Promise<void> => {
       onError: (err, subject) => logger.error('gdpr erasure subscriber error', { subject, err }),
     });
 
-    const httpServer = createServer({ config, logger, isReady: () => grpcReady });
+    const httpServer = createServer({
+      config,
+      logger,
+      isReady: () => grpcReady,
+      readiness: { pool, nats },
+    });
     await httpServer.listen({ port: config.port, host: config.host });
 
     logger.info('service.rescue running', {
@@ -58,14 +66,22 @@ const main = async (): Promise<void> => {
       environment: config.environment,
     });
 
+    const teardown = (): Promise<void> =>
+      runServiceShutdown({ httpServer, grpc, nats, pool, logger });
+
     const shutdown = async (signal: string): Promise<void> => {
       logger.info('service.rescue shutting down', { signal });
-      await runServiceShutdown({ httpServer, grpc, nats, pool, logger });
+      await teardown();
       process.exit(0);
     };
 
     process.once('SIGTERM', () => void shutdown('SIGTERM'));
     process.once('SIGINT', () => void shutdown('SIGINT'));
+
+    // ADS-1040: last-resort handlers so an idle DB-pool 'error' event (or
+    // any stray rejection) drains via the same teardown and exits non-zero,
+    // instead of crashing the process undrained under `restart: always`.
+    installProcessErrorHandlers({ logger, onFatal: teardown });
   } catch (err) {
     logger.error('service.rescue failed to start', { err });
     try {

--- a/services/rescue/src/server.ts
+++ b/services/rescue/src/server.ts
@@ -1,4 +1,4 @@
-import { createMicroserviceServer } from '@adopt-dont-shop/service-bootstrap';
+import { createMicroserviceServer, type ReadinessDeps } from '@adopt-dont-shop/service-bootstrap';
 import type { FastifyInstance } from 'fastify';
 
 import type { createLogger } from '@adopt-dont-shop/observability';
@@ -9,6 +9,7 @@ export type CreateServerOptions = {
   config: RescueConfig;
   logger?: ReturnType<typeof createLogger>;
   isReady?: () => boolean;
+  readiness?: ReadinessDeps;
 };
 
 export const createServer = (opts: CreateServerOptions): FastifyInstance => {
@@ -17,6 +18,7 @@ export const createServer = (opts: CreateServerOptions): FastifyInstance => {
     config: opts.config,
     logger: opts.logger,
     isReady: opts.isReady,
+    readiness: opts.readiness,
   });
 };
 


### PR DESCRIPTION
## Summary

Bundles three **runtime-resilience** findings from the 2026-08 production-readiness review ([ADS-1039](https://linear.app/ideasquared/issue/ADS-1039)) that share the same boot/shutdown surface, so they land as one coherent change:

- **ADS-1040 (Critical)** — idle DB-pool errors and stray rejections no longer crash services.
- **ADS-1046 (High)** — a real dependency-aware `/health/ready` (DB/NATS/Redis), distinct from liveness.
- **ADS-1051 (Medium)** — the gateway's graceful shutdown is now bounded by a deadline.

## Changes

- **`packages/db`** — `buildPool` attaches a persistent `pool.on('error')` listener so an idle-client error (Postgres failover/restart/idle-reap) is delivered to a listener instead of re-thrown as an unhandled `'error'` (which terminates the process → crash-loop under `restart: always`).
- **`packages/service-bootstrap`** (new shared primitives):
  - `installProcessErrorHandlers()` — `uncaughtException`/`unhandledRejection` handlers that log the cause, drain via the service's existing teardown, and `exit(1)`.
  - `registerReadinessRoute()` / `checkReadiness()` — `/health/ready` probing DB (`SELECT 1`), NATS (`isClosed()`), Redis (`PING`) with a short per-probe timeout; returns `503 {status:'degraded'}` with a per-dependency breakdown when any is unreachable. Wired into `createMicroserviceServer`. `/health/simple` stays pure liveness.
  - `withShutdownDeadline()` — extracted from `runServiceShutdown` so bespoke teardowns can share the same 25s deadline race (→ `exit(1)`).
- **10 gRPC services** (`services/*/src/index.ts` + `server.ts`) — install the process handlers on the same teardown used for SIGTERM/SIGINT, and pass `{ pool, nats }` to `/health/ready`.
- **`services/gateway`** — adds `/health/ready` (NATS-only; its rate-limit Redis is deliberately degraded-tolerant, so its loss must not pull the gateway out of rotation), and routes the hand-rolled `io`/redis/http/nats/grpc-clients teardown through `withShutdownDeadline` + installs the process handlers.

**Scope boundary:** this changes application code only. Pointing the Docker `healthcheck` / `depends_on: service_healthy` boot gate at the new dependency-aware probe risks cross-service startup deadlocks, so that orchestrator rewiring is left to the deploy tickets (ADS-1045); the endpoint is now available for LB / readiness probes.

## Before requesting review

- [x] Ran the equivalent gates locally (`turbo type-check` + `turbo test:coverage` + `turbo lint` + `prettier --check`)
- [x] Tests for new behaviour added (TDD)
- [ ] If touching `.env` requirements, updated `.env.example`'s REQUIRED block — _n/a_
- [x] Considered consumer impact — touches `packages/*` + `services/*`; rebuilt and tested all consuming services

## Test plan

- [x] Existing tests pass — service-bootstrap (99), db (17), gateway (1091), plus the 10 gRPC services' `test:coverage` gates
- [x] New behaviour is covered by tests — readiness probe (healthy/degraded/timeout), process handlers (uncaught/rejection/teardown-throws/re-entrancy), `withShutdownDeadline`, pool error listener, gateway `/health/ready`
- [ ] Tested manually — _n/a (unit/integration only)_
- [x] No TypeScript errors — `turbo type-check` (23 tasks) green
- [x] Lint passes — `turbo lint` green (0 errors); gateway coverage 83.8/71.5/77.6/83.7 stays above its 82/70/76/82 gate

## Related

- Tracking: **ADS-1039** — Production Readiness Review (2026-08)
- **ADS-1040**, **ADS-1046**, **ADS-1051**

---
_Generated by [Claude Code](https://claude.ai/code/session_01639moQdBwbM99aMdsQ7CXK)_