### PR TITLE
docs(skills): rewrite audit-logging and fix backend-endpoint audit references

### DIFF
--- a/.claude/skills/audit-logging/SKILL.md
+++ b/.claude/skills/audit-logging/SKILL.md
@@ -1,210 +1,213 @@
 ---
 name: audit-logging
 description: >
-  When and how to emit audit events in service.backend. Apply when working on any
-  service or route that creates, updates, or deletes user data, performs an
-  authentication action, or otherwise changes state that needs forensic record.
+  When and how to emit audit events in the microservices backend. Apply when
+  working on any gRPC handler or service action that creates, updates, or
+  deletes user data, performs an authentication action, or otherwise changes
+  state that needs a forensic record.
 ---
 
 # Audit Logging
 
-The backend separates **operational logs** (Layer 1 — `logger.*`) from **audit
-events** (Layer 2 — durable `audit_logs` table). This skill is about Layer 2.
+The backend separates **operational logs** (Layer 1 — `logger.*`) from
+**audit events** (Layer 2 — durable `audit.audit_events` table). This skill
+is about Layer 2.
 
 | | Layer 1 — `logger.*` | Layer 2 — audit |
 |---|---|---|
 | Purpose | Debugging, ops | Forensics: who did what to what |
-| Storage | console + files + Loki | `audit_logs` table + Loki |
+| Storage | console + files + Loki | `audit.audit_events` table (owned by `services/audit`) + Loki |
 | Mutable | Yes | No (immutable, append-only) |
-| How | `logger.info/warn/error` | `AuditLogService.log()` or `auditRoute()` |
+| How | `logger.info/warn/error` via `@adopt-dont-shop/observability` | `publish({ type: '<domain>.actionTaken', … })` inside `withTransaction` |
 
-## When to audit (Layer 2)
+## How the audit pipeline actually works
 
-Emit an audit row for any action a security/compliance reviewer would want to
-reconstruct months later:
+There is **no** `AuditLogService.log()` and **no** `auditRoute()` middleware.
+Every state-changing microservice publishes a `<domain>.actionTaken` NATS
+event from inside a `withTransaction` block; `services/audit` subscribes to
+the wildcard `*.actionTaken` subject and inserts every event into
+`audit.audit_events`. Idempotency is handled by the producer's NATS message
+id, so JetStream redeliveries collapse to `ON CONFLICT DO NOTHING` inserts.
 
-- Create / update / delete of business entities (users, pets, applications, rescues,
-  invitations, etc.)
+```
+handler
+  └── withTransaction(deps, ({ client, publish }) => {
+        client.query(...)                             ← DB write
+        publish({ type: 'pets.actionTaken', … })      ← NATS event (queued)
+      })
+        │  (commit succeeds)
+        ▼
+      NATS *.actionTaken
+        │
+        ▼
+      services/audit  ── INSERT INTO audit.audit_events (idempotent)
+```
+
+`withTransaction` (in `@adopt-dont-shop/events`) enforces **publish-after-
+commit**: it queues the event during the block and only sends it to NATS
+after `COMMIT` succeeds, so a rollback drops the event with no work needed.
+
+## When to audit
+
+Emit an audit row for any action a security / compliance reviewer would want
+to reconstruct months later:
+
+- Create / update / delete of business entities (users, pets, applications,
+  rescues, invitations, etc.)
 - Authentication events (login, logout, password reset, MFA changes)
 - Authorisation changes (role grant, permission change, suspension)
-- Sensitive reads (admin viewing a user's PII record) — use `audit: true` on `fieldMask`
+- Sensitive reads (admin viewing a user's PII record) — use `audit: true`
+  on the field-mask hook, which fans out into an `actionTaken` publish
 - Bulk operations, exports, data deletions
 
-Don't audit pure read-only endpoints unless they expose sensitive data. Don't audit
-health checks, static assets, or anything a system user couldn't act on.
+Don't audit pure read-only endpoints unless they expose sensitive data.
+Don't audit health checks, static assets, or anything a system user could
+not act on.
 
-## Decision rule: pick exactly ONE path
-
-```
-┌─────────────────────────────────────────────────────────────────────────┐
-│  Service runs the write inside a Sequelize transaction?                 │
-│  ──────────────────────────────────────────────────────────────────────│
-│   Yes  →  AuditLogService.log({..., transaction: t}) INSIDE the service │
-│   No   →  Background job / cron / consumer?                             │
-│             Yes →  AuditLogService.log(...) — no transaction needed     │
-│             No  →  Route-level CRUD?                                    │
-│                     Yes → auditRoute({...}) middleware                  │
-└─────────────────────────────────────────────────────────────────────────┘
-```
-
-**Never combine both.** `auditRoute()` fires AFTER `res.finish`, which is OUTSIDE
-the service transaction — combining produces duplicate rows and breaks atomicity.
-
-## Path A — Inside a service transaction (preferred for writes)
+## The canonical pattern (state-changing handler)
 
 ```typescript
-import sequelize from '../sequelize';
-import { AuditLogService } from './auditLog.service';
+// services/pets/src/grpc/pet-handlers.ts (illustrative)
+import { requirePermission, type Principal } from '@adopt-dont-shop/authz';
+import { withTransaction } from '@adopt-dont-shop/events';
 
-return sequelize.transaction(async t => {
-  const pet = await Pet.create(payload, { transaction: t });
+import type { HandlerDeps } from './handlers.js';
 
-  await AuditLogService.log({
-    userId: actorUserId,
-    action: 'CREATE',
-    entity: 'Pet',
-    entityId: pet.petId,
-    details: { name: pet.name, rescueId: pet.rescueId },
-    transaction: t,                     // ← critical — commits with the write
+export async function createPet(
+  deps: HandlerDeps,
+  principal: Principal,
+  req: { name: string; rescueId: string },
+) {
+  requirePermission(principal, 'pet.write');
+
+  const petId = randomUUID();
+
+  await withTransaction(deps, async ({ client, publish }) => {
+    await client.query(
+      `INSERT INTO pets.pets (pet_id, name, rescue_id, created_at, updated_at)
+       VALUES ($1, $2, $3, now(), now())`,
+      [petId, req.name, req.rescueId],
+    );
+
+    publish({
+      type: 'pets.actionTaken',
+      id: `pets.created.${petId}`,
+      payload: {
+        service: 'service.pets',
+        aggregateType: 'pet',
+        aggregateId: petId,
+        action: 'create',
+        actorUserId: principal.userId,
+        details: { name: req.name, rescueId: req.rescueId },
+      },
+    });
   });
 
-  return pet;
-});
+  return { petId };
+}
 ```
 
-`pet.service.ts:174`, `application.service.ts:524`, `invitation.service.ts`,
-`foster.service.ts`, `field-permission.service.ts` follow this pattern.
+Key points:
 
-## Path B — Route-level middleware (route does the write directly)
-
-For lightweight CRUD routes whose controllers don't open a service-level transaction.
-The middleware registers `res.on('finish')` and writes the audit row only on 2xx
-responses.
-
-```typescript
-import { auditRoute } from '../middleware/audit-route';
-
-router.put('/:petId',
-  petIdParam,
-  auditRoute({
-    action: 'APPLICATION_DRAFT_UPSERTED',
-    entity: 'ApplicationDraft',
-    entityIdFrom: 'params.petId',
-    metadataFrom: ['body.status'],          // optional extra details
-  }),
-  (req, res) => ApplicationDraftController.upsertDraft(req, res)
-);
-```
-
-`application-draft.routes.ts`, `cms.routes.ts`, `reports.routes.ts` use this.
-
-Trade-off: cannot share a transaction with the handler. Acceptable when the audit row
-is best-effort observation rather than transactional invariant.
-
-## Path C — Background job / cron / consumer
-
-No transaction needed because there's no HTTP request to scope to. Just call:
-
-```typescript
-await AuditLogService.log({
-  userId: 'system',
-  action: 'DATA_RETENTION_PURGE',
-  entity: 'User',
-  entityId: user.userId,
-  details: { reason: 'gdpr-retention-window-elapsed' },
-});
-```
+- The `publish()` call is inside the `withTransaction` callback — the event
+  only fires on commit.
+- `id` is the NATS message id and must be deterministic per action (so a
+  redelivery does not duplicate rows). A `<domain>.<action>.<aggregateId>`
+  string is the usual pattern; append a timestamp when the same aggregate
+  can legitimately fire the same action twice.
+- `payload` conforms to `AuditEventPayload` in
+  `services/audit/src/nats/event-types.ts`.
 
 ## Capturing before/after for UPDATEs
 
-For sensitive entity updates, record the diff so the audit row tells the full story.
-
-### Option 1 — Read previous row in the same transaction
+For sensitive entity updates, read the previous row inside the same
+transaction and record the diff — the audit row then tells the full story.
 
 ```typescript
-const before = await FieldPermission.findOne({ where: {...}, transaction: t });
-await record.update(changes, { transaction: t });
+await withTransaction(deps, async ({ client, publish }) => {
+  const { rows: [before] } = await client.query(
+    `SELECT name, description, updated_at FROM pets.pets
+     WHERE pet_id = $1 FOR UPDATE`,
+    [petId],
+  );
+  if (!before) throw new HandlerError('NOT_FOUND', 'pet not found');
 
-await AuditLogService.log({
-  userId: actorUserId,
-  action: 'UPDATE',
-  entity: 'FieldPermission',
-  entityId: record.id,
-  details: { before: before?.toJSON(), after: record.toJSON() },
-  transaction: t,
+  const after = { ...before, ...changes };
+  await client.query(
+    `UPDATE pets.pets SET name = $1, description = $2, updated_at = now()
+     WHERE pet_id = $3`,
+    [after.name, after.description, petId],
+  );
+
+  publish({
+    type: 'pets.actionTaken',
+    id: `pets.updated.${petId}.${before.updated_at.toISOString()}`,
+    payload: {
+      service: 'service.pets',
+      aggregateType: 'pet',
+      aggregateId: petId,
+      action: 'update',
+      actorUserId: principal.userId,
+      details: { before, after },
+    },
+  });
 });
 ```
 
-See `field-permission.service.ts upsert()`.
+There is no `diffSequelize` helper — services own their own SQL and pick
+the fields worth capturing.
 
-### Option 2 — diffSequelize helper
+## Action and aggregate naming
 
-For models you mutate with `instance.set()` before `instance.save()`:
+`action` is a lower-case domain verb: `create`, `update`, `delete`, `submit`,
+`approve`, `reject`, `suspend`, `verify`, `assign_role`, `invite`.
 
-```typescript
-import { diffSequelize } from '../utils/audit-diff';
+`aggregateType` is a lower-case singular noun matching the row's home
+concept: `pet`, `application`, `user`, `rescue`, `invitation`,
+`chat_message`.
 
-pet.set(changes);
-const delta = diffSequelize(pet, ['name', 'description', 'rescueId']);
-await pet.save({ transaction: t });
+`aggregateId` is the UUID as a string.
 
-await AuditLogService.log({
-  userId: actorUserId,
-  action: 'UPDATE',
-  entity: 'Pet',
-  entityId: pet.petId,
-  details: delta,
-  transaction: t,
-});
-```
-
-The allowlist prevents accidentally auditing internal fields.
-
-## Action and entity naming
-
-`action` is an UPPER_SNAKE_CASE verb phrase. Common values are in the
-`AuditLogAction` enum in `auditLog.service.ts`. Prefer the enum value; only add a new
-one with a clear domain reason.
-
-| Pattern | Example |
-|---------|---------|
-| Generic CRUD | `CREATE`, `UPDATE`, `DELETE` |
-| Auth | `LOGIN`, `LOGOUT`, `PASSWORD_RESET`, `EMAIL_VERIFICATION` |
-| Domain event | `RESCUE_VERIFIED`, `APPLICATION_APPROVED`, `STAFF_INVITED` |
-
-`entity` is PascalCase singular matching the model name: `User`, `Pet`, `Application`.
-
-`entityId` is the primary key as a string.
+`subject` on the NATS envelope is always `<service>.actionTaken` (e.g.
+`pets.actionTaken`, `applications.actionTaken`). The audit consumer
+subscribes to the wildcard `*.actionTaken`.
 
 ## PII and secrets
 
-`details` is redacted by the Winston logger config, but treat the column as durable
-storage. Never put:
+`details` is redacted by the Winston pipeline before it's logged to Loki,
+but the `audit.audit_events` row itself is durable storage. Never put:
 
 - Plain-text passwords, reset tokens, MFA secrets
-- Full credit card or bank account numbers
+- Full credit-card or bank-account numbers
 - Unredacted government IDs
 
-Capture identifiers (userId, email, last4) instead.
+Capture identifiers (`userId`, hashed email, last4) instead.
 
 ## Why not just `logger.info()`?
 
-`logger.info` writes to a rotated file + Loki. Logs are queryable for ops but:
+`logger.info` goes to console + files + Loki. Logs are queryable for ops but:
+
 - Get compacted away
 - Have no schema
 - Aren't a system-of-record for compliance
 
-`audit_logs` is the durable record. Use both layers — log for ops noise, audit for
-forensics.
+`audit.audit_events` is the durable record. Use both layers — log for ops
+noise, audit for forensics.
 
 ## Common mistakes
 
-- Forgetting `transaction: t` inside a service transaction → audit row commits even
-  if the business write rolls back
-- Using `auditRoute()` on a route whose service runs a transaction → duplicate rows,
-  one of them outside the tx
-- Auditing reads that aren't sensitive → noisy table, no value
-- Putting secrets in `details` → durable leak
-- Inventing new `action` values that overlap with existing ones (e.g. `USER_CREATED`
-  when `CREATE` + `entity: 'User'` already conveys it)
-- Skipping the `await` — fire-and-forget audit calls are silently dropped on error
+- **Publishing outside `withTransaction`** — the event fires even when the
+  DB write rolls back. Always `publish()` from inside the callback.
+- **Reusing the `id`** — if the id repeats, the audit consumer silently
+  drops the second row. Make the id deterministic per (aggregate, action,
+  moment).
+- **Writing straight to `audit.audit_events`** — that table is owned by
+  `services/audit` and no other service has grants against it. Publish the
+  NATS event instead.
+- **Auditing reads that aren't sensitive** — noisy table, no value.
+- **Putting secrets in `details`** — durable leak.
+- **Inventing new `action` verbs that overlap with existing ones** (e.g.
+  `user_created` when `create` + `aggregateType: 'user'` already conveys
+  it).
+- **Skipping `await`** — a fire-and-forget `withTransaction` is silently
+  dropped on error.

--- a/.claude/skills/backend-endpoint/SKILL.md
+++ b/.claude/skills/backend-endpoint/SKILL.md
@@ -103,15 +103,6 @@ export async function createThing(
     [thingId, req.name, req.description ?? null, principal.userId],
   );
 
-  // Audit (see the audit-logging skill for the full pattern).
-  await deps.audit.log({
-    actorUserId: principal.userId,
-    action: 'CREATE',
-    entity: 'Thing',
-    entityId: thingId,
-    details: { name: req.name },
-  });
-
   return { thing: { thingId, name: req.name, description: req.description ?? '' } };
 }
 ```
@@ -123,9 +114,12 @@ Key points:
 - `HandlerError` carries the gRPC status code + a human message; the
   gateway translates these to HTTP status codes via
   `handleGrpcError`.
-- Transactions: pull a client from the pool, `BEGIN` / `COMMIT` /
-  `ROLLBACK` explicitly. Read an existing multi-write handler
-  (e.g. service-rescue's invitation handlers) for the local pattern.
+- Transactions: wrap the write + any NATS event in
+  `withTransaction(deps, async ({ client, publish }) => { … })` from
+  `@adopt-dont-shop/events`. It commits + publishes atomically
+  (publish-after-commit). Read an existing state-changing handler
+  (e.g. `services/auth/src/grpc/handlers.ts` Login) for the local
+  pattern.
 - Permission checks beyond authentication go in the handler — the
   authz package's `Principal` carries the resolved roles.
 
@@ -225,13 +219,13 @@ The gateway exposes hooks for these:
 
 See the `audit-logging` skill for the full pattern. Quick rules:
 
-- Audit inside the gRPC handler when the action runs in a single
-  transaction with the DB write.
-- Audit at the gateway via the `auditRoute(...)` hook for read-only
-  / no-transaction CRUD routes that have nothing meaningful to do
-  inside a transaction.
-- **Never** combine both — it produces duplicate audit rows and
-  breaks transactional atomicity.
+- Emit audit inside the same `withTransaction` block that runs the DB
+  write, by calling `publish({ type: '<domain>.actionTaken', … })`.
+  The commit + the NATS event fire atomically (`services/audit`
+  subscribes to `*.actionTaken` and persists every row).
+- Publish exactly one `actionTaken` event per user-visible action.
+- Never emit from the gateway — the write lives in the microservice
+  and the audit row must commit with it.
 
 ## Step 6 — Write tests (TDD)
 
@@ -268,8 +262,8 @@ querystring schemas reflect the real shape so the generated
 - [ ] Gateway route in `services/gateway/src/routes/<domain>.ts`,
       registered in `server.ts`
 - [ ] Authentication / permission hook applied where appropriate
-- [ ] Audit hookup: inside the handler (transactional writes) OR via
-      `auditRoute()` on the gateway — never both
+- [ ] Audit hookup: `publish({ type: '<domain>.actionTaken', … })`
+      inside the same `withTransaction` block as the write
 - [ ] Field permissions wired if the resource is field-permissioned
 - [ ] Fastify `schema:` block populated for OpenAPI generation
 - [ ] Tests first, behaviour-focused
@@ -281,7 +275,8 @@ querystring schemas reflect the real shape so the generated
   before writing yours.
 - Skipping `handleGrpcError` and writing custom catch blocks per route
   — the helper centralises the gRPC-status → HTTP-status mapping.
-- Mixing audit-in-handler and audit-on-route — pick one per action.
+- Publishing an audit event outside the `withTransaction` block — the
+  event fires even if the DB write rolls back.
 - Forgetting to register the new route plugin in `server.ts` — the
   route never mounts and the SPA gets 404.
 - Using `app.get`/`app.post` without the type param (`<{ Body … }>`)


### PR DESCRIPTION
## Summary

Third batch of the documentation accuracy pass (after #1034 and #1280). Two Claude skill files still described the deleted Express + Sequelize monolith. Anything a Claude session pulls from these gets applied verbatim to new work, so the wrong guidance is the same as wrong code.

## Changes

### `.claude/skills/audit-logging/SKILL.md` — full rewrite

The skill described a two-path decision tree (`AuditLogService.log()` + `auditRoute()` middleware) that does not exist in the codebase. None of the referenced files exist either — `AuditLogService`, `auditRoute`, `auditLog.service.ts`, `pet.service.ts:174`, `application.service.ts:524`, `invitation.service.ts`, `foster.service.ts`, `field-permission.service.ts`, `application-draft.routes.ts`, `cms.routes.ts`, `reports.routes.ts`, `diffSequelize`, and the `audit_logs` table are all deleted. The old Sequelize `transaction: t`, `Pet.create(...)`, and `FieldPermission.findOne(...)` examples describe the deleted ORM.

Replaced with the actual pipeline that services use today:

- A state-changing handler publishes a `<domain>.actionTaken` NATS event from inside a `withTransaction` block (`@adopt-dont-shop/events`).
- `services/audit` subscribes to `*.actionTaken` and inserts into `audit.audit_events` (idempotent via the producer's NATS message id).
- The `AuditEventPayload` shape is the one exported from `services/audit/src/nats/event-types.ts`.

The new "canonical pattern" and "capturing before/after for UPDATEs" examples show `withTransaction` + `publish()` with real payload keys (`service`, `aggregateType`, `aggregateId`, `action`, `actorUserId`, `details`, deterministic `id`).

### `.claude/skills/backend-endpoint/SKILL.md` — audit-related fixes

The skill's overall Fastify gateway → gRPC handler shape was already correct. Fixed the three audit-related bits that still described deleted APIs:

- Removed the `deps.audit.log({ action: 'CREATE', entity: 'Thing', … })` call from the handler example — that method doesn't exist. Handlers emit audit via `publish()` inside `withTransaction`.
- Replaced the Step 2 "Transactions" bullet ("pull a client from the pool, BEGIN/COMMIT/ROLLBACK explicitly") with `withTransaction(deps, ({ client, publish }) => …)` from `@adopt-dont-shop/events`. Pointed at `services/auth/src/grpc/handlers.ts` Login as a real reference instead of "service-rescue's invitation handlers".
- Rewrote Step 5 (Audit), the conventions checklist, and the common-mistakes list to describe the `publish()` pattern. The "audit-in-handler vs audit-on-route, never both" split is gone — with the NATS pipeline the emit only happens in the handler, so the mistake to warn about is now "publishing outside the `withTransaction` block".

## Verification

- `grep -c 'AuditLogService\|auditRoute\|sequelize\|Sequelize' .claude/skills/audit-logging/SKILL.md` returns 2, and both are intentional callouts ("There is **no** `AuditLogService.log()` and **no** `auditRoute()` middleware.", "There is no `diffSequelize` helper").
- `grep -c 'auditRoute\|AuditLogService\|deps.audit' .claude/skills/backend-endpoint/SKILL.md` returns 0.
- Every file the skills now reference exists on disk: `packages/events/src/index.ts` (`withTransaction`, `WithTransactionDeps`), `services/audit/src/nats/event-types.ts` (`AuditEventPayload`), `services/audit/src/migrations/001_create_audit_events.ts` (`audit.audit_events`), `services/auth/src/grpc/handlers.ts`.

## Follow-up

Later batches still to cover the deleted-monolith references in the remaining skill files (`backend-test`, `db-migration`, `field-permissions`, `error-handling`, `docker-build`, `api-fetch`, `feature-flags`, `new-app`, `new-lib`) plus stale mentions in a few service READMEs.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RaYKRmJpHHeaCupHKyWaTw)_