### PR TITLE
fix(frontend): remove hardcoded API host, gate DevLoginPanel to dev, harden no-debugger (ADS-1057)

### DIFF
--- a/apps/admin/src/App.tsx
+++ b/apps/admin/src/App.tsx
@@ -75,7 +75,7 @@ const AdminApp: React.FC = () => {
           </Routes>
         </Suspense>
 
-        <DevLoginPanel />
+        {import.meta.env.DEV && <DevLoginPanel />}
 
         {/* ADS-497 (slice 5): cookie banner is shown to anonymous visitors
             too, so first-time choices are persisted before sign-in. */}
@@ -267,7 +267,7 @@ const AdminApp: React.FC = () => {
       </ProtectedRoute>
 
       {/* Dev Login Panel - only shows in development */}
-      <DevLoginPanel />
+      {import.meta.env.DEV && <DevLoginPanel />}
 
       {/* ADS-497 (slice 5): on-page cookie banner. Mounted before the
           re-acceptance modal so the modal stacks on top if both surface. */}

--- a/apps/client/src/App.tsx
+++ b/apps/client/src/App.tsx
@@ -123,7 +123,7 @@ function App() {
           <ChatProvider>
             <FavoritesProvider>
               <MatchAcknowledgementProvider>
-                <DevLoginPanel />
+                {import.meta.env.DEV && <DevLoginPanel />}
                 {/* ADS-497 slice 5 (CookieBanner) + slice 2 (LegalReacceptanceModal).
                   Bundled into one lazy boundary so they share a single module
                   load — see LegalUI declaration above. The banner is anchored

--- a/apps/rescue/src/App.tsx
+++ b/apps/rescue/src/App.tsx
@@ -66,7 +66,7 @@ function App() {
           </Routes>
         </Suspense>
 
-        <DevLoginPanel />
+        {import.meta.env.DEV && <DevLoginPanel />}
         <CookieBanner />
       </>
     );
@@ -126,7 +126,7 @@ function App() {
       </Suspense>
 
       {/* Dev Login Panel - only shows in development */}
-      <DevLoginPanel />
+      {import.meta.env.DEV && <DevLoginPanel />}
 
       {/* ADS-497 (slice 5): on-page cookie banner. Mounted before the
           re-acceptance modal so the modal stacks on top if both surface. */}

--- a/packages/eslint-config-base/index.js
+++ b/packages/eslint-config-base/index.js
@@ -32,7 +32,7 @@ export default tseslint.config(
           allow: ['warn', 'error'],
         },
       ],
-      'no-debugger': 'warn',
+      'no-debugger': 'error',
       'prefer-const': 'error',
       'no-var': 'error',
       eqeqeq: ['error', 'always'],

--- a/packages/lib.utils/src/env.test.ts
+++ b/packages/lib.utils/src/env.test.ts
@@ -182,4 +182,12 @@ describe('validateUrlConfig', () => {
     expect(result.errors[0]).toContain('Invalid API base URL');
     expect(result.errors[1]).toContain('Invalid WebSocket base URL');
   });
+
+  it('treats the same-origin production default (empty base) as valid', () => {
+    // Production with no VITE_API_BASE_URL falls back to a same-origin ('')
+    // base (ADS-1057); `new URL('')` would throw, so it must not be reported
+    // invalid.
+    vi.stubEnv('MODE', 'production');
+    expect(validateUrlConfig()).toEqual({ isValid: true, errors: [] });
+  });
 });

--- a/packages/lib.utils/src/env.test.ts
+++ b/packages/lib.utils/src/env.test.ts
@@ -62,7 +62,7 @@ describe('isDebugMode', () => {
 });
 
 describe('getUrlConfig', () => {
-  it('uses production defaults in production mode', () => {
+  it('falls back to a same-origin/relative base in production when no env vars are set', () => {
     vi.stubEnv('MODE', 'production');
     vi.stubEnv('VITE_API_BASE_URL', '');
     vi.stubEnv('VITE_API_URL', '');
@@ -70,8 +70,30 @@ describe('getUrlConfig', () => {
     vi.stubEnv('VITE_WEBSOCKET_URL', '');
     vi.stubEnv('VITE_SOCKET_URL', '');
     expect(getUrlConfig()).toEqual({
-      apiBaseUrl: 'https://api.adoptdontshop.com',
-      wsBaseUrl: 'wss://api.adoptdontshop.com',
+      apiBaseUrl: '',
+      wsBaseUrl: '',
+    });
+  });
+
+  it('derives a wss:// base url from an https api base url when no ws env vars are set', () => {
+    vi.stubEnv('VITE_API_BASE_URL', 'https://api.example.com');
+    vi.stubEnv('VITE_WS_BASE_URL', '');
+    vi.stubEnv('VITE_WEBSOCKET_URL', '');
+    vi.stubEnv('VITE_SOCKET_URL', '');
+    expect(getUrlConfig()).toEqual({
+      apiBaseUrl: 'https://api.example.com',
+      wsBaseUrl: 'wss://api.example.com',
+    });
+  });
+
+  it('derives a ws:// base url from an http api base url when no ws env vars are set', () => {
+    vi.stubEnv('VITE_API_BASE_URL', 'http://localhost:5000');
+    vi.stubEnv('VITE_WS_BASE_URL', '');
+    vi.stubEnv('VITE_WEBSOCKET_URL', '');
+    vi.stubEnv('VITE_SOCKET_URL', '');
+    expect(getUrlConfig()).toEqual({
+      apiBaseUrl: 'http://localhost:5000',
+      wsBaseUrl: 'ws://localhost:5000',
     });
   });
 

--- a/packages/lib.utils/src/env.ts
+++ b/packages/lib.utils/src/env.ts
@@ -175,20 +175,25 @@ export function validateUrlConfig(): { isValid: boolean; errors: string[] } {
   const errors: string[] = [];
   const { apiBaseUrl, wsBaseUrl } = getUrlConfig();
 
-  // Validate API URL
-  try {
-    new URL(apiBaseUrl);
-  } catch {
-    errors.push(`Invalid API base URL: ${apiBaseUrl}`);
+  // An empty base is the intended same-origin/relative fallback (ADS-1057) —
+  // treat it as valid rather than passing it to `new URL()`, which throws on
+  // empty/relative input. Only absolute bases are parse-validated.
+  if (apiBaseUrl !== '') {
+    try {
+      new URL(apiBaseUrl);
+    } catch {
+      errors.push(`Invalid API base URL: ${apiBaseUrl}`);
+    }
   }
 
-  // Validate WebSocket URL
-  try {
-    // Convert ws:// to http:// for URL validation
-    const wsUrlForValidation = wsBaseUrl.replace(/^ws(s)?:/, 'http$1:');
-    new URL(wsUrlForValidation);
-  } catch {
-    errors.push(`Invalid WebSocket base URL: ${wsBaseUrl}`);
+  if (wsBaseUrl !== '') {
+    try {
+      // Convert ws:// to http:// for URL validation
+      const wsUrlForValidation = wsBaseUrl.replace(/^ws(s)?:/, 'http$1:');
+      new URL(wsUrlForValidation);
+    } catch {
+      errors.push(`Invalid WebSocket base URL: ${wsBaseUrl}`);
+    }
   }
 
   return {

--- a/packages/lib.utils/src/env.ts
+++ b/packages/lib.utils/src/env.ts
@@ -24,21 +24,16 @@ export interface EnvironmentConfig extends EnvironmentUrls {
 }
 
 /**
- * Default URL configuration for different environments
+ * Default API base URL per environment. Production intentionally has NO
+ * hardcoded external host: when VITE_API_BASE_URL is unset a production build
+ * falls back to a same-origin/relative base ('') so it can never silently ship
+ * pointing at a pinned external host (ADS-1057). The WebSocket base URL is
+ * derived from the API base URL — see deriveWsBaseUrl.
  */
-const DEFAULT_URLS = {
-  development: {
-    apiBaseUrl: 'http://localhost:5000',
-    wsBaseUrl: 'ws://localhost:5000',
-  },
-  production: {
-    apiBaseUrl: 'https://api.adoptdontshop.com',
-    wsBaseUrl: 'wss://api.adoptdontshop.com',
-  },
-  test: {
-    apiBaseUrl: 'http://localhost:5000',
-    wsBaseUrl: 'ws://localhost:5000',
-  },
+const DEFAULT_API_BASE_URL = {
+  development: 'http://localhost:5000',
+  production: '',
+  test: 'http://localhost:5000',
 } as const;
 
 /**
@@ -85,23 +80,38 @@ export function isDebugMode(): boolean {
 }
 
 /**
+ * Derive a WebSocket base URL from an HTTP API base URL by swapping the URL
+ * scheme (http→ws, https→wss). A relative/same-origin base ('') or an already
+ * ws(s) URL is returned unchanged, so the WebSocket base falls back to the same
+ * origin rather than a hardcoded external host.
+ */
+function deriveWsBaseUrl(apiBaseUrl: string): string {
+  if (apiBaseUrl.startsWith('https://')) {
+    return `wss://${apiBaseUrl.slice('https://'.length)}`;
+  }
+  if (apiBaseUrl.startsWith('http://')) {
+    return `ws://${apiBaseUrl.slice('http://'.length)}`;
+  }
+  return apiBaseUrl;
+}
+
+/**
  * Get URL configuration with proper fallbacks
  */
 export function getUrlConfig(): EnvironmentUrls {
   const mode = getEnvironmentMode();
-  const defaults = DEFAULT_URLS[mode];
 
   // Get URLs from environment variables with fallbacks
   const apiBaseUrl =
     getEnvVar('VITE_API_BASE_URL') ||
     getEnvVar('VITE_API_URL') || // Legacy support
-    defaults.apiBaseUrl;
+    DEFAULT_API_BASE_URL[mode];
 
   const wsBaseUrl =
     getEnvVar('VITE_WS_BASE_URL') ||
     getEnvVar('VITE_WEBSOCKET_URL') || // Legacy support
     getEnvVar('VITE_SOCKET_URL') || // Legacy support
-    defaults.wsBaseUrl;
+    deriveWsBaseUrl(apiBaseUrl);
 
   return {
     apiBaseUrl: apiBaseUrl.replace(/\/+$/, ''), // Remove trailing slashes


### PR DESCRIPTION
## Summary

Frontend/config hardening for ADS-1057 — three low-severity items, kept surgical:

- Production builds no longer silently default to the hardcoded external host `https://api.adoptdontshop.com` when `VITE_API_BASE_URL` is unset.
- `DevLoginPanel` is now build-time-stripped from production bundles instead of only runtime-gated.
- `no-debugger` is promoted from `warn` to `error` so a stray `debugger` fails CI.

## Changes

- **`packages/lib.utils/src/env.ts`** — replaced the pinned production URL defaults with a same-origin/relative fallback (`''`). The production default API base URL is now `''` (relative), and the WebSocket base URL is derived from the API base URL (`http→ws`, `https→wss`) rather than a separate hardcoded `wss://…` host. Dev/test keep their `localhost:5000` defaults. Consumers already fall back to `''` for a same-origin base (e.g. `apps/*/services/libraryServices.ts`, `lib.api` `getBaseUrl()`), so this aligns the shared util with that contract.
- **`packages/lib.utils/src/env.test.ts`** — updated the production-mode expectation to the same-origin fallback and added two cases covering ws-scheme derivation (`https→wss`, `http→ws`).
- **`apps/admin/src/App.tsx`, `apps/rescue/src/App.tsx`, `apps/client/src/App.tsx`** — gate each `<DevLoginPanel />` mount behind `{import.meta.env.DEV && …}` so Vite tree-shakes the panel out of production output.
- **`packages/eslint-config-base/index.js`** — `'no-debugger': 'warn'` → `'error'`. A repo-wide `\bdebugger\b` grep over `src` found no committed occurrences, so this is safe.

## Before requesting review

- [x] Ran the affected packages' `type-check`, `test:coverage`, and `lint` locally (see Test plan)
- [x] Tests for new behaviour added (TDD) — env same-origin fallback + ws derivation cases
- [ ] If touching `.env` requirements, updated `.env.example`'s REQUIRED block — n/a (no new env requirement)
- [x] If touching a `lib.*`, considered consumer impact across `app.*` and services — `lib.utils` URL helpers are not consumed by the apps for the live socket/API base (each app rolls its own `?? ''`); the same-origin fallback matches those consumers

## Test plan

Run per affected package (`corepack enable`, `pnpm install --frozen-lockfile`, `pnpm build:libs` first):

- [x] `@adopt-dont-shop/lib.utils` — type-check ✓; test:coverage ✓ (176 tests; 88.77% stmts / 80.99% branch / 98.43% funcs / 88.54% lines, all above 87/79/97/87; `env.ts` 100% funcs); lint ✓ 0 errors
- [x] `@adopt-dont-shop/app.admin` — type-check ✓; test:coverage ✓ (697 tests; 68.52 / 56.45 / 56.06 / 70.97 vs 62.5 / 50 / 50 / 65); lint ✓ 0 errors
- [x] `@adopt-dont-shop/app.rescue` — type-check ✓; test:coverage ✓ (525 tests; 43.56 / 43.07 / 37.94 / 45.13 vs 40 / 37 / 35 / 40); lint ✓ 0 errors
- [x] `@adopt-dont-shop/app.client` — type-check ✓; test:coverage ✓ (547 tests; 60.84 / 46.49 / 47.13 / 63.48 vs 55 / 41 / 41 / 57); lint ✓ 0 errors
- [x] Repo-wide `pnpm exec turbo run lint` — 49 tasks, 0 errors (confirms `no-debugger: error` breaks no package)
- [x] No TypeScript errors
- [x] Lint passes

## Related

- Linear: **ADS-1057** (tracking: **ADS-1039**).
- This PR implements only the **frontend/config subset** of ADS-1057 (hardcoded API fallback, DevLoginPanel prod stripping, `no-debugger` rule). The `/auth/register` hardening item is a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01639moQdBwbM99aMdsQ7CXK)_