### PR TITLE
docs(CLAUDE.md): fix handleGrpcError argument order

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -332,7 +332,7 @@ The gateway is the only HTTP edge. Every microservice (`auth`, `pets`, `applicat
 - Fastify plugins, one file per `/api/v1/<domain>` surface (`auth.ts`, `pets.ts`, …)
 - Validate request bodies with explicit Zod / TS-typed shapes
 - Build gRPC metadata via `buildMetadata(req)` (auth headers, request ID)
-- Translate gRPC errors via `handleGrpcError(reply, err)` so clients get the right HTTP status
+- Translate gRPC errors via `handleGrpcError(err, reply)` so clients get the right HTTP status
 - NO business logic — just REST → gRPC translation, rate-limiting, and OpenAPI schema
 
 **gRPC handlers** (`services/<name>/src/grpc/*-handlers.ts`):
@@ -377,7 +377,7 @@ export async function authRoutes(app: FastifyInstance, { client }: { client: Aut
       );
       return reply.code(200).send(res);
     } catch (err) {
-      return handleGrpcError(reply, err);
+      return handleGrpcError(err, reply);
     }
   });
 }


### PR DESCRIPTION
## Summary

Follow-up on #1280. Copilot's review on that PR caught two spots in the new Backend Patterns section where the doc showed `handleGrpcError(reply, err)` with the arguments swapped:

- `.claude/CLAUDE.md:335` — the bullet describing what gateway routes do
- `.claude/CLAUDE.md:380` — the accompanying Fastify route code example

The helper defined in `services/gateway/src/middleware/grpc-error.ts` is `handleGrpcError = (err: unknown, reply: FastifyReply)` — `err` first — and every production route calls it that way. The remaining two occurrences later in the file (API Error Handling section, lines 710 / 719) were already correct.

## Why it matters

Anyone following the swapped example would hit a TypeScript error at best (the mistyped `err` slot fails against `unknown` when TS sees a `FastifyReply` there), or an `err.code` lookup on a `FastifyReply` at runtime at worst. Since `.claude/CLAUDE.md` is loaded into every Claude session on the repo, keeping the sample wrong would keep teaching new work the wrong shape.

## Verification

- `grep -n handleGrpcError .claude/CLAUDE.md` — all four call/reference sites now read `(err, reply)`.
- Signature in `services/gateway/src/middleware/grpc-error.ts:67` confirmed: `export const handleGrpcError = (err: unknown, reply: FastifyReply): FastifyReply`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RaYKRmJpHHeaCupHKyWaTw)_