### PR TITLE
docs: fix stale command refs in .env.example and secondary docs (ADS-1060, ADS-1061)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,8 +2,8 @@
 # Adopt Don't Shop - Root Environment Configuration
 # =============================================================================
 # 👋 Quick start:
-#   1. Copy this file to .env (or let `pnpm run setup` do it for you).
-#   2. `pnpm run setup` auto-generates every secret in the "Auto-generated
+#   1. Copy this file to .env (or let `pnpm bootstrap` do it for you).
+#   2. `pnpm bootstrap` auto-generates every secret in the "Auto-generated
 #      secrets" block below — you don't need to hand-write those.
 #   3. You're only responsible for POSTGRES_PASSWORD and any third-party
 #      API keys you actually use. Everything else has a working dev default.
@@ -22,7 +22,7 @@
 # =============================================================================
 # REQUIRED — must be set before `pnpm docker:dev`
 # =============================================================================
-# `pnpm run setup` auto-generates every application secret in the
+# `pnpm bootstrap` auto-generates every application secret in the
 # "Auto-generated secrets" block below. The only value you MUST change by
 # hand is POSTGRES_PASSWORD. Search this file for each REQUIRED key listed
 # here to set or review it — none of them are "optional", regardless of
@@ -77,7 +77,7 @@ REDIS_HOST=redis
 REDIS_PORT=6379
 
 # -----------------------------------------------------------------------------
-# Auto-generated secrets — `pnpm run setup` / `pnpm secrets:generate` replace
+# Auto-generated secrets — `pnpm bootstrap` / `pnpm secrets:generate` replace
 # every placeholder below. Safe to leave as-is if you're running setup.
 # -----------------------------------------------------------------------------
 JWT_SECRET=CHANGE_THIS_TO_A_STRONG_RANDOM_SECRET_32_CHARS_MIN

--- a/.env.example
+++ b/.env.example
@@ -78,7 +78,7 @@ REDIS_PORT=6379
 
 # -----------------------------------------------------------------------------
 # Auto-generated secrets — `pnpm bootstrap` / `pnpm secrets:generate` replace
-# every placeholder below. Safe to leave as-is if you're running setup.
+# every placeholder below. Safe to leave as-is if you're running `pnpm bootstrap`.
 # -----------------------------------------------------------------------------
 JWT_SECRET=CHANGE_THIS_TO_A_STRONG_RANDOM_SECRET_32_CHARS_MIN
 JWT_REFRESH_SECRET=CHANGE_THIS_TO_A_DIFFERENT_STRONG_RANDOM_SECRET

--- a/docs/ANALYTICS-REPORTS.md
+++ b/docs/ANALYTICS-REPORTS.md
@@ -183,9 +183,9 @@ sets `last_status='failed'`, persists `last_error`, and emits
 ### Verification
 
 ```bash
-pnpm docker:dev:build          # now starts redis
-pnpm db:migrate
-pnpm db:seed:reference         # seeds permissions + role-permissions
+pnpm docker:dev:build                              # now starts redis
+docker compose exec service-audit pnpm db:migrate  # report tables
+docker compose exec service-auth pnpm db:migrate   # seeds permissions + role-permissions
 ```
 
 Then in app.admin:

--- a/docs/backend/troubleshooting.md
+++ b/docs/backend/troubleshooting.md
@@ -849,15 +849,15 @@ When reporting issues, include:
 
 ```bash
 # Application management
-pnpm start                    # Start application
+pnpm docker:dev               # Start full stack (Docker)
 pnpm dev                  # Start in development mode
 pnpm test                     # Run tests
 pnpm build               # Build for production
 
 # Database management
-pnpm db:migrate          # Run migrations
+docker compose exec service-auth pnpm db:migrate   # Run migrations (per service)
 pnpm db:seed            # Seed database
-pnpm db:reset           # Reset database
+pnpm docker:reset        # Reset database
 
 # Docker management
 docker compose up -d        # Start services

--- a/docs/infrastructure/INFRASTRUCTURE.md
+++ b/docs/infrastructure/INFRASTRUCTURE.md
@@ -199,11 +199,11 @@ pnpm install
 cp .env.example .env
 
 # Start with Docker
-docker compose up
+pnpm docker:dev
 
 # Or start subsets via Turbo filters
 pnpm dev:apps           # all React apps in parallel
-pnpm dev:backend        # backend only
+pnpm dev:services       # Postgres + Redis (Docker)
 pnpm exec turbo dev --filter=@adopt-dont-shop/app.admin   # one app
 ```
 

--- a/docs/upgrades/sequelize-7-migration.md
+++ b/docs/upgrades/sequelize-7-migration.md
@@ -1,5 +1,13 @@
 # Sequelize 6 → Sequelize 7 Migration Plan
 
+> **Historical record — do not run these commands.** This plan targeted the
+> `service.backend` monolith and its Sequelize ORM, both of which are gone:
+> `service.backend` was deleted when the backend was split into gRPC
+> microservices, and the codebase no longer uses Sequelize or any ORM (services
+> use raw SQL via `@adopt-dont-shop/db`). The commands below — including
+> `pnpm db:reset` — refer to that former workflow and resolve to no current
+> script. Kept for context only.
+
 **Linear**: ADS-531 (this document covers the Sequelize portion)
 **Status**: ⚠️ Partially shipped — `service.backend/package.json` already pins `"sequelize": "7.0.0-alpha.9"` and `sequelize-typescript` / `sequelize-cli` / `@types/sequelize` were removed. The remaining work is the bump to a stable 7.x release once one lands.
 **Recommended quarter**: After Sequelize 7 ships a stable (non-alpha) tag.


### PR DESCRIPTION
## Summary

- **ADS-1060**: `.env.example` told contributors to run `pnpm run setup`, which is not a script anywhere. All four references now point at the real onboarding entry point, `pnpm bootstrap`.
- **ADS-1061**: replaced monolith-era root commands in four secondary docs with their current monorepo equivalents, and marked one wholly-obsolete doc as historical.

## Changes

- `.env.example` — 4× `` `pnpm run setup` `` → `` `pnpm bootstrap` `` (lines 5, 6, 25, 80). No REQUIRED-var changes.
- `docs/infrastructure/INFRASTRUCTURE.md` — `docker compose up` → `pnpm docker:dev` (bare compose only starts profile-less infra); `pnpm dev:backend` → `pnpm dev:services`.
- `docs/ANALYTICS-REPORTS.md` — the Verification block's bare `pnpm db:migrate` and non-existent `pnpm db:seed:reference` → `docker compose exec service-audit pnpm db:migrate` (report tables live in the audit service) and `docker compose exec service-auth pnpm db:migrate` (permissions + role-permissions are seeded by auth's RBAC migration).
- `docs/backend/troubleshooting.md` — Common Commands block: `pnpm start` → `pnpm docker:dev`; bare `pnpm db:migrate` → `docker compose exec service-auth pnpm db:migrate`; `pnpm db:reset` → `pnpm docker:reset`. (`pnpm dev`, `pnpm test`, `pnpm build`, `pnpm db:seed` are real root scripts and were left untouched.)
- `docs/upgrades/sequelize-7-migration.md` — added a "Historical record" banner (matching the `docs/INFRA.md` convention): the doc targets the deleted `service.backend` monolith and Sequelize, both of which are gone, so its `pnpm db:reset` mentions are now banner-marked archival content rather than being rewritten inside an obsolete plan.

## Rationale (ADS-1060)

Chose to point at the existing `pnpm bootstrap` script rather than add a new `setup` script. `bootstrap` is already the onboarding entry point everywhere (README, `docs/GETTING-STARTED.md`, `scripts/bootstrap.mjs`), and ADS-993 deliberately renamed away from `setup` because pnpm shadows it as a built-in subcommand — adding a `setup` script would reintroduce that shadow. This is the least-surprising fix and keeps `.env.example` consistent with the rest of the docs.

## Before requesting review

- [ ] Ran `pnpm ci:local:quick` locally — docs-only change; ran the targeted doc/env guards instead (see Test plan)
- [ ] Tests for new behaviour added (TDD) — N/A (documentation only, no behaviour change)
- [ ] If touching `.env` requirements, updated `.env.example`'s REQUIRED block — N/A (only comment prose changed, no required vars)
- [ ] If touching a `lib.*`, considered consumer impact — N/A

## Test plan

- [x] `node scripts/check-env-example.mjs` — passes
- [x] `node scripts/check-docs-script-references.mjs` — passes
- [x] `node scripts/check-docs-index.mjs` — passes
- [x] `node scripts/check-readmes.mjs` — passes
- [x] `pnpm exec prettier --check` on the four changed `.md` files — clean (`.env.example` has no Prettier parser and is outside the repo's format globs)
- [x] Acceptance greps: `grep -n "pnpm run setup" .env.example` → nothing; `grep -rn "pnpm db:reset\|pnpm dev:backend\|pnpm db:seed:reference" docs/` → only the banner-marked historical `sequelize-7-migration.md`

## Related

- ADS-1060
- ADS-1061

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01639moQdBwbM99aMdsQ7CXK)_