### PR TITLE
feat(observability): deploy self-hosted LGTM + Alertmanager + GlitchTip stack (ADS-1041)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -671,12 +671,24 @@ jobs:
             # compose file(s) + ./observability/ config tree must already be
             # provisioned on the host (the host holds no repo checkout — see
             # docs/runbooks/observability-enable.md).
+            # Tolerant boolean read from the host .env: accepts KEY=true,
+            # KEY="true", surrounding quotes, trailing whitespace, or an inline
+            # `# comment` — the same coercions docker-compose applies — so the
+            # flag and the overlay can't disagree.
+            env_flag_true() {
+              local v
+              v="$(grep -E "^$1=" .env | head -n1 | cut -d= -f2-)" || true
+              v="${v%%#*}"                                        # strip inline comment
+              v="$(printf '%s' "$v" | tr -d '[:space:]')"         # strip whitespace
+              v="${v%\"}"; v="${v#\"}"; v="${v%\'}"; v="${v#\'}"   # strip quotes
+              [ "$v" = "true" ]
+            }
             OVERLAY_ARGS=""
-            if grep -qE '^OBSERVABILITY_ENABLED=true' .env; then
+            if env_flag_true OBSERVABILITY_ENABLED; then
               OVERLAY_ARGS="$OVERLAY_ARGS -f docker-compose.observability.yml"
               echo "Observability stack ENABLED (metrics/logs/traces/alerting)."
             fi
-            if grep -qE '^GLITCHTIP_ENABLED=true' .env; then
+            if env_flag_true GLITCHTIP_ENABLED; then
               OVERLAY_ARGS="$OVERLAY_ARGS -f docker-compose.glitchtip.yml"
               echo "GlitchTip error tracking ENABLED."
             fi

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -663,6 +663,24 @@ jobs:
               COMPOSE_FILE="docker-compose.staging.yml"
             fi
 
+            # ADS-1041: optionally layer in the self-hosted observability
+            # (Prometheus/Loki/Tempo/Grafana/Alertmanager) and GlitchTip
+            # error-tracking stacks. Enabled per-host in /opt/ads/<env>/.env
+            # (OBSERVABILITY_ENABLED=true / GLITCHTIP_ENABLED=true). Off by
+            # default → this deploy is unchanged. When enabling, the overlay
+            # compose file(s) + ./observability/ config tree must already be
+            # provisioned on the host (the host holds no repo checkout — see
+            # docs/runbooks/observability-enable.md).
+            OVERLAY_ARGS=""
+            if grep -qE '^OBSERVABILITY_ENABLED=true' .env; then
+              OVERLAY_ARGS="$OVERLAY_ARGS -f docker-compose.observability.yml"
+              echo "Observability stack ENABLED (metrics/logs/traces/alerting)."
+            fi
+            if grep -qE '^GLITCHTIP_ENABLED=true' .env; then
+              OVERLAY_ARGS="$OVERLAY_ARGS -f docker-compose.glitchtip.yml"
+              echo "GlitchTip error tracking ENABLED."
+            fi
+
             # Materialize the file-mounted Docker secrets consumed via
             # `file: ./secrets/<name>` by BOTH docker-compose.prod.yml and
             # docker-compose.staging.yml. The set must match the `secrets:`
@@ -703,7 +721,7 @@ jobs:
             # start (the Dockerfile.service entrypoint runs
             # `pnpm run --if-present db:migrate`), so there is no separate
             # migrate sidecar to wait on. [post-monolith; was ADS-393]
-            docker compose -f $COMPOSE_FILE --env-file .env up -d
+            docker compose -f $COMPOSE_FILE $OVERLAY_ARGS --env-file .env up -d
 
             # ADS-824: wait for every service to report healthy, not just the
             # gateway. Ordered so infrastructure-layer services are checked

--- a/docker-compose.glitchtip.yml
+++ b/docker-compose.glitchtip.yml
@@ -1,0 +1,167 @@
+# ============================================================================
+# GlitchTip (self-hosted, Sentry-compatible error tracking) — prod/staging
+# overlay (ADS-1041)
+# ============================================================================
+# Opt-in overlay, independent of docker-compose.observability.yml (metrics/logs/
+# traces). The deploy workflow adds `-f docker-compose.glitchtip.yml` only when
+# the host .env sets GLITCHTIP_ENABLED=true. Bring it up manually with:
+#
+#   docker compose -f docker-compose.<env>.yml -f docker-compose.glitchtip.yml \
+#     --env-file .env up -d
+#
+# Backend services report to GlitchTip via the existing Sentry SDK once SENTRY_DSN
+# is set in the host .env. Create an org+project in the GlitchTip UI first (reach
+# glitchtip-web over an SSH tunnel), copy the project DSN, and set e.g.
+#   SENTRY_DSN=http://<publicKey>@glitchtip-web:8080/<projectId>
+# GlitchTip runs its OWN Postgres so it never touches the app DB's connection
+# budget. Datastore images reuse the base stack's already-pinned digests; the
+# glitchtip app image is tag-pinned — VERIFY/pin the tag before enabling.
+#
+# Config MUST be provisioned onto the host at /opt/ads/<env>/ (the host holds no
+# repo checkout). Required host .env vars: GLITCHTIP_SECRET_KEY, GLITCHTIP_DB_PASSWORD.
+# ============================================================================
+
+x-glitchtip-logging: &gt-logging
+  driver: json-file
+  options:
+    max-size: "10m"
+    max-file: "5"
+
+x-glitchtip-env: &gt-env
+  DATABASE_URL: "postgres://glitchtip:${GLITCHTIP_DB_PASSWORD:?Error: GLITCHTIP_DB_PASSWORD required to enable GlitchTip}@glitchtip-postgres:5432/glitchtip"
+  SECRET_KEY: "${GLITCHTIP_SECRET_KEY:?Error: GLITCHTIP_SECRET_KEY required to enable GlitchTip}"
+  REDIS_URL: "redis://glitchtip-redis:6379/0"
+  PORT: "8080"
+  # Base URL used to build links in emails / the UI. Reached via SSH tunnel by
+  # default; set to your reverse-proxy URL if you front it.
+  GLITCHTIP_DOMAIN: "${GLITCHTIP_DOMAIN:-http://localhost:8000}"
+  DEFAULT_FROM_EMAIL: "${GLITCHTIP_FROM_EMAIL:-alerts@adoptdontshop.com}"
+  EMAIL_URL: "${GLITCHTIP_EMAIL_URL:-consolemail://}"
+  # Lock the instance down — no open sign-up; invite users from the admin.
+  ENABLE_OPEN_USER_REGISTRATION: "false"
+  CELERY_WORKER_AUTOSCALE: "1,3"
+  CELERY_WORKER_MAX_TASKS_PER_CHILD: "10000"
+
+x-glitchtip-hardening: &gt-hardening
+  restart: always
+  cap_drop:
+    - ALL
+  security_opt:
+    - no-new-privileges:true
+  logging: *gt-logging
+
+services:
+  # Dedicated Postgres for GlitchTip — reuses the base stack's digest-pinned
+  # postgis image (already on the host) rather than pulling a new one.
+  glitchtip-postgres:
+    <<: *gt-hardening
+    image: postgis/postgis:16-3.4@sha256:44126d872ac91993766c341e369c539e8196614321765d36a6f1bab0419a5fa5
+    environment:
+      POSTGRES_USER: glitchtip
+      POSTGRES_PASSWORD: "${GLITCHTIP_DB_PASSWORD:?Error: GLITCHTIP_DB_PASSWORD required to enable GlitchTip}"
+      POSTGRES_DB: glitchtip
+    volumes:
+      - glitchtip_pg_data:/var/lib/postgresql/data
+    expose:
+      - "5432"
+    healthcheck:
+      test: ['CMD-SHELL', 'pg_isready -U glitchtip -d glitchtip']
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    deploy:
+      resources:
+        limits:
+          cpus: '1.0'
+          memory: 512m
+        reservations:
+          cpus: '0.1'
+          memory: 128m
+
+  # Ephemeral Celery broker/cache — no persistence needed (tasks re-queue).
+  glitchtip-redis:
+    <<: *gt-hardening
+    image: redis:7.4-alpine@sha256:6ab0b6e7381779332f97b8ca76193e45b0756f38d4c0dcda72dbb3c32061ab99
+    command: redis-server --save "" --appendonly no
+    expose:
+      - "6379"
+    healthcheck:
+      test: ['CMD-SHELL', 'redis-cli ping | grep -q PONG']
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    deploy:
+      resources:
+        limits:
+          cpus: '0.5'
+          memory: 256m
+        reservations:
+          cpus: '0.1'
+          memory: 64m
+
+  # One-shot schema migration — runs to completion before web/worker start.
+  glitchtip-migrate:
+    <<: *gt-hardening
+    image: glitchtip/glitchtip:v4.1
+    command: ./manage.py migrate
+    environment:
+      <<: *gt-env
+    restart: "no"
+    depends_on:
+      glitchtip-postgres:
+        condition: service_healthy
+
+  glitchtip-web:
+    <<: *gt-hardening
+    image: glitchtip/glitchtip:v4.1
+    environment:
+      <<: *gt-env
+    expose:
+      - "8080"
+    depends_on:
+      glitchtip-postgres:
+        condition: service_healthy
+      glitchtip-redis:
+        condition: service_healthy
+      glitchtip-migrate:
+        condition: service_completed_successfully
+    healthcheck:
+      test: ['CMD-SHELL', 'wget --no-verbose --tries=1 --spider http://localhost:8080/_health/ || exit 1']
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 30s
+    deploy:
+      resources:
+        limits:
+          cpus: '1.0'
+          memory: 768m
+        reservations:
+          cpus: '0.1'
+          memory: 128m
+
+  glitchtip-worker:
+    <<: *gt-hardening
+    image: glitchtip/glitchtip:v4.1
+    command: ./bin/run-celery-with-beat.sh
+    environment:
+      <<: *gt-env
+    depends_on:
+      glitchtip-postgres:
+        condition: service_healthy
+      glitchtip-redis:
+        condition: service_healthy
+      glitchtip-migrate:
+        condition: service_completed_successfully
+    deploy:
+      resources:
+        limits:
+          cpus: '1.0'
+          memory: 512m
+        reservations:
+          cpus: '0.1'
+          memory: 128m
+
+volumes:
+  glitchtip_pg_data:
+    driver: local

--- a/docker-compose.glitchtip.yml
+++ b/docker-compose.glitchtip.yml
@@ -116,8 +116,10 @@ services:
     image: glitchtip/glitchtip:v4.1
     environment:
       <<: *gt-env
-    expose:
-      - "8080"
+    ports:
+      # Loopback-only (host :8000 → container :8080) — not publicly reachable;
+      # reach the UI via an SSH tunnel. Matches GLITCHTIP_DOMAIN's default.
+      - '127.0.0.1:8000:8080'
     depends_on:
       glitchtip-postgres:
         condition: service_healthy

--- a/docker-compose.observability.yml
+++ b/docker-compose.observability.yml
@@ -1,0 +1,194 @@
+# ============================================================================
+# Self-hosted observability stack — prod/staging overlay (ADS-1041)
+# ============================================================================
+# Opt-in overlay layered on top of docker-compose.prod.yml / .staging.yml. The
+# deploy workflow adds `-f docker-compose.observability.yml` only when the host
+# .env sets OBSERVABILITY_ENABLED=true, so existing deploys are unchanged until
+# an operator turns it on. Bring it up manually with:
+#
+#   docker compose -f docker-compose.<env>.yml -f docker-compose.observability.yml \
+#     --env-file .env up -d
+#
+# Services attach to the base file's `default` network (ads-<env>-network), so
+# the app services resolve loki/prometheus/tempo/alertmanager by name and expose
+# no host ports — reach Grafana over an SSH tunnel (see docs/runbooks/
+# observability-enable.md). All app services must have LOKI_URL / OTEL_EXPORTER_
+# OTLP_ENDPOINT / SENTRY_DSN set in the host .env for signals to flow.
+#
+# Config lives under ./observability/ and MUST be provisioned onto the host at
+# /opt/ads/<env>/observability/ alongside the compose file (the host holds no
+# repo checkout — deploy.yml:517). Images are tag-pinned to match the dev
+# `observability` profile; Renovate digest-pins them (ADS-1053).
+# ============================================================================
+
+x-obs-logging: &obs-logging
+  driver: json-file
+  options:
+    max-size: "10m"
+    max-file: "5"
+
+x-obs-hardening: &obs-hardening
+  restart: always
+  cap_drop:
+    - ALL
+  security_opt:
+    - no-new-privileges:true
+  logging: *obs-logging
+
+services:
+  prometheus:
+    <<: *obs-hardening
+    image: prom/prometheus:v3.1.0
+    command:
+      - '--config.file=/etc/prometheus/prometheus.yml'
+      # 30d retention covers the 30-day SLO error-budget window (docs/slo.md).
+      - '--storage.tsdb.retention.time=30d'
+      - '--web.enable-lifecycle'
+    volumes:
+      - ./observability/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - ./infra/prometheus/rules:/etc/prometheus/rules:ro
+      - prometheus_data:/prometheus
+    expose:
+      - "9090"
+    healthcheck:
+      test: ['CMD-SHELL', 'wget --no-verbose --tries=1 --spider http://localhost:9090/-/ready || exit 1']
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 30s
+    deploy:
+      resources:
+        limits:
+          cpus: '1.0'
+          memory: 1g
+        reservations:
+          cpus: '0.1'
+          memory: 128m
+
+  loki:
+    <<: *obs-hardening
+    image: grafana/loki:3.2.0
+    command: -config.file=/etc/loki/loki-config.yaml
+    volumes:
+      - ./observability/loki/loki-config.yaml:/etc/loki/loki-config.yaml:ro
+      - loki_data:/loki
+    expose:
+      - "3100"
+    healthcheck:
+      test: ['CMD-SHELL', 'wget --no-verbose --tries=1 --spider http://localhost:3100/ready || exit 1']
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 30s
+    deploy:
+      resources:
+        limits:
+          cpus: '1.0'
+          memory: 1g
+        reservations:
+          cpus: '0.1'
+          memory: 128m
+
+  tempo:
+    <<: *obs-hardening
+    image: grafana/tempo:2.6.1
+    command: -config.file=/etc/tempo/tempo.yaml
+    volumes:
+      - ./observability/tempo/tempo.yaml:/etc/tempo/tempo.yaml:ro
+      - tempo_data:/var/tempo
+    expose:
+      - "3200"   # Tempo query API (Grafana)
+      - "4318"   # OTLP/HTTP ingest (services → OTEL_EXPORTER_OTLP_ENDPOINT)
+    healthcheck:
+      test: ['CMD-SHELL', 'wget --no-verbose --tries=1 --spider http://localhost:3200/ready || exit 1']
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 30s
+    deploy:
+      resources:
+        limits:
+          cpus: '1.0'
+          memory: 1g
+        reservations:
+          cpus: '0.1'
+          memory: 128m
+
+  alertmanager:
+    <<: *obs-hardening
+    image: prom/alertmanager:v0.28.0
+    command:
+      - '--config.file=/etc/alertmanager/alertmanager.yml'
+      - '--storage.path=/alertmanager'
+    volumes:
+      - ./observability/alertmanager/alertmanager.yml:/etc/alertmanager/alertmanager.yml:ro
+      - ./observability/alertmanager/secrets:/etc/alertmanager/secrets:ro
+      - alertmanager_data:/alertmanager
+    expose:
+      - "9093"
+    healthcheck:
+      test: ['CMD-SHELL', 'wget --no-verbose --tries=1 --spider http://localhost:9093/-/ready || exit 1']
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 30s
+    deploy:
+      resources:
+        limits:
+          cpus: '0.5'
+          memory: 256m
+        reservations:
+          cpus: '0.1'
+          memory: 64m
+
+  grafana:
+    <<: *obs-hardening
+    image: grafana/grafana:11.3.0
+    environment:
+      # Real admin password required — no anonymous access, no default creds.
+      GF_SECURITY_ADMIN_PASSWORD: '${GF_SECURITY_ADMIN_PASSWORD:?Error: GF_SECURITY_ADMIN_PASSWORD required to enable observability}'
+      GF_AUTH_ANONYMOUS_ENABLED: 'false'
+      GF_AUTH_DISABLE_LOGIN_FORM: 'false'
+      GF_USERS_ALLOW_SIGN_UP: 'false'
+      # Reached via SSH tunnel to localhost; set GF_SERVER_ROOT_URL in the host
+      # .env if you front it with a reverse proxy.
+      GF_SERVER_ROOT_URL: '${GF_SERVER_ROOT_URL:-http://localhost:3030}'
+      # Stay on our own infra — no update checks / usage phone-home.
+      GF_ANALYTICS_REPORTING_ENABLED: 'false'
+      GF_ANALYTICS_CHECK_FOR_UPDATES: 'false'
+    volumes:
+      - grafana_data:/var/lib/grafana
+      - ./observability/grafana/provisioning:/etc/grafana/provisioning:ro
+    expose:
+      - "3000"
+    depends_on:
+      prometheus:
+        condition: service_healthy
+      loki:
+        condition: service_healthy
+    healthcheck:
+      test: ['CMD-SHELL', 'wget --no-verbose --tries=1 --spider http://localhost:3000/api/health || exit 1']
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 30s
+    deploy:
+      resources:
+        limits:
+          cpus: '0.5'
+          memory: 512m
+        reservations:
+          cpus: '0.1'
+          memory: 64m
+
+volumes:
+  prometheus_data:
+    driver: local
+  loki_data:
+    driver: local
+  tempo_data:
+    driver: local
+  alertmanager_data:
+    driver: local
+  grafana_data:
+    driver: local

--- a/docker-compose.observability.yml
+++ b/docker-compose.observability.yml
@@ -10,9 +10,11 @@
 #     --env-file .env up -d
 #
 # Services attach to the base file's `default` network (ads-<env>-network), so
-# the app services resolve loki/prometheus/tempo/alertmanager by name and expose
-# no host ports — reach Grafana over an SSH tunnel (see docs/runbooks/
-# observability-enable.md). All app services must have LOKI_URL / OTEL_EXPORTER_
+# the app services resolve loki/prometheus/tempo/alertmanager by name. The
+# operator-facing UIs (Grafana, Prometheus, Alertmanager) bind to host loopback
+# (127.0.0.1) only — NOT publicly reachable; reach them via an SSH tunnel (see
+# docs/runbooks/observability-enable.md). Loki + Tempo stay internal-only
+# (Grafana proxies to them). All app services must have LOKI_URL / OTEL_EXPORTER_
 # OTLP_ENDPOINT / SENTRY_DSN set in the host .env for signals to flow.
 #
 # Config lives under ./observability/ and MUST be provisioned onto the host at
@@ -48,8 +50,10 @@ services:
       - ./observability/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
       - ./infra/prometheus/rules:/etc/prometheus/rules:ro
       - prometheus_data:/prometheus
-    expose:
-      - "9090"
+    ports:
+      # Loopback-only — not publicly reachable; operators reach the UI (Status →
+      # Targets / Alerts) via an SSH tunnel. See observability-enable.md.
+      - '127.0.0.1:9090:9090'
     healthcheck:
       test: ['CMD-SHELL', 'wget --no-verbose --tries=1 --spider http://localhost:9090/-/ready || exit 1']
       interval: 30s
@@ -124,8 +128,9 @@ services:
       - ./observability/alertmanager/alertmanager.yml:/etc/alertmanager/alertmanager.yml:ro
       - ./observability/alertmanager/secrets:/etc/alertmanager/secrets:ro
       - alertmanager_data:/alertmanager
-    expose:
-      - "9093"
+    ports:
+      # Loopback-only — not publicly reachable; reach the UI via an SSH tunnel.
+      - '127.0.0.1:9093:9093'
     healthcheck:
       test: ['CMD-SHELL', 'wget --no-verbose --tries=1 --spider http://localhost:9093/-/ready || exit 1']
       interval: 30s
@@ -159,8 +164,10 @@ services:
     volumes:
       - grafana_data:/var/lib/grafana
       - ./observability/grafana/provisioning:/etc/grafana/provisioning:ro
-    expose:
-      - "3000"
+    ports:
+      # Loopback-only (host :3030 → container :3000) — not publicly reachable;
+      # reach it via an SSH tunnel. Matches GF_SERVER_ROOT_URL's default.
+      - '127.0.0.1:3030:3000'
     depends_on:
       prometheus:
         condition: service_healthy

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -79,6 +79,14 @@ x-service-env: &service-env
   # service REQUIRES a valid x-principal-token (forged x-user-* headers
   # lose); the gateway signs with the same key.
   PRINCIPAL_SIGNING_KEY_FILE: /run/secrets/principal_signing_key
+  # ADS-1041: observability shipping. Inert (empty) unless set in the host .env
+  # AND the observability stack is enabled (docker-compose.observability.yml).
+  #   LOKI_URL=http://loki:3100  OTEL_EXPORTER_OTLP_ENDPOINT=http://tempo:4318
+  # SENTRY_DSN activates backend error tracking (GlitchTip) — initializeSentry
+  # runs only when SENTRY_DSN is set AND NODE_ENV is production/staging.
+  LOKI_URL: ${LOKI_URL:-}
+  OTEL_EXPORTER_OTLP_ENDPOINT: ${OTEL_EXPORTER_OTLP_ENDPOINT:-}
+  SENTRY_DSN: ${SENTRY_DSN:-}
 
 # Healthcheck timing tiers (mirrors the dev docker-compose.yml ADS-860
 # standard): infra probes fast without a start_period (database) or with a
@@ -263,6 +271,10 @@ services:
       # ADS-800: the gateway signs the x-principal-token it forwards on
       # every downstream gRPC call.
       PRINCIPAL_SIGNING_KEY_FILE: /run/secrets/principal_signing_key
+      # ADS-1041: observability shipping (inert unless set in the host .env).
+      LOKI_URL: ${LOKI_URL:-}
+      OTEL_EXPORTER_OTLP_ENDPOINT: ${OTEL_EXPORTER_OTLP_ENDPOINT:-}
+      SENTRY_DSN: ${SENTRY_DSN:-}
     # Gateway has no DB; it needs the upload-signing secret plus the
     # principal-signing key (ADS-800 — it is the token signer).
     secrets:

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -67,6 +67,14 @@ x-service-env: &service-env
   # service REQUIRES a valid x-principal-token (forged x-user-* headers
   # lose); the gateway signs with the same key.
   PRINCIPAL_SIGNING_KEY_FILE: /run/secrets/principal_signing_key
+  # ADS-1041: observability shipping. Inert (empty) unless set in the host .env
+  # AND the observability stack is enabled (docker-compose.observability.yml).
+  #   LOKI_URL=http://loki:3100  OTEL_EXPORTER_OTLP_ENDPOINT=http://tempo:4318
+  # SENTRY_DSN activates backend error tracking (GlitchTip) — initializeSentry
+  # runs only when SENTRY_DSN is set AND NODE_ENV is production/staging.
+  LOKI_URL: ${LOKI_URL:-}
+  OTEL_EXPORTER_OTLP_ENDPOINT: ${OTEL_EXPORTER_OTLP_ENDPOINT:-}
+  SENTRY_DSN: ${SENTRY_DSN:-}
 
 # Healthcheck timing tiers (mirrors the dev docker-compose.yml ADS-860
 # standard): infra probes fast without a start_period (database) or with a
@@ -226,6 +234,10 @@ services:
       # ADS-800: the gateway signs the x-principal-token it forwards on
       # every downstream gRPC call.
       PRINCIPAL_SIGNING_KEY_FILE: /run/secrets/principal_signing_key
+      # ADS-1041: observability shipping (inert unless set in the host .env).
+      LOKI_URL: ${LOKI_URL:-}
+      OTEL_EXPORTER_OTLP_ENDPOINT: ${OTEL_EXPORTER_OTLP_ENDPOINT:-}
+      SENTRY_DSN: ${SENTRY_DSN:-}
     # Gateway has no DB; it needs the upload-signing secret plus the
     # principal-signing key (ADS-800 — it is the token signer).
     secrets:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,6 +25,11 @@ x-service-env: &ms-env
   # services REQUIRE it (forged x-user-* headers lose). Optional — unset
   # keeps the legacy header-trust behaviour for phased rollout.
   PRINCIPAL_SIGNING_KEY: ${PRINCIPAL_SIGNING_KEY:-}
+  # ADS-1041: ship logs to Loki + traces to Tempo when the observability
+  # profile is up. Inert (empty) unless set in .env, e.g.
+  # LOKI_URL=http://loki:3100 / OTEL_EXPORTER_OTLP_ENDPOINT=http://tempo:4318.
+  LOKI_URL: ${LOKI_URL:-}
+  OTEL_EXPORTER_OTLP_ENDPOINT: ${OTEL_EXPORTER_OTLP_ENDPOINT:-}
 
 x-service-deps: &ms-deps
   database:
@@ -280,12 +285,16 @@ services:
     restart: unless-stopped
 
   # ============================================================================
-  # OBSERVABILITY STACK (profile: observability)
+  # OBSERVABILITY STACK (profile: observability) — mirrors the prod/staging
+  # stack in docker-compose.observability.yml (ADS-1041).
   # ----------------------------------------------------------------------------
-  # Opt-in log aggregator. Bring up with:
-  #   docker compose --profile observability up -d loki grafana
-  # The backend container ships logs via winston-loki when LOKI_URL is set;
-  # add LOKI_URL=http://loki:3100 to your .env to enable.
+  # Loki (logs) + Prometheus (metrics) + Tempo (traces) + Grafana (dashboards)
+  # + Alertmanager (routing). Bring up with:
+  #   docker compose --profile observability up -d
+  # Services ship logs/traces only when the endpoints are set in .env:
+  #   LOKI_URL=http://loki:3100
+  #   OTEL_EXPORTER_OTLP_ENDPOINT=http://tempo:4318
+  # Grafana: http://localhost:3030  ·  Prometheus: :9090  ·  Alertmanager: :9093
   # ============================================================================
 
   loki:
@@ -308,6 +317,9 @@ services:
       - '127.0.0.1:9090:9090'
     volumes:
       - ./observability/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      # ADS-1041/ADS-806: mount the committed SLO alert rules so rule_files in
+      # prometheus.yml actually loads them (dev can test firing alerts locally).
+      - ./infra/prometheus/rules:/etc/prometheus/rules:ro
       - prometheus_data:/prometheus
     command:
       - '--config.file=/etc/prometheus/prometheus.yml'
@@ -349,6 +361,44 @@ services:
         condition: service_healthy
     restart: unless-stopped
 
+  # Tempo — distributed-trace backend (ADS-1041). Services export OTLP/HTTP here
+  # when OTEL_EXPORTER_OTLP_ENDPOINT=http://tempo:4318 is set. Added to dev so it
+  # mirrors the prod/staging stack (docker-compose.observability.yml).
+  tempo:
+    profiles: ["observability", "full"]
+    image: grafana/tempo:2.6.1
+    command: -config.file=/etc/tempo/tempo.yaml
+    ports:
+      - '127.0.0.1:3200:3200'   # Tempo API (Grafana queries here)
+      - '127.0.0.1:4318:4318'   # OTLP/HTTP ingest
+    volumes:
+      - ./observability/tempo/tempo.yaml:/etc/tempo/tempo.yaml:ro
+      - tempo_data:/var/tempo
+    restart: unless-stopped
+    healthcheck:
+      <<: *hc-observability-timing
+      test: ['CMD-SHELL', 'wget --no-verbose --tries=1 --spider http://localhost:3200/ready || exit 1']
+
+  # Alertmanager — routes the SLO alert rules by severity (ADS-1041/ADS-1052).
+  # Ships inert (no notifier secrets); wire Slack/email per
+  # observability/alertmanager/alertmanager.yml.
+  alertmanager:
+    profiles: ["observability", "full"]
+    image: prom/alertmanager:v0.28.0
+    command:
+      - '--config.file=/etc/alertmanager/alertmanager.yml'
+      - '--storage.path=/alertmanager'
+    ports:
+      - '127.0.0.1:9093:9093'
+    volumes:
+      - ./observability/alertmanager/alertmanager.yml:/etc/alertmanager/alertmanager.yml:ro
+      - ./observability/alertmanager/secrets:/etc/alertmanager/secrets:ro
+      - alertmanager_data:/alertmanager
+    restart: unless-stopped
+    healthcheck:
+      <<: *hc-observability-timing
+      test: ['CMD-SHELL', 'wget --no-verbose --tries=1 --spider http://localhost:9093/-/ready || exit 1']
+
   # ==========================================================================
   # EXTRACTED MICROSERVICES (CAD-style). Opt-in via `--profile services`.
   # The gateway is the single REST surface fronting /api/* and routes each
@@ -366,6 +416,10 @@ services:
     environment:
       NODE_ENV: ${NODE_ENV:-development}
       NATS_URL: nats://nats:4222
+      # ADS-1041: logs → Loki, traces → Tempo when the observability profile is
+      # up. Inert unless set in .env (see the *ms-env anchor above).
+      LOKI_URL: ${LOKI_URL:-}
+      OTEL_EXPORTER_OTLP_ENDPOINT: ${OTEL_EXPORTER_OTLP_ENDPOINT:-}
       # Shared Redis store for cross-replica rate limiting (ADS-805).
       # Same Redis the other microservices use; the gateway gets its own
       # key namespace via the plugin's default nameSpace.
@@ -580,6 +634,8 @@ volumes:
   loki_data:
   grafana_data:
   prometheus_data:
+  tempo_data:
+  alertmanager_data:
 
 # ============================================================================
 # NETWORKS

--- a/docs/README.md
+++ b/docs/README.md
@@ -185,6 +185,7 @@ Documentation for the adopt-don't-shop monorepo, organized by audience. The root
 - [Service level objectives & alerting](./slo.md) — per-service SLOs, error budgets, and the Prometheus rules under `infra/prometheus/rules/`
 - [Observability and alerting](./observability-alerting.md) — metrics, logs, alert routing (legacy — superseded by `slo.md`)
 - [Runbooks index](./runbooks/README.md) — runbook catalogue
+- [Enable observability stack runbook](./runbooks/observability-enable.md) — turn on the self-hosted metrics/logs/traces/alerting + GlitchTip stack in prod/staging
 - [Dev stack troubleshooting runbook](./runbooks/dev-stack-troubleshooting.md) — symptom → diagnosis → fix for local `pnpm docker:dev` failures
 - [5xx spike runbook](./runbooks/5xx-spike.md) — diagnose elevated server errors
 - [Applications cutover runbook](./runbooks/applications-cutover.md) — _obsolete_: the per-domain cutover mechanism has been removed

--- a/docs/env-reference.md
+++ b/docs/env-reference.md
@@ -262,13 +262,32 @@ SERVE_LOCAL_UPLOADS=true
 # VITE_STATSIG_CLIENT_KEY=client-...
 ```
 
-## Error tracking (Sentry)
+## Error tracking (Sentry / GlitchTip)
+
+Backend error tracking uses the Sentry SDK, initialized at service boot
+(ADS-1041). It is a **no-op unless `SENTRY_DSN` is set AND `NODE_ENV` is
+`production`/`staging`**. In prod/staging the DSN points at the self-hosted
+**GlitchTip** stack (`docker-compose.glitchtip.yml`) — create a project in the
+GlitchTip UI and copy its DSN (internal form
+`http://<publicKey>@glitchtip-web:8080/<projectId>`). See
+`docs/runbooks/observability-enable.md`.
 
 ```env
-# SENTRY_DSN=your-sentry-dsn-url
-# VITE_SENTRY_DSN=your-sentry-dsn-url
-# Build/release tag reported to Sentry. CI typically sets this to the git SHA.
+# SENTRY_DSN=http://<publicKey>@glitchtip-web:8080/<projectId>
+# VITE_SENTRY_DSN=your-frontend-dsn-url
+# Build/release tag reported to Sentry/GlitchTip. CI typically sets this to the git SHA.
 # SENTRY_RELEASE=
+
+# --- Self-hosted GlitchTip (prod/staging, docker-compose.glitchtip.yml) ------
+# Enable the GlitchTip overlay on this host, then re-deploy.
+# GLITCHTIP_ENABLED=true
+# Django SECRET_KEY + its dedicated Postgres password (required when enabled).
+# GLITCHTIP_SECRET_KEY=<random 50+ chars>
+# GLITCHTIP_DB_PASSWORD=<random>
+# Base URL for links in the UI/emails; SMTP + from-address (optional).
+# GLITCHTIP_DOMAIN=https://errors.example.com
+# GLITCHTIP_EMAIL_URL=smtp://user:pass@smtp.example.com:587
+# GLITCHTIP_FROM_EMAIL=alerts@adoptdontshop.com
 ```
 
 ## Rate limiting & security
@@ -334,18 +353,30 @@ LEGAL_REMINDER_CRON_DRY_RUN=false
 
 ## Metrics / Observability
 
+The self-hosted stack (Prometheus + Loki + Tempo + Grafana + Alertmanager) is an
+**opt-in overlay** in prod/staging (`docker-compose.observability.yml`, ADS-1041).
+Turn it on per-host with `OBSERVABILITY_ENABLED=true` and point the services'
+shipping endpoints at the in-network backends. All three endpoints are inert
+(disabled) when unset. Full operator steps: `docs/runbooks/observability-enable.md`.
+
 ```env
+# Enable the observability overlay on this host, then re-deploy.
+# OBSERVABILITY_ENABLED=true
+
+# ADS-1041: ship logs to Loki (winston-loki). In prod/staging the in-network URL:
+# LOKI_URL=http://loki:3100
+
 # ADS-660: OpenTelemetry distributed tracing. When unset, the SDK does
 # NOT start — the backend boots without traces and only the W3C
-# traceparent scaffold runs. Set the endpoint to ship spans to a
-# collector (Tempo / Jaeger / OTel Collector). See
-# docs/observability/tracing.md for local-dev setup.
-# OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318
+# traceparent scaffold runs. In prod/staging point it at the in-network Tempo;
+# for local dev use a Jaeger/collector on :4318. See docs/observability/tracing.md.
+# OTEL_EXPORTER_OTLP_ENDPOINT=http://tempo:4318
 # OTEL_SERVICE_NAME=adopt-dont-shop-backend
 # Sampling. `parentbased_traceidratio` honours upstream sampling
 # decisions and falls back to the ratio for new roots. Ratio in [0, 1].
+# In production keep the ratio well below 1.0 to bound trace volume.
 # OTEL_TRACES_SAMPLER=parentbased_traceidratio
-# OTEL_TRACES_SAMPLER_ARG=1.0
+# OTEL_TRACES_SAMPLER_ARG=0.1
 ```
 
 ## Grafana
@@ -360,6 +391,13 @@ to start Grafana without it, ADS-968).
 # true to opt back into read-only anonymous access — see
 # observability/grafana/README.md.
 # GRAFANA_ANONYMOUS_ENABLED=true
+
+# --- prod/staging (docker-compose.observability.yml) -------------------------
+# Required to enable the observability overlay — Grafana refuses to start
+# without it. Anonymous access is forced off; reach Grafana over an SSH tunnel.
+# GF_SECURITY_ADMIN_PASSWORD=<random>
+# Set if you front Grafana with a reverse proxy (defaults to localhost:3030).
+# GF_SERVER_ROOT_URL=https://grafana.example.com
 ```
 
 ## External verification APIs (rescue onboarding)

--- a/docs/observability/tracing.md
+++ b/docs/observability/tracing.md
@@ -20,6 +20,17 @@ OTEL_TRACES_SAMPLER=parentbased_traceidratio  # optional
 OTEL_TRACES_SAMPLER_ARG=1.0                   # optional
 ```
 
+## Deployed backend (prod/staging, ADS-1041)
+
+In prod/staging the traces backend is self-hosted **Tempo**, part of the opt-in
+observability overlay (`docker-compose.observability.yml`). Point the services at
+the in-network Tempo by setting `OTEL_EXPORTER_OTLP_ENDPOINT=http://tempo:4318`
+in the host `.env` (with `OBSERVABILITY_ENABLED=true`). Tempo receives OTLP/HTTP
+on `:4318` and Grafana queries it on `:3200` via the provisioned Tempo
+datasource. Keep `OTEL_TRACES_SAMPLER_ARG` well below 1.0 in production. Verify
+spans are arriving after enabling (Grafana → Explore → Tempo). See
+`docs/runbooks/observability-enable.md`.
+
 ## Local viewer (Jaeger)
 
 We deliberately do NOT bundle Jaeger in `docker-compose.yml` — the

--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -12,18 +12,19 @@ diagnosis → fix format.
 
 ## Index
 
-| Runbook                                                          | When to open it                                                                |
-| ---------------------------------------------------------------- | ------------------------------------------------------------------------------ |
-| [`dev-stack-troubleshooting.md`](./dev-stack-troubleshooting.md) | Local `pnpm docker:dev` failures (not prod on-call)                            |
-| [`5xx-spike.md`](./5xx-spike.md)                                 | `HighFiveHundredRate` page; 5xx ratio >1% over 5m                              |
-| [`redis-outage.md`](./redis-outage.md)                           | `redis` container unhealthy; rate-limiters misbehaving                         |
-| [`db-pool-exhaustion.md`](./db-pool-exhaustion.md)               | `acquire timeout` errors; p95 latency climbs in lockstep                       |
-| [`deploy-rollback.md`](./deploy-rollback.md)                     | Bad deploy: image is live but error rate is up                                 |
-| [`migration-failure.md`](./migration-failure.md)                 | A schema-owning service stuck in `restarting` after a deploy ran a migration   |
-| [`maintenance-mode.md`](./maintenance-mode.md)                   | Planned outage, controlled brownout, or kill-switch needed                     |
-| [`jetstream-backlog.md`](./jetstream-backlog.md)                 | NATS JetStream consumer lag / backlog                                          |
-| [`gdpr-erasure-incident.md`](./gdpr-erasure-incident.md)         | GDPR erasure run failed mid-way                                                |
-| [`applications-cutover.md`](./applications-cutover.md)           | _Obsolete_ — per-domain cutover flags removed; gateway always registers routes |
+| Runbook                                                          | When to open it                                                                      |
+| ---------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
+| [`dev-stack-troubleshooting.md`](./dev-stack-troubleshooting.md) | Local `pnpm docker:dev` failures (not prod on-call)                                  |
+| [`5xx-spike.md`](./5xx-spike.md)                                 | `HighFiveHundredRate` page; 5xx ratio >1% over 5m                                    |
+| [`redis-outage.md`](./redis-outage.md)                           | `redis` container unhealthy; rate-limiters misbehaving                               |
+| [`db-pool-exhaustion.md`](./db-pool-exhaustion.md)               | `acquire timeout` errors; p95 latency climbs in lockstep                             |
+| [`deploy-rollback.md`](./deploy-rollback.md)                     | Bad deploy: image is live but error rate is up                                       |
+| [`migration-failure.md`](./migration-failure.md)                 | A schema-owning service stuck in `restarting` after a deploy ran a migration         |
+| [`maintenance-mode.md`](./maintenance-mode.md)                   | Planned outage, controlled brownout, or kill-switch needed                           |
+| [`jetstream-backlog.md`](./jetstream-backlog.md)                 | NATS JetStream consumer lag / backlog                                                |
+| [`gdpr-erasure-incident.md`](./gdpr-erasure-incident.md)         | GDPR erasure run failed mid-way                                                      |
+| [`applications-cutover.md`](./applications-cutover.md)           | _Obsolete_ — per-domain cutover flags removed; gateway always registers routes       |
+| [`observability-enable.md`](./observability-enable.md)           | Setup guide — turn on the self-hosted metrics/logs/traces/alerting + GlitchTip stack |
 
 ## On-call principles
 

--- a/docs/runbooks/observability-enable.md
+++ b/docs/runbooks/observability-enable.md
@@ -106,8 +106,8 @@ Tempo datasources and the three dashboards (`service-overview`,
 
 ## 6. GlitchTip project + DSN (if enabled)
 
-1. Tunnel to GlitchTip web (`ssh -L 8000:glitchtip-web:8080 ...`) and create an
-   org + project in the UI.
+1. Tunnel to GlitchTip web (`ssh -L 8000:localhost:8000 deploy@$HOST`, published
+   on host loopback) and create an org + project in the UI.
 2. Copy the project DSN and set it in the host `.env`:
    `SENTRY_DSN=http://<publicKey>@glitchtip-web:8080/<projectId>`
 3. Re-deploy so the app services pick it up. `initializeSentry` activates

--- a/docs/runbooks/observability-enable.md
+++ b/docs/runbooks/observability-enable.md
@@ -1,0 +1,132 @@
+# Enabling the self-hosted observability stack (ADS-1041)
+
+Setup guide (not a firefighting runbook) for turning on the self-hosted
+observability + error-tracking stacks in staging/production. Everything is
+**opt-in and off by default** — the app stack is unchanged until you complete
+these steps.
+
+## What you get
+
+| Overlay                            | Services                                        | Signals                                          |
+| ---------------------------------- | ----------------------------------------------- | ------------------------------------------------ |
+| `docker-compose.observability.yml` | Prometheus, Loki, Tempo, Grafana, Alertmanager  | metrics, logs, traces, dashboards, alert routing |
+| `docker-compose.glitchtip.yml`     | GlitchTip web + worker + its own Postgres/Redis | backend error tracking (Sentry-compatible)       |
+
+The two are independent — enable either or both.
+
+> ⚠️ **Capacity first.** These add ~5 (observability) + ~4 (GlitchTip)
+> containers to a single host the production-readiness review already flags as
+> near its memory/DB-connection ceiling (ADS-1039). Check `docker stats` and
+> free RAM/disk headroom before enabling, and prefer enabling on **staging
+> first**. If the host can't take it, the alternative is a dedicated monitoring
+> VPS (move the overlay there and point the endpoints at it).
+
+## 1. Provision files onto the host
+
+The deploy host holds no repo checkout (`deploy.yml`), so copy the overlay
+compose file(s) and the config tree to `/opt/ads/<env>/` alongside the base
+compose, preserving paths:
+
+```
+/opt/ads/<env>/
+├── docker-compose.observability.yml
+├── docker-compose.glitchtip.yml          # only if enabling GlitchTip
+├── infra/prometheus/rules/               # the SLO alert rules
+└── observability/
+    ├── prometheus/prometheus.yml
+    ├── loki/loki-config.yaml
+    ├── tempo/tempo.yaml
+    ├── alertmanager/alertmanager.yml
+    ├── alertmanager/secrets/             # notifier secrets (see step 4)
+    └── grafana/provisioning/             # datasources + dashboards
+```
+
+(e.g. `scp -r docker-compose.observability.yml infra observability deploy@$HOST:/opt/ads/production/`)
+
+## 2. Set host `.env` values
+
+Add to `/opt/ads/<env>/.env` (see `docs/env-reference.md` for the full list):
+
+```env
+# Turn the overlay(s) on for this host
+OBSERVABILITY_ENABLED=true
+GLITCHTIP_ENABLED=true            # only if enabling GlitchTip
+
+# Point services at the in-network backends
+LOKI_URL=http://loki:3100
+OTEL_EXPORTER_OTLP_ENDPOINT=http://tempo:4318
+OTEL_TRACES_SAMPLER=parentbased_traceidratio
+OTEL_TRACES_SAMPLER_ARG=0.1
+
+# Grafana admin (required — Grafana refuses to start without it)
+GF_SECURITY_ADMIN_PASSWORD=<random>
+
+# GlitchTip (required when GLITCHTIP_ENABLED=true)
+GLITCHTIP_SECRET_KEY=<random 50+ chars>
+GLITCHTIP_DB_PASSWORD=<random>
+```
+
+Leave `SENTRY_DSN` unset for now — you mint it from GlitchTip in step 6.
+
+## 3. Deploy
+
+Re-run `.github/workflows/deploy.yml` for the environment. With the flags set,
+the deploy layers the overlay(s) into `docker compose up -d` automatically.
+(Manual equivalent on the host:
+`docker compose -f docker-compose.<env>.yml -f docker-compose.observability.yml --env-file .env up -d`.)
+
+Confirm containers are healthy: `docker compose -f docker-compose.<env>.yml -f docker-compose.observability.yml ps`.
+
+## 4. Wire Alertmanager (decide the destination)
+
+Alertmanager starts **inert** — alerts group and show in its UI but nothing is
+sent. To route `critical`/`warning`:
+
+1. Drop the secret on the host, e.g. the Slack incoming-webhook URL into
+   `observability/alertmanager/secrets/slack_api_url` (git-ignored, mounted at
+   `/etc/alertmanager/secrets/`).
+2. Uncomment the `slack_configs` / `email_configs` block under the
+   `critical-pager` / `warning-chat` receiver in
+   `observability/alertmanager/alertmanager.yml`.
+3. Reload: `docker compose ... kill -s HUP alertmanager` (or restart it).
+
+Validate config with `amtool check-config observability/alertmanager/alertmanager.yml`.
+
+## 5. Reach Grafana
+
+Grafana has no public port. Tunnel to it:
+
+```
+ssh -L 3030:localhost:3030 deploy@$HOST   # then browse http://localhost:3030
+```
+
+Log in as `admin` / `GF_SECURITY_ADMIN_PASSWORD`. The Prometheus, Loki, and
+Tempo datasources and the three dashboards (`service-overview`,
+`domain-operations`, `audit-events`) are provisioned automatically.
+
+## 6. GlitchTip project + DSN (if enabled)
+
+1. Tunnel to GlitchTip web (`ssh -L 8000:glitchtip-web:8080 ...`) and create an
+   org + project in the UI.
+2. Copy the project DSN and set it in the host `.env`:
+   `SENTRY_DSN=http://<publicKey>@glitchtip-web:8080/<projectId>`
+3. Re-deploy so the app services pick it up. `initializeSentry` activates
+   automatically (NODE_ENV is production/staging).
+
+## 7. Verify signals
+
+- **Metrics:** Grafana → `service-overview` populates; Prometheus → Status →
+  Targets shows all 11 `service-*` jobs `UP` (incl. `service-chat`, `service-cms`).
+- **Logs:** Grafana → Explore → Loki → `{service="service.gateway"}` returns lines.
+- **Traces:** Grafana → Explore → Tempo → recent traces appear (hit an endpoint first).
+- **Alerts:** Prometheus → Alerts lists the SLO rules as `inactive`/`pending`.
+- **Errors:** trigger a handled error and confirm it lands in GlitchTip.
+
+## Disabling / rollback
+
+Set `OBSERVABILITY_ENABLED=false` (and/or `GLITCHTIP_ENABLED=false`) in the host
+`.env` and re-deploy — the overlay is dropped from `up -d`. Stop leftover
+containers with
+`docker compose -f docker-compose.<env>.yml -f docker-compose.observability.yml down`.
+App services keep running; their shipping endpoints go inert. Named volumes
+(metrics/logs/traces/GlitchTip data) persist unless you `down -v`.

--- a/docs/slo.md
+++ b/docs/slo.md
@@ -117,15 +117,23 @@ runbook to open on fire.
 
 ## Severity & on-call
 
-The rules label severity but **deliberately do not configure Alertmanager
-routing or receivers** — that needs a real destination (PagerDuty key / Slack
-webhook) which does not exist in this repo yet. Wire routing when a destination
-is provisioned. Until then the convention is:
+As of ADS-1041 the rules are **loaded** by Prometheus and routed by
+Alertmanager (severity-based) in the deployed observability stack
+(`docker-compose.observability.yml` / dev `observability` profile). Alertmanager
+ships **inert** — the `critical-pager` / `warning-chat` receivers carry no
+notifier config, so alerts group and show in the UI but nothing is sent until an
+operator drops a Slack webhook / SMTP secret in and uncomments the receiver block
+(`observability/alertmanager/alertmanager.yml`; see
+`docs/runbooks/observability-enable.md`). The routing convention:
 
-| Severity   | Intended routing (TODO: wire) | Response             |
-| ---------- | ----------------------------- | -------------------- |
-| `critical` | page                          | ack within 5 min     |
-| `warning`  | chat channel                  | review within 30 min |
+| Severity   | Alertmanager route | Once wired   | Response             |
+| ---------- | ------------------ | ------------ | -------------------- |
+| `critical` | `critical-pager`   | page         | ack within 5 min     |
+| `warning`  | `warning-chat`     | chat channel | review within 30 min |
+
+Retention is sized to the objectives above: Prometheus keeps **30 days** of
+metrics (the error-budget window), Loki **14 days** of logs, Tempo **3 days** of
+traces.
 
 Each `critical`/`warning` rule annotates a `runbook` — open it from the alert.
 Runbook index: [`docs/runbooks/README.md`](./runbooks/README.md).

--- a/infra/prometheus/rules/README.md
+++ b/infra/prometheus/rules/README.md
@@ -8,13 +8,13 @@ that **actually exists** in the current stack (see the metrics table in
 
 ## Files
 
-| File | Rules |
-| --- | --- |
-| `service-down.yml` | `ServiceDown` — scrape `up == 0` per service |
-| `high-error-rate.yml` | `HighErrorRate` (HTTP 5xx), `HighGrpcErrorRate` (gRPC non-OK) |
-| `p95-latency.yml` | `HttpP95LatencyHigh`, `GrpcP95LatencyHigh` |
-| `gdpr-saga.yml` | `GdprSagaFailed`, `GdprSagaTimedOut`, `GdprErasureRequestedNotCompleted` |
-| `gateway-resilience.yml` | `GatewayCircuitOpen`, `GatewayRateLimitSpike` |
+| File                     | Rules                                                                    |
+| ------------------------ | ------------------------------------------------------------------------ |
+| `service-down.yml`       | `ServiceDown` — scrape `up == 0` per service                             |
+| `high-error-rate.yml`    | `HighErrorRate` (HTTP 5xx), `HighGrpcErrorRate` (gRPC non-OK)            |
+| `p95-latency.yml`        | `HttpP95LatencyHigh`, `GrpcP95LatencyHigh`                               |
+| `gdpr-saga.yml`          | `GdprSagaFailed`, `GdprSagaTimedOut`, `GdprErasureRequestedNotCompleted` |
+| `gateway-resilience.yml` | `GatewayCircuitOpen`, `GatewayRateLimitSpike`                            |
 
 ## Assumptions
 
@@ -63,10 +63,18 @@ promtool check rules infra/prometheus/rules/*.yml
 (YAML structure is also CI-checkable with any YAML loader; promtool
 additionally validates the PromQL expressions.)
 
-## Out of scope
+## Alertmanager (ADS-1041)
 
-**Alertmanager routing & receivers are not configured here.** Routing needs a
-real destination (PagerDuty integration key / Slack webhook) that this repo
-does not yet have. The rules set a `severity` label and a `runbook` annotation;
-wire `severity`-based routes in Alertmanager once a destination exists. See
-`docs/slo.md` for the intended severity → routing convention.
+These files are now **loaded** by Prometheus (`rule_files:` in
+`observability/prometheus/prometheus.yml`) and routed by **Alertmanager**
+(`observability/alertmanager/alertmanager.yml`) in both the dev `observability`
+profile and the prod/staging overlay (`docker-compose.observability.yml`).
+
+Routing keys off the `severity` label: `critical` → the `critical-pager`
+receiver, `warning` → `warning-chat`. Both receivers ship **inert** (no notifier
+config) so the stack starts with zero secrets and simply drops notifications.
+Wire a real destination by uncommenting the Slack/email block in
+`alertmanager.yml` and dropping the secret into
+`observability/alertmanager/secrets/` — see
+`docs/runbooks/observability-enable.md`. `docs/slo.md` documents the intended
+severity → routing convention.

--- a/observability/alertmanager/alertmanager.yml
+++ b/observability/alertmanager/alertmanager.yml
@@ -1,0 +1,76 @@
+# Alertmanager routing for the deployed observability stack (ADS-1041 / ADS-1052).
+#
+# Routes the SLO alert rules (infra/prometheus/rules/, loaded by Prometheus) by
+# their `severity` label. Ships INERT: both receivers are defined but carry no
+# notifier configs, so Alertmanager starts cleanly with zero secrets and simply
+# drops notifications (alerts still group and show in the Alertmanager UI).
+#
+# Wire a real destination LATER (the ADS-1041 "template both, decide later"
+# choice): uncomment the slack_configs / email_configs block under the relevant
+# receiver and drop the secret into observability/alertmanager/secrets/ on the
+# host (mounted read-only at /etc/alertmanager/secrets/). Alertmanager reads the
+# webhook URL / SMTP password from a file so it never lands in `docker inspect`.
+# Reload with `docker compose kill -s HUP alertmanager` (or restart).
+
+global:
+  resolve_timeout: 5m
+
+route:
+  # Group alerts so a burst from one service arrives as one notification.
+  group_by: ['alertname', 'severity', 'job']
+  group_wait: 30s
+  group_interval: 5m
+  repeat_interval: 4h
+  # Default sink — inert. Every alert also matches a severity child route below.
+  receiver: 'warning-chat'
+  routes:
+    - matchers:
+        - severity = "critical"
+      receiver: 'critical-pager'
+      # Page fast and re-page more often for criticals.
+      group_wait: 10s
+      repeat_interval: 1h
+    - matchers:
+        - severity = "warning"
+      receiver: 'warning-chat'
+
+# Suppress a warning for the same alertname/job once its critical is already
+# firing (e.g. don't send "high latency" warning while "service down" pages).
+inhibit_rules:
+  - source_matchers: [severity = "critical"]
+    target_matchers: [severity = "warning"]
+    equal: ['alertname', 'job']
+
+receivers:
+  # ---- CRITICAL → paging channel -----------------------------------------
+  # Inert until a notifier is added. Recommended: Slack (or PagerDuty/Opsgenie
+  # for true on-call escalation). To activate Slack, create the secret file
+  #   observability/alertmanager/secrets/slack_api_url   (the incoming-webhook URL)
+  # and uncomment:
+  - name: 'critical-pager'
+    # slack_configs:
+    #   - channel: '#alerts-critical'
+    #     api_url_file: /etc/alertmanager/secrets/slack_api_url
+    #     send_resolved: true
+    #     title: '[{{ .Status | toUpper }}] {{ .CommonLabels.alertname }}'
+    #     text: >-
+    #       {{ range .Alerts }}{{ .Annotations.summary }}
+    #       {{ .Annotations.description }}
+    #       Runbook: {{ .Annotations.runbook }}
+    #       {{ end }}
+
+  # ---- WARNING → chat channel --------------------------------------------
+  # Inert until a notifier is added. Slack example (create
+  #   observability/alertmanager/secrets/slack_api_url) or SMTP email:
+  - name: 'warning-chat'
+    # slack_configs:
+    #   - channel: '#alerts'
+    #     api_url_file: /etc/alertmanager/secrets/slack_api_url
+    #     send_resolved: true
+    # email_configs:
+    #   - to: 'oncall@adoptdontshop.com'
+    #     from: 'alertmanager@adoptdontshop.com'
+    #     smarthost: 'smtp.example.com:587'
+    #     auth_username: 'alertmanager@adoptdontshop.com'
+    #     auth_password_file: /etc/alertmanager/secrets/smtp_password
+    #     send_resolved: true

--- a/observability/alertmanager/secrets/.gitignore
+++ b/observability/alertmanager/secrets/.gitignore
@@ -1,0 +1,5 @@
+# Alertmanager notifier secrets (Slack webhook URL, SMTP password) are dropped
+# here on the host and mounted read-only at /etc/alertmanager/secrets/. Never
+# commit real values — keep the directory tracked, ignore its contents.
+*
+!.gitignore

--- a/observability/grafana/provisioning/datasources/tempo.yaml
+++ b/observability/grafana/provisioning/datasources/tempo.yaml
@@ -1,0 +1,12 @@
+apiVersion: 1
+
+# Auto-provisioned Tempo datasource (ADS-1041). Grafana picks this up on boot
+# via the provisioning bind-mount. Traces arrive from every service's OTel SDK
+# (OTEL_EXPORTER_OTLP_ENDPOINT=http://tempo:4318); Grafana queries Tempo on :3200.
+datasources:
+  - name: Tempo
+    type: tempo
+    access: proxy
+    uid: tempo
+    url: http://tempo:3200
+    isDefault: false

--- a/observability/loki/loki-config.yaml
+++ b/observability/loki/loki-config.yaml
@@ -1,0 +1,56 @@
+# Loki config for the deployed observability stack (ADS-1041).
+#
+# Dev (docker-compose.yml `observability` profile) runs Loki with its built-in
+# local-config.yaml; prod/staging mount THIS file instead so retention and
+# on-disk layout are pinned rather than left at the image default. Single-binary
+# filesystem mode — no object store, no clustering — which suits the
+# single-host deploy. All services ship logs here via winston-loki when
+# LOKI_URL=http://loki:3100 is set (packages/observability/src/logger.ts).
+auth_enabled: false
+
+server:
+  http_listen_port: 3100
+  grpc_listen_port: 9096
+  log_level: info
+
+common:
+  instance_addr: 127.0.0.1
+  path_prefix: /loki
+  storage:
+    filesystem:
+      chunks_directory: /loki/chunks
+      rules_directory: /loki/rules
+  replication_factor: 1
+  ring:
+    kvstore:
+      store: inmemory
+
+schema_config:
+  configs:
+    - from: 2024-01-01
+      store: tsdb
+      object_store: filesystem
+      schema: v13
+      index:
+        prefix: index_
+        period: 24h
+
+limits_config:
+  # 14-day log retention. Metrics carry the 30-day SLO error-budget window
+  # (Prometheus); logs are far heavier per day, so they get a shorter window to
+  # bound disk on the single host. Tune per host capacity.
+  retention_period: 336h
+  reject_old_samples: true
+  reject_old_samples_max_age: 168h
+  ingestion_rate_mb: 8
+  ingestion_burst_size_mb: 16
+
+compactor:
+  working_directory: /loki/compactor
+  retention_enabled: true
+  delete_request_store: filesystem
+
+# Don't phone home usage analytics — this stack processes UK user data and stays
+# on our own infra by design (ADS-1041).
+analytics:
+  reporting_enabled: false

--- a/observability/prometheus/prometheus.yml
+++ b/observability/prometheus/prometheus.yml
@@ -2,9 +2,20 @@ global:
   scrape_interval: 15s
   evaluation_interval: 15s
 
-# Alerting rules — committed in infra/prometheus/rules/ (ADS-806).
-# rule_files:
-#   - /etc/prometheus/rules/*.yml
+# Alerting rules — committed in infra/prometheus/rules/ (ADS-806), loaded here
+# (ADS-1041). The rules dir is bind-mounted at /etc/prometheus/rules by the dev
+# `observability` profile and by docker-compose.observability.yml in prod/staging.
+rule_files:
+  - /etc/prometheus/rules/*.yml
+
+# Route firing alerts to Alertmanager (ADS-1041). Alertmanager runs alongside
+# Prometheus in the same stack (dev `observability` profile /
+# docker-compose.observability.yml). If it is not running the rules still
+# evaluate and show in the Prometheus UI; only routing/paging is unavailable.
+alerting:
+  alertmanagers:
+    - static_configs:
+        - targets: ['alertmanager:9093']
 
 scrape_configs:
   # Gateway — the single REST edge and the /metrics aggregation point
@@ -42,6 +53,13 @@ scrape_configs:
       - targets: ['service-applications:5005']
     metrics_path: /metrics
 
+  # ADS-1052: service-chat was missing from the scrape config despite exposing
+  # /metrics via the same createMicroserviceServer() path as every other service.
+  - job_name: service-chat
+    static_configs:
+      - targets: ['service-chat:5006']
+    metrics_path: /metrics
+
   - job_name: service-moderation
     static_configs:
       - targets: ['service-moderation:5007']
@@ -55,4 +73,10 @@ scrape_configs:
   - job_name: service-audit
     static_configs:
       - targets: ['service-audit:5009']
+    metrics_path: /metrics
+
+  # ADS-1052: service-cms was missing from the scrape config (same gap as chat).
+  - job_name: service-cms
+    static_configs:
+      - targets: ['service-cms:5010']
     metrics_path: /metrics

--- a/observability/tempo/tempo.yaml
+++ b/observability/tempo/tempo.yaml
@@ -1,0 +1,39 @@
+# Tempo config for the deployed observability stack (ADS-1041).
+#
+# Single-binary, local-filesystem trace storage — matches the single-host
+# deploy. Every service's OpenTelemetry SDK (packages/observability/src/
+# opentelemetry.ts) exports OTLP/HTTP here when OTEL_EXPORTER_OTLP_ENDPOINT is
+# set (=http://tempo:4318). Grafana queries Tempo on :3200.
+server:
+  http_listen_port: 3200
+  log_level: info
+
+distributor:
+  receivers:
+    otlp:
+      protocols:
+        http:
+          endpoint: 0.0.0.0:4318
+        grpc:
+          endpoint: 0.0.0.0:4317
+
+ingester:
+  max_block_duration: 5m
+
+compactor:
+  compaction:
+    # 3-day trace retention — enough to investigate an incident, cheap on disk.
+    # Traces are the highest-volume signal; keep the window short on one host.
+    block_retention: 72h
+
+storage:
+  trace:
+    backend: local
+    wal:
+      path: /var/tempo/wal
+    local:
+      path: /var/tempo/blocks
+
+# Stay on our own infra — no usage phone-home (ADS-1041).
+usage_report:
+  reporting_enabled: false

--- a/packages/service-bootstrap/src/server.test.ts
+++ b/packages/service-bootstrap/src/server.test.ts
@@ -213,6 +213,36 @@ describe('createMicroserviceServer — x-request-id propagation', () => {
   });
 });
 
+describe('createMicroserviceServer — Sentry initialization (ADS-1041)', () => {
+  it('initializes error tracking at boot (reports disabled without a DSN in test env)', async () => {
+    // Sentry init logs its enablement decision via the provided logger — with
+    // no DSN in the test env it reports "disabled". Observing that line proves
+    // the boot path now invokes initializeSentry (the call site it was missing),
+    // without reaching into the SDK.
+    const infoMessages: string[] = [];
+    const capturingLogger = {
+      info: (msg: string) => {
+        infoMessages.push(msg);
+      },
+      error: () => undefined,
+      warn: () => undefined,
+      debug: () => undefined,
+      silly: () => undefined,
+    } as unknown as ReturnType<typeof import('@adopt-dont-shop/observability').createLogger>;
+
+    const server = createMicroserviceServer({
+      serviceName: 'service.test',
+      config: baseConfig,
+      logger: capturingLogger,
+    });
+    try {
+      expect(infoMessages.some(msg => /sentry/i.test(msg))).toBe(true);
+    } finally {
+      await server.close();
+    }
+  });
+});
+
 describe('createMicroserviceServer — error handler', () => {
   let server: FastifyInstance;
 

--- a/packages/service-bootstrap/src/server.test.ts
+++ b/packages/service-bootstrap/src/server.test.ts
@@ -215,10 +215,11 @@ describe('createMicroserviceServer — x-request-id propagation', () => {
 
 describe('createMicroserviceServer — Sentry initialization (ADS-1041)', () => {
   it('initializes error tracking at boot (reports disabled without a DSN in test env)', async () => {
-    // Sentry init logs its enablement decision via the provided logger — with
-    // no DSN in the test env it reports "disabled". Observing that line proves
-    // the boot path now invokes initializeSentry (the call site it was missing),
-    // without reaching into the SDK.
+    // initializeSentry always logs its decision via the provided logger — one of
+    // "Sentry is disabled" / "Sentry initialized successfully" / "Failed to
+    // initialize Sentry". The /sentry/i matcher below covers all three, so this
+    // proves the boot path now invokes initializeSentry (the call site it was
+    // missing) regardless of NODE_ENV / SENTRY_DSN, without reaching into the SDK.
     const infoMessages: string[] = [];
     const capturingLogger = {
       info: (msg: string) => {

--- a/packages/service-bootstrap/src/server.ts
+++ b/packages/service-bootstrap/src/server.ts
@@ -7,7 +7,12 @@
 //   - x-request-id   — echoed on every response.
 //   - Error handler   — logs + returns {error:'internal_error'}.
 
-import { createLogger, registerMetrics, registerRequestId } from '@adopt-dont-shop/observability';
+import {
+  createLogger,
+  initializeSentry,
+  registerMetrics,
+  registerRequestId,
+} from '@adopt-dont-shop/observability';
 import Fastify, { type FastifyInstance } from 'fastify';
 
 import { registerReadinessRoute, type ReadinessDeps } from './readiness.js';
@@ -34,6 +39,11 @@ export const createMicroserviceServer = (opts: CreateServerOptions): FastifyInst
   const { serviceName, config } = opts;
   const logger = opts.logger ?? createLogger({ serviceName });
   const isReady = opts.isReady ?? (() => true);
+
+  // ADS-1041: initialize backend error tracking (GlitchTip/Sentry SDK). No-op
+  // unless SENTRY_DSN is set AND NODE_ENV is production/staging, so it's safe to
+  // call unconditionally at boot — this is the call site the SDK was missing.
+  initializeSentry({ serviceName, logger });
 
   // Disable Fastify's built-in pino — winston handles service-level lines
   // (boot, shutdown, error handler) and OTel's HTTP auto-instrumentation

--- a/services/gateway/src/index.ts
+++ b/services/gateway/src/index.ts
@@ -2,7 +2,7 @@ import Redis from 'ioredis';
 import { connect, type NatsConnection } from 'nats';
 import type { Server as IOServer } from 'socket.io';
 
-import { createLogger } from '@adopt-dont-shop/observability';
+import { createLogger, initializeSentry } from '@adopt-dont-shop/observability';
 import {
   assertPrincipalVerificationConfig,
   installProcessErrorHandlers,
@@ -28,6 +28,12 @@ import { attachSocketServer } from './ws/socket-server.js';
 
 const main = async (): Promise<void> => {
   const logger = createLogger({ serviceName: 'service.gateway' });
+
+  // ADS-1041: initialize backend error tracking (GlitchTip/Sentry SDK). No-op
+  // unless SENTRY_DSN is set AND NODE_ENV is production/staging. The gateway
+  // boots its own server (not createMicroserviceServer), so it needs its own
+  // call site.
+  initializeSentry({ serviceName: 'service.gateway', logger });
 
   let nats: NatsConnection | undefined;
   let io: IOServer | undefined;


### PR DESCRIPTION
## Summary

<!-- What does this PR do? 1-3 bullet points. -->

- Gives the (already-built) backend instrumentation something to run against in prod/staging: a self-hosted **LGTM** stack (Loki, Grafana, Tempo, Prometheus) + **Alertmanager** + self-hosted **GlitchTip** error tracking, shipped as opt-in Compose overlays. Fixes ADS-1041 ("the system runs blind") and unblocks ADS-1052.
- **Off by default** — app services get the shipping endpoints wired but inert (`${VAR:-}`), and the backends only start when a host `.env` flag turns the overlay on. Existing deploys are byte-for-byte unchanged.
- Fixes the ticket's "dead Sentry": `initializeSentry` had **no call site**, so backend error tracking never ran. Wired it into service boot.

## Changes

<!-- List the key files/areas changed. -->

- **Configs** (`observability/`): enabled the committed SLO alert rules + Alertmanager routing in `prometheus.yml` and added the missing `service-chat`/`service-cms` scrape jobs (ADS-1052); new Loki (14d), Tempo (OTLP/HTTP, 3d), and Alertmanager (severity routing, inert until a Slack/email secret is dropped in) configs; Grafana Tempo datasource. Analytics phone-home disabled on Loki/Tempo/Grafana.
- **Overlays**: `docker-compose.observability.yml` (Prometheus 30d, Loki, Tempo, Grafana, Alertmanager — internal-only, hardened, admin-password-required) and `docker-compose.glitchtip.yml` (web + worker + own Postgres/Redis so it never touches the app DB's connection budget). Layered onto prod/staging by the deploy only when `OBSERVABILITY_ENABLED` / `GLITCHTIP_ENABLED` are set in the host `.env`.
- **App wiring** (`docker-compose.{prod,staging}.yml`): pass `LOKI_URL` / `OTEL_EXPORTER_OTLP_ENDPOINT` / `SENTRY_DSN` to every service + gateway, inert by default. Dev (`docker-compose.yml`): added Tempo + Alertmanager + the rules mount for parity.
- **Code**: `packages/service-bootstrap` `createMicroserviceServer` + `services/gateway` boot now call `initializeSentry` (covers all 10 domain services + gateway, once each; still a no-op unless `SENTRY_DSN` + `NODE_ENV` prod/staging). Boot test added.
- **Docs**: new `docs/runbooks/observability-enable.md` (provision → configure → enable → wire Alertmanager → Grafana → GlitchTip DSN → verify → rollback, with a single-host capacity warning); `env-reference`, `slo.md`, rules README, `tracing.md` updated.

## Before requesting review

<!-- Quick PR-readiness signal — see CONTRIBUTING.md for context. -->

- [ ] Ran `pnpm ci:local:quick` locally — ran the affected package suite + targeted type-check/compose validation instead (see Test plan); full gates run in CI
- [x] Tests for new behaviour added (TDD) — `server.test.ts` covers the Sentry boot call site
- [ ] If touching `.env` requirements, updated `.env.example`'s REQUIRED block — N/A: no REQUIRED vars changed; the new vars are optional, opt-in, prod-host-only and documented in `docs/env-reference.md` per repo convention
- [x] If touching a `lib.*`, considered consumer impact — `service-bootstrap` change is inert unless `SENTRY_DSN` is set; consumers are the 10 services + gateway

## Test plan

<!-- How did you verify this works? Check off items as you go. -->

- [x] Affected package tests pass — `@adopt-dont-shop/service-bootstrap` 115/115 (incl. new Sentry boot test); full `pnpm test` runs in CI
- [x] New behaviour is covered by tests
- [x] Tested manually — `docker compose config` validates dev (`--profile observability`) and prod+overlays / staging+overlays cleanly; observability services join the correct env network; app services pick up the inert endpoints; Prometheus/Alertmanager/rule configs structurally validated (11 scrape jobs incl. chat+cms; severity routes match rule labels)
- [x] No TypeScript errors — `type-check` green on `service-bootstrap` + `service.gateway`
- [x] Lint passes — pre-commit lint-staged (prettier + turbo lint) green on changed files

## Screenshots / recordings

<!-- For UI changes, attach a screenshot or recording. Delete if not applicable. -->

N/A — infrastructure + config, no app UI changes.

## Related

<!-- Link to Linear ticket, related PRs, or issues. -->

- ADS-1041 — [Critical] No observability stack in prod/staging (this PR)
- ADS-1052 — Alerting & background-job failures unobservable (partially unblocked: rules loaded, Alertmanager deployed, chat/cms scraped; DLQ/job/cron counters + receiver wiring remain)
- ADS-1039 — Production Readiness Review (parent)

### Follow-ups (not in this PR)
- Verify OTLP trace arrival after enabling (endpoint set to the collector-root form per repo convention; non-fatal if the exporter needs `/v1/traces` appended).
- Digest-pin the new observability/GlitchTip images (Renovate) and confirm the GlitchTip image tag before first enable.
- Remaining ADS-1052 items: DLQ depth + `*_failures_total` counters, `FOR UPDATE SKIP LOCKED` cron claim.

---
_Generated by [Claude Code](https://claude.ai/code/session_016W4c3UAkS94RxnkYpfdi3i)_