### PR TITLE
fix(security): fail closed on unsigned principals in every deployed env (ADS-1050)

### DIFF
--- a/packages/service-bootstrap/src/principal.test.ts
+++ b/packages/service-bootstrap/src/principal.test.ts
@@ -223,37 +223,82 @@ describe('assertPrincipalVerificationConfig', () => {
     resetDefaultPrincipalSigningKeyForTests();
   };
 
-  it('does not throw when a signing key is configured (even in production)', () => {
-    withKey('a-signing-key-that-is-at-least-32-bytes');
-    expect(() => assertPrincipalVerificationConfig({ NODE_ENV: 'production' })).not.toThrow();
-  });
+  const STRONG_KEY = 'a-signing-key-that-is-at-least-32-bytes';
 
-  it('throws when the signing key is shorter than 32 bytes', () => {
-    withKey('too-short-key');
-    expect(() => assertPrincipalVerificationConfig({ NODE_ENV: 'production' })).toThrow(
-      InsecurePrincipalConfigError
+  describe('with a signing key configured (the secure path)', () => {
+    it.each(['development', 'test', 'staging', 'production', 'qa', ''])(
+      'does not throw for NODE_ENV=%j when a strong key is set',
+      NODE_ENV => {
+        withKey(STRONG_KEY);
+        expect(() => assertPrincipalVerificationConfig({ NODE_ENV })).not.toThrow();
+      }
     );
+
+    it('does not throw for an unset NODE_ENV when a strong key is set', () => {
+      withKey(STRONG_KEY);
+      expect(() => assertPrincipalVerificationConfig({})).not.toThrow();
+    });
+
+    it('throws when the signing key is shorter than 32 bytes', () => {
+      withKey('too-short-key');
+      expect(() => assertPrincipalVerificationConfig({ NODE_ENV: 'production' })).toThrow(
+        InsecurePrincipalConfigError
+      );
+    });
   });
 
-  it('throws in production when no key is set and no escape hatch', () => {
-    withKey(undefined);
-    expect(() => assertPrincipalVerificationConfig({ NODE_ENV: 'production' })).toThrow(
-      InsecurePrincipalConfigError
+  describe('without a signing key', () => {
+    it('allows unsigned header-trust in development', () => {
+      withKey(undefined);
+      expect(() => assertPrincipalVerificationConfig({ NODE_ENV: 'development' })).not.toThrow();
+    });
+
+    it('allows unsigned header-trust in test', () => {
+      withKey(undefined);
+      expect(() => assertPrincipalVerificationConfig({ NODE_ENV: 'test' })).not.toThrow();
+    });
+
+    // ADS-1050: the bug being fixed. A staging deploy without the key must NOT
+    // silently fall back to trusting forgeable x-user-* headers.
+    it('fails closed in staging', () => {
+      withKey(undefined);
+      expect(() => assertPrincipalVerificationConfig({ NODE_ENV: 'staging' })).toThrow(
+        InsecurePrincipalConfigError
+      );
+    });
+
+    it('fails closed in production', () => {
+      withKey(undefined);
+      expect(() => assertPrincipalVerificationConfig({ NODE_ENV: 'production' })).toThrow(
+        InsecurePrincipalConfigError
+      );
+    });
+
+    it.each(['qa', 'staging-2', 'PRODUCTION', ''])(
+      'fails closed for an unrecognised/empty NODE_ENV=%j (treated as deployed)',
+      NODE_ENV => {
+        withKey(undefined);
+        expect(() => assertPrincipalVerificationConfig({ NODE_ENV })).toThrow(
+          InsecurePrincipalConfigError
+        );
+      }
     );
-  });
 
-  it('allows production header-trust only with the explicit ALLOW_UNSIGNED_PRINCIPAL opt-in', () => {
-    withKey(undefined);
-    expect(() =>
-      assertPrincipalVerificationConfig({
-        NODE_ENV: 'production',
-        ALLOW_UNSIGNED_PRINCIPAL: 'true',
-      })
-    ).not.toThrow();
-  });
+    it('fails closed when NODE_ENV is unset (safe default)', () => {
+      withKey(undefined);
+      expect(() => assertPrincipalVerificationConfig({})).toThrow(InsecurePrincipalConfigError);
+    });
 
-  it('does not throw outside production when no key is set (dev / phased rollout)', () => {
-    withKey(undefined);
-    expect(() => assertPrincipalVerificationConfig({ NODE_ENV: 'development' })).not.toThrow();
+    // ADS-1050: ALLOW_UNSIGNED_PRINCIPAL was a second bypass — it could
+    // force-open production. It must no longer open ANY deployed environment.
+    it.each(['production', 'staging', 'qa'])(
+      'ALLOW_UNSIGNED_PRINCIPAL=true cannot force-open deployed NODE_ENV=%j',
+      NODE_ENV => {
+        withKey(undefined);
+        expect(() =>
+          assertPrincipalVerificationConfig({ NODE_ENV, ALLOW_UNSIGNED_PRINCIPAL: 'true' })
+        ).toThrow(InsecurePrincipalConfigError);
+      }
+    );
   });
 });

--- a/packages/service-bootstrap/src/principal.ts
+++ b/packages/service-bootstrap/src/principal.ts
@@ -27,12 +27,20 @@ export class InsecurePrincipalConfigError extends Error {
   }
 }
 
-// Boot-time guard (ADS-800 hardening). Without PRINCIPAL_SIGNING_KEY,
-// extractPrincipal falls back to trusting unsigned x-user-* headers — fine
-// for dev and the phased-rollout window, but in production a missing key
-// would silently let anything that can reach the service forge identity (the
-// real cross-service authz boundary). Fail closed in production unless the
-// operator explicitly opts into header-trust via ALLOW_UNSIGNED_PRINCIPAL.
+// Environments where trusting unsigned x-user-* headers (no PRINCIPAL_SIGNING_KEY)
+// is acceptable: only a developer's machine and the automated test run. Every
+// other value — staging, production, or anything unrecognised/empty — is a
+// deployed environment reachable by other actors and must fail closed.
+const HEADER_TRUST_ALLOWED_ENVS = new Set(['development', 'test']);
+
+// Boot-time guard (ADS-800 hardening, broadened in ADS-1050). Without
+// PRINCIPAL_SIGNING_KEY, extractPrincipal falls back to trusting unsigned
+// x-user-* headers. That is only safe for local development and the automated
+// test run; in any DEPLOYED environment a missing key would silently let
+// anything that can reach the service forge identity (e.g. x-user-roles: admin
+// — the real cross-service authz boundary). So we fail closed everywhere the
+// NODE_ENV is not development/test. An unset or unrecognised NODE_ENV is
+// treated as deployed — the safe default.
 export function assertPrincipalVerificationConfig(env: NodeJS.ProcessEnv = process.env): void {
   const key = getDefaultPrincipalSigningKey();
   if (key) {
@@ -46,16 +54,22 @@ export function assertPrincipalVerificationConfig(env: NodeJS.ProcessEnv = proce
     }
     return;
   }
-  const isProduction = env.NODE_ENV === 'production';
-  const allowUnsigned = env.ALLOW_UNSIGNED_PRINCIPAL === 'true';
-  if (isProduction && !allowUnsigned) {
-    throw new InsecurePrincipalConfigError(
-      'PRINCIPAL_SIGNING_KEY is required in production: without it the service trusts ' +
-        'unsigned x-user-* headers, which any client that can reach it could forge. ' +
-        'Set PRINCIPAL_SIGNING_KEY, or set ALLOW_UNSIGNED_PRINCIPAL=true to explicitly ' +
-        'accept header-trust (phased-rollout only).'
-    );
+  // No key. Only development/test may fall back to header-trust.
+  //
+  // ALLOW_UNSIGNED_PRINCIPAL is deliberately NOT consulted here: it used to
+  // force-open production (the second bypass ADS-1050 closes), and it must not
+  // be able to open ANY deployed environment. In development/test the fallback
+  // is already allowed, so the flag is now a no-op — tracked for full removal
+  // from env docs under ADS-1039.
+  const nodeEnv = env.NODE_ENV;
+  if (nodeEnv !== undefined && HEADER_TRUST_ALLOWED_ENVS.has(nodeEnv)) {
+    return;
   }
+  throw new InsecurePrincipalConfigError(
+    `PRINCIPAL_SIGNING_KEY is required outside development/test (NODE_ENV=${nodeEnv ?? '<unset>'}): ` +
+      'without it the service trusts unsigned x-user-* headers, which any client that can ' +
+      'reach it could forge. Set PRINCIPAL_SIGNING_KEY.'
+  );
 }
 
 // Verification config (ADS-800). When a signing key is present the


### PR DESCRIPTION
## Summary

- Broaden the boot-time principal header-trust guard (`assertPrincipalVerificationConfig`) so it **fails closed in every deployed environment**, not only when `NODE_ENV === 'production'` exactly.
- Fixes the reported bug: a **staging** deploy (`NODE_ENV=staging`) without `PRINCIPAL_SIGNING_KEY` silently fell back to trusting unsigned `x-user-*` headers, so an internal actor that could reach a service could forge `x-user-roles: admin`.
- Neutralise the `ALLOW_UNSIGNED_PRINCIPAL` escape hatch (the flagged second bypass) so it can no longer force-open a deployed environment.

## Changes

- **`packages/service-bootstrap/src/principal.ts`** — invert the guard from "is production → fail closed" to "is **not** development/test → fail closed". Only `development` and `test` may fall back to header-trust; `staging`, `production`, any unrecognised value, an empty string, and an **unset** `NODE_ENV` all now require the signing key and throw the existing `InsecurePrincipalConfigError` when it is absent (unset/unknown treated as deployed — the safe default). `ALLOW_UNSIGNED_PRINCIPAL` is no longer consulted, so it cannot force-open a deployed env; it is effectively a no-op now (dev/test already allow the fallback), with a code comment flagging it for full removal under ADS-1039.
- **`packages/service-bootstrap/src/principal.test.ts`** — extend the `assertPrincipalVerificationConfig` suite: dev/test without key allowed; **staging without key throws (the bug)**; production without key throws; unrecognised/empty/unset `NODE_ENV` without key throws; every env **with** a strong key allowed; and `ALLOW_UNSIGNED_PRINCIPAL=true` cannot open production/staging/qa. The one prior test asserting the now-closed production bypass was updated to assert the secure behaviour; all other existing tests preserved.

## Before requesting review

- [x] Tests for new behaviour added (TDD — red confirmed before the fix, then green)
- [x] No `.env` requirement changes in this PR (see follow-up on `ALLOW_UNSIGNED_PRINCIPAL` / `.env.example`)
- [x] Considered consumer impact: guard is invoked from `startGrpcServer` (all gRPC services) and gateway boot; behaviour only tightens for deployed envs that were already expected to set `PRINCIPAL_SIGNING_KEY`.

## Test plan

Run from the repo root against `@adopt-dont-shop/service-bootstrap` (this package has no coverage threshold):

- [x] `pnpm exec turbo run type-check --filter=@adopt-dont-shop/service-bootstrap` — pass
- [x] `cd packages/service-bootstrap && pnpm exec vitest run` — pass (7 files, 114 tests; was 99)
- [x] `pnpm exec turbo run lint --filter=@adopt-dont-shop/service-bootstrap` — pass (ESLint incl. prettier/prettier, after `prettier --write` on the changed files)

## Related

- ADS-1050 — broaden the principal header-trust guard to fail closed in every deployed environment (this PR).
- ADS-1039 — tracking issue.

### Deliberate follow-ups (out of scope here)

- **mTLS for inter-service gRPC** — the other half of the ticket. This is infrastructure, not application code, and is intentionally **not** implemented here; it should be tracked as a dedicated follow-up.
- **Retire `ALLOW_UNSIGNED_PRINCIPAL`** — the flag is now inert. Removing the env var and its mention in docs (e.g. `docs/backbone-infra-review.md`, which still describes the old "escape hatch" behaviour) is left for a dedicated cleanup under ADS-1039 to keep this change surgical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01639moQdBwbM99aMdsQ7CXK)_