### PR TITLE
docs(adr): add ADR 0007, 0009, 0010 proposals (ADS-1043, ADS-1045, ADS-1055)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -57,7 +57,7 @@ Documentation for the adopt-don't-shop monorepo, organized by audience. The root
 - [ADR 0004 — Postgres read-replica routing](./adr/0004-postgres-read-replica-routing.md) — optional read-replica pool in `@adopt-dont-shop/db`
 - [ADR 0005 — Pact contract tests](./adr/0005-pact-contract-tests.md) — contract-testing model for gateway ↔ service boundaries
 - [ADR 0006 — field-permission enforcement](./adr/0006-field-permission-enforcement.md) — `fieldMask`/`fieldWriteGuard` in `@adopt-dont-shop/authz`, wired into `services/rescue`; what's enforced vs. deferred
-- [ADR 0007 — Postgres backups, PITR & restore verification](./adr/0007-postgres-backups-pitr-restore.md) — proposal to add restore-verification CI, enforced S3 retention/Object Lock, and pgBackRest WAL/PITR
+- [ADR 0007 — Postgres backups, PITR & restore verification](./adr/0007-postgres-backups-pitr-restore.md) — _proposed_: restore-verification CI, enforced S3 retention/Object Lock, and pgBackRest WAL/PITR
 - [ADR 0008 — pre-deploy migration strategy](./adr/0008-pre-deploy-migration-strategy.md) — _proposed_: gated pre-deploy migration runner, `CREATE INDEX CONCURRENTLY` on populated tables, and expand/contract discipline
 - [ADR 0009 — deployment strategy & high availability](./adr/0009-deployment-strategy-and-ha.md) — _proposed_: auto-rollback-on-failed-health + documented single-host SPOF/RTO/RPO vs. multi-replica / orchestrator tradeoffs (ADS-1045)
 - [ADR 0010 — frontend quality gates](./adr/0010-frontend-quality-gates.md) — _proposed_: re-enable jsx-a11y, add `no-non-null-assertion`, tighten the container CSP, ratchet app coverage floors

--- a/docs/README.md
+++ b/docs/README.md
@@ -57,7 +57,10 @@ Documentation for the adopt-don't-shop monorepo, organized by audience. The root
 - [ADR 0004 — Postgres read-replica routing](./adr/0004-postgres-read-replica-routing.md) — optional read-replica pool in `@adopt-dont-shop/db`
 - [ADR 0005 — Pact contract tests](./adr/0005-pact-contract-tests.md) — contract-testing model for gateway ↔ service boundaries
 - [ADR 0006 — field-permission enforcement](./adr/0006-field-permission-enforcement.md) — `fieldMask`/`fieldWriteGuard` in `@adopt-dont-shop/authz`, wired into `services/rescue`; what's enforced vs. deferred
+- [ADR 0007 — Postgres backups, PITR & restore verification](./adr/0007-postgres-backups-pitr-restore.md) — proposal to add restore-verification CI, enforced S3 retention/Object Lock, and pgBackRest WAL/PITR
 - [ADR 0008 — pre-deploy migration strategy](./adr/0008-pre-deploy-migration-strategy.md) — _proposed_: gated pre-deploy migration runner, `CREATE INDEX CONCURRENTLY` on populated tables, and expand/contract discipline
+- [ADR 0009 — deployment strategy & high availability](./adr/0009-deployment-strategy-and-ha.md) — _proposed_: auto-rollback-on-failed-health + documented single-host SPOF/RTO/RPO vs. multi-replica / orchestrator tradeoffs (ADS-1045)
+- [ADR 0010 — frontend quality gates](./adr/0010-frontend-quality-gates.md) — _proposed_: re-enable jsx-a11y, add `no-non-null-assertion`, tighten the container CSP, ratchet app coverage floors
 - [ADR — sticky sessions for Socket.IO](./architecture/adr-socket-sticky-sessions.md) — connection-cap mitigation for the WebSocket edge
 - [Frontend technical architecture](./frontend/technical-architecture.md) — app shells, routing, state, styling
 - [Matching system scope](./matching-system-scope.md) — implementation state, scoring design, and remaining gaps for the pet-adopter matchmaking subsystem (supersedes the frontend recommendations plan)

--- a/docs/adr/0007-postgres-backups-pitr-restore.md
+++ b/docs/adr/0007-postgres-backups-pitr-restore.md
@@ -1,0 +1,311 @@
+# ADR 0007 — Postgres backups, PITR & restore verification (ADS-1043)
+
+- Status: Proposed
+- Date: 2026-08-05
+- Scope: `scripts/snapshot-postgres.sh`, `.github/workflows/backup.yml`,
+  `docs/operations/snapshot-policy.md`, production S3 backup bucket — the
+  Postgres backup, retention, and restore-verification pipeline
+
+## Context
+
+Production Postgres is protected by a single logical dump. `.github/workflows/backup.yml:17`
+runs `scripts/snapshot-postgres.sh` on a `cron: '0 2 * * *'` schedule (daily at
+02:00 UTC), and the script takes one `pg_dump --serializable-deferrable`
+(`scripts/snapshot-postgres.sh:33`), gzips it, and uploads it to S3. There is no
+WAL archiving and no continuous archiving of any kind, so the recovery point is
+whatever the last nightly dump captured — an RPO of **up to ~24 hours**. The
+`snapshot-policy.md` doc already acknowledges this: "Daily at 02:00 UTC, hourly
+WAL is out of scope (see ADS-443 for streaming replication / PITR design)"
+(`docs/operations/snapshot-policy.md:33`).
+
+Three gaps make the current posture weaker than "daily logical dump" already
+implies:
+
+1. **Restore is never proven.** The only restorability signal in the pipeline is
+   a size check — `if [[ "$DUMP_BYTES" -lt 1024 ]]` (`scripts/snapshot-postgres.sh:37`)
+   fails the run when the dump is suspiciously small. A dump that is large but
+   corrupt, truncated mid-stream, or missing objects passes. Nothing ever loads
+   a backup back into a database, so we have no evidence any snapshot is
+   restorable until the day we need one.
+
+2. **Retention enforcement is unverified and immutability is absent.** The upload
+   sets `--metadata "Class=tier1,Retention=30d"` (`scripts/snapshot-postgres.sh:46`),
+   which is S3 **user-metadata** — a descriptive tag, not a lifecycle rule and not
+   Object Lock; the policy doc itself notes lifecycle rules "cannot filter by
+   user-metadata, so the metadata is descriptive only"
+   (`docs/operations/snapshot-policy.md:27`). The docs then disagree on whether
+   real enforcement exists behind that tag: `db-backup-runbook.md:52,58` asserts
+   the S3 bucket's lifecycle rule sets the 30-day off-site retention "**not** the
+   script", yet `snapshot-policy.md:27-28` treats that same lifecycle pruning as
+   something that "must be configured on the `postgres/` prefix" (aspirational).
+   Crucially, there is **no lifecycle, versioning, or Object Lock configuration
+   anywhere in the repository** to verify either claim. So retention enforcement is
+   unverified — a doc-vs-reality gap — and immutability is definitively absent:
+   nothing in the repo prevents a snapshot from being deleted or overwritten (by an
+   attacker or an errant `aws s3 rm`), and Object Lock would require bucket
+   versioning that no committed config enables.
+
+3. **The drill log the policy mandates is missing — and the docs disagree on its
+   cadence.** `snapshot-policy.md:84` requires a restore drill and says "Track
+   outcomes in `docs/operations/restore-drills.md`". That file **does not exist**
+   in the repository — there is no evidence any restore drill has ever been
+   recorded. The two docs also disagree on how often to drill:
+   `snapshot-policy.md:83` mandates a **monthly** drill, while
+   `db-backup-runbook.md:54,199` mandates a **quarterly** one — a mismatch Phase 1
+   must reconcile when it stands the log up. A restore runbook exists
+   (`docs/operations/restore.md`) but, per point 1, its happy path has never been
+   exercised end-to-end in an automated or logged way.
+
+Net: backups are logical-only, unverified, retention is unenforced, and there is
+no PITR. This ADR proposes the target design; it makes no code or config change.
+
+### Relationship to ADS-443
+
+`snapshot-policy.md:33` defers PITR / streaming replication to **ADS-443**. The
+fix direction for ADS-1043 (restore-provability, retention enforcement) partly
+overlaps ADS-443 (WAL archiving → PITR), because the same backup tool naturally
+provides both. This ADR treats the two as one workstream: the restore-verification
+and retention pieces (ADS-1043) can ship independently and first, and the
+WAL/PITR piece is the same pgBackRest adoption ADS-443 describes. If this ADR is
+accepted, ADS-443 becomes the implementation ticket for the PITR phase rather than
+a separate "out of scope" design — the maintainer should confirm which ticket
+owns which phase (see Open questions).
+
+## Options considered
+
+### Option A — Keep `pg_dump`, add automated restore verification only
+
+Leave the nightly logical dump as-is, but add a CI job that pulls the latest
+dump, restores it into a throwaway Postgres, and asserts row counts / a schema
+diff. Add an S3 lifecycle rule + Object Lock and start the drill log.
+
+- **Pro:** Smallest change; no new backup tooling or WAL storage; directly closes
+  the "restore never proven" and "retention unverified / not immutable" gaps that
+  are the core of ADS-1043.
+- **Con:** Does nothing for RPO — still up to ~24h of data loss on a failure at
+  01:59 UTC. Logical restore RTO on a large DB is slow (single-threaded replay of
+  a SQL stream). PITR remains impossible.
+
+### Option B — Adopt pgBackRest (WAL archiving + base backups → PITR)
+
+Replace/augment the dump with pgBackRest: periodic base backups plus continuous
+WAL archiving to S3, giving point-in-time recovery. Keep an automated
+restore-verification job on top, plus lifecycle + Object Lock.
+
+- **Pro:** RPO drops from ~24h to the WAL archive interval (minutes). Supports
+  PITR to any point in the retention window. Parallel restore, incremental/
+  differential backups, built-in `pgbackrest verify`, first-class S3 + retention
+  support. Self-hosted-friendly (we run Postgres in a container on Hetzner per
+  `backup.yml`).
+- **Con:** New operational surface (a `pgbackrest` sidecar/cron, `archive_command`
+  on the primary, a repo bucket). WAL storage grows continuously and needs
+  monitoring. Requires `archive_mode = on` and a Postgres restart to enable.
+
+### Option C — Adopt wal-g
+
+Same PITR shape as B (base backups + WAL push to S3) via wal-g instead of
+pgBackRest.
+
+- **Pro:** Similar PITR capability; single Go binary, simple config; strong S3
+  support.
+- **Con:** Thinner operational tooling than pgBackRest (less mature `verify`,
+  weaker built-in retention/differential story); smaller institutional knowledge.
+  No decisive advantage over B for our footprint.
+
+### Option D — Migrate to managed Postgres with built-in PITR
+
+Move production Postgres off the self-hosted container to a managed provider
+(RDS, Cloud SQL, Crunchy, etc.) and rely on the provider's automated backups +
+PITR.
+
+- **Pro:** PITR, retention, and restore tooling become the provider's problem;
+  least backup code to own long-term.
+- **Con:** Large infra/cost change well beyond ADS-1043's scope; the stack is
+  currently self-hosted on Hetzner with PostGIS. Migration is its own project and
+  does not close today's gap on the current DB in a reasonable timeframe. Still
+  warrants an independent restore-verification drill regardless of provider
+  claims.
+
+## Decision
+
+**Adopt Option B (pgBackRest) as the target, delivered in phases, with Option A's
+restore-verification job shipped first.**
+
+Rationale:
+
+- The two most urgent, cheapest-to-fix findings in ADS-1043 are "restore never
+  proven" and "retention unverified / not immutable". Both are addressable
+  **without** changing the backup tool, so an automated restore-verification CI job + S3 lifecycle/Object
+  Lock + a drill log should land first (Phase 1) and immediately raise
+  confidence.
+- The remaining finding — ~24h RPO and no PITR — genuinely needs continuous WAL
+  archiving. pgBackRest is preferred over wal-g (Option C) for its mature
+  `verify`, retention (`repo-retention-full` / `-diff`), and parallelism, and
+  over managed Postgres (Option D) because it fits the current self-hosted
+  Hetzner + container + PostGIS setup and can be delivered incrementally rather
+  than as a migration project.
+- This aligns ADS-1043 and ADS-443: Phase 1 satisfies ADS-1043's core; Phase 2
+  (pgBackRest WAL/PITR) is the ADS-443 design, now with a concrete tool choice.
+
+Explicitly out of scope for this ADR: choosing managed vs self-hosted long-term
+(Option D remains a valid future direction, tracked separately if pursued).
+
+## Implementation sketch
+
+_Described, not applied. Nothing below is committed by this PR._
+
+### Phase 1 — restore verification, retention enforcement, drill log (ADS-1043 core)
+
+**1. Automated restore-verification CI job.** A scheduled workflow that, after
+the nightly snapshot, restores the latest dump into a disposable Postgres and
+asserts it loaded. Outline:
+
+```yaml
+# .github/workflows/backup-verify.yml (illustrative)
+name: Backup verify
+on:
+  schedule:
+    - cron: '30 3 * * *' # after the 02:00 snapshot has uploaded
+  workflow_dispatch: {}
+jobs:
+  restore-latest:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgis/postgis:16-3.4
+        env: { POSTGRES_PASSWORD: verify }
+        ports: ['5432:5432']
+    steps:
+      - name: Fetch newest dump from S3
+        run: |
+          KEY="$(aws s3 ls "s3://$BACKUP_BUCKET/postgres/" --recursive \
+            | sort | tail -n1 | awk '{print $4}')"
+          aws s3 cp "s3://$BACKUP_BUCKET/$KEY" dump.sql.gz
+      - name: Restore into throwaway DB
+        run: gunzip -c dump.sql.gz | psql "$VERIFY_DSN"
+      - name: Assert schema + row counts
+        run: |
+          # fail if core tables are absent or empty
+          psql "$VERIFY_DSN" -v ON_ERROR_STOP=1 -c \
+            "SELECT count(*) FROM auth.users;" # ...per-schema sentinels
+          # optional: diff information_schema against a checked-in baseline
+```
+
+The assertion step is the point: it proves the dump **restores** and lands a
+non-empty, schema-correct database — replacing the `-lt 1024` byte heuristic at
+`scripts/snapshot-postgres.sh:37` as the real restorability signal. A failed run
+pages whoever owns backups.
+
+**2. S3 lifecycle + Object Lock + versioning.** Replace the cosmetic
+`Retention=30d` metadata (`scripts/snapshot-postgres.sh:46`) with enforced
+controls on the `postgres/` prefix:
+
+```json
+// S3 lifecycle rule (illustrative) — actually prunes at 30d
+{
+  "Rules": [
+    {
+      "ID": "postgres-snapshots-30d",
+      "Filter": { "Prefix": "postgres/" },
+      "Status": "Enabled",
+      "Expiration": { "Days": 30 },
+      "NoncurrentVersionExpiration": { "NoncurrentDays": 30 }
+    }
+  ]
+}
+```
+
+Object Lock (compliance or governance mode) requires **bucket versioning
+enabled** and must be set at/near bucket creation; new snapshot objects then
+carry a retention date that blocks deletion/overwrite for the window:
+
+```
+# bucket: versioning + default Object Lock retention
+Versioning:        Enabled
+ObjectLockEnabled: true
+DefaultRetention:  { Mode: GOVERNANCE, Days: 30 }   # or COMPLIANCE if immutable
+```
+
+The metadata tag can stay as a human-readable label, but retention is now
+enforced by the lifecycle rule + lock, not implied by a string.
+
+**3. Restore-drill log.** Create the file the policy already references
+(`docs/operations/snapshot-policy.md:84`), `docs/operations/restore-drills.md`,
+as a running table (date, operator, backup key restored, target env, row-count /
+schema-diff result, RTO observed, notes). The Phase 1 CI job can append or a
+scheduled manual drill can, but the log must exist and be linked from the docs
+index. Standing the log up also forces reconciling the monthly
+(`snapshot-policy.md:83`) vs quarterly (`db-backup-runbook.md:54,199`) cadence
+mismatch — pick one cadence and correct whichever doc is wrong.
+
+### Phase 2 — pgBackRest WAL archiving + base backups → PITR (ADS-443)
+
+On the primary, enable archiving and point it at pgBackRest:
+
+```ini
+# postgresql.conf (illustrative)
+archive_mode = on
+archive_command = 'pgbackrest --stanza=prod archive-push %p'
+```
+
+```ini
+# /etc/pgbackrest/pgbackrest.conf (illustrative)
+[global]
+repo1-type = s3
+repo1-s3-bucket = adopt-dont-shop-prod-backups
+repo1-s3-region = eu-west-2
+repo1-path = /pgbackrest
+repo1-retention-full = 4          # keep N full backups
+repo1-retention-diff = 14
+repo1-cipher-type = aes-256-cbc
+
+[prod]
+pg1-path = /var/lib/postgresql/data
+```
+
+Base backups via cron (e.g. weekly full + daily diff), continuous WAL push via
+`archive_command`. Restore/PITR then becomes
+`pgbackrest --stanza=prod --type=time --target="..." restore`, and the Phase 1
+verification job can additionally run `pgbackrest verify` and periodically
+exercise a real PITR restore to a throwaway instance.
+
+## Risks & rollout
+
+- **Phased rollout.** Phase 1 is additive and low-risk — a new verify workflow, a
+  bucket lifecycle/lock change, and a docs file. It touches no write path on the
+  primary and can ship and prove value before Phase 2. Phase 2 changes primary
+  Postgres config (`archive_mode = on` needs a restart) and should land in a
+  maintenance window after rehearsal on staging.
+- **WAL storage growth.** Continuous WAL archiving grows the repo bucket
+  unboundedly without retention; `repo-retention-*` plus lifecycle rules must be
+  set from day one, and archive volume/latency monitored (a stuck
+  `archive_command` can back up WAL on the primary and eventually stall writes).
+- **Object Lock is hard to undo.** COMPLIANCE mode cannot be shortened or removed
+  even by root for the retention window — pick GOVERNANCE unless true immutability
+  is required, and choose the window deliberately (Open questions).
+- **Cost.** Object Lock + versioning retain more objects (each snapshot version
+  kept for the window) and WAL archiving adds continuous PUTs and storage — a
+  real but modest S3 bill increase that should be estimated before enabling.
+- **Testing the restore path is the whole point.** The verify job must fail loudly
+  and be watched; a green-but-not-actually-asserting job would recreate today's
+  false confidence. Assertions should check real row counts / schema, not just
+  "psql exited 0".
+
+## Open questions for the maintainer
+
+1. **Managed vs self-hosted Postgres?** Is a managed provider with built-in PITR
+   (Option D) on the roadmap, or do we commit to self-hosted + pgBackRest? This
+   decides whether Phase 2 is worth building.
+2. **Target RPO and RTO?** What data-loss window is acceptable (drives whether ~24h
+   is tolerable short-term and the WAL push interval), and what restore time must
+   we meet (drives base-backup cadence and parallelism)?
+3. **Object Lock retention window and mode?** How many days, and GOVERNANCE
+   (overridable by privileged roles) vs COMPLIANCE (truly immutable)? This is
+   effectively irreversible for the chosen window.
+4. **Ticket ownership between ADS-1043 and ADS-443.** Does ADS-1043 own Phase 1
+   (verify + retention + drills) and ADS-443 own Phase 2 (pgBackRest PITR), or
+   should they be merged? `snapshot-policy.md:33` currently frames PITR as
+   ADS-443's job.
+5. **Who owns restore drills going forward** — and should the monthly drill be
+   fully automated by the Phase 1 CI job, or remain a human-run exercise that the
+   log records?

--- a/docs/adr/0009-deployment-strategy-and-ha.md
+++ b/docs/adr/0009-deployment-strategy-and-ha.md
@@ -1,0 +1,238 @@
+# ADR 0009 — Deployment strategy & high availability (ADS-1045)
+
+- Status: Proposed
+- Date: 2026-08-05
+- Scope: `.github/workflows/deploy.yml`, `.github/workflows/rollback.yml`,
+  `docker-compose.prod.yml` — production release mechanics and single-host
+  topology. No code or config is changed by this ADR; it is a decision
+  proposal only.
+
+## Context
+
+ADS-1045 flags that the production deploy is an **in-place, single-replica,
+single-host** recreate with **post-cutover** health checks and **no automatic
+rollback**. Each of those is verifiable in the repo today:
+
+- **In-place cutover.** The deploy job SSHes to the host and runs
+  `docker compose -f $COMPOSE_FILE $OVERLAY_ARGS --env-file .env up -d`
+  (`.github/workflows/deploy.yml:736`). Plain `docker compose up` recreates
+  every container whose image tag changed by **stopping the old container,
+  then starting the new one** — there is no overlap. Because the new
+  `DEPLOY_SHA` was already written to `.env` a few lines earlier
+  (`deploy.yml:627`), every service and app container is recreated on the same
+  pass, so the whole stack turns over within one window.
+- **Single replica, single host, every component a SPOF.**
+  `docker-compose.prod.yml` declares exactly one container per service. There
+  is no `replicas:` key anywhere in the file; each service instead pins a fixed
+  `container_name` (`ads_prod_gateway` at `docker-compose.prod.yml:262`,
+  `ads_prod_db` at `:152`, and so on), and the `deploy:` blocks carry only
+  `resources` limits (`docker-compose.prod.yml:62-69`) — no `replicas`, no
+  `update_config`. There is one `database` (`:150`), one `redis` (`:186`), one
+  `nats` (`:224`), one gateway, one of each of the ten gRPC services, and one
+  `nginx`, all on a single Hetzner host (`deploy.yml:600`,
+  `secrets.HETZNER_HOST`). Any one of Postgres / Redis / NATS / the host itself
+  is a hard single point of failure with no standby.
+- **Health checks run AFTER cutover.** Only once `up -d` has already swapped
+  the containers does the workflow wait for health: the shared
+  `scripts/wait-for-services.sh` gate over all eleven services
+  (`deploy.yml:744-755`) and the `/api/v1/auth/login` route smoke check
+  (`deploy.yml:761-770`). By the time these run, live traffic is already
+  hitting the new containers.
+- **No automatic rollback.** The job runs under `set -euo pipefail`
+  (`deploy.yml:606`), so if the health gate or smoke check fails the script
+  exits non-zero **and stops there** — the new (unhealthy) containers keep
+  running. The previous good SHA is still on disk in `.last_sha`, but that file
+  is only _written_ on success (`deploy.yml:777`) and nothing _reads_ it on
+  failure. Recovery is entirely manual: a human must notice the outage and
+  dispatch `rollback.yml`, which is `workflow_dispatch`-only and **requires the
+  operator to type the target SHA by hand** (`.github/workflows/rollback.yml:3-16`).
+
+Net effect: every deploy has a downtime window (old container down before new
+container is up), a failed deploy is a **live outage that persists until a
+human intervenes**, and even a perfect deploy leaves every stateful component
+without redundancy. This ADR proposes how far to close that gap, and what to
+consciously accept.
+
+## Options considered
+
+Ordered by cost/complexity, cheapest first.
+
+### Option A — Stay single-host; add auto-rollback + start-first + a documented SPOF budget
+
+Keep the one-host compose topology but remove the _worst_ failure mode and
+shrink the downtime window:
+
+1. **Automatic rollback-on-failed-health.** When the health gate or smoke
+   check fails, the deploy script re-points `DEPLOY_SHA` to the value in
+   `.last_sha` and re-runs `docker compose up -d` before exiting non-zero, so a
+   bad deploy self-heals back to the last-known-good SHA instead of sitting
+   broken. This works with plain compose today — no orchestrator needed.
+2. **Start-first recreate** to shrink (not eliminate) the per-service downtime
+   window. **Caveat, verified:** `deploy.update_config.order: start-first` is a
+   **Swarm-only** directive — `docker compose up` (what `deploy.yml:736` runs)
+   silently ignores `update_config`. So "start-first" here means _either_
+   migrating the deploy to `docker stack deploy` (Swarm) _or_ scripting a
+   manual blue-green swap in the workflow (start the new container under a
+   temp name, health-check it, then swap). The YAML block alone is not enough.
+3. **Document the accepted SPOF** with an explicit RTO/RPO and a
+   maintenance-window policy for deploys, so the residual single-host risk is a
+   consciously-owned decision rather than an accident.
+
+- **Pros:** Lowest cost. Auto-rollback needs no new infrastructure and kills
+  the "failed deploy = open-ended outage" mode outright. RTO/RPO + maintenance
+  windows make the residual risk explicit and reviewable.
+- **Cons:** Postgres / Redis / NATS / host stay single points of failure — this
+  option caps availability at "one host's uptime, minus planned windows." True
+  zero-downtime start-first is more than a YAML line (see caveat).
+
+### Option B — Multi-replica stateless services on the one host, behind the proxy
+
+Run `replicas > 1` for the stateless tier (gateway + the ten gRPC services)
+behind the existing `nginx`, so a rolling recreate can drain one replica while
+another serves. **Blockers, verified:** every service sets a fixed
+`container_name` (`docker-compose.prod.yml:262`, …), and Compose refuses to
+scale a service that has one — those must be removed first. Stateful singletons
+(Postgres/Redis/NATS) are unchanged and remain SPOFs.
+
+- **Pros:** Real rolling deploys and app-tier resilience to a single container
+  crash, still on one box.
+- **Cons:** Only masks _stateless_ failures; the host and every stateful
+  singleton are still SPOFs, so the availability ceiling barely moves. Needs
+  container_name removal, per-service internal DNS/load-balancing across
+  replicas, and connection-pool math against the single Postgres. Moderate work
+  for a ceiling still set by one host.
+
+### Option C — Move to an orchestrator with rolling deploys + managed HA Postgres
+
+Adopt Docker Swarm / Nomad / Kubernetes across ≥2 hosts: native rolling updates
+with real `order: start-first`, health-gated automatic rollback built into the
+platform, and a replicated/managed Postgres (streaming replication or a managed
+provider) plus Redis/NATS clustering.
+
+- **Pros:** The only option that actually removes the host and datastore SPOFs
+  and delivers genuine zero-downtime deploys and HA.
+- **Cons:** Largest cost by far — new infrastructure, multi-host networking,
+  stateful-service HA operations, and a migration off the current single-host
+  compose model. Disproportionate to today's scale if the single-host risk is
+  acceptable with a documented RTO/RPO.
+
+## Decision
+
+**Adopt Option A now; defer Options B and C to a follow-up epic.**
+
+Rationale: the highest-severity issue in ADS-1045 is not the single replica —
+it is that a _failed_ deploy is an _unbounded live outage_ waiting on a human.
+Automatic rollback-on-failed-health fixes exactly that, works with the current
+`docker compose up` mechanics with **no** orchestrator change, and is
+low-risk to add. Pair it with an explicitly documented SPOF budget (RTO/RPO)
+and a maintenance-window policy so the residual single-host risk is a decision
+on record, not a surprise.
+
+Sequence the start-first piece as a fast-follow, not a blocker: because
+`deploy.update_config` is Swarm-only (see Option A caveat), genuine start-first
+means choosing between a Swarm migration and a scripted blue-green swap — a
+larger change than auto-rollback and best decided once the maintainer answers
+the open questions below. Multi-host HA and managed Postgres (Options B/C) are
+real work with real value but should ride their own epic; this ADR should not
+smuggle a platform migration in under a deploy-hardening ticket.
+
+## Implementation sketch
+
+Described, **not applied** — illustrative only.
+
+**1. Start-first block (Swarm only — will NOT take effect under
+`docker compose up`).** If and only if the deploy moves to `docker stack
+deploy`, each stateless service would gain:
+
+```yaml
+# docker-compose.prod.yml — ONLY honoured by `docker stack deploy` (Swarm),
+# ignored by the current `docker compose up -d` at deploy.yml:736.
+deploy:
+  replicas: 2
+  update_config:
+    order: start-first # boot the new task before stopping the old
+    failure_action: rollback
+  rollback_config:
+    order: stop-first
+```
+
+Under plain compose, the equivalent is a scripted swap in the workflow (start
+`service-x-next`, health-check it, repoint nginx, remove the old container).
+
+**2. Auto-rollback step in `deploy.yml` (works with plain compose today).**
+After the existing health gate (`deploy.yml:744-770`), wrap the failure path so
+it reverts to `.last_sha` instead of exiting broken:
+
+```bash
+# Illustrative — appended after the wait-for-services + smoke check.
+if ! ./scripts/wait-for-services.sh "$COMPOSE_FILE" 30 2 "${HEALTH_TARGETS[@]}"; then
+  echo "Health gate failed — rolling back to last-known-good."
+  LAST_GOOD="$(cat .last_sha)"                       # written on prior success (deploy.yml:777)
+  sed -i "s/^DEPLOY_SHA=.*/DEPLOY_SHA=$LAST_GOOD/" .env
+  docker compose -f "$COMPOSE_FILE" --env-file .env up -d
+  ./scripts/wait-for-services.sh "$COMPOSE_FILE" 30 2 "${HEALTH_TARGETS[@]}"
+  echo "Rolled back to $LAST_GOOD." >&2
+  exit 1                                             # deploy still fails, but the stack is healthy
+fi
+```
+
+Note the ordering bug this must avoid: `DEPLOY_SHA` in `.env` is already the
+_new_ SHA (`deploy.yml:627`), and `.last_sha` still holds the _previous_ good
+SHA because it is only overwritten on success (`deploy.yml:777`). The rollback
+must read `.last_sha` **before** any code path rewrites it.
+
+**3. Documented RTO/RPO + maintenance-window section** (new subsection in
+`docs/operations/deploy.md` or `docs/infrastructure/INFRASTRUCTURE.md`), stating
+at minimum: the accepted **RTO** (how long a full host/datastore loss may take
+to recover from backup — bounded by the restore runbook), the accepted **RPO**
+(worst-case data loss, bounded by snapshot cadence in
+`docs/operations/snapshot-policy.md`), the deploy **maintenance window** policy
+(when in-place deploys may run and expected user-visible downtime), and an
+explicit statement that Postgres/Redis/NATS/host are unreplicated SPOFs by
+current design.
+
+## Risks & rollout
+
+- **Start-first requires two versions to coexist briefly.** Any start-first or
+  multi-replica scheme means old and new code serve traffic simultaneously for
+  a window, which is only safe if schema changes are backward-compatible. This
+  ties directly to the expand/contract migration work in ADS-1044 (proposed
+  ADR 0008, landing in a separate PR): start-first must not ship ahead of
+  expand/contract discipline, or a
+  not-yet-contracted column can break the still-running old version.
+- **Auto-rollback and already-applied migrations.** Each service migrates its
+  own schema on container start (the `Dockerfile.service` entrypoint runs
+  `db:migrate`). If a deploy applies a forward migration and _then_ fails
+  health, rolling the _images_ back to `.last_sha` does **not** roll the
+  _schema_ back — the old image may run against a newer schema. Auto-rollback is
+  therefore only safe under the same expand/contract guarantee (ADS-1044;
+  proposed ADR 0008): forward migrations must be additive and
+  old-code-compatible.
+  Destructive/contracting migrations must never ship in the same deploy as the
+  code that depends on them.
+- **Stateful singletons still SPOF under Option A.** Auto-rollback and
+  start-first do nothing for a Postgres/Redis/NATS/host failure. Option A's
+  value is bounded to deploy safety; the documented RTO/RPO is what makes that
+  boundary an accepted decision rather than a gap.
+- **Rollout order.** Ship auto-rollback + the RTO/RPO doc first (self-contained,
+  low blast radius). Decide Swarm-vs-scripted-swap for start-first only after
+  the open questions are answered. Treat multi-host HA as a separate epic.
+
+## Open questions for the maintainer
+
+1. **Accept the single-host SPOF with a documented RTO/RPO, or invest in
+   multi-host now?** Option A accepts it explicitly; Options B/C start buying it
+   down at materially higher cost. What availability target actually matters for
+   this product today?
+2. **What RTO/RPO are we willing to commit to?** These numbers drive everything
+   downstream (snapshot cadence, whether a warm standby is needed) and belong in
+   the docs regardless of which option is chosen.
+3. **Managed / replicated Postgres for HA — on the roadmap or out of scope?**
+   It is the single biggest lever on real availability and the biggest
+   operational commitment; deciding it gates Option C.
+4. **Start-first via Swarm migration or a scripted blue-green swap?** Since
+   `deploy.update_config` is inert under `docker compose up`, this is an
+   either/or that shapes how much of `deploy.yml` changes.
+5. **Is an orchestrator (Swarm/Nomad/K8s) on the roadmap at all?** If yes, some
+   of Option A's scripting is throwaway and we may prefer to invest once; if no,
+   Option A is the durable answer.

--- a/docs/adr/0010-frontend-quality-gates.md
+++ b/docs/adr/0010-frontend-quality-gates.md
@@ -1,0 +1,264 @@
+# ADR 0010 — Frontend quality gates: a11y lint, no-non-null-assertion, container CSP, coverage floors (ADS-1055)
+
+- Status: Proposed
+- Date: 2026-08-05
+- Scope: `packages/eslint-config-react`, `packages/eslint-config-base`,
+  `packages/eslint-config-node`, `Dockerfile.app`,
+  `services/gateway/src/routes/users.ts` (proto-assertion hotspot),
+  `apps/rescue` + `apps/client` vitest coverage thresholds (proposal only —
+  no code or config changed in this PR)
+
+## Context
+
+ADS-1055 (under epic ADS-1039) flags four frontend quality gates that have
+quietly eroded. Each was verified against the current tree before writing this
+ADR; the specifics matter because the fixes differ per concern.
+
+**1. Accessibility linting is disabled.** `packages/eslint-config-react/index.js:6`
+carries `// TODO: re-add eslint-plugin-jsx-a11y once it supports eslint 10`, and
+the shared React config never registers the plugin or any of its rules. So
+`alt`/label/ARIA/keyboard-handler regressions land invisibly across all three
+apps, even though the repo ships an `accessibility` skill that asks contributors
+to meet WCAG targets. The stated blocker — no eslint-10-compatible release — no
+longer holds; `eslint-plugin-jsx-a11y` publishes a flat-config build that runs
+under eslint 10.
+
+**2. No `no-non-null-assertion` rule.** None of the three ESLint layers
+(`packages/eslint-config-base`, `eslint-config-node`, `eslint-config-react`)
+enables `@typescript-eslint/no-non-null-assertion`, so the `!` operator is
+unguarded despite the repo's "no type assertions without clear justification"
+guideline. A
+grep for the non-null-assertion form across `apps/*/src` and
+`services/gateway/src` (excluding tests) returns on the order of 50–90 sites
+(approximate — the exact figure depends on how strictly comments/strings are
+filtered; the ticket cites ~50–60). The hotspot is
+`services/gateway/src/routes/users.ts`, which alone carries ~16, every one of
+them on a proto response field the code assumes is populated —
+e.g. `composePreferences(notif.preferences!, privacy.preferences!)`
+(`services/gateway/src/routes/users.ts:311`, `:375`, `:421`) and
+`AuthV1.User.toJSON(res.user!)` (`:599`, `:668`, `:725`, `:773`, `:1351`). Each
+`!` is a silent runtime-crash risk if the upstream service ever returns the
+optional field unset.
+
+**3. The container-baked CSP is far broader than the proxy's.** `Dockerfile.app`
+bakes an nginx `Content-Security-Policy` into `/etc/nginx/security-headers.conf`
+with `connect-src 'self' wss: https:` (`Dockerfile.app:191`). That permits the
+SPA to open an XHR/fetch/WebSocket to _any_ `https:`/`wss:` origin. The proxy
+layer, by contrast, pins the exact API host: the app vhosts in
+`nginx/nginx.prod.conf` set `connect-src 'self' https://api.__PROD_HOSTNAME__ wss://api.__PROD_HOSTNAME__`
+(`nginx/nginx.prod.conf:149`, `:181`, `:266`; the api vhost itself narrows to
+`connect-src 'self'`, `:213`), and `deploy/gateway/nginx.conf` pins the same
+`https://api.adoptdontshop.com wss://api.adoptdontshop.com`
+(`deploy/gateway/nginx.conf:150`, `:272`). The layered policies disagree: in
+normal operation the outer proxy's tighter header wins, but if an app container
+is ever served directly (a preview env, a misrouted deploy, a compromised
+proxy), the baked-in `connect-src` is the only policy in force and it allows
+exfiltration to an attacker-controlled origin. A defence-in-depth control should
+not depend on a second layer always being present.
+
+**4. App coverage floors are low for user-facing flows.** The per-app vitest
+thresholds are:
+
+- `apps/rescue/vitest.config.ts:36` — statements 40, branches 37, functions 35,
+  **lines 40**.
+- `apps/client/vitest.config.ts:42` — statements 55, branches 41, functions 41,
+  **lines 57**.
+- `apps/admin/vitest.config.ts:42` — statements 62.5, branches 50, functions 50,
+  lines 65 (higher, shown for contrast).
+
+The two adopter/rescue-facing apps — the ones carrying the primary user journeys
+(swipe/discovery, applications, profile) — have the weakest floors. Both were
+"ratcheted to measured baseline (2026-06-16); buffered for CI variance" per the
+inline comments, i.e. the number tracks _what coverage happens to be_, not a
+target the team is climbing toward.
+
+## Options considered
+
+Four independent sub-decisions; each has its own options and tradeoffs.
+
+### a11y linting
+
+- **A. Re-enable `eslint-plugin-jsx-a11y` in `eslint-config-react`.** Restores
+  static checks at author time / in CI for every app and lib that extends the
+  React config. Catches the common regressions (missing `alt`, unlabelled
+  controls, click-without-key handlers) cheaply. Downside: turning it on against
+  an existing codebase surfaces a backlog at once; if added as `error` it blocks
+  every PR touching an offending file until fixed.
+- **B. Add `axe` (e.g. `@axe-core/playwright`) to the e2e suite.** Tests the
+  _rendered_ DOM, so it catches runtime/dynamic issues static lint can't. But it
+  only covers pages the e2e suite actually drives, runs late (full-stack, slow),
+  and gives coarser file-level attribution than a lint error on the JSX line.
+- **C. Both.** Static lint as the fast first line; axe as runtime defence for the
+  critical journeys. More setup, best coverage.
+
+### `no-non-null-assertion`
+
+- **A. Enable as `error` immediately.** Honest and enforced, but requires fixing
+  all ~50–90 sites in the same change — a large, cross-cutting diff that fights
+  the "small increments" rule and risks rushed guard code.
+- **B. Enable as `warn`, then ratchet to `error`.** Surfaces every site without
+  blocking, lets the count be driven down incrementally, then flips to `error`
+  once near zero. Slower, and a `warn` can be ignored indefinitely without a
+  follow-up commitment.
+- **C. Enable as `error` with targeted `eslint-disable` on the proto hotspots +
+  a follow-up to remove them.** Enforced everywhere new, with the known gateway
+  cluster explicitly exempted. Downside: scatters `eslint-disable` comments that
+  tend to become permanent.
+
+### container CSP
+
+- **A. Tighten `Dockerfile.app`'s `connect-src` to match the proxy's pinned
+  policy** (parameterised per environment). Removes the exfiltration surface even
+  when the container is served without the proxy — true defence-in-depth. Cost:
+  the baked header must learn the API host, so it needs a build `ARG` or a
+  runtime env substitution at container start, and a too-tight value breaks
+  legitimate API/WebSocket traffic if the host is wrong.
+- **B. Rely solely on the proxy; accept the risk.** Zero work, and in the
+  documented topology the proxy header always wins. But it leaves a latent
+  misconfiguration where a single routing mistake exposes an
+  exfiltration-friendly policy — exactly the "served without the outer proxy"
+  threat model the ticket calls out.
+
+### coverage floors
+
+- **A. One-shot raise** to a target (e.g. rescue/client lines → 70/75). Clear
+  destination, but a large jump likely lands red immediately and forces a big
+  test-writing push before anything merges.
+- **B. Incremental ratchet per app.** Nudge each floor up a few points per PR as
+  tests are added, keeping CI green throughout. Slower to reach the target but
+  never blocks the pipeline; matches how the floors were set originally.
+
+## Decision
+
+A defensible recommendation per concern, formed from the evidence above. This is
+a proposal — nothing here is applied in this PR.
+
+- **a11y — re-enable `eslint-plugin-jsx-a11y` now (Option A), pursue axe later
+  (toward C).** The original blocker is gone, and static lint is the cheapest,
+  most localised signal. Introduce it at the plugin's `recommended` set but at
+  `warn` severity first so the existing backlog is visible without blocking every
+  PR, then promote the high-value rules to `error` once the backlog is burned
+  down. Add axe to the e2e critical-journey specs as a follow-up for runtime
+  defence; it complements rather than replaces the lint.
+- **`no-non-null-assertion` — add as `warn`, then ratchet to `error`, with the
+  gateway proto hotspot cleaned up first (Option B, informed by C).** Clean
+  `services/gateway/src/routes/users.ts` up front by replacing the `res.user!` /
+  `*.preferences!` assertions with an explicit guard/assert helper (a proto
+  response missing a field is a real error worth surfacing, not asserting away),
+  then enable the rule repo-wide at `warn` and drive the remaining count down
+  before flipping to `error`. Avoids both a giant one-shot diff and a scatter of
+  permanent `eslint-disable` comments.
+- **CSP — tighten the container CSP to match the proxy (Option A).** Mirror the
+  proxy's pinned `connect-src` in `Dockerfile.app`, parameterised by the
+  environment's API host, so the container is safe on its own. Defence-in-depth
+  is the whole point of a baked header; relying solely on the proxy defeats it.
+- **coverage — incremental ratchet per app (Option B).** Nudge the rescue and
+  client floors upward a few points at a time toward an agreed target, keeping CI
+  green. Prioritise the rescue app (lowest floors, core rescue-staff journeys).
+
+## Implementation sketch
+
+Concrete, described-not-applied changes. **None of this is committed in this
+PR** — the fences are illustrative of the eventual follow-up work.
+
+**a11y — `packages/eslint-config-react/index.js`** (remove the `:6` TODO, wire
+the plugin's flat config):
+
+```js
+import jsxA11y from 'eslint-plugin-jsx-a11y';
+// ...
+export default [
+  ...baseConfig,
+  pluginReact.configs.flat.recommended,
+  jsxA11y.flatConfigs.recommended, // ADS-1055: re-enabled (eslint-10 support now ships)
+  {
+    // ...existing plugins/settings/rules...
+    rules: {
+      // Start soft to surface the backlog without blocking, then ratchet
+      // the high-value rules to 'error'.
+      'jsx-a11y/alt-text': 'warn',
+      'jsx-a11y/anchor-is-valid': 'warn',
+      // ...
+    },
+  },
+];
+```
+
+**`no-non-null-assertion` — `packages/eslint-config-base`** (add the rule to the
+shared base so every layer inherits it):
+
+```js
+rules: {
+  // ADS-1055: enable as warn first; ratchet to 'error' once the count nears zero.
+  '@typescript-eslint/no-non-null-assertion': 'warn',
+}
+```
+
+Clean the gateway hotspot first, e.g. replace
+`AuthV1.User.toJSON(res.user!)` with a guarded read:
+
+```ts
+if (!res.user) throw new Error('adminUpdateUser: response missing user');
+return reply.send({ success: true, data: AuthV1.User.toJSON(res.user) });
+```
+
+**CSP — `Dockerfile.app:191`** (tighten `connect-src` to the pinned host,
+parameterised so the baked header is not hard-coded to one environment):
+
+```dockerfile
+ARG API_ORIGIN=https://api.example.com
+ARG API_WSS=wss://api.example.com
+# ...connect-src 'self' ${API_ORIGIN} ${API_WSS}; ...   (was: connect-src 'self' wss: https:)
+```
+
+**coverage — ratchet the two low apps** (one small bump per PR):
+
+```ts
+// apps/rescue/vitest.config.ts:36
+thresholds: { statements: 45, branches: 42, functions: 40, lines: 45 }, // was 40/37/35/40
+
+// apps/client/vitest.config.ts:42
+thresholds: { statements: 60, branches: 46, functions: 46, lines: 62 }, // was 55/41/41/57
+```
+
+## Risks & rollout
+
+- **Lint churn.** Turning on jsx-a11y and `no-non-null-assertion` against an
+  existing tree surfaces a backlog immediately. Starting both at `warn` keeps CI
+  green while the counts are driven down; the ratchet-to-`error` step is a
+  separate, deliberate PR per rule so the blocking change is small and reviewable.
+- **eslint-10 / jsx-a11y compatibility.** The plugin must be on a flat-config,
+  eslint-10-compatible release; pin the version and confirm `pnpm lint` runs
+  clean on the config change alone before enabling any rules. The sibling note in
+  `index.js:17-21` about `eslint-plugin-react`'s `version: 'detect'` crash under
+  eslint 10 is a reminder that plugin/eslint-version drift here is real — verify,
+  don't assume.
+- **CSP breaking legitimate traffic.** A too-tight `connect-src` blocks the very
+  API/WebSocket calls the app needs. The container value must be parameterised
+  per environment (build `ARG` or runtime substitution) and validated against the
+  proxy's pinned host before rollout; ship behind a preview/staging check.
+  Because the proxy header already wins in normal operation, this change is
+  low-risk to production behaviour and high-value only in the degraded topology.
+- **Coverage ratchet sequencing.** Raising a floor above current coverage turns
+  CI red on the raising PR. Each bump must land _with_ the tests that justify it,
+  a few points at a time, so no PR is blocked waiting on a large test backlog.
+  Rescue first (lowest floors, core journeys), then client.
+
+## Open questions for the maintainer
+
+1. **jsx-a11y strictness:** start at the plugin's `recommended` set, or the
+   stricter `strict` set? And which rules (if any) should be `error` from day one
+   versus `warn`-then-ratchet?
+2. **`no-non-null-assertion` target severity:** land as `warn` and ratchet, or go
+   straight to hard `error` with the gateway hotspot exempted via
+   `eslint-disable` — and is there appetite to fix all ~50–90 sites up front?
+3. **CSP allowlist:** what exact `connect-src` origins should the container bake
+   per environment (does the pinned `https://api.<host>` + `wss://api.<host>`
+   fully cover it, or are there analytics/CDN/third-party endpoints the SPA also
+   calls that the proxy currently permits by other means)?
+4. **Coverage targets and timeline:** what line/branch floors are we climbing
+   toward for rescue and client (e.g. parity with admin's 65 lines?), and over
+   how many milestones?
+5. **Enforcement home:** should any of these gates be blocking in CI now, or only
+   after a warn-period grace window — and do we want axe-in-e2e tracked as its own
+   follow-up ticket under ADS-1039?


### PR DESCRIPTION
## Summary

- Consolidates the three remaining ADR proposal PRs — **#1294** (ADR 0007), **#1295** (ADR 0009), **#1298** (ADR 0010) — into a single branch.
- They each inserted their `docs/README.md` index line at the same anchor (after ADR 0006), so once **ADR 0008 (#1297)** merged, all three became pairwise-conflicting (`mergeable_state: dirty`). One branch with a single, correctly-ordered index update resolves that cleanly.
- Docs-only; every ADR is `Status: Proposed`. Content is byte-identical to the three source branches' final (review-fixed) versions.

## Changes

- `docs/adr/0007-postgres-backups-pitr-restore.md` — ADR 0007, Postgres backups, PITR & restore verification (ADS-1043).
- `docs/adr/0009-deployment-strategy-and-ha.md` — ADR 0009, deployment strategy & high availability (ADS-1045).
- `docs/adr/0010-frontend-quality-gates.md` — ADR 0010, frontend quality gates (ADS-1055).
- `docs/README.md` — registers all three in the Architecture index in numeric order (0006, 0007, 0008, 0009, 0010).

## Before requesting review

- [x] Docs gates pass: `check-docs-index`, `check-readmes`, `check-docs-freshness` (0 broken links, 0 stale), `check-docs-script-references`; `prettier --check` clean on all four files.
- [x] Tests for new behaviour added (TDD) — N/A, docs-only proposals.
- [x] `.env` requirements unchanged — N/A.
- [x] No `lib.*` touched — N/A.

## Test plan

N/A — docs only. Verified the four doc gates and prettier locally (all green). Each ADR remains grounded in verified `file:line` evidence and carries its recommended decision, implementation sketch, and open questions.

## Screenshots / recordings

N/A — docs only.

## Related

- Linear: **ADS-1043**, **ADS-1045**, **ADS-1055** (parent epic **ADS-1039**).
- Supersedes **#1294**, **#1295**, **#1298** (being closed in favour of this consolidated PR).
- Sibling ADR already merged: **#1297** (ADR 0008 / ADS-1044).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01639moQdBwbM99aMdsQ7CXK)_