### PR TITLE
fix(auth): drop the redundant users.email index (ADS-1054)

### DIFF
--- a/services/auth/src/migrations/029_drop_redundant_email_index.ts
+++ b/services/auth/src/migrations/029_drop_redundant_email_index.ts
@@ -1,0 +1,16 @@
+import type { MigrationBuilder } from 'node-pg-migrate';
+
+// ADS-1054: auth.users.email carried two identical unique btree indexes.
+// The column-level `unique: true` in 001_create_users.ts already backs the
+// email uniqueness with the constraint index `users_email_key`; the explicit
+// `createIndex('users', 'email', { name: 'users_email_unique', unique: true })`
+// on the same single `email` column duplicated it exactly (same column, same
+// uniqueness, same method). Drop the redundant standalone index — the column
+// constraint (`users_email_key`) still enforces uniqueness.
+export const up = async (pgm: MigrationBuilder): Promise<void> => {
+  pgm.dropIndex('users', 'email', { name: 'users_email_unique' });
+};
+
+export const down = async (pgm: MigrationBuilder): Promise<void> => {
+  pgm.createIndex('users', 'email', { name: 'users_email_unique', unique: true });
+};


### PR DESCRIPTION
## Summary

- `auth.users.email` carried **two identical unique btree indexes**. The column-level `unique: true` in `001_create_users.ts` already backs email uniqueness with the constraint index `users_email_key`; a separate explicit `createIndex(... name: 'users_email_unique', unique: true)` on the *same single column* duplicated it exactly.
- This PR removes the redundant standalone index via a new migration. The `users_email_key` UNIQUE constraint still enforces email uniqueness — behaviour is unchanged, we just stop maintaining a second identical index on every write.

## Changes

- `services/auth/src/migrations/029_drop_redundant_email_index.ts` — new migration. `up` drops `users_email_unique`; `down` recreates it (exact inverse of `001_create_users.ts:92`).

No model/`indexes` array to keep in sync: the auth service is raw-SQL (no Sequelize/ORM), so the migration is the only source of truth for the schema.

## Before requesting review

- [x] Ran the auth quality gates locally (see Test plan)
- [x] Tests for new behaviour: migration smoke test (`migrations.test.ts`) still green; schema state verified empirically against a real Postgres
- [ ] If touching `.env` requirements, updated `.env.example`'s REQUIRED block — n/a
- [ ] If touching a `lib.*`, considered consumer impact — n/a

## Test plan

Reproduced the **Schema Equivalence (migrate vs sync)** compute step for auth against a fresh Postgres using the exact CI image version (postgis `16-3.4`):

- [x] All auth migrations (001–029) apply cleanly against a fresh DB (`pnpm db:migrate`)
- [x] Post-migration, exactly one email index remains — `users_email_key` (the unique constraint); `users_email_unique` is gone
- [x] Uniqueness still enforced (the `users_email_key` UNIQUE constraint is intact)
- [x] Migration reverses: `down` recreates `users_email_unique`, `up` drops it again
- [x] No TypeScript errors (`turbo run type-check --filter=@adopt-dont-shop/service.auth`)
- [x] Lint passes (`turbo run lint --filter=@adopt-dont-shop/service.auth` — 0 errors)
- [x] Tests + coverage pass (`pnpm run test:coverage` — 24 files, 392 tests; thresholds green, coverage unchanged from baseline)

## Related

- Implements **ADS-1054** — but **only** the duplicate-`users.email`-index removal.
- Tracking issue: **ADS-1039**.
- The other ADS-1054 items — native enums, cross-service N+1, and the ledger — are intentionally **deferred** and out of scope for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01639moQdBwbM99aMdsQ7CXK)_