### PR TITLE
fix(security): reject placeholder and reused secrets at boot in production (ADS-1047)

### DIFF
--- a/packages/config-secrets/src/index.test.ts
+++ b/packages/config-secrets/src/index.test.ts
@@ -4,7 +4,13 @@ import { join } from 'node:path';
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
-import { parsePort, readSecret, requireHexSecret, requireSecret } from './index.js';
+import {
+  parsePort,
+  readSecret,
+  requireDistinctSecrets,
+  requireHexSecret,
+  requireSecret,
+} from './index.js';
 
 describe('readSecret', () => {
   let tmp: string;
@@ -139,6 +145,29 @@ describe('requireSecret', () => {
       requireSecret('JWT_SECRET', { JWT_SECRET: 'env-value', JWT_SECRET_FILE: file })
     ).toThrow(/JWT_SECRET and JWT_SECRET_FILE are both set/);
   });
+
+  it('rejects a CHANGE_THIS placeholder value in production (ADS-1047)', () => {
+    expect(() =>
+      requireSecret('JWT_SECRET', { NODE_ENV: 'production', JWT_SECRET: 'CHANGE_THIS_jwt_secret' })
+    ).toThrow(/JWT_SECRET is set to a placeholder value/);
+  });
+
+  it('matches the placeholder prefix case-insensitively', () => {
+    expect(() =>
+      requireSecret('JWT_SECRET', { NODE_ENV: 'production', JWT_SECRET: 'change_this_now' })
+    ).toThrow(/JWT_SECRET is set to a placeholder value/);
+  });
+
+  it('allows a placeholder-looking value outside production (dev/test use throwaways)', () => {
+    expect(
+      requireSecret('JWT_SECRET', { NODE_ENV: 'development', JWT_SECRET: 'CHANGE_THIS_jwt_secret' })
+    ).toBe('CHANGE_THIS_jwt_secret');
+  });
+
+  it('accepts a real (non-placeholder) secret in production', () => {
+    const value = 'a-real-access-signing-secret-value-32b';
+    expect(requireSecret('JWT_SECRET', { NODE_ENV: 'production', JWT_SECRET: value })).toBe(value);
+  });
 });
 
 describe('requireHexSecret', () => {
@@ -174,6 +203,35 @@ describe('requireHexSecret', () => {
 
   it('throws when the secret is missing', () => {
     expect(() => requireHexSecret('ENCRYPTION_KEY', {})).toThrow(/ENCRYPTION_KEY is required/);
+  });
+});
+
+describe('requireDistinctSecrets', () => {
+  it('does nothing outside production, even when two secrets are reused', () => {
+    expect(() =>
+      requireDistinctSecrets(
+        { JWT_SECRET: 'same', JWT_REFRESH_SECRET: 'same' },
+        { NODE_ENV: 'development' }
+      )
+    ).not.toThrow();
+  });
+
+  it('throws in production when two secrets share a value, naming the pair', () => {
+    expect(() =>
+      requireDistinctSecrets(
+        { JWT_SECRET: 'same-value', JWT_REFRESH_SECRET: 'same-value' },
+        { NODE_ENV: 'production' }
+      )
+    ).toThrow(/JWT_SECRET and JWT_REFRESH_SECRET must be distinct/);
+  });
+
+  it('passes in production when every secret is distinct', () => {
+    expect(() =>
+      requireDistinctSecrets(
+        { JWT_SECRET: 'a', JWT_REFRESH_SECRET: 'b', ENCRYPTION_KEY: 'c' },
+        { NODE_ENV: 'production' }
+      )
+    ).not.toThrow();
   });
 });
 

--- a/packages/config-secrets/src/index.test.ts
+++ b/packages/config-secrets/src/index.test.ts
@@ -168,6 +168,15 @@ describe('requireSecret', () => {
     const value = 'a-real-access-signing-secret-value-32b';
     expect(requireSecret('JWT_SECRET', { NODE_ENV: 'production', JWT_SECRET: value })).toBe(value);
   });
+
+  it('trims NODE_ENV so whitespace cannot fail-open the production placeholder check', () => {
+    expect(() =>
+      requireSecret('JWT_SECRET', {
+        NODE_ENV: ' production ',
+        JWT_SECRET: 'CHANGE_THIS_jwt_secret',
+      })
+    ).toThrow(/JWT_SECRET is set to a placeholder value/);
+  });
 });
 
 describe('requireHexSecret', () => {
@@ -232,6 +241,15 @@ describe('requireDistinctSecrets', () => {
         { NODE_ENV: 'production' }
       )
     ).not.toThrow();
+  });
+
+  it('trims NODE_ENV so whitespace cannot fail-open the production distinct check', () => {
+    expect(() =>
+      requireDistinctSecrets(
+        { JWT_SECRET: 'same', JWT_REFRESH_SECRET: 'same' },
+        { NODE_ENV: 'production\n' }
+      )
+    ).toThrow(/JWT_SECRET and JWT_REFRESH_SECRET must be distinct/);
   });
 });
 

--- a/packages/config-secrets/src/index.ts
+++ b/packages/config-secrets/src/index.ts
@@ -24,8 +24,14 @@ const PLACEHOLDER_PREFIX = 'change_this';
 const isPlaceholderValue = (value: string): boolean =>
   value.toLowerCase().startsWith(PLACEHOLDER_PREFIX);
 
+// Trim NODE_ENV before comparing — env-file values can carry trailing/leading
+// whitespace, and a raw `=== 'production'` would then fail-open, silently
+// skipping the production-only security checks below. Mirrors how services read
+// NODE_ENV elsewhere (`env.NODE_ENV?.trim()`).
+const isProductionEnv = (env: NodeJS.ProcessEnv): boolean => env.NODE_ENV?.trim() === 'production';
+
 const assertNotPlaceholder = (name: string, value: string, env: NodeJS.ProcessEnv): void => {
-  if (env.NODE_ENV === 'production' && isPlaceholderValue(value)) {
+  if (isProductionEnv(env) && isPlaceholderValue(value)) {
     throw new Error(
       `${name} is set to a placeholder value — replace it with a real secret before deploying to production`
     );
@@ -167,7 +173,7 @@ export const requireDistinctSecrets = (
   secrets: Record<string, string>,
   env: NodeJS.ProcessEnv = process.env
 ): void => {
-  if (env.NODE_ENV !== 'production') {
+  if (!isProductionEnv(env)) {
     return;
   }
   const seenByValue = new Map<string, string>();

--- a/packages/config-secrets/src/index.ts
+++ b/packages/config-secrets/src/index.ts
@@ -13,6 +13,25 @@
 
 import { readFileSync } from 'node:fs';
 
+// ADS-1047: reject obvious `.env.example` placeholders at boot in production.
+// The length/hex checks below let a `CHANGE_THIS…`-style value (>= the byte
+// floor) boot cleanly, so a deploy that forgot to substitute real secrets runs
+// with a known, guessable credential. Match the repo-wide `CHANGE_THIS`
+// placeholder convention (see `.env.example` and lib.validation's env schema).
+// Production-gated only: dev/test/e2e legitimately use throwaway values.
+const PLACEHOLDER_PREFIX = 'change_this';
+
+const isPlaceholderValue = (value: string): boolean =>
+  value.toLowerCase().startsWith(PLACEHOLDER_PREFIX);
+
+const assertNotPlaceholder = (name: string, value: string, env: NodeJS.ProcessEnv): void => {
+  if (env.NODE_ENV === 'production' && isPlaceholderValue(value)) {
+    throw new Error(
+      `${name} is set to a placeholder value — replace it with a real secret before deploying to production`
+    );
+  }
+};
+
 /**
  * Resolve a secret value from either a file-mounted Docker secret or a
  * plain env var.
@@ -78,6 +97,7 @@ export const requireSecret = (
     const detail = description !== undefined ? ` (${description})` : '';
     throw new Error(`${name} is required${detail}`);
   }
+  assertNotPlaceholder(name, value, env);
   if (opts?.minBytes !== undefined && Buffer.byteLength(value, 'utf8') < opts.minBytes) {
     throw new Error(`${name} must be at least ${opts.minBytes} bytes`);
   }
@@ -130,4 +150,34 @@ export const parsePort = (raw: string | undefined, fallback: number, name: strin
     throw new Error(`${name} must be a positive integer, got "${trimmed}"`);
   }
   return value;
+};
+
+/**
+ * Assert that a service's own signing/encryption secrets are all distinct
+ * (ADS-1047). Reusing one value for two secrets (e.g. `JWT_SECRET` ===
+ * `JWT_REFRESH_SECRET`) means a single disclosure compromises both, defeating
+ * the reason they are separate keys. `config-secrets` only sees one service's
+ * secrets, so this covers intra-service reuse; cross-service distinctness is a
+ * deploy-time concern (scripts/validate-env.ts).
+ *
+ * Production-gated: dev/test may reuse throwaway values. Pass the resolved
+ * values keyed by their env-var name so the error can name the offending pair.
+ */
+export const requireDistinctSecrets = (
+  secrets: Record<string, string>,
+  env: NodeJS.ProcessEnv = process.env
+): void => {
+  if (env.NODE_ENV !== 'production') {
+    return;
+  }
+  const seenByValue = new Map<string, string>();
+  for (const [name, value] of Object.entries(secrets)) {
+    const previousName = seenByValue.get(value);
+    if (previousName !== undefined) {
+      throw new Error(
+        `${previousName} and ${name} must be distinct — reusing a secret widens the blast radius of a single disclosure`
+      );
+    }
+    seenByValue.set(value, name);
+  }
 };

--- a/services/auth/src/config.test.ts
+++ b/services/auth/src/config.test.ts
@@ -133,4 +133,34 @@ describe('loadConfig', () => {
     expect(config.host).toBe('localhost');
     expect(config.schema).toBe('custom_schema');
   });
+
+  it('rejects reused access/refresh signing secrets in production (ADS-1047)', () => {
+    expect(() =>
+      loadConfig({
+        ...REQUIRED,
+        NODE_ENV: 'production',
+        // Same value for both signing secrets defeats their separation.
+        JWT_REFRESH_SECRET: VALID_ACCESS_SECRET,
+      })
+    ).toThrow(/JWT_SECRET and JWT_REFRESH_SECRET must be distinct/);
+  });
+
+  it('rejects a CHANGE_THIS placeholder signing secret in production (ADS-1047)', () => {
+    expect(() =>
+      loadConfig({
+        ...REQUIRED,
+        NODE_ENV: 'production',
+        JWT_SECRET: 'CHANGE_THIS_to_a_real_access_signing_secret',
+      })
+    ).toThrow(/JWT_SECRET is set to a placeholder value/);
+  });
+
+  it('tolerates reused signing secrets outside production (dev convenience)', () => {
+    const config = loadConfig({
+      ...REQUIRED,
+      JWT_REFRESH_SECRET: VALID_ACCESS_SECRET,
+    });
+    expect(config.jwtSecret).toBe(VALID_ACCESS_SECRET);
+    expect(config.jwtRefreshSecret).toBe(VALID_ACCESS_SECRET);
+  });
 });

--- a/services/auth/src/config.ts
+++ b/services/auth/src/config.ts
@@ -1,4 +1,9 @@
-import { parsePort, requireHexSecret, requireSecret } from '@adopt-dont-shop/config-secrets';
+import {
+  parsePort,
+  requireDistinctSecrets,
+  requireHexSecret,
+  requireSecret,
+} from '@adopt-dont-shop/config-secrets';
 
 export type AuthConfig = {
   // HTTP port for the boot-readiness surface (/health/simple). Distinct
@@ -59,6 +64,18 @@ export const loadConfig = (env: NodeJS.ProcessEnv = process.env): AuthConfig => 
   const encryptionKey = requireHexSecret('ENCRYPTION_KEY', env, {
     description: 'AES-256-GCM key for encrypting TOTP secrets at rest',
   });
+
+  // The access/refresh signing secrets are separate keys by design (a leaked
+  // access secret must not also forge refresh tokens); enforce they aren't
+  // reused for the same value in production (ADS-1047).
+  requireDistinctSecrets(
+    {
+      JWT_SECRET: jwtSecret,
+      JWT_REFRESH_SECRET: jwtRefreshSecret,
+      ENCRYPTION_KEY: encryptionKey,
+    },
+    env
+  );
 
   return {
     port,


### PR DESCRIPTION
## Summary

ADS-1047 found that the "single source of truth" env validator (`lib.validation`'s `validateEnv`) **never runs at service boot** — only the `pnpm validate:env` CLI imports it — so its production hardening (placeholder rejection, distinct-secret pairs) was dead at runtime. The layer that *does* run at every service's boot, `@adopt-dont-shop/config-secrets`, only checked length/hex — so a `CHANGE_THIS…`-style secret over the byte floor, or the same value reused for two keys, booted cleanly.

This PR adds that enforcement **where it actually runs** (config-secrets), production-gated so dev/test/e2e are unaffected.

## Changes

- **`packages/config-secrets`**
  - `requireSecret` now rejects a `CHANGE_THIS…` placeholder value (the repo-wide convention in `.env.example` / the env schema) when `NODE_ENV=production` — a deploy that forgot to substitute a real secret fails fast instead of running a guessable credential.
  - New `requireDistinctSecrets(secrets, env)` helper rejects intra-service secret reuse in production (e.g. `JWT_SECRET === JWT_REFRESH_SECRET`), which defeats the reason they're separate keys. Cross-service distinctness stays a deploy-time concern.
- **`services/auth`** — wires `requireDistinctSecrets` into the access/refresh/encryption-key set (auth is the only service loading multiple must-be-distinct secrets).

Both checks are **production-gated** (`NODE_ENV=production`); dev/test/e2e boot with `NODE_ENV=development` and keep using throwaway values unchanged — verified against the docker-compose default (`NODE_ENV: ${NODE_ENV:-development}`).

**Deliberately out of scope (follow-up):** rewriting `lib.validation`'s env schema off the deleted monolith's `DB_HOST`/`DB_USERNAME`/`SESSION_SECRET` contract onto the live `DATABASE_URL` / `*_FILE` one, and wiring `pnpm validate:env` into `deploy.yml`. That `.env`-file validator can't see file-mounted Docker secrets, so it's a weaker layer than the per-service boot checks strengthened here — the rewrite is a larger, separate change and worth its own ticket.

## Before requesting review

- [x] Ran the equivalent gates locally (`turbo type-check` + `turbo test:coverage` across all services + config-secrets, `lint`, `prettier --check`)
- [x] Tests for new behaviour added (TDD)
- [ ] If touching `.env` requirements, updated `.env.example`'s REQUIRED block — _n/a (no new required vars; placeholder convention unchanged)_
- [x] Considered consumer impact — `config-secrets` is imported by every service's `config.ts`; the new checks are production-gated and additive

## Test plan

- [x] `config-secrets` — 38 tests pass (added placeholder + `requireDistinctSecrets` coverage)
- [x] `service.auth` — 395 tests pass, coverage thresholds held (added reused/placeholder-in-production + dev-tolerance tests)
- [x] **All 21 `services/*` type-check + test:coverage tasks pass** — confirms the boot-path change breaks no service (non-auth services only load `DATABASE_URL`, a `postgres://` string, through `requireSecret`, so the placeholder check is a no-op for them)
- [x] No TypeScript errors; lint clean (0 errors); prettier clean

## Related

- **ADS-1047** — the env validator never runs at boot or deploy (this PR delivers the boot-time enforcement)
- Tracking: **ADS-1039**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01639moQdBwbM99aMdsQ7CXK)_