### PR TITLE
fix(tooling): scaffold READMEs + eslint-config package hygiene (ADS-1059, ADS-1062)

### DIFF
--- a/packages/eslint-config-base/package.json
+++ b/packages/eslint-config-base/package.json
@@ -12,6 +12,12 @@
     "eslint",
     "eslintconfig"
   ],
+  "scripts": {
+    "lint": "eslint .",
+    "lint:fix": "eslint . --fix",
+    "format": "prettier --write \"*.js\"",
+    "format:check": "prettier --check \"*.js\""
+  },
   "peerDependencies": {
     "eslint": "^9.0.0 || ^10.0.0",
     "typescript-eslint": "^8.0.0",

--- a/packages/eslint-config-node/package.json
+++ b/packages/eslint-config-node/package.json
@@ -13,6 +13,12 @@
     "eslintconfig",
     "node"
   ],
+  "scripts": {
+    "lint": "eslint .",
+    "lint:fix": "eslint . --fix",
+    "format": "prettier --write \"*.js\"",
+    "format:check": "prettier --check \"*.js\""
+  },
   "dependencies": {
     "@adopt-dont-shop/eslint-config-base": "workspace:*"
   },

--- a/packages/eslint-config-react/package.json
+++ b/packages/eslint-config-react/package.json
@@ -13,6 +13,12 @@
     "eslintconfig",
     "react"
   ],
+  "scripts": {
+    "lint": "eslint .",
+    "lint:fix": "eslint . --fix",
+    "format": "prettier --write \"*.js\"",
+    "format:check": "prettier --check \"*.js\""
+  },
   "dependencies": {
     "@adopt-dont-shop/eslint-config-base": "workspace:*"
   },

--- a/scripts/check-workspace-consistency.mjs
+++ b/scripts/check-workspace-consistency.mjs
@@ -41,9 +41,11 @@
  *  14. Every services/* and packages/lib.* declares coverage thresholds in
  *     its own vitest.config.ts — the shared default is 0%, so an override
  *     is mandatory (ADS-1004).
- *  15. Every services/* and e2e package.json ships lint, format and
- *     format:check scripts (ADS-1003) — lib.* and app.* already require
- *     these via their check #1 script lists.
+ *  15. Every services/*, e2e and non-lib.* packages/* package.json ships
+ *     lint, format and format:check scripts (ADS-1003 / ADS-1062) — lib.*
+ *     and app.* already require these via their check #1 script lists. The
+ *     non-lib shared packages (eslint-config-*, db, authz, …) are included
+ *     so their source is actually linted and format-checked.
  *
  * Common script bodies (lint = 'eslint .'|'eslint src', type-check =
  * 'tsc --noEmit', test = 'vitest run') drift produces a warning, not failure.
@@ -1108,10 +1110,16 @@ function main() {
   // ADS-1029: every testable package must be reachable by a CI test filter.
   failures.push(...checkCiFilterReachability());
 
-  // 14. services/* and e2e must ship lint/format/format:check too — libs/apps
-  //     already require them via REQUIRED_LIB_SCRIPTS / REQUIRED_APP_SCRIPTS
-  //     (ADS-1003).
-  for (const dir of [...services.map(svc => `services/${svc}`), 'e2e']) {
+  // 14. services/*, e2e and every non-lib.* packages/* must ship
+  //     lint/format/format:check too — libs/apps already require them via
+  //     REQUIRED_LIB_SCRIPTS / REQUIRED_APP_SCRIPTS (ADS-1003), and the
+  //     non-lib shared packages (eslint-config-*, db, authz, …) are now in
+  //     scope so their source can't silently escape `pnpm lint` /
+  //     `pnpm format:check` (ADS-1062).
+  const nonLibPackageDirs = packages
+    .filter(name => !name.startsWith('lib.'))
+    .map(name => `packages/${name}`);
+  for (const dir of [...services.map(svc => `services/${svc}`), ...nonLibPackageDirs, 'e2e']) {
     let pkg;
     try {
       pkg = JSON.parse(readFileSync(join(ROOT, dir, 'package.json'), 'utf8'));

--- a/scripts/create-new-lib.js
+++ b/scripts/create-new-lib.js
@@ -200,7 +200,7 @@ function printSuccess(libName, libType) {
   log('', 'reset');
   log('📦 Use in apps:', 'bright');
   log('   Add to package.json dependencies:', 'cyan');
-  log(`   "@adopt-dont-shop/lib-${libName}": "workspace:*"`, 'cyan');
+  log(`   "@adopt-dont-shop/lib.${libName}": "workspace:*"`, 'cyan');
   log('', 'reset');
   log('📖 Documentation:', 'bright');
   log(`   See lib.${libName}/README.md for detailed usage instructions`, 'cyan');

--- a/scripts/generators.test.mjs
+++ b/scripts/generators.test.mjs
@@ -20,6 +20,20 @@ import { isWorkspaceCovered } from './lib/template-engine.mjs';
 
 const SCRIPTS_DIR = dirname(fileURLToPath(import.meta.url));
 
+// The canonical README section headings scripts/check-readmes.mjs enforces per
+// workspace family. A freshly-scaffolded package must ship all of them so
+// `pnpm check:readmes` passes with zero manual README edits (ADS-1059).
+const SHARED_README_HEADINGS = [
+  '## Purpose',
+  '## Location in the architecture',
+  '## Scripts',
+  '## Environment variables consumed',
+  '## Testing notes',
+  '## Ownership',
+];
+const APP_README_HEADINGS = [...SHARED_README_HEADINGS, '## Public surface'];
+const LIB_README_HEADINGS = [...SHARED_README_HEADINGS, '## Public API / exports'];
+
 const WORKSPACE_MANIFEST = [
   'packages:',
   "  - 'apps/*'",
@@ -66,6 +80,15 @@ describe('pnpm new-app (create-new-app.js)', () => {
     runGenerator('create-new-app.js', ['app.portal', '--template', 'minimal']);
     expect(readFileSync(join(root, 'pnpm-workspace.yaml'), 'utf8')).toBe(before);
   });
+
+  it('scaffolds a README with every heading check:readmes requires for apps (ADS-1059)', () => {
+    runGenerator('create-new-app.js', ['app.dashboard', '--template', 'minimal']);
+
+    const readme = readFileSync(join(root, 'apps', 'dashboard', 'README.md'), 'utf8');
+    for (const heading of APP_README_HEADINGS) {
+      expect(readme).toContain(heading);
+    }
+  });
 });
 
 describe('pnpm new-lib (create-new-lib.js)', () => {
@@ -91,6 +114,33 @@ describe('pnpm new-lib (create-new-lib.js)', () => {
     // package.json now (there isn't even one in the temp root).
     runGenerator('create-new-lib.js', ['gadgets', '--type=utility', '--skip-install']);
     expect(existsSync(join(root, 'package.json'))).toBe(false);
+  });
+
+  it('scaffolds a README with every heading check:readmes requires for libs (ADS-1059)', () => {
+    runGenerator('create-new-lib.js', [
+      'widgets',
+      'Widget helpers',
+      '--type=utility',
+      '--skip-install',
+    ]);
+
+    const readme = readFileSync(join(root, 'packages', 'lib.widgets', 'README.md'), 'utf8');
+    for (const heading of LIB_README_HEADINGS) {
+      expect(readme).toContain(heading);
+    }
+  });
+
+  it('prints a copy-pasteable workspace dependency using a dot, not a hyphen (ADS-1059)', () => {
+    const output = runGenerator('create-new-lib.js', [
+      'widgets',
+      '--type=utility',
+      '--skip-install',
+    ]);
+
+    // The "Use in apps" next-step must be a resolvable @adopt-dont-shop/lib.<name>
+    // dependency — the old generator printed an unresolvable lib-<name>.
+    expect(output).toContain('"@adopt-dont-shop/lib.widgets": "workspace:*"');
+    expect(output).not.toContain('lib-widgets');
   });
 });
 

--- a/scripts/templates/app/common/README.md
+++ b/scripts/templates/app/common/README.md
@@ -1,0 +1,46 @@
+# @adopt-dont-shop/{{APP_NAME}}
+
+<!-- Scaffolded by `pnpm new-app`. Fill in each section — keep the headings so
+`pnpm check:readmes` (docs/templates/README.app.md) stays green. -->
+
+## Purpose
+
+<!-- TODO: One paragraph — who uses this app and what it's for. -->
+
+## Location in the architecture
+
+<!-- TODO: Which gateway routes this app depends on, and how it reaches the
+backend (nginx in prod, the Vite dev proxy locally). Link to
+[`docs/frontend/technical-architecture.md`](../../docs/frontend/technical-architecture.md)
+for the shared app-shell pattern instead of repeating it here. -->
+
+## Scripts
+
+```bash
+pnpm dev          # Vite dev server
+pnpm build        # tsc && vite build
+pnpm test         # Vitest (run mode)
+pnpm lint         # ESLint
+pnpm type-check   # TypeScript type-check
+```
+
+## Public surface
+
+<!-- TODO: Apps don't export a package API — list the routes / pages this app
+owns (or link to its router config) so a reader knows what's here. -->
+
+## Environment variables consumed
+
+<!-- TODO: Table of the `VITE_*` vars this app reads, with defaults and whether
+they're required. Link to [`docs/env-reference.md`](../../docs/env-reference.md)
+for vars shared across apps rather than duplicating them. -->
+
+## Testing notes
+
+<!-- TODO: Anything specific to this app's tests — MSW handlers, fixtures,
+known-flaky areas. -->
+
+## Ownership
+
+See [`.github/CODEOWNERS`](../../.github/CODEOWNERS) for the current owner of
+`/apps/`.

--- a/scripts/templates/lib/common/README.md
+++ b/scripts/templates/lib/common/README.md
@@ -2,334 +2,36 @@
 
 {{LIB_DESCRIPTION}}
 
-## 📦 Installation
+<!-- Scaffolded by `pnpm new-lib`. Fill in each section — keep the headings so
+`pnpm check:readmes` (docs/templates/README.lib.md) stays green. -->
+
+## Purpose
+
+<!-- TODO: One paragraph — what this library does and who consumes it (which
+apps or services). If it's a service-only shared package rather than a `lib.*`,
+say so — see the decision tree in
+[`CONTRIBUTING.md`](../../CONTRIBUTING.md#where-does-my-code-go). -->
+
+## Location in the architecture
+
+<!-- TODO: Where this fits relative to the rest of the workspace — link to the
+relevant section of [`docs/README.md`](../../docs/README.md#libraries) rather
+than re-explaining the monorepo layout here. -->
+
+## Scripts
 
 ```bash
-# From the workspace root
-pnpm add @adopt-dont-shop/lib.{{LIB_NAME}}
-
-# Or add to your package.json
-{
-  "dependencies": {
-    "@adopt-dont-shop/lib.{{LIB_NAME}}": "workspace:*"
-  }
-}
+pnpm dev          # build --watch (or vite build --watch for React libs)
+pnpm build        # production build
+pnpm test         # Vitest (run mode)
+pnpm lint         # ESLint
+pnpm type-check   # TypeScript type-check
 ```
 
-## 🚀 Quick Start
+## Public API / exports
 
-```typescript
-import { {{SERVICE_NAME}}, {{SERVICE_NAME}}Config } from '@adopt-dont-shop/lib.{{LIB_NAME}}';
-
-// Using the singleton instance
-import { {{LIB_NAME}}Service } from '@adopt-dont-shop/lib.{{LIB_NAME}}';
-
-// Basic usage
-const result = await {{LIB_NAME}}Service.exampleMethod({ test: 'data' });
-console.log(result);
-
-// Or create a custom instance
-const config: {{SERVICE_NAME}}Config = {
-  apiUrl: 'https://api.example.com',
-  debug: true,
-};
-
-const customService = new {{SERVICE_NAME}}(config);
-const customResult = await customService.exampleMethod({ custom: 'data' });
-```
-
-## 🔧 Configuration
-
-### {{SERVICE_NAME}}Config
-
-| Property | Type | Default | Description |
-|----------|------|---------|-------------|
-| `apiUrl` | `string` | `process.env.VITE_API_BASE_URL` | Base API URL |
-| `debug` | `boolean` | `process.env.NODE_ENV === 'development'` | Enable debug logging |
-| `headers` | `Record<string, string>` | `{}` | Custom headers for requests |
-
-### Environment Variables
-
-```bash
-# API Configuration (Vite apps use VITE_ prefix)
-VITE_API_BASE_URL=http://localhost:4000
-
-# Development
-NODE_ENV=development
-```
-
-## 📖 API Reference
-
-### {{SERVICE_NAME}}
-
-#### Constructor
-
-```typescript
-new {{SERVICE_NAME}}(config?: {{SERVICE_NAME}}Config)
-```
-
-#### Methods
-
-##### `exampleMethod(data, options)`
-
-Example method that demonstrates the library's capabilities.
-
-```typescript
-await service.exampleMethod(
-  { key: 'value' },
-  { 
-    timeout: 5000,
-    useCache: true,
-    metadata: { requestId: 'abc123' }
-  }
-);
-```
-
-**Parameters:**
-- `data` (Record<string, unknown>): Input data
-- `options` ({{SERVICE_NAME}}Options): Operation options
-
-**Returns:** `Promise<BaseResponse>`
-
-##### `updateConfig(config)`
-
-Update the service configuration.
-
-```typescript
-service.updateConfig({ debug: true, apiUrl: 'https://new-api.com' });
-```
-
-##### `getConfig()`
-
-Get current configuration.
-
-```typescript
-const config = service.getConfig();
-```
-
-##### `clearCache()`
-
-Clear the internal cache.
-
-```typescript
-service.clearCache();
-```
-
-##### `healthCheck()`
-
-Check service health.
-
-```typescript
-const isHealthy = await service.healthCheck();
-```
-
-## 🏗️ Usage in Apps
-
-### React/Vite Apps (app.client, app.admin, app.rescue)
-
-1. **Add to package.json:**
-```json
-{
-  "dependencies": {
-    "@adopt-dont-shop/lib.{{LIB_NAME}}": "workspace:*"
-  }
-}
-```
-
-2. **Import and use:**
-```typescript
-// src/services/index.ts
-export { {{LIB_NAME}}Service } from '@adopt-dont-shop/lib.{{LIB_NAME}}';
-
-// In your component
-import { {{LIB_NAME}}Service } from '@/services';
-
-function MyComponent() {
-  const [data, setData] = useState(null);
-
-  useEffect(() => {
-    const fetchData = async () => {
-      try {
-        const result = await {{LIB_NAME}}Service.exampleMethod({ 
-          component: 'MyComponent' 
-        });
-        setData(result.data);
-      } catch (error) {
-        console.error('Error:', error);
-      }
-    };
-
-    fetchData();
-  }, []);
-
-  return <div>{/* Your JSX */}</div>;
-}
-```
-
-### Node.js Backend (service.backend)
-
-1. **Add to package.json:**
-```json
-{
-  "dependencies": {
-    "@adopt-dont-shop/lib.{{LIB_NAME}}": "workspace:*"
-  }
-}
-```
-
-2. **Import and use:**
-```typescript
-// src/services/{{LIB_NAME}}.service.ts
-import { {{SERVICE_NAME}} } from '@adopt-dont-shop/lib.{{LIB_NAME}}';
-
-export const {{CAMEL_CASE_NAME}}Service = new {{SERVICE_NAME}}({
-  apiUrl: process.env.API_URL,
-  debug: process.env.NODE_ENV === 'development',
-});
-
-// In your routes or controllers
-import { {{CAMEL_CASE_NAME}}Service } from '../services/{{LIB_NAME}}.service';
-
-app.get('/api/{{LIB_NAME}}/example', async (req, res) => {
-  try {
-    const result = await {{CAMEL_CASE_NAME}}Service.exampleMethod(req.body);
-    res.json(result);
-  } catch (error) {
-    res.status(500).json({ error: error.message });
-  }
-});
-```
-
-## 🐳 Docker Integration
-
-Libraries are automatically available to apps through the optimized workspace pattern in `Dockerfile.app`. No additional configuration needed — just add the dependency to your app's `package.json` and run `pnpm install` at the repo root.
-
-## 🧪 Testing
-
-### Run Tests
-
-```bash
-# Unit tests
-pnpm test
-
-# Watch mode
-pnpm test:watch
-
-# Coverage
-pnpm test:coverage
-```
-
-### Test Structure
-
-```
-src/
-├── services/
-│   ├── {{LIB_NAME}}-service.ts
-│   └── __tests__/
-│       └── {{LIB_NAME}}-service.test.ts
-└── types/
-    └── index.ts
-```
-
-## 🏗️ Development
-
-### Build the Library
-
-```bash
-# Development build with watch
-pnpm dev
-
-# Production build
-pnpm build
-
-# Clean build artifacts
-pnpm clean
-```
-
-### Code Quality
-
-```bash
-# Lint
-pnpm lint
-
-# Fix linting issues
-pnpm lint:fix
-
-# Type checking
-pnpm type-check
-```
-
-## 📁 Project Structure
-
-```
-lib.{{LIB_NAME}}/
-├── src/
-│   ├── services/
-│   │   ├── {{LIB_NAME}}-service.ts     # Main service implementation
-│   │   └── __tests__/
-│   │       └── {{LIB_NAME}}-service.test.ts
-│   ├── types/
-│   │   └── index.ts                  # TypeScript type definitions
-│   └── index.ts                      # Main entry point
-├── dist/                             # Built output (generated)
-├── vitest.config.ts                 # Vitest test configuration
-├── package.json                     # Package configuration
-├── tsconfig.json                    # TypeScript configuration
-├── eslint.config.js                 # ESLint flat configuration
-├── .prettierrc.json                 # Prettier configuration
-└── README.md                        # This file
-```
-
-## 🔗 Integration Examples
-
-### With Other Libraries
-
-```typescript
-import { apiService } from '@adopt-dont-shop/lib.api';
-import { authService } from '@adopt-dont-shop/lib.auth';
-import { {{LIB_NAME}}Service } from '@adopt-dont-shop/lib.{{LIB_NAME}}';
-
-// Configure with shared dependencies
-{{LIB_NAME}}Service.updateConfig({
-  apiUrl: apiService.getConfig().baseUrl,
-  headers: {
-    'Authorization': `Bearer ${authService.getToken()}`,
-  },
-});
-```
-
-### Error Handling
-
-```typescript
-import { {{LIB_NAME}}Service, ErrorResponse } from '@adopt-dont-shop/lib.{{LIB_NAME}}';
-
-try {
-  const result = await {{LIB_NAME}}Service.exampleMethod(data);
-  // Handle success
-} catch (error) {
-  const errorResponse = error as ErrorResponse;
-  console.error('Error:', errorResponse.error);
-  console.error('Code:', errorResponse.code);
-  console.error('Details:', errorResponse.details);
-}
-```
-
-## 🚀 Deployment
-
-### NPM Package (if publishing externally)
-
-```bash
-# Build and test
-pnpm build
-pnpm test
-
-# Publish
-npm publish
-```
-
-### Workspace Integration
-
-The library is already integrated into the workspace. Apps can import it using:
+The canonical list lives in `src/index.ts`. Consumers add the dependency and
+import from the package root:
 
 ```json
 {
@@ -339,43 +41,25 @@ The library is already integrated into the workspace. Apps can import it using:
 }
 ```
 
-## 🤝 Contributing
-
-1. Make changes to the library
-2. Add/update tests
-3. Run `pnpm build` to ensure it builds correctly
-4. Run `pnpm test` to ensure tests pass
-5. Update documentation as needed
-
-## 📄 License
-
-MIT License - see the LICENSE file for details.
-
-## 🔧 Troubleshooting
-
-### Common Issues
-
-1. **Module not found**
-   - Ensure the library is built: `pnpm build`
-   - Check workspace dependencies are installed: `pnpm install`
-
-2. **Type errors**
-   - Run type checking: `pnpm type-check`
-   - Ensure TypeScript version compatibility
-
-3. **Build failures**
-   - Clean and rebuild: `pnpm clean && pnpm build`
-   - Check for circular dependencies
-
-### Debug Mode
-
-Enable debug logging:
-
 ```typescript
-{{LIB_NAME}}Service.updateConfig({ debug: true });
+import { {{SERVICE_NAME}}, {{LIB_NAME}}Service } from '@adopt-dont-shop/lib.{{LIB_NAME}}';
 ```
 
-Or set environment variable:
-```bash
-NODE_ENV=development
-```
+<!-- TODO: Summarise the grouped public surface (types, hooks, services) rather
+than duplicating every export's signature here. -->
+
+## Environment variables consumed
+
+<!-- TODO: Table of any env vars this library reads directly. Most `lib.*`
+packages take config via constructor args instead — say so if that's the case
+here. -->
+
+## Testing notes
+
+<!-- TODO: Anything specific to this library's tests — how it's mocked by
+consumers, fixtures, known edge cases. -->
+
+## Ownership
+
+See [`.github/CODEOWNERS`](../../.github/CODEOWNERS) for the current owner of
+`/packages/`.


### PR DESCRIPTION
## Summary

- **ADS-1059**: `pnpm new-app` / `new-lib` now scaffold packages whose README passes `check:readmes` with zero manual edits, and `new-lib`'s "Use in apps" hint prints a resolvable `workspace:*` dependency.
- **ADS-1062**: the three `eslint-config-*` packages now lint and format-check their own `index.js`, and the workspace-consistency guard requires the lint/format baseline on every non-`lib.*` `packages/*` so a shared package can't silently drop those scripts.

## Changes

**ADS-1059 — scaffold hygiene**
- Add `scripts/templates/app/common/README.md` — the app templates shipped **no** README at all, so `new-app` output failed `check:readmes` with "README.md does not exist". The new template carries all headings the guard enforces for apps (`## Purpose`, `## Location in the architecture`, `## Scripts`, `## Public surface`, `## Environment variables consumed`, `## Testing notes`, `## Ownership`).
- Rewrite `scripts/templates/lib/common/README.md` from emoji headings (`## 📦 Installation`, …) to the canonical lib headings (`## Public API / exports` in place of the app's `## Public surface`).
- Fix `scripts/create-new-lib.js` — the printed dependency was `@adopt-dont-shop/lib-${libName}` (hyphen), which pnpm cannot resolve; now `@adopt-dont-shop/lib.${libName}` (dot), matching every real lib.
- Extend `scripts/generators.test.mjs` (TDD): assert the scaffolded app and lib READMEs contain every heading `check:readmes` requires, and that the printed dependency uses the dot form (not `lib-<name>`).

**ADS-1062 — package hygiene**
- Add `lint` / `lint:fix` / `format` / `format:check` scripts (targeting `*.js`) to `eslint-config-base`, `eslint-config-node`, `eslint-config-react`. Their `index.js` was previously linted/format-checked by nothing.
- Extend `scripts/check-workspace-consistency.mjs` so the existing lint/format/format:check baseline (already required for `services/*` and `e2e`) also covers non-`lib.*` `packages/*`.

**Scope note (ADS-1062 AC2 — guard tightening deferred).** The ticket also proposes a full `type-check` + `test` baseline for every `services/*` and `packages/*`. I did the **minimal** tightening (lint/format/format:check across non-lib packages, which all 10 other non-lib packages already satisfy). Requiring `type-check`/`test` broadly would need per-package carve-outs — the three `eslint-config-*` packages are plain JS with no TypeScript and no tests, and `test-utils` lacks `build`/`clean`/`dev` — so it would balloon the PR. Recommended as a follow-up.

## Before requesting review

- [x] Ran the affected gates locally
- [x] Tests for new behaviour added (TDD)
- [ ] If touching `.env` requirements, updated `.env.example`'s REQUIRED block — n/a
- [ ] If touching a `lib.*`, considered consumer impact — n/a (no `lib.*` touched)

## Test plan

- [x] `node scripts/check-readmes.mjs` → pass
- [x] `node scripts/check-workspace-consistency.mjs` → pass (and verified it fails when a non-lib package drops `format:check`)
- [x] `pnpm test:scripts` → 161 passed (incl. the new generator tests)
- [x] `turbo run lint format:check --filter=@adopt-dont-shop/eslint-config-*` → 6 tasks pass; verified a deliberate `var` in `index.js` makes `lint` exit 1
- [x] `prettier --check` clean on changed files

## Related

- ADS-1059
- ADS-1062

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01639moQdBwbM99aMdsQ7CXK)_