### PR TITLE
chore(config): remove dead env knobs METRICS_AUTH_TOKEN, DEBUG_ERRORS, FORCE_SEED (ADS-1056)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -138,16 +138,7 @@ UPLOAD_DIR=./uploads
 # -----------------------------------------------------------------------------
 # Development options
 # -----------------------------------------------------------------------------
-# Force database seeding on startup (dev/test only — wipes + reseeds DB on
-# every boot). Ignored when NODE_ENV=production.
-FORCE_SEED=false
-
 # Password assigned to every seeded user. If unset, the seeder generates a
 # random password once and prints it to stdout.
 SEED_PASSWORD=DevPassword123!
-
-# ADS-512: include raw error messages in API responses. NEVER set to true
-# in production — startup validation refuses to boot with
-# DEBUG_ERRORS=true while NODE_ENV=production.
-DEBUG_ERRORS=false
 # =============================================================================

--- a/docs/env-reference.md
+++ b/docs/env-reference.md
@@ -335,10 +335,6 @@ LEGAL_REMINDER_CRON_DRY_RUN=false
 ## Metrics / Observability
 
 ```env
-# Bearer token required on GET /metrics (Prometheus scrape). Leave unset
-# to disable auth in dev; required in production (route 404s without it).
-# METRICS_AUTH_TOKEN=CHANGE_THIS_METRICS_BEARER_TOKEN
-
 # ADS-660: OpenTelemetry distributed tracing. When unset, the SDK does
 # NOT start — the backend boots without traces and only the W3C
 # traceparent scaffold runs. Set the endpoint to ship spans to a
@@ -413,11 +409,6 @@ EXPOSE_API_DOCS=true
 # WATCHPACK_POLLING=true
 ```
 
-`DEBUG_ERRORS=false` (in `.env.example`) includes raw error messages in API
-responses when `true` — ADS-512: **never** set `true` in production;
-startup validation refuses to boot with `DEBUG_ERRORS=true` while
-`NODE_ENV=production`.
-
 ## Seeder demo data (dev/test only)
 
 ```env
@@ -447,4 +438,3 @@ Before deploying to production, ensure you have:
 - Enabled HTTPS for all frontend URLs
 - Set `NODE_ENV=production`
 - Reviewed and limited rate limiting settings
-- Disabled debug logging / errors (`DEBUG_ERRORS=false`)

--- a/docs/runbooks/5xx-spike.md
+++ b/docs/runbooks/5xx-spike.md
@@ -15,8 +15,7 @@
 # 1. Confirm the alert is still firing (not a stale page).
 #    The gateway exposes only the http_request_duration_seconds histogram
 #    (no http_requests_total counter). Grep the histogram's _count series.
-curl -s -H "Authorization: Bearer $METRICS_AUTH_TOKEN" \
-  https://${PROD_HOSTNAME}/metrics \
+curl -s https://${PROD_HOSTNAME}/metrics \
   | grep -E '^http_request_duration_seconds_count{.*status_code="5'
 
 # 2. Which routes are bleeding? (last 30m of gateway access logs)

--- a/packages/lib.validation/src/schemas/env.test.ts
+++ b/packages/lib.validation/src/schemas/env.test.ts
@@ -8,10 +8,9 @@ import {
 } from './env';
 
 // ADS-707: regression coverage for the shared env schema. These tests pin
-// the public contract that the backend boot validator + CLI gate both
-// depend on. Per-environment refinement logic (production-only checks,
-// db-name choice) is still owned by the backend validator, not this
-// schema, so it is exercised there.
+// the public contract the CLI env gate depends on, including the
+// production-only refinements (productionOnlyCheck / validateEnv) that this
+// module layers on top of the base schema.
 
 const STRONG_SECRET = 'A'.repeat(40);
 const STRONG_SECRET_B = 'B'.repeat(40);

--- a/packages/lib.validation/src/schemas/env.test.ts
+++ b/packages/lib.validation/src/schemas/env.test.ts
@@ -10,8 +10,8 @@ import {
 // ADS-707: regression coverage for the shared env schema. These tests pin
 // the public contract that the backend boot validator + CLI gate both
 // depend on. Per-environment refinement logic (production-only checks,
-// DEBUG_ERRORS gates, db-name choice) is still owned by the backend
-// validator, not this schema, so it is exercised there.
+// db-name choice) is still owned by the backend validator, not this
+// schema, so it is exercised there.
 
 const STRONG_SECRET = 'A'.repeat(40);
 const STRONG_SECRET_B = 'B'.repeat(40);
@@ -384,14 +384,6 @@ describe('validateEnv', () => {
       expect(errorPaths(result)).toContain('STATSIG_SERVER_SECRET_KEY');
     });
 
-    it('errors when DEBUG_ERRORS=true in production', () => {
-      const env = validProdEnv();
-      env.DEBUG_ERRORS = 'true';
-      const result = validateEnv(env);
-      expect(errorPaths(result)).toContain('DEBUG_ERRORS');
-      expect(errorMessages(result)).toContain('not allowed in production');
-    });
-
     it('warns when BCRYPT_ROUNDS is below 12 in production', () => {
       const env = validProdEnv();
       env.BCRYPT_ROUNDS = '10';
@@ -421,13 +413,13 @@ describe('validateEnv', () => {
     it('separates errors and warnings by level', () => {
       const env = validProdEnv();
       env.BCRYPT_ROUNDS = '4'; // warning
-      env.DEBUG_ERRORS = 'true'; // error
+      env.CORS_ORIGIN = undefined; // error
       const result = validateEnv(env);
       expect(result.ok).toBe(false);
       expect(result.errors.every((e) => e.level === 'error')).toBe(true);
       expect(result.warnings.every((w) => w.level === 'warning')).toBe(true);
       expect(result.warnings.map((w) => w.path)).toContain('BCRYPT_ROUNDS');
-      expect(result.errors.map((e) => e.path)).toContain('DEBUG_ERRORS');
+      expect(result.errors.map((e) => e.path)).toContain('CORS_ORIGIN');
     });
 
     it('accepts an alternate valid ENCRYPTION_KEY (mixed case hex)', () => {

--- a/packages/lib.validation/src/schemas/env.ts
+++ b/packages/lib.validation/src/schemas/env.ts
@@ -60,8 +60,8 @@ export const envCorsOriginField = z.string().refine(
 
 /**
  * Base schema — applied to every environment. Per-environment refinements
- * (production-only requirements, etc.) live in the
- * backend validator next to the issue formatter.
+ * (production-only requirements, etc.) are layered on top of this base by
+ * productionOnlyCheck / validateEnv in this module.
  */
 export const envBaseSchema = z.object({
   NODE_ENV: z.enum(['development', 'test', 'production']),

--- a/packages/lib.validation/src/schemas/env.ts
+++ b/packages/lib.validation/src/schemas/env.ts
@@ -60,7 +60,7 @@ export const envCorsOriginField = z.string().refine(
 
 /**
  * Base schema — applied to every environment. Per-environment refinements
- * (production-only requirements, DEBUG_ERRORS gates, etc.) live in the
+ * (production-only requirements, etc.) live in the
  * backend validator next to the issue formatter.
  */
 export const envBaseSchema = z.object({
@@ -106,9 +106,6 @@ export const envBaseSchema = z.object({
   WORKER_ENABLED: booleanString('WORKER_ENABLED').optional(),
   BCRYPT_ROUNDS: numericString('BCRYPT_ROUNDS').optional(),
 
-  // ADS-512: DEBUG_ERRORS is allowed only outside production. Refined below.
-  DEBUG_ERRORS: booleanString('DEBUG_ERRORS').optional(),
-
   // Per-environment DB names — refined below.
   DEV_DB_NAME: z.string().optional(),
   TEST_DB_NAME: z.string().optional(),
@@ -129,7 +126,6 @@ export const envBaseSchema = z.object({
   SMS_PROVIDER: z.enum(['console', 'twilio']).optional(),
   PUSH_PROVIDER: z.enum(['console', 'fcm']).optional(),
   EMAIL_PROVIDER: z.enum(['console', 'ethereal', 'resend']).optional(),
-  METRICS_AUTH_TOKEN: z.string().optional(),
   SENTRY_DSN: z.string().optional(),
   ANON_SWIPE_LIMIT: numericString('ANON_SWIPE_LIMIT').optional(),
 });
@@ -278,16 +274,6 @@ const productionOnlyCheck = (env: EnvMap): ValidationIssue[] => {
       message:
         'STATSIG_SERVER_SECRET_KEY is required in production — missing key silently disables ' +
         'all server-side feature flags',
-      level: 'error',
-    });
-  }
-
-  // ADS-512: DEBUG_ERRORS leaks raw error messages to clients — never allow in prod.
-  if (env.DEBUG_ERRORS === 'true') {
-    issues.push({
-      path: 'DEBUG_ERRORS',
-      message:
-        'DEBUG_ERRORS=true is not allowed in production (leaks raw error messages to clients)',
       level: 'error',
     });
   }


### PR DESCRIPTION
## Summary

- Removes three documented env knobs that **nothing reads at runtime**, so they no longer mislead operators: `METRICS_AUTH_TOKEN`, `DEBUG_ERRORS`, `FORCE_SEED`.
- Drops the false claim that `DEBUG_ERRORS` gates raw error messages / "refuses to boot in production" — that behaviour only existed as a schema refinement guarding a value no service consumes.
- Leaves read-replica routing (`READ_DATABASE_URL`) untouched — it is a real, tested `@adopt-dont-shop/db` feature, just not yet wired into service configs.

## Deadness verification (Step 1)

Grepped the whole repo (`services/`, `packages/`, `apps/`, `scripts/`, `docker-compose*.yml`, `deploy/`, `.github/`) for real runtime reads — `process.env.X`, `config.x`, schema-derived accessors. Declarations in the schema and mentions in `.env.example`/docs do **not** count.

| Var | Runtime reads found | Verdict |
| --- | --- | --- |
| `METRICS_AUTH_TOKEN` | None. Only the `env.ts` schema declaration + doc mentions. No `/metrics` route reads it — the microservices expose an **unauthenticated** `/metrics` endpoint (`packages/observability/src/metrics.ts`, per `docs/slo.md`). | Dead → removed |
| `FORCE_SEED` | None. Only `.env.example`. Not even declared in the schema. No seeder reads it (only `SEED_PASSWORD` is read, in `services/auth/src/db/seed-data.ts`). | Dead → removed |
| `DEBUG_ERRORS` | Only read inside the env schema's **own** production refinement (`env.ts` `productionOnlyCheck`) + its tests. No service reads it to change error output — the "include raw error messages in API responses" feature does not exist. | Dead → removed |

**Note on the `DEBUG_ERRORS` "refuses to boot" claim:** the ticket states that behaviour "does not exist." Strictly, it *did* exist — as the schema refinement that rejected `DEBUG_ERRORS=true` in production. But that refinement was the only consumer of the value and it guarded a non-existent feature (nothing else reads `DEBUG_ERRORS`), so it was a self-referential validation with no real effect on the app. Removing the knob **and** its refinement eliminates the misleading guard and makes the removed docs claim accurate.

## Read-replica routing (Step 3)

`READ_DATABASE_URL` is **not** currently in `.env.example`, and the `@adopt-dont-shop/db` read-replica support + its ADR (`docs/adr/0004-postgres-read-replica-routing.md`) already document it accurately as optional/not-yet-wired. The surgical choice was therefore to **leave it untouched** — no schema, `.env.example`, or `packages/db` changes. Nothing about the feature is removed.

## Changes

- `packages/lib.validation/src/schemas/env.ts` — removed the `METRICS_AUTH_TOKEN` and `DEBUG_ERRORS` schema entries and the `DEBUG_ERRORS` production refinement; updated a stale comment.
- `packages/lib.validation/src/schemas/env.test.ts` — removed the `DEBUG_ERRORS`-in-production test; retargeted the "separates errors and warnings by level" test's error case to `CORS_ORIGIN`; updated a stale comment.
- `.env.example` — removed the `FORCE_SEED` and `DEBUG_ERRORS` blocks (incl. the false "refuses to boot" comment). `SEED_PASSWORD` kept.
- `docs/env-reference.md` — removed the `METRICS_AUTH_TOKEN` block, the `DEBUG_ERRORS` paragraph, and the `DEBUG_ERRORS` production-checklist item.
- `docs/runbooks/5xx-spike.md` — dropped the dead `Authorization: Bearer $METRICS_AUTH_TOKEN` header from the `/metrics` curl (endpoint is unauthenticated), so the on-call runbook is accurate.

**Docs deliberately left as-is** (historical / already-correct): `docs/observability-alerting.md` and `docs/backend/service-backend-prd.md` describe the deleted monolith (the former is explicitly superseded by `docs/slo.md`); `docs/slo.md` and `infra/prometheus/rules/README.md` reference `METRICS_AUTH_TOKEN` only to state it does **not** exist in the current stack — useful deadness signals, not misleading.

## Before requesting review

- [x] Tests for changed behaviour updated (env schema regression suite)
- [x] Touching `.env` requirements → updated `.env.example`
- [x] `lib.*` consumer impact considered — `EnvVars` is defined only in `env.ts` and imported nowhere else; repo-wide type-check is green.

## Test plan

- [x] `pnpm exec turbo run type-check --filter=@adopt-dont-shop/lib.validation` → pass
- [x] `cd packages/lib.validation && pnpm exec vitest run --coverage` → 228 passed; coverage stmts 95.51/93, branches 94.05/90, funcs 83.33/77, lines 96.41/94 (all thresholds cleared)
- [x] `pnpm exec turbo run lint --filter=@adopt-dont-shop/lib.validation` → pass (0 errors; 6 pre-existing warnings in untouched files)
- [x] `pnpm exec turbo run type-check` (whole repo) → 82/82 pass — no consumer references the removed fields
- [x] `pnpm build:libs` → 24/24 succeed
- [x] `pnpm exec prettier --check` on changed `.md`/`.ts` files → clean

## Screenshots / recordings

N/A — config/docs only.

## Related

- ADS-1056 — remove dead config knobs that mislead operators
- ADS-1039 — tracking

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01639moQdBwbM99aMdsQ7CXK)_