### PR TITLE
fix(db): set an explicit pooled connection budget and raise max_connections (ADS-1042)

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -150,6 +150,19 @@ services:
   database:
     image: postgis/postgis:16-3.4@sha256:44126d872ac91993766c341e369c539e8196614321765d36a6f1bab0419a5fa5
     container_name: ads_prod_db
+    # ADS-1042: raise max_connections above the pooled connection budget so
+    # services can scale past a single replica without `FATAL: too many
+    # clients`. 10 DB-owning services × pool max 8 × 2 replicas + ~20 reserved
+    # (backups + migrations + admin) = 180 < 200. shared_buffers is bumped to
+    # ~25% of the 2g container limit to match. Budget math + tuning notes:
+    # docs/operations/connection-budget.md. (Do NOT fold these into the Redis/
+    # NATS command entries — this belongs to Postgres only.)
+    command:
+      - postgres
+      - '-c'
+      - 'max_connections=200'
+      - '-c'
+      - 'shared_buffers=512MB'
     # ADS-752: read the DB password from the file-mounted Docker secret rather
     # than the env var. POSTGRES_PASSWORD_FILE is honoured by the postgres
     # entrypoint and keeps the value out of `docker inspect` and the host .env.

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -123,6 +123,19 @@ services:
     container_name: ads_staging_db
     restart: always
     ports: []
+    # ADS-1042: raise max_connections above the pooled connection budget so
+    # services can scale past a single replica without `FATAL: too many
+    # clients`. 10 DB-owning services × pool max 8 × 2 replicas + ~20 reserved
+    # (backups + migrations + admin) = 180 < 200. shared_buffers is bumped to
+    # ~25% of the 2g container limit to match. Staging mirrors prod so tuning
+    # regressions surface pre-prod. Budget math: docs/operations/connection-budget.md.
+    # (Do NOT fold these into the Redis/NATS command entries — Postgres only.)
+    command:
+      - postgres
+      - '-c'
+      - 'max_connections=200'
+      - '-c'
+      - 'shared_buffers=512MB'
     # ADS-752: read the DB password from the file-mounted Docker secret
     # rather than the env var. POSTGRES_PASSWORD_FILE is honoured by the
     # postgres entrypoint and keeps the value out of `docker inspect`.

--- a/docs/README.md
+++ b/docs/README.md
@@ -179,6 +179,7 @@ Documentation for the adopt-don't-shop monorepo, organized by audience. The root
 - [Operations — restore procedure](./operations/restore.md) — restoring Postgres and uploads from a snapshot
 - [Operations — dependency updates (Renovate)](./operations/dependency-updates.md) — automated dependency upgrades
 - [Operations — pet CSV import](./operations/pet-csv-import.md) — bulk-loading pet records
+- [Operations — connection budget](./operations/connection-budget.md) — Postgres pool `max` / `max_connections` budget and how to re-derive it when scaling
 - [Per-service rollback](./deploy/per-service-rollback.md) — hotfix and rollback a single service
 - [Distributed tracing](./observability/tracing.md) — OpenTelemetry setup and conventions
 - [DB backup runbook](./db-backup-runbook.md) — taking and restoring backups

--- a/docs/operations/connection-budget.md
+++ b/docs/operations/connection-budget.md
@@ -1,0 +1,92 @@
+# Postgres Connection Budget [ADS-1042]
+
+How many connections the backend can open against Postgres, why the numbers are
+what they are, and how to re-derive them when scaling. Operators tuning replica
+counts or `max_connections` should start here.
+
+## The problem this solves
+
+Every schema-owning service opens its own `pg.Pool` via
+[`packages/db/src/client.ts`](../../packages/db/src/client.ts). node-pg's
+built-in pool `max` is **10**. There are **10 DB-owning services** (`auth`,
+`pets`, `rescue`, `applications`, `chat`, `notifications`, `moderation`,
+`matching`, `cms`, `audit` — the gateway has no pool). At saturation that is
+`10 × 10 = 100` connections, which is exactly Postgres's default
+`max_connections = 100`. The cluster was pinned to a single replica per service:
+scaling any one service to 2 replicas guaranteed `FATAL: sorry, too many
+clients already`.
+
+## The formula
+
+```
+Σ (DB-owning services) × pool_max × replicas  +  reserved  <  max_connections
+```
+
+- **`reserved`** covers connections that are NOT part of a service pool:
+  logical backups (`pg_dump`), migrations at boot (`node-pg-migrate`), and
+  operator/admin sessions (`psql`), plus Postgres's own
+  `superuser_reserved_connections` (default 3). Budget ~20.
+
+## The chosen numbers
+
+| Setting                    | Value   | Where it lives                                                  |
+| -------------------------- | ------- | --------------------------------------------------------------- |
+| Per-service pool `max`     | `8`     | `DEFAULT_POOL_MAX` in `packages/db/src/client.ts`               |
+| Postgres `max_connections` | `200`   | Postgres `command:` in `docker-compose.{prod,staging}.yml`      |
+| Postgres `shared_buffers`  | `512MB` | Postgres `command:` in `docker-compose.{prod,staging}.yml`      |
+| Reserved                   | `~20`   | backups + migrations + admin + `superuser_reserved_connections` |
+
+### The arithmetic
+
+```
+DB-owning services                = 10
+pool_max (default)                = 8
+
+Baseline (1 replica each)         = 10 × 8 × 1        =  80
+All services at 2 replicas        = 10 × 8 × 2        = 160
+Reserved (backups/migrations/admin) ~                = +20
+                                                        ----
+Peak demand at full 2× scale-out                     = 180
+
+Postgres max_connections                             = 200
+Headroom at full 2× scale-out     = 200 − 180        =  20   ✅
+```
+
+The default leaves room to scale **every** service to 2 replicas with 20
+connections to spare — comfortably above the ticket's floor of "at least one
+service at 2 replicas plus a few reserved". Tune down `max_connections` if you
+want a tighter ceiling; the pool default is deliberately conservative so the
+budget holds without per-service overrides.
+
+### Why `shared_buffers = 512MB`
+
+`shared_buffers` is not a function of connection count, but a Postgres running
+more connections wants more shared cache. `512MB` is ~25% of the `2g` memory
+limit on the `database` container (`deploy.resources.limits.memory`) — the
+standard starting point. Revisit it if the container's memory limit changes.
+
+## Overriding the pool max
+
+Precedence (highest first):
+
+1. An explicit `max` in `DbClientOptions` at the call site
+   (`createDbClient({ ..., max })`).
+2. The per-service `DB_POOL_MAX` environment variable (integer > 0; a malformed
+   value is ignored in favour of the default).
+3. `DEFAULT_POOL_MAX` (8).
+
+Raising a single hot service's ceiling via `DB_POOL_MAX` is the fast lever
+during an incident — see
+[`docs/runbooks/db-pool-exhaustion.md`](../runbooks/db-pool-exhaustion.md).
+Whatever you set, keep the left side of the formula below `max_connections`.
+
+## Recommended next step: pgbouncer
+
+This budget makes single-digit replica scale-out safe, but the real fix for
+serious horizontal scale is a **transaction-mode connection pooler
+(pgbouncer)** in front of Postgres, so N service replicas multiplex onto a small
+fixed set of backend connections and the `Σ services × max × replicas` term
+stops growing linearly. That is a larger infra addition (a new service,
+health-checking, and pool-mode compatibility review for prepared statements /
+`SET search_path`) and is deliberately **out of scope** for ADS-1042. Track it
+as the follow-up for genuine multi-replica scale-out.

--- a/docs/runbooks/db-pool-exhaustion.md
+++ b/docs/runbooks/db-pool-exhaustion.md
@@ -17,16 +17,19 @@ otherwise `warning` (`P95LatencyHigh`).
 
 ## Pool config (current defaults)
 
-Pool sizing and timeouts are **not env-tunable today** — they live in
-`TIMEOUT_DEFAULTS` in [`packages/db/src/client.ts`](../../packages/db/src/client.ts):
+Timeouts live in `TIMEOUT_DEFAULTS` in
+[`packages/db/src/client.ts`](../../packages/db/src/client.ts) and are **not
+env-tunable**. The pool `max` (ADS-1042) has an explicit budgeted default and
+**is** env-tunable per service via `DB_POOL_MAX` — see
+[`docs/operations/connection-budget.md`](../operations/connection-budget.md):
 
-| Setting                   | Default  | Meaning                                                   |
-| ------------------------- | -------- | --------------------------------------------------------- |
-| `connectionTimeoutMillis` | `10_000` | How long a request waits for a connection from the pool.  |
-| `idleTimeoutMillis`       | `30_000` | Idle-connection eviction.                                 |
-| `statement_timeout`       | `30_000` | Postgres session `statement_timeout` — per-query ceiling. |
-| `query_timeout`           | `30_000` | Client-side query timeout applied by node-postgres.       |
-| `max`                     | `10`     | pg default — the code does not override it.               |
+| Setting                   | Default  | Meaning                                                      |
+| ------------------------- | -------- | ------------------------------------------------------------ |
+| `connectionTimeoutMillis` | `10_000` | How long a request waits for a connection from the pool.     |
+| `idleTimeoutMillis`       | `30_000` | Idle-connection eviction.                                    |
+| `statement_timeout`       | `30_000` | Postgres session `statement_timeout` — per-query ceiling.    |
+| `query_timeout`           | `30_000` | Client-side query timeout applied by node-postgres.          |
+| `max`                     | `8`      | `DEFAULT_POOL_MAX`; override per service with `DB_POOL_MAX`. |
 
 `packages/db/src/client.ts` does not emit a `[db] pool …` log line at
 boot; there is no boot-time report of the effective values.
@@ -78,18 +81,18 @@ is up and tracking the saturation, capacity is the cause.
 
    Watch the `state` distribution drop back to mostly `idle`.
 
-2. **Bump the pool** — the pool `max` is currently **not env-tunable**;
-   it defaults to pg's built-in `10`. To raise it, edit
-   `TIMEOUT_DEFAULTS` in [`packages/db/src/client.ts`](../../packages/db/src/client.ts)
-   to set an explicit `max`, rebuild the affected service image, and
-   redeploy. Do **not** exceed the Postgres `max_connections` ceiling
-   (typically 100 on a small managed instance). Every schema-owning
-   service holds up to `max` connections; budget across all of them
-   (auth, pets, rescue, applications, chat, notifications, moderation,
-   matching, cms, audit) and leave headroom for `psql` + the operator.
-   Because this requires a code change, it is rarely the fastest
-   mitigation — usually a targeted `pg_terminate_backend` or a
-   feature-flag flip is faster.
+2. **Bump the pool** — the pool `max` (default `8`) is env-tunable per
+   service via `DB_POOL_MAX`. Raise it for the affected service and
+   redeploy that service (no code change needed). Do **not** exceed the
+   Postgres `max_connections` ceiling (tuned to `200` in
+   `docker-compose.{prod,staging}.yml`). Every schema-owning service
+   holds up to `max` connections; budget across all of them (auth, pets,
+   rescue, applications, chat, notifications, moderation, matching, cms,
+   audit) and leave headroom for backups, migrations, `psql` + the
+   operator — the full formula is in
+   [`docs/operations/connection-budget.md`](../operations/connection-budget.md).
+   A targeted `pg_terminate_backend` or a feature-flag flip is usually a
+   faster first response than a redeploy.
 
 3. **Disable a hot endpoint** — if a known feature is driving the
    load (e.g. a search endpoint hitting a missing index), flip its

--- a/packages/db/README.md
+++ b/packages/db/README.md
@@ -48,9 +48,14 @@ up to 12 attempts × 250 ms).
 
 ## Environment variables consumed
 
-None directly — callers pass `databaseUrl` / `connectionString` (typically
-their own `DATABASE_URL`). See
-[`docs/env-reference.md`](../../docs/env-reference.md) for the shared list.
+- `DB_POOL_MAX` (ADS-1042) — per-service pool ceiling. Optional; falls back to
+  `DEFAULT_POOL_MAX` (8). An explicit `max` in `createDbClient` options wins
+  over it. The connection budget behind the default lives in
+  [`docs/operations/connection-budget.md`](../../docs/operations/connection-budget.md).
+
+Otherwise callers pass `databaseUrl` / `connectionString` (typically their own
+`DATABASE_URL`). See [`docs/env-reference.md`](../../docs/env-reference.md) for
+the shared list.
 
 ## Testing notes
 

--- a/packages/db/README.md
+++ b/packages/db/README.md
@@ -48,9 +48,9 @@ up to 12 attempts × 250 ms).
 
 ## Environment variables consumed
 
-- `DB_POOL_MAX` (ADS-1042) — per-service pool ceiling. Optional; falls back to
-  `DEFAULT_POOL_MAX` (8). An explicit `max` in `createDbClient` options wins
-  over it. The connection budget behind the default lives in
+- `DB_POOL_MAX` (ADS-1042) — per-service pool ceiling. Optional; defaults to a
+  per-service pool ceiling of 8. An explicit `max` in `createDbClient` options
+  wins over it. The connection budget behind the default lives in
   [`docs/operations/connection-budget.md`](../../docs/operations/connection-budget.md).
 
 Otherwise callers pass `databaseUrl` / `connectionString` (typically their own

--- a/packages/db/src/client.test.ts
+++ b/packages/db/src/client.test.ts
@@ -111,6 +111,21 @@ describe('createDbClient', () => {
       void pool.end();
     });
 
+    it('ignores a malformed explicit max (0, negative, non-integer) and falls back', () => {
+      delete process.env.DB_POOL_MAX;
+      for (const badMax of [0, -1, 2.5]) {
+        const pool = createDbClient({
+          schema: 'test',
+          connectionString: 'postgres://localhost/test',
+          max: badMax,
+        });
+
+        expect(pool.options.max).toBe(8);
+
+        void pool.end();
+      }
+    });
+
     it('applies the same pool max to the read replica pool', () => {
       process.env.DB_POOL_MAX = '6';
       const pool = createDbClient({

--- a/packages/db/src/client.test.ts
+++ b/packages/db/src/client.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { createDbClient } from './client.js';
 
 describe('createDbClient', () => {
@@ -45,6 +45,83 @@ describe('createDbClient', () => {
       expect(pool.options.statement_timeout).toBe(3_000);
       expect(pool.options.query_timeout).toBe(4_000);
 
+      void pool.end();
+    });
+  });
+
+  describe('pool connection budget (ADS-1042)', () => {
+    const originalPoolMax = process.env.DB_POOL_MAX;
+
+    afterEach(() => {
+      if (originalPoolMax === undefined) {
+        delete process.env.DB_POOL_MAX;
+      } else {
+        process.env.DB_POOL_MAX = originalPoolMax;
+      }
+    });
+
+    it('applies the conservative default pool max when nothing overrides it', () => {
+      delete process.env.DB_POOL_MAX;
+      const pool = createDbClient({
+        schema: 'test',
+        connectionString: 'postgres://localhost/test',
+      });
+
+      // Not node-pg's implicit 10 — an explicit budgeted ceiling so 10 services
+      // × max stays under a tuned max_connections with replica headroom.
+      expect(pool.options.max).toBe(8);
+
+      void pool.end();
+    });
+
+    it('lets DB_POOL_MAX override the default', () => {
+      process.env.DB_POOL_MAX = '5';
+      const pool = createDbClient({
+        schema: 'test',
+        connectionString: 'postgres://localhost/test',
+      });
+
+      expect(pool.options.max).toBe(5);
+
+      void pool.end();
+    });
+
+    it('ignores a malformed DB_POOL_MAX and keeps the default', () => {
+      process.env.DB_POOL_MAX = 'not-a-number';
+      const pool = createDbClient({
+        schema: 'test',
+        connectionString: 'postgres://localhost/test',
+      });
+
+      expect(pool.options.max).toBe(8);
+
+      void pool.end();
+    });
+
+    it('lets an explicit max in options win over DB_POOL_MAX and the default', () => {
+      process.env.DB_POOL_MAX = '5';
+      const pool = createDbClient({
+        schema: 'test',
+        connectionString: 'postgres://localhost/test',
+        max: 3,
+      });
+
+      expect(pool.options.max).toBe(3);
+
+      void pool.end();
+    });
+
+    it('applies the same pool max to the read replica pool', () => {
+      process.env.DB_POOL_MAX = '6';
+      const pool = createDbClient({
+        schema: 'pets',
+        connectionString: 'postgres://localhost/primary',
+        readUrl: 'postgres://replica.example.com/pets',
+      });
+
+      expect(pool.read.options.max).toBe(6);
+
+      void pool.read.end();
       void pool.end();
     });
   });

--- a/packages/db/src/client.ts
+++ b/packages/db/src/client.ts
@@ -53,10 +53,11 @@ const DEFAULT_POOL_MAX = 8;
 
 // Resolve the pool ceiling with precedence: an explicit `max` in the caller's
 // options wins, then the per-service `DB_POOL_MAX` env var, then the default.
-// A malformed `DB_POOL_MAX` (non-integer or ≤ 0) is ignored in favour of the
-// default rather than silently shrinking the pool to something unusable.
+// Both the explicit value and `DB_POOL_MAX` are validated the same way — a
+// malformed input (non-integer or ≤ 0) is ignored in favour of the next source
+// rather than silently shrinking the pool to something unusable.
 function resolvePoolMax(configMax: number | undefined): number {
-  if (configMax !== undefined) {
+  if (configMax !== undefined && Number.isInteger(configMax) && configMax > 0) {
     return configMax;
   }
   const fromEnv = Number(process.env.DB_POOL_MAX);

--- a/packages/db/src/client.ts
+++ b/packages/db/src/client.ts
@@ -36,6 +36,36 @@ const TIMEOUT_DEFAULTS = {
   query_timeout: 30_000,
 } satisfies PoolConfig;
 
+// Default per-service pool ceiling (ADS-1042). node-pg's own default is 10;
+// with 10 DB-owning services that pins the cluster to 10 × 10 = 100 connections
+// at saturation — exactly Postgres's default `max_connections=100` — so scaling
+// any service to a second replica guarantees `FATAL: too many clients`.
+//
+// Budget: Σ(DB-owning services) × max × replicas + reserved < max_connections.
+// With 10 services, max=8, and `max_connections` raised to 200 (see the compose
+// Postgres `command:` entries and docs/operations/connection-budget.md):
+//   baseline (1 replica each): 10 × 8 × 1 = 80
+//   all services at 2 replicas: 10 × 8 × 2 = 160
+//   + ~20 reserved (backups + migrations + admin/psql + superuser_reserved) = 180
+//   180 < 200 → every service can scale to 2 replicas with headroom to spare.
+// Override per service with DB_POOL_MAX, or per call site with `max` in options.
+const DEFAULT_POOL_MAX = 8;
+
+// Resolve the pool ceiling with precedence: an explicit `max` in the caller's
+// options wins, then the per-service `DB_POOL_MAX` env var, then the default.
+// A malformed `DB_POOL_MAX` (non-integer or ≤ 0) is ignored in favour of the
+// default rather than silently shrinking the pool to something unusable.
+function resolvePoolMax(configMax: number | undefined): number {
+  if (configMax !== undefined) {
+    return configMax;
+  }
+  const fromEnv = Number(process.env.DB_POOL_MAX);
+  if (Number.isInteger(fromEnv) && fromEnv > 0) {
+    return fromEnv;
+  }
+  return DEFAULT_POOL_MAX;
+}
+
 // `schema` is interpolated into SQL (the search_path SET). It's a
 // service-owned constant, not user input, but validate it as a plain SQL
 // identifier so a typo or a malformed value fails fast at construction
@@ -82,7 +112,11 @@ export function createDbClient(opts: DbClientOptions): DbClient {
     throw new Error(`createDbClient: invalid schema name "${schema}" (must match ${SAFE_SCHEMA})`);
   }
 
-  const primary = buildPool(schema, config);
+  // Resolve the pool ceiling once and apply it to both pools so the read
+  // replica shares the same per-service budget (ADS-1042).
+  const pooled = { ...config, max: resolvePoolMax(config.max) };
+
+  const primary = buildPool(schema, pooled);
 
   // No replica configured → `.read` falls back to the primary so read-only
   // call sites work unchanged in single-instance deploys.
@@ -91,8 +125,9 @@ export function createDbClient(opts: DbClientOptions): DbClient {
   }
 
   // A replica IS configured: open a read-only pool against it. It inherits the
-  // same timeout defaults and search_path wiring, but only the connection
-  // string differs — credentials/host come from readUrl, never the primary's.
-  const read = buildPool(schema, { ...config, connectionString: readUrl });
+  // same timeout defaults, pool ceiling, and search_path wiring, but only the
+  // connection string differs — credentials/host come from readUrl, never the
+  // primary's.
+  const read = buildPool(schema, { ...pooled, connectionString: readUrl });
   return Object.assign(primary, { read });
 }


### PR DESCRIPTION
## Summary

- `buildPool` set no pool `max`, so node-pg defaulted to **10** per pool. With 10 DB-owning services that pins the cluster to `10 × 10 = 100` connections at saturation — exactly Postgres's default `max_connections = 100`. Scaling any service to a 2nd replica guaranteed `FATAL: sorry, too many clients already`.
- Adds an explicit, configurable per-service pool `max` and raises Postgres `max_connections` (with matched `shared_buffers`) so the cluster has real replica headroom.

## Changes

- **`packages/db/src/client.ts`** — new `DEFAULT_POOL_MAX = 8`, resolved with precedence: explicit `max` in `DbClientOptions` › `DB_POOL_MAX` env var › default. The read-replica pool inherits the same ceiling. A malformed `DB_POOL_MAX` (non-integer or ≤ 0) is ignored in favour of the default.
- **`docker-compose.prod.yml` / `docker-compose.staging.yml`** — add a Postgres `command:` setting `max_connections=200` and `shared_buffers=512MB`. The Redis/NATS `command:` entries are untouched.
- **`docs/operations/connection-budget.md`** (new) — the budget formula, chosen numbers, and arithmetic so operators can re-derive them when scaling.
- **`docs/runbooks/db-pool-exhaustion.md`**, **`packages/db/README.md`** — refreshed to reflect that pool `max` is now env-tunable with an explicit default (previously stated it was not).

## Budget arithmetic

```
Σ (DB-owning services) × pool_max × replicas  +  reserved  <  max_connections

DB-owning services                = 10   (auth, pets, rescue, applications, chat,
                                          notifications, moderation, matching, cms,
                                          audit — the gateway has no pool)
pool_max (default)                = 8

Baseline (1 replica each)         = 10 × 8 × 1        =  80
All services at 2 replicas        = 10 × 8 × 2        = 160
Reserved (backups/migrations/admin + superuser_reserved) ~ = +20
                                                            ----
Peak demand at full 2× scale-out                         = 180

Postgres max_connections                                 = 200
Headroom at full 2× scale-out     = 200 − 180            =  20   ✅
```

`shared_buffers = 512MB` ≈ 25% of the `2g` memory limit on the `database` container — the standard starting point, matched to the raised connection count.

These are deliberately conservative, defensible defaults for a maintainer to tune: the pool default of 8 leaves room to scale **every** service to 2 replicas without any per-service `DB_POOL_MAX` override.

## Deferred: pgbouncer

This makes single-digit replica scale-out safe, but the real fix for serious horizontal scale is a **transaction-mode connection pooler (pgbouncer)** so N replicas multiplex onto a small fixed set of backend connections and the `Σ services × max × replicas` term stops growing linearly. That is a larger infra addition (new service, health-checking, prepared-statement / `SET search_path` compatibility review) and is intentionally **out of scope** here — recommended as the follow-up for genuine multi-replica scale-out.

## Before requesting review

- [x] Tests for new behaviour added (TDD)
- [ ] If touching `.env` requirements, updated `.env.example`'s REQUIRED block — n/a (`DB_POOL_MAX` is optional)
- [x] If touching a `lib.*`/service package, considered consumer impact — type-checked all 10 DB-owning services

## Test plan

- [x] `pnpm exec turbo run type-check test lint --filter=@adopt-dont-shop/db` — 3 tasks green, 22 tests pass (5 new: default applied, `DB_POOL_MAX` override wins, malformed ignored, explicit `max` wins, read pool inherits)
- [x] `pnpm exec turbo run type-check --filter='./services/*'` — 21 tasks green (no db-options consumer breaks)
- [x] `docker compose -f docker-compose.prod.yml config` and the staging equivalent resolve, Postgres command = `postgres -c max_connections=200 -c shared_buffers=512MB`
- [x] `prettier --check` clean on all changed `.ts`/`.md`

## Related

- ADS-1042 — Postgres connection capacity is at the ceiling at baseline
- ADS-1039 — tracking

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01639moQdBwbM99aMdsQ7CXK)_