### PR TITLE
feat(observability): meter DLQ + job/email failures and lock cron runs (ADS-1052)

### DIFF
--- a/packages/events/package.json
+++ b/packages/events/package.json
@@ -35,6 +35,7 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
+    "@adopt-dont-shop/observability": "workspace:*",
     "nats": "^2.29.3"
   },
   "peerDependencies": {

--- a/packages/events/src/dead-letter-metrics.test.ts
+++ b/packages/events/src/dead-letter-metrics.test.ts
@@ -1,0 +1,39 @@
+import type { NatsConnection } from 'nats';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { getMetricsRegistry, __resetMetricsForTest } from '@adopt-dont-shop/observability';
+
+import { recordDeadLetter, __resetDeadLetterMetricsForTest } from './dead-letter-metrics.js';
+import { deadLetter } from './subscribe.js';
+
+describe('events_dead_letter_total metric', () => {
+  beforeEach(() => {
+    // Fresh shared registry + fresh counter singleton per test so the
+    // counter re-registers against the new registry.
+    __resetMetricsForTest();
+    __resetDeadLetterMetricsForTest();
+  });
+
+  it('is exposed on the shared /metrics registry and counts per subject', async () => {
+    recordDeadLetter('pets.created');
+    recordDeadLetter('pets.created');
+    recordDeadLetter('chat.messageSent');
+
+    const text = await getMetricsRegistry().metrics();
+    expect(text).toContain('events_dead_letter_total{subject="pets.created"} 2');
+    expect(text).toContain('events_dead_letter_total{subject="chat.messageSent"} 1');
+  });
+
+  it('deadLetter() increments the counter after parking the message', async () => {
+    const publish = vi.fn(async () => ({ seq: 1 }));
+    const nc = { jetstream: vi.fn(() => ({ publish })) } as unknown as NatsConnection;
+
+    await deadLetter(nc, 'applications.submitted', '{"id":"e1"}', new Error('boom'));
+
+    // The message was published to the DLQ...
+    expect(publish).toHaveBeenCalledTimes(1);
+    // ...and the dead-letter was metered.
+    const text = await getMetricsRegistry().metrics();
+    expect(text).toContain('events_dead_letter_total{subject="applications.submitted"} 1');
+  });
+});

--- a/packages/events/src/dead-letter-metrics.ts
+++ b/packages/events/src/dead-letter-metrics.ts
@@ -1,0 +1,43 @@
+// Dead-letter metric (ADS-1052).
+//
+// A single Prometheus counter tracks how many messages have been parked in
+// the dead-letter stream, labelled by the original subject:
+//   events_dead_letter_total{subject="pets.created"} — messages dead-lettered
+//
+// The counter is registered on the shared observability registry so it
+// appears on the /metrics endpoint alongside the standard HTTP/gRPC
+// histograms. It is incremented by deadLetter() in subscribe.ts whenever a
+// poison message is parked. Mirrors the audit service's gdpr-metrics module.
+
+import { Counter, getMetricsRegistry } from '@adopt-dont-shop/observability';
+
+// Module-level singleton so the counter is only registered once across all
+// calls (prom-client throws if the same metric name is registered twice in
+// the same process).
+let _counter: InstanceType<typeof Counter<'subject'>> | null = null;
+
+const getDeadLetterCounter = (): InstanceType<typeof Counter<'subject'>> => {
+  if (_counter) {
+    return _counter;
+  }
+  const registry = getMetricsRegistry();
+  _counter = new Counter<'subject'>({
+    name: 'events_dead_letter_total',
+    help: 'Total messages parked in the dead-letter stream, by original subject.',
+    labelNames: ['subject'],
+    registers: [registry],
+  });
+  return _counter;
+};
+
+// recordDeadLetter increments the counter for the given original subject.
+// Called by deadLetter() after a message is parked in the DLQ.
+export const recordDeadLetter = (subject: string): void => {
+  getDeadLetterCounter().inc({ subject });
+};
+
+// --- Test-only helper -------------------------------------------------------
+
+export const __resetDeadLetterMetricsForTest = (): void => {
+  _counter = null;
+};

--- a/packages/events/src/subscribe.ts
+++ b/packages/events/src/subscribe.ts
@@ -7,6 +7,7 @@ import {
   type NatsConnection,
 } from 'nats';
 
+import { recordDeadLetter } from './dead-letter-metrics.js';
 import { DLQ_SUBJECT_PREFIX, DOMAIN_STREAM } from './stream.js';
 
 export type SubscribeOptions = {
@@ -210,4 +211,7 @@ export async function deadLetter(
     .publish(`${DLQ_SUBJECT_PREFIX}${originalSubject}`, new TextEncoder().encode(raw), {
       headers: h,
     });
+  // Meter the dead-letter on the shared registry so /metrics exposes
+  // events_dead_letter_total{subject}. Counted after the park succeeds.
+  recordDeadLetter(originalSubject);
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -771,6 +771,9 @@ importers:
 
   packages/events:
     dependencies:
+      '@adopt-dont-shop/observability':
+        specifier: workspace:*
+        version: link:../observability
       nats:
         specifier: ^2.29.3
         version: 2.29.3

--- a/services/notifications/src/email/worker.test.ts
+++ b/services/notifications/src/email/worker.test.ts
@@ -1,7 +1,10 @@
 import type { Pool } from 'pg';
 import type { Logger } from 'winston';
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { getMetricsRegistry, __resetMetricsForTest } from '@adopt-dont-shop/observability';
+
+import { __resetNotificationsMetricsForTest } from '../metrics.js';
 import { startEmailWorker } from './worker.js';
 import type { EmailProvider, ProviderSendResult, QueuedEmail } from './types.js';
 
@@ -229,6 +232,60 @@ describe('email worker', () => {
     try {
       await worker.tick();
       expect(provider.send).toHaveBeenCalledTimes(1);
+    } finally {
+      await worker.stop();
+    }
+  });
+});
+
+describe('email worker failure metrics', () => {
+  beforeEach(() => {
+    // Fresh registry + counter singletons so the counter starts at 0.
+    __resetMetricsForTest();
+    __resetNotificationsMetricsForTest();
+  });
+
+  it('counts a provider failure under notifications_email_failures_total{reason="provider"}', async () => {
+    const claimed = [queuedFixture({ emailId: 'em-P' })];
+    const { pool } = makePool([{ rows: claimed.map(toRow) }, { rows: [] }]);
+    const provider = makeProvider({ success: false, error: 'smtp 451' });
+    const worker = startEmailWorker({
+      pool,
+      nats: {} as never,
+      provider,
+      logger: quietLogger(),
+      pollIntervalMs: 60_000,
+    });
+    try {
+      await worker.tick();
+      const text = await getMetricsRegistry().metrics();
+      expect(text).toContain('notifications_email_failures_total{reason="provider"} 1');
+    } finally {
+      await worker.stop();
+    }
+  });
+
+  it('counts a dispatch throw under notifications_email_failures_total{reason="dispatch"}', async () => {
+    const claimed = [queuedFixture({ emailId: 'em-D' })];
+    const { pool } = makePool([{ rows: claimed.map(toRow) }, { rows: [] }]);
+    const provider: EmailProvider = {
+      send: vi.fn(async () => {
+        throw new Error('connection reset');
+      }),
+      getName: () => 'test-provider',
+      validateConfiguration: () => true,
+    };
+    const worker = startEmailWorker({
+      pool,
+      nats: {} as never,
+      provider,
+      logger: quietLogger(),
+      pollIntervalMs: 60_000,
+    });
+    try {
+      await worker.tick();
+      const text = await getMetricsRegistry().metrics();
+      expect(text).toContain('notifications_email_failures_total{reason="dispatch"} 1');
     } finally {
       await worker.stop();
     }

--- a/services/notifications/src/email/worker.ts
+++ b/services/notifications/src/email/worker.ts
@@ -15,6 +15,7 @@ import type { NatsConnection } from 'nats';
 import type { Pool } from 'pg';
 import type { Logger } from 'winston';
 
+import { recordEmailFailure } from '../metrics.js';
 import { isEmailChannelOpen } from './preferences.js';
 import { claimDueEmails, markFailed, markSent } from './queue.js';
 import type { EmailProvider, QueuedEmail } from './types.js';
@@ -88,6 +89,7 @@ const dispatchOne = async (
     // Treat all provider failures as retriable — the markFailed query
     // terminates the row once current_retries >= max_retries.
     await markFailed(pool, email.emailId, result.error ?? 'provider returned failure', true);
+    recordEmailFailure('provider');
     logger.warn('email.worker.failed', {
       emailId: email.emailId,
       provider: provider.getName(),
@@ -128,6 +130,7 @@ export const startEmailWorker = (opts: EmailWorkerOptions): RunningEmailWorker =
             emailId: email.emailId,
             err,
           });
+          recordEmailFailure('dispatch');
           // Mark as retriable failure so it doesn't get stuck in 'sending'.
           return markFailed(
             opts.pool,

--- a/services/notifications/src/index.ts
+++ b/services/notifications/src/index.ts
@@ -23,6 +23,7 @@ import { startGrpcServer, type RunningGrpcServer } from './grpc/server.js';
 import { registerSubscribers } from './nats/subscribers.js';
 import { createPushProvider } from './push/providers/factory.js';
 import { startPushWorker, type RunningPushWorker } from './push/worker.js';
+import { claimScheduledRun } from './scheduler/claim.js';
 import { runWeeklyDigest } from './scheduler/jobs/weekly-digest.js';
 import { startScheduler, type RunningScheduler } from './scheduler/scheduler.js';
 import { createServer } from './server.js';
@@ -185,7 +186,12 @@ const main = async (): Promise<void> => {
             },
           },
         ],
-        { logger }
+        {
+          logger,
+          // Cross-instance run claim so multiple replicas don't each send the
+          // weekly digest — only the replica that wins the slot runs it.
+          claimRun: (jobName, scheduledFor) => claimScheduledRun(pool!, jobName, scheduledFor),
+        }
       );
     }
     const httpServer = createServer({

--- a/services/notifications/src/metrics.ts
+++ b/services/notifications/src/metrics.ts
@@ -1,0 +1,64 @@
+// Notifications service custom metrics (ADS-1052).
+//
+// Two Prometheus counters surface failures that were previously log-only:
+//   notifications_scheduled_job_failures_total{job}   — a scheduled job's
+//     run() threw (e.g. the weekly digest failed for one cadence).
+//   notifications_email_failures_total{reason}        — an email failed to
+//     send. reason="provider" (the provider returned success=false) or
+//     reason="dispatch" (dispatching threw before/around the provider call).
+//
+// Both are registered on the shared observability registry so they appear on
+// the existing /metrics endpoint. Mirrors the audit service's gdpr-metrics
+// module: module-level singletons guarded so prom-client never sees a
+// duplicate registration in the same process.
+
+import { Counter, getMetricsRegistry } from '@adopt-dont-shop/observability';
+
+let _jobFailures: InstanceType<typeof Counter<'job'>> | null = null;
+let _emailFailures: InstanceType<typeof Counter<'reason'>> | null = null;
+
+const getJobFailureCounter = (): InstanceType<typeof Counter<'job'>> => {
+  if (_jobFailures) {
+    return _jobFailures;
+  }
+  _jobFailures = new Counter<'job'>({
+    name: 'notifications_scheduled_job_failures_total',
+    help: 'Total scheduled-job run failures, by job name.',
+    labelNames: ['job'],
+    registers: [getMetricsRegistry()],
+  });
+  return _jobFailures;
+};
+
+// recordScheduledJobFailure increments the counter when a scheduled job's
+// run() throws.
+export const recordScheduledJobFailure = (job: string): void => {
+  getJobFailureCounter().inc({ job });
+};
+
+export type EmailFailureReason = 'provider' | 'dispatch';
+
+const getEmailFailureCounter = (): InstanceType<typeof Counter<'reason'>> => {
+  if (_emailFailures) {
+    return _emailFailures;
+  }
+  _emailFailures = new Counter<'reason'>({
+    name: 'notifications_email_failures_total',
+    help: 'Total email send failures, by reason (provider | dispatch).',
+    labelNames: ['reason'],
+    registers: [getMetricsRegistry()],
+  });
+  return _emailFailures;
+};
+
+// recordEmailFailure increments the counter when an email fails to send.
+export const recordEmailFailure = (reason: EmailFailureReason): void => {
+  getEmailFailureCounter().inc({ reason });
+};
+
+// --- Test-only helper -------------------------------------------------------
+
+export const __resetNotificationsMetricsForTest = (): void => {
+  _jobFailures = null;
+  _emailFailures = null;
+};

--- a/services/notifications/src/migrations/010_create_scheduled_job_runs.ts
+++ b/services/notifications/src/migrations/010_create_scheduled_job_runs.ts
@@ -1,0 +1,24 @@
+import type { MigrationBuilder } from 'node-pg-migrate';
+
+// Cross-instance scheduled-run claims (ADS-1052).
+//
+// The tick scheduler runs per-replica; without a shared claim, every replica
+// fires the weekly digest and users get duplicate emails. Each intended run
+// is a row keyed by (job_name, scheduled_for) — the interval-quantised slot.
+// A replica claims a slot with INSERT ... ON CONFLICT DO NOTHING; the primary
+// key makes the claim atomic, so exactly one replica runs a given slot.
+
+export const up = async (pgm: MigrationBuilder): Promise<void> => {
+  pgm.createTable('scheduled_job_runs', {
+    job_name: { type: 'text', notNull: true },
+    scheduled_for: { type: 'timestamptz', notNull: true },
+    claimed_at: { type: 'timestamptz', notNull: true, default: pgm.func('now()') },
+  });
+  pgm.addConstraint('scheduled_job_runs', 'scheduled_job_runs_pkey', {
+    primaryKey: ['job_name', 'scheduled_for'],
+  });
+};
+
+export const down = async (pgm: MigrationBuilder): Promise<void> => {
+  pgm.dropTable('scheduled_job_runs');
+};

--- a/services/notifications/src/migrations/migrations.test.ts
+++ b/services/notifications/src/migrations/migrations.test.ts
@@ -51,6 +51,8 @@ describe('notifications migrations', () => {
     '006_create_email_preferences.ts',
     '007_email_queue_stale_sending_idx.ts',
     '008_create_processed_events.ts',
+    '009_device_token_global_unique.ts',
+    '010_create_scheduled_job_runs.ts',
   ])('%s exports `up` and `down` functions', async filename => {
     const mod = (await import(`./${filename}`)) as {
       up: unknown;

--- a/services/notifications/src/scheduler/claim.test.ts
+++ b/services/notifications/src/scheduler/claim.test.ts
@@ -1,0 +1,69 @@
+import type { Pool } from 'pg';
+import { describe, expect, it, vi } from 'vitest';
+
+import { claimScheduledRun } from './claim.js';
+
+// A Pool double backed by an in-memory set of claimed slots, modelling
+// INSERT ... ON CONFLICT DO NOTHING: the first insert of a (job, slot) key
+// returns rowCount 1, any later insert of the same key returns rowCount 0.
+const makeConn = () => {
+  const claimed = new Set<string>();
+  const queries: Array<{ sql: string; params: unknown[] }> = [];
+  const conn = {
+    query: vi.fn(async (sql: string, params: unknown[]) => {
+      queries.push({ sql, params });
+      const [jobName, scheduledFor] = params as [string, Date];
+      const key = `${jobName}::${scheduledFor.toISOString()}`;
+      if (claimed.has(key)) {
+        return { rowCount: 0, rows: [] };
+      }
+      claimed.add(key);
+      return { rowCount: 1, rows: [] };
+    }),
+  };
+  return { conn: conn as unknown as Pool, queries };
+};
+
+const SLOT = new Date('2026-08-03T00:00:00.000Z');
+
+describe('claimScheduledRun', () => {
+  it('wins a fresh slot (rowCount 1 → true)', async () => {
+    const { conn } = makeConn();
+    const won = await claimScheduledRun(conn, 'weekly-digest', SLOT);
+    expect(won).toBe(true);
+  });
+
+  it('issues an INSERT ... ON CONFLICT DO NOTHING keyed by job + slot', async () => {
+    const { conn, queries } = makeConn();
+    await claimScheduledRun(conn, 'weekly-digest', SLOT);
+    expect(queries).toHaveLength(1);
+    expect(queries[0].sql).toContain('INSERT INTO scheduled_job_runs');
+    expect(queries[0].sql).toContain('ON CONFLICT (job_name, scheduled_for) DO NOTHING');
+    expect(queries[0].params).toEqual(['weekly-digest', SLOT]);
+  });
+
+  it('loses to an existing claim for the same slot (rowCount 0 → false)', async () => {
+    const { conn } = makeConn();
+    await claimScheduledRun(conn, 'weekly-digest', SLOT);
+    const second = await claimScheduledRun(conn, 'weekly-digest', SLOT);
+    expect(second).toBe(false);
+  });
+
+  it('lets exactly one of two concurrent claimants win the same slot', async () => {
+    const { conn } = makeConn();
+    const results = await Promise.all([
+      claimScheduledRun(conn, 'weekly-digest', SLOT),
+      claimScheduledRun(conn, 'weekly-digest', SLOT),
+    ]);
+    expect(results.filter(Boolean)).toHaveLength(1);
+  });
+
+  it('lets both claimants win when the slots differ', async () => {
+    const { conn } = makeConn();
+    const laterSlot = new Date('2026-08-10T00:00:00.000Z');
+    const a = await claimScheduledRun(conn, 'weekly-digest', SLOT);
+    const b = await claimScheduledRun(conn, 'weekly-digest', laterSlot);
+    expect(a).toBe(true);
+    expect(b).toBe(true);
+  });
+});

--- a/services/notifications/src/scheduler/claim.ts
+++ b/services/notifications/src/scheduler/claim.ts
@@ -1,0 +1,32 @@
+// Cross-instance scheduled-run claim (ADS-1052).
+//
+// The scheduler runs per-replica with an in-memory nextRunAt, so with >1
+// replica each would independently fire the weekly digest — duplicate
+// emails. `claimScheduledRun` makes a given (job, scheduled-slot) run
+// exclusive across replicas: the first replica to INSERT the slot row wins
+// and runs the job; every other replica's INSERT hits the primary-key
+// conflict, is a no-op, and skips.
+//
+// INSERT ... ON CONFLICT DO NOTHING is the atomic claim — Postgres
+// serialises the concurrent inserts on the primary key, so exactly one of
+// two concurrent claimants sees rowCount === 1. (The email queue uses
+// FOR UPDATE SKIP LOCKED to drain a queue of many rows; a single-slot claim
+// is cleaner as an idempotent insert — no pre-seeded rows to lock.)
+
+import type { Pool, PoolClient } from 'pg';
+
+export type DbConn = Pool | PoolClient;
+
+export const claimScheduledRun = async (
+  conn: DbConn,
+  jobName: string,
+  scheduledFor: Date
+): Promise<boolean> => {
+  const res = await conn.query(
+    `INSERT INTO scheduled_job_runs (job_name, scheduled_for)
+     VALUES ($1, $2)
+     ON CONFLICT (job_name, scheduled_for) DO NOTHING`,
+    [jobName, scheduledFor]
+  );
+  return res.rowCount === 1;
+};

--- a/services/notifications/src/scheduler/scheduler.test.ts
+++ b/services/notifications/src/scheduler/scheduler.test.ts
@@ -1,6 +1,9 @@
 import type { Logger } from 'winston';
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { getMetricsRegistry, __resetMetricsForTest } from '@adopt-dont-shop/observability';
+
+import { __resetNotificationsMetricsForTest } from '../metrics.js';
 import { startScheduler, type ScheduledJob } from './scheduler.js';
 
 const quietLogger = (): Logger =>
@@ -121,6 +124,138 @@ describe('scheduler', () => {
       const lateRun = await scheduler.tick();
       expect(lateRun).toEqual(['hourly']);
       expect(runs.length).toBe(2);
+    } finally {
+      await scheduler.stop();
+    }
+  });
+});
+
+describe('scheduler metrics + cross-instance claim', () => {
+  beforeEach(() => {
+    // Fresh registry + counter singletons so the failure counter starts at 0
+    // and re-registers on the new registry.
+    __resetMetricsForTest();
+    __resetNotificationsMetricsForTest();
+  });
+
+  it('increments notifications_scheduled_job_failures_total when a job throws', async () => {
+    const jobs: ScheduledJob[] = [
+      {
+        name: 'flaky',
+        intervalMs: 60_000,
+        runOnStart: true,
+        run: async () => {
+          throw new Error('boom');
+        },
+      },
+    ];
+    const scheduler = startScheduler(jobs, {
+      logger: quietLogger(),
+      tickIntervalMs: 60_000,
+      now: () => 1_000_000,
+    });
+    try {
+      await scheduler.tick();
+      const text = await getMetricsRegistry().metrics();
+      expect(text).toContain('notifications_scheduled_job_failures_total{job="flaky"} 1');
+    } finally {
+      await scheduler.stop();
+    }
+  });
+
+  it('skips the job (does not run, not in fired) when the claim is lost', async () => {
+    const runs: string[] = [];
+    const claimRun = vi.fn(async () => false);
+    const jobs: ScheduledJob[] = [
+      {
+        name: 'weekly',
+        intervalMs: 60_000,
+        runOnStart: true,
+        run: async () => {
+          runs.push('weekly');
+        },
+      },
+    ];
+    const scheduler = startScheduler(jobs, {
+      logger: quietLogger(),
+      tickIntervalMs: 60_000,
+      now: () => 1_000_000,
+      claimRun,
+    });
+    try {
+      const fired = await scheduler.tick();
+      expect(claimRun).toHaveBeenCalledTimes(1);
+      expect(fired).toEqual([]);
+      expect(runs).toEqual([]);
+    } finally {
+      await scheduler.stop();
+    }
+  });
+
+  it('runs the job when the claim is won, keyed by the interval-quantised slot', async () => {
+    const runs: string[] = [];
+    const claimCalls: Array<{ job: string; scheduledFor: Date }> = [];
+    const claimRun = vi.fn(async (job: string, scheduledFor: Date) => {
+      claimCalls.push({ job, scheduledFor });
+      return true;
+    });
+    const jobs: ScheduledJob[] = [
+      {
+        name: 'weekly',
+        intervalMs: 60_000,
+        runOnStart: true,
+        run: async () => {
+          runs.push('weekly');
+        },
+      },
+    ];
+    const scheduler = startScheduler(jobs, {
+      logger: quietLogger(),
+      tickIntervalMs: 60_000,
+      now: () => 1_000_000,
+      claimRun,
+    });
+    try {
+      const fired = await scheduler.tick();
+      expect(fired).toEqual(['weekly']);
+      expect(runs).toEqual(['weekly']);
+      // slot = floor(1_000_000 / 60_000) * 60_000 = 960_000
+      expect(claimCalls).toEqual([{ job: 'weekly', scheduledFor: new Date(960_000) }]);
+    } finally {
+      await scheduler.stop();
+    }
+  });
+
+  it('skips the job when the claim query errors — never risks a duplicate', async () => {
+    const runs: string[] = [];
+    const logger = quietLogger();
+    const claimRun = vi.fn(async () => {
+      throw new Error('db down');
+    });
+    const jobs: ScheduledJob[] = [
+      {
+        name: 'weekly',
+        intervalMs: 60_000,
+        runOnStart: true,
+        run: async () => {
+          runs.push('weekly');
+        },
+      },
+    ];
+    const scheduler = startScheduler(jobs, {
+      logger,
+      tickIntervalMs: 60_000,
+      now: () => 1_000_000,
+      claimRun,
+    });
+    try {
+      const fired = await scheduler.tick();
+      expect(fired).toEqual([]);
+      expect(runs).toEqual([]);
+      expect(logger.error).toHaveBeenCalledWith(
+        'scheduler.claim_error',
+        expect.objectContaining({ name: 'weekly', err: 'db down' })
+      );
     } finally {
       await scheduler.stop();
     }

--- a/services/notifications/src/scheduler/scheduler.ts
+++ b/services/notifications/src/scheduler/scheduler.ts
@@ -7,11 +7,14 @@
 // tick loop matches the CAD-style "minimal external surface" approach
 // and is trivial to test with a mocked clock.
 //
-// Replicas + locking: this implementation does NOT lock across
-// instances yet. The first follow-up before running multiple replicas
-// is to swap the in-memory `nextRunAt` for a row in a `scheduled_jobs`
-// table that's claimed with FOR UPDATE SKIP LOCKED (same pattern as
-// the email queue worker).
+// Replicas + locking: cross-instance locking is OPTIONAL, via the
+// `claimRun` hook (see SchedulerOptions). When wired, the scheduler claims
+// each job's interval-quantised slot before running so only one replica
+// runs the job; when omitted it runs single-instance (test / single-replica
+// behaviour). The claim is an `INSERT ... ON CONFLICT DO NOTHING` on
+// `scheduled_job_runs` (scheduler/claim.ts) — chosen over FOR UPDATE SKIP
+// LOCKED because a single-slot claim needs no pre-seeded row to lock; the
+// email queue worker still uses SKIP LOCKED to drain its many-row queue.
 
 import type { Logger } from 'winston';
 

--- a/services/notifications/src/scheduler/scheduler.ts
+++ b/services/notifications/src/scheduler/scheduler.ts
@@ -15,6 +15,8 @@
 
 import type { Logger } from 'winston';
 
+import { recordScheduledJobFailure } from '../metrics.js';
+
 export type ScheduledJob = {
   name: string;
   // Period between runs in milliseconds. The scheduler's tick interval
@@ -38,6 +40,13 @@ export type SchedulerOptions = {
   tickIntervalMs?: number;
   // Now provider — injectable so tests can advance time deterministically.
   now?: () => number;
+  // Cross-instance run claim. When provided, the scheduler tries to claim
+  // the job's scheduled slot before running it; only the replica that wins
+  // the claim runs the job (the others skip). `scheduledFor` is the slot the
+  // run belongs to, quantised to the job's interval so concurrent replicas
+  // compute the same key. Returns true when this replica may run the job.
+  // Omitted → no locking (single-instance / test behaviour).
+  claimRun?: (job: string, scheduledFor: Date) => Promise<boolean>;
 };
 
 export type RunningScheduler = {
@@ -62,6 +71,36 @@ export const startScheduler = (jobs: ScheduledJob[], opts: SchedulerOptions): Ru
     nextRunAt.set(job.name, job.runOnStart ? 0 : now() + job.intervalMs);
   }
 
+  // Try to claim a job's scheduled slot across instances. Returns true when
+  // this replica may run the job — always true when no claimRun is wired
+  // (single-instance / test behaviour).
+  const claimSlot = async (job: ScheduledJob, ts: number): Promise<boolean> => {
+    if (!opts.claimRun) {
+      return true;
+    }
+    // Quantise the run to the job's interval so two replicas firing in the
+    // same window compute the same claim key.
+    const scheduledFor = new Date(Math.floor(ts / job.intervalMs) * job.intervalMs);
+    try {
+      const won = await opts.claimRun(job.name, scheduledFor);
+      if (!won) {
+        opts.logger.info('scheduler.job_claimed_elsewhere', {
+          name: job.name,
+          scheduledFor: scheduledFor.toISOString(),
+        });
+      }
+      return won;
+    } catch (err) {
+      // A claim error means we can't prove we're the sole runner — skip
+      // rather than risk a duplicate send; the next interval retries.
+      opts.logger.error('scheduler.claim_error', {
+        name: job.name,
+        err: err instanceof Error ? err.message : String(err),
+      });
+      return false;
+    }
+  };
+
   const tick = async (): Promise<string[]> => {
     if (!running) {
       return [];
@@ -73,13 +112,17 @@ export const startScheduler = (jobs: ScheduledJob[], opts: SchedulerOptions): Ru
       if (due > ts) {
         continue;
       }
-      fired.push(job.name);
       // Schedule the next run BEFORE awaiting — a slow job can take longer
       // than intervalMs, in which case the next tick still finds it due
       // (intentional — caller may want overlapping runs blocked, but the
       // current implementation simply re-runs as soon as the previous
       // finishes).
       nextRunAt.set(job.name, ts + job.intervalMs);
+      // Cross-instance lock: only the replica that wins the slot runs it.
+      if (!(await claimSlot(job, ts))) {
+        continue;
+      }
+      fired.push(job.name);
       try {
         await job.run();
         opts.logger.info('scheduler.job_ok', { name: job.name });
@@ -88,6 +131,7 @@ export const startScheduler = (jobs: ScheduledJob[], opts: SchedulerOptions): Ru
           name: job.name,
           err: err instanceof Error ? err.message : String(err),
         });
+        recordScheduledJobFailure(job.name);
       }
     }
     return fired;


### PR DESCRIPTION
## Summary

- The remaining **code** follow-ups for ADS-1052 that #1291 (ADS-1041) named. The observability **config** — LGTM + Alertmanager stack, Prometheus alert rules, chat/cms scrape jobs, and `initializeSentry` wiring — already shipped in #1291 and is **not touched** here.
- Meters dead-lettered events on the shared registry so `/metrics` exposes DLQ volume.
- Counts previously log-only notifications failures (scheduled jobs + email sends).
- Adds a cross-instance run claim so multiple notifications replicas no longer each send the weekly digest.

## Changes

- `packages/events/src/dead-letter-metrics.ts` (new) + `subscribe.ts`: `deadLetter()` increments `events_dead_letter_total{subject}` on the shared observability registry after parking the poison message. Adds `@adopt-dont-shop/observability` as an events dependency (mirrors the audit service's `gdpr-metrics`).
- `services/notifications/src/metrics.ts` (new): two counters registered on the shared registry.
- `services/notifications/src/scheduler/scheduler.ts`: increments `notifications_scheduled_job_failures_total{job}` when a job's `run()` throws; new optional `claimRun` hook that claims the interval-quantised slot before running (skips if the claim is lost, or on a claim error — never risks a duplicate).
- `services/notifications/src/email/worker.ts`: `notifications_email_failures_total{reason}` on a provider failure (`reason="provider"`) and a dispatch throw (`reason="dispatch"`).
- `services/notifications/src/scheduler/claim.ts` (new) + `migrations/010_create_scheduled_job_runs.ts` (new): `INSERT ... ON CONFLICT DO NOTHING` claim keyed by `(job_name, scheduled_for)`; wired into the scheduler in `index.ts`.

## Metric names added

- `events_dead_letter_total{subject}`
- `notifications_scheduled_job_failures_total{job}`
- `notifications_email_failures_total{reason}` (`reason` ∈ `provider` | `dispatch`)

## Design note — SKIP LOCKED vs ON CONFLICT

The ticket allowed `FOR UPDATE SKIP LOCKED` **or** `INSERT ... ON CONFLICT DO NOTHING`. I used the ON CONFLICT variant: for a single-slot claim it is the cleaner atomic primitive (no pre-seeded rows to lock), and the composite primary key serialises concurrent inserts so exactly one of two concurrent claimants sees `rowCount === 1`. The email queue continues to use `FOR UPDATE SKIP LOCKED` for draining a queue of many rows. **All three items are implemented — nothing deferred.**

## Before requesting review

- [x] Tests for new behaviour added (TDD)
- [ ] Ran `pnpm ci:local:quick` (ran targeted turbo gates instead — see Test plan)
- [x] No `.env` requirement changes
- [x] No `lib.*` touched

## Test plan

- [x] `turbo run type-check test:coverage lint --filter=@adopt-dont-shop/events` — green (99 tests; `dead-letter-metrics.ts` 100%)
- [x] `turbo run type-check lint --filter=@adopt-dont-shop/service.notifications` — green (0 errors)
- [x] `turbo run test:coverage --filter=@adopt-dont-shop/service.notifications` (isolated) — green, thresholds met; `claim.ts` 100%
- [x] **Schema Equivalence (migrate vs sync)** — reproduced locally: ran all 10 notifications migrations against a fresh Postgres 16; applied cleanly and `notifications.scheduled_job_runs` was created with primary key `(job_name, scheduled_for)`
- [x] Prettier clean on both packages

Behaviour covered by tests: DLQ counter increments on dead-letter; scheduler + email failure counters increment on failure; the claim lets exactly one of two concurrent claimants win.

## Related

- **ADS-1052** — this ticket (code follow-ups)
- Tracking: **ADS-1039**
- Config half shipped in **#1291** (ADS-1041): alert rules, chat/cms scrape jobs, Alertmanager, Sentry wiring — not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01639moQdBwbM99aMdsQ7CXK)_