### PR TITLE
fix(gateway): set cookies and strip tokens from the register response body (ADS-1057)

### DIFF
--- a/services/gateway/src/routes/auth.test.ts
+++ b/services/gateway/src/routes/auth.test.ts
@@ -10,6 +10,7 @@ import {
   type LoginResponse,
   type LogoutResponse,
   type RefreshTokenResponse,
+  type RegisterResponse,
 } from '@adopt-dont-shop/proto';
 
 import type { AuthClient } from '../grpc-clients/auth-client.js';
@@ -114,6 +115,27 @@ const LOGIN_RES: LoginResponse = {
     userType: AuthV1.UserRole.USER_ROLE_ADOPTER,
     status: AuthV1.UserStatus.USER_STATUS_ACTIVE,
     emailVerified: true,
+    phoneVerified: false,
+    twoFactorEnabled: false,
+    createdAt: '2026-01-01T00:00:00Z',
+    updatedAt: '2026-01-01T00:00:00Z',
+  },
+  tokens: {
+    accessToken: 'a.jwt',
+    refreshToken: 'r.jwt',
+    accessExpiresAt: '2026-06-05T18:30:00Z',
+    refreshExpiresAt: '2026-07-05T18:00:00Z',
+  },
+  permissions: ['pets.read'],
+};
+
+const REGISTER_RES: RegisterResponse = {
+  user: {
+    userId: 'usr-1',
+    email: 'a@example.com',
+    userType: AuthV1.UserRole.USER_ROLE_ADOPTER,
+    status: AuthV1.UserStatus.USER_STATUS_ACTIVE,
+    emailVerified: false,
     phoneVerified: false,
     twoFactorEnabled: false,
     createdAt: '2026-01-01T00:00:00Z',
@@ -543,6 +565,79 @@ describe('auth account-lifecycle routes', () => {
         privacyPolicyAccepted: true,
         userAgent: 'vitest',
       });
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('POST /auth/register sets the token pair as httpOnly cookies plus a JS-readable session marker (ADS-1057)', async () => {
+    const m = makeClient();
+    const app = await makeApp(m.client);
+    try {
+      m.registerMock.mockResolvedValueOnce(REGISTER_RES);
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/v1/auth/register',
+        payload: {
+          email: 'a@example.com',
+          password: 'longenoughpw',
+          firstName: 'A',
+          lastName: 'B',
+          termsAccepted: true,
+          privacyPolicyAccepted: true,
+        },
+      });
+
+      expect(res.statusCode).toBe(201);
+      const byName = Object.fromEntries(res.cookies.map(c => [c.name, c]));
+
+      expect(byName.accessToken?.value).toBe('a.jwt');
+      expect(byName.accessToken?.httpOnly).toBe(true);
+      expect(byName.accessToken?.path).toBe('/');
+
+      expect(byName.refreshToken?.value).toBe('r.jwt');
+      expect(byName.refreshToken?.httpOnly).toBe(true);
+      expect(byName.refreshToken?.path).toBe('/api/v1/auth');
+
+      expect(byName.hasSession?.value).toBe('1');
+      expect(byName.hasSession?.httpOnly).toBeFalsy();
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('POST /auth/register never returns the token pair in the JSON body (ADS-1057)', async () => {
+    const m = makeClient();
+    const app = await makeApp(m.client);
+    try {
+      m.registerMock.mockResolvedValueOnce(REGISTER_RES);
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/v1/auth/register',
+        payload: {
+          email: 'a@example.com',
+          password: 'longenoughpw',
+          firstName: 'A',
+          lastName: 'B',
+          termsAccepted: true,
+          privacyPolicyAccepted: true,
+        },
+      });
+
+      expect(res.statusCode).toBe(201);
+      // ADS-1057: the token pair rides home as httpOnly cookies, never in the
+      // JSON body — the tokens are stripped explicitly, not left to the
+      // response schema, so a schema change can't reintroduce the leak.
+      const body = res.json() as {
+        user?: { email?: string };
+        tokens?: unknown;
+        accessToken?: unknown;
+        refreshToken?: unknown;
+      };
+      expect(body.user?.email).toBe('a@example.com');
+      expect(body.tokens).toBeUndefined();
+      expect(body.accessToken).toBeUndefined();
+      expect(body.refreshToken).toBeUndefined();
     } finally {
       await app.close();
     }

--- a/services/gateway/src/routes/auth.ts
+++ b/services/gateway/src/routes/auth.ts
@@ -526,8 +526,6 @@ export const registerAuthRoutes = async (
                   status: { type: 'string' },
                 },
               },
-              accessToken: { type: 'string' },
-              refreshToken: { type: 'string' },
             },
           },
           400: {
@@ -562,8 +560,19 @@ export const registerAuthRoutes = async (
           },
           buildMetadata(req)
         );
-        const json = AuthV1.RegisterResponse.toJSON(res) as Record<string, unknown>;
-        return reply.code(201).send(withApiUser(json, res.user));
+        // ADS-1057: mirror /auth/login (ADS-919) — the freshly-minted token
+        // pair rides home as httpOnly cookies and is stripped from the JSON
+        // body explicitly, so a response-schema change can't silently
+        // reintroduce a token-in-body leak.
+        if (res.tokens) {
+          setAuthCookies(req, reply, res.tokens);
+        }
+        const json = AuthV1.RegisterResponse.toJSON(res) as Record<string, unknown> & {
+          tokens?: unknown;
+        };
+        const { tokens, ...jsonWithoutTokens } = json;
+        void tokens;
+        return reply.code(201).send(withApiUser(jsonWithoutTokens, res.user));
       } catch (err) {
         return handleGrpcError(err, reply);
       }


### PR DESCRIPTION
## Summary

- `/auth/register` relied on Fastify response-schema serialization to drop the access/refresh token pair from the JSON body, rather than removing it explicitly — a future schema change could silently reintroduce a token-in-body leak.
- Mirror the hardened `/auth/login` handler (ADS-919): on success, set the issued token pair as httpOnly cookies via `setAuthCookies` and explicitly strip the tokens from the response body so they can never appear in JSON regardless of the response schema.

## Changes

- `services/gateway/src/routes/auth.ts` — in the `/auth/register` success path, call `setAuthCookies(req, reply, res.tokens)` when tokens are present, then destructure/omit `tokens` from the `toJSON` output before sending (same helper, same shape as login). Dropped the now-dead `accessToken`/`refreshToken` fields from the 201 response schema.
- `services/gateway/src/routes/auth.test.ts` — added two tests mirroring the login cookie test: register sets the httpOnly `accessToken`/`refreshToken` cookies plus the JS-readable `hasSession` marker, and the register JSON body contains no token fields (`tokens`, `accessToken`, `refreshToken` all undefined).

## Before requesting review

- [x] Tests for new behaviour added (TDD)
- [ ] If touching `.env` requirements, updated `.env.example`'s REQUIRED block (n/a)
- [ ] If touching a `lib.*`, considered consumer impact (n/a)

## Test plan

- [x] Existing tests pass — `cd services/gateway && pnpm run test:coverage`: 76 files, 1093 tests passed; thresholds held (statements 83.79% / branches 71.55% / functions 77.55% / lines 83.67%)
- [x] New behaviour is covered by tests
- [x] No TypeScript errors — `pnpm exec turbo run type-check --filter=@adopt-dont-shop/service.gateway`
- [x] Lint passes — `pnpm exec turbo run lint --filter=@adopt-dont-shop/service.gateway`

## Related

- Implements the `/auth/register` item of ADS-1057 (token-body fragility), tracked under ADS-1039.
- Scoped to the gateway only. The frontend items are a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01639moQdBwbM99aMdsQ7CXK)_