### PR TITLE
ci: cancel superseded CodeQL runs and path-filter schema-equivalence (ADS-1064, ADS-1065)

### DIFF
--- a/.github/workflow-source-paths.yml
+++ b/.github/workflow-source-paths.yml
@@ -41,7 +41,8 @@ consumers:
   # canonical list: its migrate job only needs to run when migration or
   # schema-owning DB code changes, so both its `push` and `pull_request`
   # triggers use a narrow filter (services/*/src/migrations/**,
-  # services/*/src/db/**, packages/db/**, pnpm-lock.yaml, and the workflow
-  # file). It is therefore not a canonical consumer — the guard's drift check
+  # services/*/src/db/**, the packages the migrate job builds — packages/db/**,
+  # packages/observability/**, packages/events/** — pnpm-lock.yaml, and the
+  # workflow file). It is therefore not a canonical consumer — the guard's drift check
   # does not apply, only the literal-path-exists check. Recorded here so the
   # single source of truth documents the deliberate divergence.

--- a/.github/workflow-source-paths.yml
+++ b/.github/workflow-source-paths.yml
@@ -36,3 +36,12 @@ consumers:
       - '**/Dockerfile*'
       - 'docker-compose*.yml'
       - '.dockerignore'
+
+  # schema-equivalence.yml (ADS-1065) intentionally does NOT consume the
+  # canonical list: its migrate job only needs to run when migration or
+  # schema-owning DB code changes, so both its `push` and `pull_request`
+  # triggers use a narrow filter (services/*/src/migrations/**,
+  # services/*/src/db/**, packages/db/**, pnpm-lock.yaml, and the workflow
+  # file). It is therefore not a canonical consumer — the guard's drift check
+  # does not apply, only the literal-path-exists check. Recorded here so the
+  # single source of truth documents the deliberate divergence.

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -18,6 +18,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
+  cancel-in-progress: ${{ github.event_name != 'schedule' }}
+
 jobs:
   analyze:
     name: CodeQL

--- a/.github/workflows/schema-equivalence.yml
+++ b/.github/workflows/schema-equivalence.yml
@@ -14,10 +14,26 @@ name: Schema Equivalence
 # matching.
 
 on:
+  # ADS-1065: the migrate job is only meaningful when migration or
+  # schema-owning DB code changes, so scope both triggers to those paths.
+  # This narrow filter intentionally diverges from the canonical
+  # .github/workflow-source-paths.yml list — see the note there.
   push:
     branches: [main, develop]
+    paths:
+      - 'services/*/src/migrations/**'
+      - 'services/*/src/db/**'
+      - 'packages/db/**'
+      - 'pnpm-lock.yaml'
+      - '.github/workflows/schema-equivalence.yml'
   pull_request:
     branches: [main, develop]
+    paths:
+      - 'services/*/src/migrations/**'
+      - 'services/*/src/db/**'
+      - 'packages/db/**'
+      - 'pnpm-lock.yaml'
+      - '.github/workflows/schema-equivalence.yml'
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/schema-equivalence.yml
+++ b/.github/workflows/schema-equivalence.yml
@@ -24,6 +24,8 @@ on:
       - 'services/*/src/migrations/**'
       - 'services/*/src/db/**'
       - 'packages/db/**'
+      - 'packages/observability/**'
+      - 'packages/events/**'
       - 'pnpm-lock.yaml'
       - '.github/workflows/schema-equivalence.yml'
   pull_request:
@@ -32,6 +34,8 @@ on:
       - 'services/*/src/migrations/**'
       - 'services/*/src/db/**'
       - 'packages/db/**'
+      - 'packages/observability/**'
+      - 'packages/events/**'
       - 'pnpm-lock.yaml'
       - '.github/workflows/schema-equivalence.yml'
   workflow_dispatch:


### PR DESCRIPTION
## Summary

- **ADS-1064** — Add a `concurrency` block to the CodeQL workflow so rapid pushes to a PR cancel the superseded (up to 30-min) analysis instead of running every one to completion.
- **ADS-1065** — Add a `paths:` filter to `schema-equivalence.yml` so its ~20-min Postgres + 10-service migration job only runs when migration/schema-owning code changes, not on doc-only or frontend-only PRs.

## Changes

- `.github/workflows/codeql.yml` — new `concurrency` block mirroring `security.yml` (the sibling security scan on the same weekly schedule): `group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}` with `cancel-in-progress: ${{ github.event_name != 'schedule' }}`. Keying on `github.event_name` plus gating cancellation off for `schedule` leaves the weekly Monday scan untouched while PR pushes cancel stale runs.
- `.github/workflows/schema-equivalence.yml` — scoped both the `push` and `pull_request` triggers (matching the house pattern of filtering both identically, as `security.yml`/`quality.yml` do) to migration-relevant paths: `services/*/src/migrations/**`, `services/*/src/db/**`, `packages/db/**`, `pnpm-lock.yaml`, and the workflow file itself. Job names are unchanged, so the branch-protection required-check list keeps matching.
- `.github/workflow-source-paths.yml` — documented the deliberate divergence: `schema-equivalence.yml` uses a narrow migration-only filter and is intentionally NOT a canonical consumer, so `scripts/check-workflow-paths.mjs` applies only its literal-path-exists check (which passes) and not the canonical drift check.

Notes / deviations:
- The ticket-suggested `services/**/src/migrate.ts` path does not exist in the repo (each service runs `pnpm db:migrate`; there is no `migrate.ts`), so it was omitted — a filter path that matches nothing silently gates nothing (ADS-1030) and would fail the guard's existence check.
- ADS-1065's secondary suggestion (switch `setup-workspace` → `checkout-and-setup` to restore the `lib-dist` cache) was left out of scope to keep this PR surgical; worth a follow-up.

## Before requesting review

- [ ] Ran `pnpm ci:local:quick` locally (or installed the pre-push hook — see CONTRIBUTING.md)
- [ ] Tests for new behaviour added (TDD)
- [ ] If touching `.env` requirements, updated `.env.example`'s REQUIRED block
- [ ] If touching a `lib.*`, considered consumer impact across `app.*` and `service.backend`

## Test plan

- [x] `node scripts/check-workflow-paths.mjs` passes (`OK — workflow path filters match … and every literal filter path exists.`)
- [x] All three changed YAML files parse cleanly
- [ ] Push twice in quick succession to this PR and confirm the first CodeQL run is cancelled while the weekly scheduled run is unaffected
- [ ] Confirm a docs-only / frontend-only PR skips the schema-equivalence migrate job, and a migration/DB-code PR still runs it

## Related

- ADS-1064 — CodeQL workflow has no `concurrency` block
- ADS-1065 — `schema-equivalence.yml` runs a ~20-min migration job on every PR with no `paths:` filter

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01639moQdBwbM99aMdsQ7CXK)_