### PR TITLE
ci: keep Schema Equivalence required check reporting on all PRs (ADS-1065)

### DIFF
--- a/.github/workflow-source-paths.yml
+++ b/.github/workflow-source-paths.yml
@@ -38,11 +38,15 @@ consumers:
       - '.dockerignore'
 
   # schema-equivalence.yml (ADS-1065) intentionally does NOT consume the
-  # canonical list: its migrate job only needs to run when migration or
-  # schema-owning DB code changes, so both its `push` and `pull_request`
-  # triggers use a narrow filter (services/*/src/migrations/**,
-  # services/*/src/db/**, the packages the migrate job builds — packages/db/**,
-  # packages/observability/**, packages/events/** — pnpm-lock.yaml, and the
-  # workflow file). It is therefore not a canonical consumer — the guard's drift check
-  # does not apply, only the literal-path-exists check. Recorded here so the
-  # single source of truth documents the deliberate divergence.
+  # canonical list, and it no longer carries a trigger-level `paths:` filter at
+  # all: a required check filtered out at the trigger level never reports and
+  # permanently blocks non-migration PRs. It now triggers on every push/PR and
+  # scopes the expensive migrate job INTERNALLY, via a `dorny/paths-filter`
+  # `changes` job over the migration/schema-owning paths (services/*/src/
+  # migrations/**, services/*/src/db/**, the packages the migrate job builds —
+  # packages/db/**, packages/observability/**, packages/events/** —
+  # pnpm-lock.yaml, and the workflow file); the always-on gate job reports the
+  # required check. It is therefore not a canonical consumer — the guard's
+  # drift check does not apply, only the literal-path-exists check (which also
+  # scans that in-job `filters:` block). Recorded here so the single source of
+  # truth documents the deliberate divergence.

--- a/.github/workflows/schema-equivalence.yml
+++ b/.github/workflows/schema-equivalence.yml
@@ -14,30 +14,21 @@ name: Schema Equivalence
 # matching.
 
 on:
-  # ADS-1065: the migrate job is only meaningful when migration or
-  # schema-owning DB code changes, so scope both triggers to those paths.
-  # This narrow filter intentionally diverges from the canonical
-  # .github/workflow-source-paths.yml list — see the note there.
+  # The workflow triggers on ALL pushes/PRs so the required
+  # "Schema Equivalence (migrate vs sync)" gate job always reports a status.
+  #
+  # ADS-1065 originally scoped the *triggers* to migration paths to skip the
+  # ~20-min migrate job on unrelated PRs. But a required check whose workflow
+  # is filtered out at the trigger level never reports — it sits at
+  # "Expected — waiting for status" forever, permanently blocking every
+  # non-migration PR. The path scoping therefore lives in the `changes` job
+  # below instead: the expensive `compute` job is gated on it, while the
+  # lightweight gate job runs unconditionally and passes when compute is
+  # skipped. Same cost savings, no stuck required check.
   push:
     branches: [main, develop]
-    paths:
-      - 'services/*/src/migrations/**'
-      - 'services/*/src/db/**'
-      - 'packages/db/**'
-      - 'packages/observability/**'
-      - 'packages/events/**'
-      - 'pnpm-lock.yaml'
-      - '.github/workflows/schema-equivalence.yml'
   pull_request:
     branches: [main, develop]
-    paths:
-      - 'services/*/src/migrations/**'
-      - 'services/*/src/db/**'
-      - 'packages/db/**'
-      - 'packages/observability/**'
-      - 'packages/events/**'
-      - 'pnpm-lock.yaml'
-      - '.github/workflows/schema-equivalence.yml'
   workflow_dispatch:
 
 concurrency:
@@ -48,8 +39,35 @@ permissions:
   contents: read
 
 jobs:
+  # Decide whether the expensive compute job needs to run. Same
+  # migration/schema-owning paths ADS-1065 put on the triggers — the migrate
+  # job is only meaningful when these change; `packages/{db,observability,
+  # events}` are the packages the compute job builds.
+  changes:
+    name: Detect migration changes
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      migrations: ${{ steps.filter.outputs.migrations }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
+        id: filter
+        with:
+          filters: |
+            migrations:
+              - 'services/*/src/migrations/**'
+              - 'services/*/src/db/**'
+              - 'packages/db/**'
+              - 'packages/observability/**'
+              - 'packages/events/**'
+              - 'pnpm-lock.yaml'
+              - '.github/workflows/schema-equivalence.yml'
+
   schema-equivalence-compute:
     name: Schema Equivalence (compute)
+    needs: changes
+    if: needs.changes.outputs.migrations == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 20
 
@@ -81,7 +99,7 @@ jobs:
       ENCRYPTION_KEY: '0000000000000000000000000000000000000000000000000000000000000000'
 
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: ./.github/actions/setup-workspace
 
       - name: Build shared libraries
@@ -118,21 +136,30 @@ jobs:
 
   schema-equivalence-migrate-vs-sync:
     name: Schema Equivalence (migrate vs sync)
-    needs: schema-equivalence-compute
+    needs: [changes, schema-equivalence-compute]
+    # Always run so this required check reports on every PR — including the
+    # non-migration PRs where `compute` is skipped.
     if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 2
     steps:
       - name: Summarise compute result
         env:
+          CHANGES: ${{ needs.changes.result }}
           RESULT: ${{ needs.schema-equivalence-compute.result }}
         run: |
+          # A failed change-detection job is a real CI-infra failure — surface
+          # it rather than silently passing as "nothing to verify".
+          if [ "$CHANGES" != "success" ]; then
+            echo "::error::Migration-change detection job result: $CHANGES"
+            exit 1
+          fi
           case "$RESULT" in
             success)
               echo "Schema equivalence check passed."
               ;;
             skipped)
-              echo "Compute job skipped — nothing to verify."
+              echo "Compute job skipped — no migration/schema changes to verify."
               ;;
             *)
               echo "::error::Schema equivalence compute job result: $RESULT"

--- a/.github/workflows/schema-equivalence.yml
+++ b/.github/workflows/schema-equivalence.yml
@@ -67,7 +67,11 @@ jobs:
   schema-equivalence-compute:
     name: Schema Equivalence (compute)
     needs: changes
-    if: needs.changes.outputs.migrations == 'true'
+    # Run when migration/schema code changed, or on a manual run — a
+    # `workflow_dispatch` is an explicit request to validate migrations on
+    # demand (matching how ci.yml treats manual dispatch), so it must not be
+    # skipped by change detection.
+    if: ${{ needs.changes.outputs.migrations == 'true' || github.event_name == 'workflow_dispatch' }}
     runs-on: ubuntu-latest
     timeout-minutes: 20
 


### PR DESCRIPTION
## Summary

- Fixes a regression from **ADS-1065** (#1300): the trigger-level `paths:` filter it added to `schema-equivalence.yml` made the **required** "Schema Equivalence (migrate vs sync)" check never report on non-migration PRs, leaving them stuck at "Expected — waiting for status" and un-mergeable (e.g. **#1304**).
- Root cause: a required check whose workflow is filtered out at the trigger level produces no status at all — the always-on gate job can only save you if the workflow actually triggers.
- Fix: trigger on every push/PR again (gate job always reports) and move the path scoping **inside** the workflow, so the expensive job still only runs on migration PRs.

## Changes

- **`.github/workflows/schema-equivalence.yml`**
  - Removed the `on.push.paths` / `on.pull_request.paths` filters.
  - Added a lightweight `changes` job using `dorny/paths-filter` (same migration/schema-owning globs ADS-1065 used, pinned to the repo's existing `v4.0.2` SHA).
  - Gated the heavy `schema-equivalence-compute` job on `needs.changes.outputs.migrations == 'true'`.
  - The required `schema-equivalence-migrate-vs-sync` gate job keeps `if: always()`, now `needs: [changes, compute]`: it passes when compute is `success` or `skipped`, and fails on a compute failure or a change-detection failure.
- **`.github/workflow-source-paths.yml`** — updated the schema-equivalence divergence note to describe the in-job scoping (it no longer carries a trigger-level filter).

## Behaviour

| PR type | `changes` | `compute` (~20 min) | Required gate check |
| --- | --- | --- | --- |
| No migration/DB changes | migrations=false | **skipped** | reports **success** |
| Migration/DB changes | migrations=true | runs | reflects compute result |
| Change-detection fails | failure | skipped | **fails** (surfaced, not masked) |

Same cost savings as ADS-1065 (heavy job still only runs when migration/schema code changes), without the stuck required check. This PR itself touches the workflow file (in the migration filter), so its own `compute` job runs — validating the migrate path end-to-end.

## Test plan

- [x] `node scripts/check-workflow-paths.mjs` — passes (schema-equivalence is a documented non-consumer; the in-job `filters:` block's only literal paths, `pnpm-lock.yaml` and the workflow file, exist).
- [x] `pnpm test:scripts` guard suite for workflow paths — 8/8 pass.
- [x] Both YAML files parse cleanly.
- [x] Logic verified: non-migration PR → compute skipped → gate reports success; migration PR → gate reflects compute; detection failure → gate fails.

## Related

- **ADS-1065** — origin of the regression (CI concurrency + schema-equivalence paths filter).
- Unblocks **#1304** and every future non-migration PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01639moQdBwbM99aMdsQ7CXK)_