### PR TITLE
feat(events): add transactional outbox for domain events (ADS-1048)

### DIFF
--- a/packages/events/README.md
+++ b/packages/events/README.md
@@ -2,10 +2,48 @@
 
 ## Purpose
 
-NATS publish-after-commit + idempotent-subscriber helpers for the backend
-microservices. Encodes the two CAD-lesson disciplines that pay off most: no
-domain event ever fires on a rolled-back transaction, and no single bad message
-can tear down a subscription loop.
+Transactional-outbox event delivery + idempotent-subscriber helpers for the
+backend microservices. Encodes the disciplines that pay off most: no domain
+event ever fires on a rolled-back transaction, no committed event is ever lost,
+and no single bad message can tear down a subscription loop.
+
+### Transactional outbox (ADS-1048)
+
+`withTransaction` no longer publishes to JetStream directly after `COMMIT` (the
+old commit-then-publish dual-write, where a crash between the commit and the
+ack lost the event forever). Instead every staged event is written as a row in
+an `event_outbox` table **inside the same transaction** as the business write —
+so the event is durable atomically with the state change it describes.
+
+Delivery is then two-phase:
+
+- **Inline fast-path** — right after commit, `withTransaction` publishes the
+  just-staged rows and deletes them on ack. Best-effort: a failure here is
+  swallowed (the row stays in the outbox), so it never fails the caller.
+- **Relay** (`startOutboxRelay`, started once per service at boot) — a
+  background sweep that publishes any rows the inline path did not clear
+  (process died in the commit→publish window, or JetStream was unreachable) and
+  deletes them on ack. This is the durability guarantee, and doubles as the
+  reconciliation job. A row is deleted on successful publish, so the table is a
+  self-cleaning queue, not an append-only log.
+
+Each event-publishing service adds a migration that creates `event_outbox` in
+its own schema (re-exporting the DDL from
+[`src/outbox-schema.ts`](src/outbox-schema.ts) via the `./outbox-schema`
+subpath) and starts the relay in its boot sequence. The table is referenced
+unqualified everywhere, resolving to the calling service's schema through the
+connection search_path — the same pattern as the consumer-side
+`processed_events` / `claimEvent` ledger.
+
+Redelivery is safe by construction: JetStream de-dups on `Nats-Msg-Id` within
+its duplicate window and every business consumer is idempotent on the event id,
+so a row the inline path published but crashed before deleting is harmlessly
+re-published by the relay.
+
+Observability: `events_outbox_pending` (gauge — unpublished backlog, the
+primary alert signal), `events_outbox_published_total`, and
+`events_outbox_publish_failures_total` are exposed on the shared `/metrics`
+registry.
 
 This is a service-only shared package (not a `lib.*`) — imported by every
 schema-owning service. See the decision tree in
@@ -35,9 +73,19 @@ pnpm type-check   # TypeScript type-check
 
 The canonical list lives in [`src/index.ts`](src/index.ts):
 
-- `withTransaction({ pool, nats }, fn)` — runs `fn` inside a Postgres
-  transaction with a buffered `publish(...)`; staged events reach NATS **only
-  after** `COMMIT` (no phantom events on rollback).
+- `withTransaction({ pool, nats, logger? }, fn)` — runs `fn` inside a Postgres
+  transaction with a buffered `publish(...)`; staged events are written to the
+  `event_outbox` table in the same transaction (no phantom events on rollback,
+  no lost events after commit) and delivered inline + by the relay.
+- `startOutboxRelay({ pool, nats, logger? }, { intervalMs?, batchSize? })` —
+  starts the background outbox relay; returns a handle whose `stop()` clears
+  it. Call once per event-publishing service at boot; stop it on shutdown.
+- `relayOutboxOnce({ pool, nats }, batchSize)` — publishes one batch of pending
+  outbox rows and returns the count. The relay's unit of work, also usable as a
+  one-shot reconciliation job.
+- `OUTBOX_TABLE` — the `event_outbox` table name. The DDL is re-exported from
+  the `@adopt-dont-shop/events/outbox-schema` subpath for per-service
+  migrations.
 - `subscribe(nats, { subject, durable, onError, deliverNew? }, handler)` — a
   poison-pill-safe consumer loop (errors reported via `onError`, malformed JSON
   skipped). The `durable` name is the JetStream consumer identity — shared for

--- a/packages/events/package.json
+++ b/packages/events/package.json
@@ -15,6 +15,12 @@
       "production": "./dist/index.js",
       "import": "./src/index.ts",
       "default": "./src/index.ts"
+    },
+    "./outbox-schema": {
+      "types": "./src/outbox-schema.ts",
+      "production": "./dist/outbox-schema.js",
+      "import": "./src/outbox-schema.ts",
+      "default": "./src/outbox-schema.ts"
     }
   },
   "files": [
@@ -39,10 +45,17 @@
     "nats": "^2.29.3"
   },
   "peerDependencies": {
+    "node-pg-migrate": "^8.0.4",
     "pg": "^8.22.0"
+  },
+  "peerDependenciesMeta": {
+    "node-pg-migrate": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "@types/pg": "^8.15.5",
+    "node-pg-migrate": "^8.0.4",
     "pg": "^8.22.0"
   }
 }

--- a/packages/events/src/gdpr-saga.test.ts
+++ b/packages/events/src/gdpr-saga.test.ts
@@ -118,9 +118,15 @@ describe('registerGdprSubscriber', () => {
     });
     await flush();
 
-    // BEGIN + COMMIT bracket the erase callback.
+    // BEGIN opens the transaction and COMMIT closes it; the completion event
+    // is staged into the outbox in-transaction (INSERT before COMMIT) and the
+    // inline fast-path deletes that row after commit.
     expect(queries[0]).toBe('BEGIN');
-    expect(queries[queries.length - 1]).toBe('COMMIT');
+    expect(queries).toContain('COMMIT');
+    const commitIdx = queries.indexOf('COMMIT');
+    const insertIdx = queries.findIndex(q => q.includes('INSERT INTO event_outbox'));
+    expect(insertIdx).toBeGreaterThan(0);
+    expect(insertIdx).toBeLessThan(commitIdx);
 
     // Completion event published to JetStream after commit.
     expect(bus.published).toHaveLength(1);

--- a/packages/events/src/index.ts
+++ b/packages/events/src/index.ts
@@ -1,5 +1,13 @@
 export { withTransaction } from './publish.js';
 export type { DomainEvent, TransactionalScope, WithTransactionDeps } from './publish.js';
+export { startOutboxRelay, relayOutboxOnce, __resetOutboxMetricsForTest } from './outbox.js';
+export type {
+  OutboxRelayDeps,
+  OutboxRelayOptions,
+  OutboxRelayHandle,
+  OutboxLogger,
+} from './outbox.js';
+export { OUTBOX_TABLE } from './outbox-schema.js';
 export { subscribe } from './subscribe.js';
 export type { MessageHandler, SubscribeOptions, SubscriptionHandle } from './subscribe.js';
 export { ensureStream, DOMAIN_STREAM, DOMAIN_SUBJECTS } from './stream.js';

--- a/packages/events/src/outbox-schema.ts
+++ b/packages/events/src/outbox-schema.ts
@@ -1,0 +1,65 @@
+// Transactional-outbox table DDL — the publish-side durability primitive
+// (ADS-1048).
+//
+// `withTransaction` stages every domain event as a row in this table INSIDE
+// the same Postgres transaction as the business write, so the event is durable
+// atomically with the state change it describes. A background relay
+// (`startOutboxRelay`) publishes pending rows to JetStream and DELETEs them on
+// ack; the inline fast-path in `withTransaction` does the same immediately
+// after commit so the happy path keeps its low latency. The row is the queue
+// entry — a self-cleaning queue, NOT an append-only log — so the table only
+// ever holds not-yet-published events and never grows unbounded.
+//
+// Mirror of the consumer-side `processed_events` / `claimEvent` pattern: the
+// table is referenced UNQUALIFIED everywhere, resolving to the calling
+// service's own schema via the connection search_path (@adopt-dont-shop/db).
+// Every event-publishing service adds a migration that re-exports the `up` /
+// `down` below, so the DDL is defined once here and stays in lock-step with
+// the SQL in `outbox.ts` that reads and writes these columns.
+
+import type { MigrationBuilder } from 'node-pg-migrate';
+
+// The one table name shared by the DDL, the inserter, and the relay. Keeping
+// it here (imported by outbox.ts) means the column contract has a single
+// source of truth.
+export const OUTBOX_TABLE = 'event_outbox';
+
+export const up = async (pgm: MigrationBuilder): Promise<void> => {
+  pgm.createTable(OUTBOX_TABLE, {
+    // App-generated id (crypto.randomUUID) so the inline fast-path can DELETE
+    // exactly the rows it just inserted without relying on RETURNING order.
+    outbox_id: { type: 'uuid', primaryKey: true },
+    // Monotonic per-service sequence — the FIFO the relay drains by. `now()`
+    // is transaction-start time, so two events staged in one transaction share
+    // created_at; seq is the only tiebreaker that preserves intra-transaction
+    // publish order.
+    seq: { type: 'bigserial', notNull: true },
+    // The DomainEvent.id — becomes the JetStream Nats-Msg-Id for broker-side
+    // de-dup. Nullable: callers that omit it opt out of dedup (documented on
+    // DomainEvent), so the outbox must not force one.
+    event_id: { type: 'text' },
+    // The NATS subject (DomainEvent.type), e.g. `pets.unit.statusChanged`.
+    subject: { type: 'text', notNull: true },
+    // The business payload (DomainEvent.payload). The published envelope
+    // (`{ id, occurredAt, payload }`) is reconstructed from these columns so it
+    // is identical whether the inline path or the relay sends it.
+    payload: { type: 'jsonb', notNull: true },
+    // Domain occurrence time, fixed at stage time (NOT publish time) so a
+    // relay-published event carries the same occurredAt the caller intended.
+    occurred_at: { type: 'timestamptz', notNull: true },
+    created_at: { type: 'timestamptz', notNull: true, default: pgm.func('now()') },
+    // Relay bookkeeping — how many publish attempts this row has taken and the
+    // last failure, for triage when JetStream is unreachable and rows pile up.
+    attempts: { type: 'integer', notNull: true, default: 0 },
+    last_attempt_at: { type: 'timestamptz' },
+    last_error: { type: 'text' },
+  });
+
+  // The relay's hot query is `... ORDER BY seq LIMIT n FOR UPDATE SKIP LOCKED`.
+  // An index on seq keeps that O(log n) as a backlog drains.
+  pgm.createIndex(OUTBOX_TABLE, 'seq', { name: 'event_outbox_seq_idx' });
+};
+
+export const down = async (pgm: MigrationBuilder): Promise<void> => {
+  pgm.dropTable(OUTBOX_TABLE);
+};

--- a/packages/events/src/outbox.test.ts
+++ b/packages/events/src/outbox.test.ts
@@ -1,0 +1,262 @@
+import type { NatsConnection } from 'nats';
+import type { Pool, PoolClient } from 'pg';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { getMetricsRegistry, __resetMetricsForTest } from '@adopt-dont-shop/observability';
+
+import {
+  flushInline,
+  insertOutboxRecords,
+  relayOutboxOnce,
+  startOutboxRelay,
+  toOutboxRecord,
+  __resetOutboxMetricsForTest,
+  type OutboxRecord,
+} from './outbox.js';
+
+function decodeBody(body: unknown): Record<string, unknown> {
+  const s = body instanceof Uint8Array ? new TextDecoder().decode(body) : String(body);
+  return JSON.parse(s) as Record<string, unknown>;
+}
+
+const record = (over: Partial<OutboxRecord> = {}): OutboxRecord => ({
+  outboxId: 'ob-1',
+  eventId: 'evt-1',
+  subject: 'pets.created',
+  payload: { petId: 'p1' },
+  occurredAt: new Date('2026-01-15T10:30:00Z'),
+  ...over,
+});
+
+// A pg pool/client double whose `query` is scripted by matching on the SQL
+// keyword. Each test supplies what the claim SELECT/UPDATE returns.
+function makePool(claimRows: Record<string, unknown>[]) {
+  const query = vi.fn(async (sql: string) => {
+    if (sql.includes('UPDATE') && sql.includes('RETURNING')) {
+      return { rows: claimRows };
+    }
+    if (sql.includes('SELECT count(*)')) {
+      return { rows: [{ count: String(claimRows.length) }] };
+    }
+    return { rows: [] };
+  });
+  const client = { query, release: vi.fn() };
+  const pool = { connect: vi.fn(async () => client), query };
+  return {
+    pool: pool as unknown as Pool,
+    client: client as unknown as PoolClient,
+    query,
+    clientMock: client,
+  };
+}
+
+function makeNats() {
+  const jsPublish = vi
+    .fn()
+    .mockResolvedValue({ stream: 'DOMAIN_EVENTS', seq: 1, duplicate: false });
+  const nats = { jetstream: vi.fn().mockReturnValue({ publish: jsPublish }) };
+  return { nats: nats as unknown as NatsConnection, jsPublish };
+}
+
+describe('toOutboxRecord', () => {
+  it('carries the event type as subject and the id as eventId', () => {
+    const rec = toOutboxRecord({ type: 'pets.created', id: 'evt-9', payload: { a: 1 } });
+    expect(rec.subject).toBe('pets.created');
+    expect(rec.eventId).toBe('evt-9');
+    expect(rec.payload).toEqual({ a: 1 });
+    expect(typeof rec.outboxId).toBe('string');
+  });
+
+  it('defaults a missing event id to null (opt-out of dedup)', () => {
+    const rec = toOutboxRecord({ type: 'pets.created', payload: {} });
+    expect(rec.eventId).toBeNull();
+  });
+});
+
+describe('insertOutboxRecords', () => {
+  it('inserts every staged record in one multi-row statement', async () => {
+    const query = vi.fn().mockResolvedValue({ rows: [] });
+    await insertOutboxRecords({ query }, [
+      record({ outboxId: 'ob-1', subject: 'a.x' }),
+      record({ outboxId: 'ob-2', subject: 'b.y' }),
+    ]);
+
+    expect(query).toHaveBeenCalledTimes(1);
+    const [sql, params] = query.mock.calls[0];
+    expect(sql).toContain('INSERT INTO event_outbox');
+    // 2 rows × 5 columns = 10 bound params.
+    expect(params).toHaveLength(10);
+    expect(params).toContain('ob-1');
+    expect(params).toContain('ob-2');
+  });
+
+  it('is a no-op for an empty batch', async () => {
+    const query = vi.fn();
+    await insertOutboxRecords({ query }, []);
+    expect(query).not.toHaveBeenCalled();
+  });
+});
+
+describe('relayOutboxOnce', () => {
+  beforeEach(() => {
+    __resetMetricsForTest();
+    __resetOutboxMetricsForTest();
+  });
+
+  it('publishes each claimed row to its subject and deletes it on ack', async () => {
+    const { pool, query } = makePool([
+      {
+        outbox_id: 'ob-1',
+        event_id: 'evt-1',
+        subject: 'pets.created',
+        payload: { petId: 'p1' },
+        occurred_at: new Date('2026-01-15T10:30:00Z'),
+      },
+    ]);
+    const { nats, jsPublish } = makeNats();
+
+    const published = await relayOutboxOnce({ pool, nats }, 100);
+
+    expect(published).toBe(1);
+    expect(jsPublish).toHaveBeenCalledTimes(1);
+    expect(jsPublish.mock.calls[0][0]).toBe('pets.created');
+    expect(decodeBody(jsPublish.mock.calls[0][1])).toMatchObject({ id: 'evt-1' });
+    expect(jsPublish.mock.calls[0][2]).toMatchObject({ msgID: 'evt-1' });
+    // The row is removed once published (self-cleaning queue).
+    const deleted = query.mock.calls.some(
+      ([sql, params]) => String(sql).includes('DELETE FROM event_outbox') && params?.[0] === 'ob-1'
+    );
+    expect(deleted).toBe(true);
+  });
+
+  it('returns 0 and never touches JetStream when nothing is pending', async () => {
+    const { pool } = makePool([]);
+    const { nats, jsPublish } = makeNats();
+
+    const published = await relayOutboxOnce({ pool, nats }, 100);
+
+    expect(published).toBe(0);
+    expect(jsPublish).not.toHaveBeenCalled();
+  });
+
+  it('leaves the row and stamps last_error when a publish fails', async () => {
+    const { pool, query } = makePool([
+      {
+        outbox_id: 'ob-1',
+        event_id: 'evt-1',
+        subject: 'pets.created',
+        payload: {},
+        occurred_at: new Date(),
+      },
+    ]);
+    const nats = {
+      jetstream: vi.fn().mockReturnValue({
+        publish: vi.fn().mockRejectedValue(new Error('no stream ack')),
+      }),
+    } as unknown as NatsConnection;
+
+    const published = await relayOutboxOnce({ pool, nats }, 100);
+
+    expect(published).toBe(0);
+    // No DELETE — the row survives for the next sweep...
+    const deleted = query.mock.calls.some(([sql]) => String(sql).includes('DELETE'));
+    expect(deleted).toBe(false);
+    // ...and the failure is recorded on the row.
+    const stamped = query.mock.calls.some(
+      ([sql, params]) => String(sql).includes('SET last_error') && params?.[1] === 'no stream ack'
+    );
+    expect(stamped).toBe(true);
+  });
+
+  it('counts successes and failures on the shared metrics registry', async () => {
+    const { pool } = makePool([
+      { outbox_id: 'ob-1', event_id: 'e1', subject: 's.a', payload: {}, occurred_at: new Date() },
+    ]);
+    const { nats } = makeNats();
+
+    await relayOutboxOnce({ pool, nats }, 100);
+
+    const text = await getMetricsRegistry().metrics();
+    expect(text).toContain('events_outbox_published_total 1');
+  });
+});
+
+describe('flushInline', () => {
+  beforeEach(() => {
+    __resetMetricsForTest();
+    __resetOutboxMetricsForTest();
+  });
+
+  it('publishes then deletes each record on the given client', async () => {
+    const query = vi.fn().mockResolvedValue({ rows: [] });
+    const { nats, jsPublish } = makeNats();
+
+    await flushInline(nats, { query }, [
+      record({ outboxId: 'ob-1' }),
+      record({ outboxId: 'ob-2' }),
+    ]);
+
+    expect(jsPublish).toHaveBeenCalledTimes(2);
+    const deletes = query.mock.calls.filter(([sql]) => String(sql).includes('DELETE'));
+    expect(deletes).toHaveLength(2);
+  });
+
+  it('stops on the first publish failure, leaving remaining rows for the relay', async () => {
+    const query = vi.fn().mockResolvedValue({ rows: [] });
+    const publish = vi
+      .fn()
+      .mockResolvedValueOnce({ seq: 1 })
+      .mockRejectedValueOnce(new Error('boom'));
+    const nats = { jetstream: vi.fn().mockReturnValue({ publish }) } as unknown as NatsConnection;
+
+    await flushInline(nats, { query }, [
+      record({ outboxId: 'ob-1' }),
+      record({ outboxId: 'ob-2' }),
+    ]);
+
+    // First published + deleted; second attempted then abandoned (no delete).
+    expect(publish).toHaveBeenCalledTimes(2);
+    const deletes = query.mock.calls.filter(([sql]) => String(sql).includes('DELETE'));
+    expect(deletes).toHaveLength(1);
+    expect(deletes[0][1][0]).toBe('ob-1');
+  });
+
+  it('never throws on a publish failure (the outbox row is the durability guarantee)', async () => {
+    const query = vi.fn().mockResolvedValue({ rows: [] });
+    const nats = {
+      jetstream: vi.fn().mockReturnValue({ publish: vi.fn().mockRejectedValue(new Error('x')) }),
+    } as unknown as NatsConnection;
+
+    await expect(flushInline(nats, { query }, [record()])).resolves.toBeUndefined();
+  });
+});
+
+describe('startOutboxRelay', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    __resetMetricsForTest();
+    __resetOutboxMetricsForTest();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('sweeps the outbox on each interval and stops when stopped', async () => {
+    const { pool, query } = makePool([
+      { outbox_id: 'ob-1', event_id: 'e1', subject: 's.a', payload: {}, occurred_at: new Date() },
+    ]);
+    const { nats, jsPublish } = makeNats();
+
+    const handle = startOutboxRelay({ pool, nats }, { intervalMs: 100 });
+
+    await vi.advanceTimersByTimeAsync(100);
+    expect(jsPublish).toHaveBeenCalledTimes(1);
+
+    handle.stop();
+    jsPublish.mockClear();
+    await vi.advanceTimersByTimeAsync(300);
+    expect(jsPublish).not.toHaveBeenCalled();
+    // sanity: the claim query did run while active.
+    expect(query).toHaveBeenCalled();
+  });
+});

--- a/packages/events/src/outbox.test.ts
+++ b/packages/events/src/outbox.test.ts
@@ -29,10 +29,11 @@ const record = (over: Partial<OutboxRecord> = {}): OutboxRecord => ({
 });
 
 // A pg pool/client double whose `query` is scripted by matching on the SQL
-// keyword. Each test supplies what the claim SELECT/UPDATE returns.
+// keyword. Each test supplies what the claim `SELECT ... FOR UPDATE` returns;
+// BEGIN/COMMIT/DELETE/UPDATE all fall through to an empty result.
 function makePool(claimRows: Record<string, unknown>[]) {
   const query = vi.fn(async (sql: string) => {
-    if (sql.includes('UPDATE') && sql.includes('RETURNING')) {
+    if (sql.includes('FOR UPDATE SKIP LOCKED')) {
       return { rows: claimRows };
     }
     if (sql.includes('SELECT count(*)')) {
@@ -163,7 +164,7 @@ describe('relayOutboxOnce', () => {
     expect(deleted).toBe(false);
     // ...and the failure is recorded on the row.
     const stamped = query.mock.calls.some(
-      ([sql, params]) => String(sql).includes('SET last_error') && params?.[1] === 'no stream ack'
+      ([sql, params]) => String(sql).includes('last_error') && params?.[1] === 'no stream ack'
     );
     expect(stamped).toBe(true);
   });
@@ -228,6 +229,18 @@ describe('flushInline', () => {
     } as unknown as NatsConnection;
 
     await expect(flushInline(nats, { query }, [record()])).resolves.toBeUndefined();
+  });
+
+  it('counts an inline publish failure on the shared failure metric', async () => {
+    const query = vi.fn().mockResolvedValue({ rows: [] });
+    const nats = {
+      jetstream: vi.fn().mockReturnValue({ publish: vi.fn().mockRejectedValue(new Error('x')) }),
+    } as unknown as NatsConnection;
+
+    await flushInline(nats, { query }, [record()]);
+
+    const text = await getMetricsRegistry().metrics();
+    expect(text).toContain('events_outbox_publish_failures_total 1');
   });
 });
 

--- a/packages/events/src/outbox.ts
+++ b/packages/events/src/outbox.ts
@@ -1,0 +1,357 @@
+// Transactional-outbox insert + relay (ADS-1048).
+//
+// The publish-side half of the outbox. `outbox-schema.ts` owns the table DDL;
+// this module owns the SQL that reads and writes it plus the relay loop that
+// drains it to JetStream.
+//
+// Two publish paths share the SAME encode step (`publishRecord`) so a message
+// is byte-identical whether it left via the inline fast-path or the relay:
+//
+//   * Inline fast-path (publish.ts) — right after COMMIT, publish the rows we
+//     just inserted and DELETE them. Keeps the happy-path latency the old
+//     commit-then-publish had.
+//   * Relay (`startOutboxRelay`) — a background sweep that publishes any rows
+//     the inline path did NOT clear (process died in the commit→publish
+//     window, or JetStream was briefly unreachable). This is what closes the
+//     lost-event hole; it is also usable as a one-shot reconciliation job via
+//     `relayOutboxOnce`.
+//
+// A row is DELETEd on successful publish, so the table is a self-cleaning queue
+// (only unpublished events live in it) — no unbounded ledger. Redelivery is
+// safe: JetStream de-dups on Nats-Msg-Id within its duplicate window and every
+// business consumer is idempotent on the event id (`claimEvent`), so a row the
+// inline path published but crashed before deleting is harmlessly re-published
+// by the relay.
+
+import { randomUUID } from 'node:crypto';
+
+import type { JetStreamClient, NatsConnection } from 'nats';
+import type { Pool, PoolClient } from 'pg';
+
+import { Counter, Gauge, getMetricsRegistry } from '@adopt-dont-shop/observability';
+
+import { OUTBOX_TABLE } from './outbox-schema.js';
+import type { DomainEvent } from './publish.js';
+
+// Anything that can run a parameterised query — the transaction client (inline
+// path) or a pooled connection (relay). Keeps the SQL helpers agnostic to
+// which one they run on.
+type Queryable = Pick<Pool, 'query'> | Pick<PoolClient, 'query'>;
+
+// A pending event, as staged in the outbox and as needed to publish it.
+export type OutboxRecord = {
+  outboxId: string;
+  eventId: string | null;
+  subject: string;
+  payload: unknown;
+  occurredAt: Date;
+};
+
+// Optional structured logger — the relay logs a swept tick's failures if given
+// one, but never requires it (kept dependency-light on purpose).
+export type OutboxLogger = {
+  warn?: (message: string, meta?: unknown) => void;
+  error?: (message: string, meta?: unknown) => void;
+};
+
+export type OutboxRelayDeps = {
+  pool: Pool;
+  nats: NatsConnection;
+  logger?: OutboxLogger;
+};
+
+const encoder = new TextEncoder();
+
+// Turn a staged DomainEvent into an outbox record. `occurredAt` and the outbox
+// id are fixed HERE (stage time), not at publish time, so the inline path and
+// the relay agree on both.
+export const toOutboxRecord = (event: DomainEvent): OutboxRecord => ({
+  outboxId: randomUUID(),
+  eventId: event.id ?? null,
+  subject: event.type,
+  payload: event.payload,
+  occurredAt: event.occurredAt ?? new Date(),
+});
+
+// The single encode-and-publish step. Envelope shape matches subscribe.ts's
+// EventEnvelope; msgID sets Nats-Msg-Id for broker-side de-dup when an id is
+// present.
+export const publishRecord = async (js: JetStreamClient, rec: OutboxRecord): Promise<void> => {
+  const envelope = {
+    id: rec.eventId ?? undefined,
+    occurredAt: rec.occurredAt,
+    payload: rec.payload,
+  };
+  await js.publish(rec.subject, encoder.encode(JSON.stringify(envelope)), {
+    ...(rec.eventId ? { msgID: rec.eventId } : {}),
+  });
+};
+
+// Insert staged records into the outbox in a single multi-row statement. Run
+// on the transaction client so the rows commit atomically with the business
+// write. A no-op for an empty batch (the common "no events staged" path).
+export const insertOutboxRecords = async (
+  client: Queryable,
+  records: readonly OutboxRecord[]
+): Promise<void> => {
+  if (records.length === 0) {
+    return;
+  }
+  const values: string[] = [];
+  const params: unknown[] = [];
+  records.forEach((rec, i) => {
+    const b = i * 5;
+    values.push(`($${b + 1}, $${b + 2}, $${b + 3}, $${b + 4}, $${b + 5})`);
+    params.push(
+      rec.outboxId,
+      rec.eventId,
+      rec.subject,
+      JSON.stringify(rec.payload),
+      rec.occurredAt
+    );
+  });
+  await client.query(
+    `INSERT INTO ${OUTBOX_TABLE} (outbox_id, event_id, subject, payload, occurred_at)
+     VALUES ${values.join(', ')}`,
+    params
+  );
+};
+
+const deleteOutboxRow = async (executor: Queryable, outboxId: string): Promise<void> => {
+  await executor.query(`DELETE FROM ${OUTBOX_TABLE} WHERE outbox_id = $1`, [outboxId]);
+};
+
+// Best-effort inline publish of the rows a transaction just staged. Publishes
+// each in seq order and DELETEs it on ack. On the FIRST failure it stops and
+// leaves that row and every later one for the relay — preserving order and
+// never throwing, because the outbox row is the durability guarantee now (a
+// failure here is latency, not loss).
+//
+// `executor` is the just-committed transaction client — reusing it means the
+// delete needs no extra connection. The publish is fast (local JetStream ack),
+// so the brief hold on that connection is negligible next to the transaction
+// it just ran.
+export const flushInline = async (
+  nats: NatsConnection,
+  executor: Queryable,
+  records: readonly OutboxRecord[],
+  logger?: OutboxLogger
+): Promise<void> => {
+  if (records.length === 0) {
+    return;
+  }
+  const js = nats.jetstream();
+  for (const rec of records) {
+    try {
+      await publishRecord(js, rec);
+      await deleteOutboxRow(executor, rec.outboxId);
+      recordOutboxPublished();
+    } catch (err) {
+      logger?.warn?.('outbox inline publish failed; relay will retry', {
+        subject: rec.subject,
+        err,
+      });
+      return;
+    }
+  }
+};
+
+const rowToRecord = (row: {
+  outbox_id: string;
+  event_id: string | null;
+  subject: string;
+  payload: unknown;
+  occurred_at: Date;
+}): OutboxRecord => ({
+  outboxId: row.outbox_id,
+  eventId: row.event_id,
+  subject: row.subject,
+  payload: row.payload,
+  occurredAt: row.occurred_at,
+});
+
+// Claim a batch and publish it. The claim UPDATE bumps attempts and locks the
+// batch with FOR UPDATE SKIP LOCKED (so concurrent relays across replicas take
+// disjoint batches), then autocommits — releasing the locks BEFORE we do any
+// network I/O. Each row is published then DELETEd; a publish failure records
+// last_error and leaves the row for the next tick. Returns the count published
+// so the caller can drain until a short batch signals the backlog is empty.
+export const relayOutboxOnce = async (
+  deps: Pick<OutboxRelayDeps, 'pool' | 'nats'>,
+  batchSize: number
+): Promise<number> => {
+  const { pool, nats } = deps;
+  const client = await pool.connect();
+  try {
+    const { rows } = await client.query(
+      `UPDATE ${OUTBOX_TABLE}
+          SET attempts = attempts + 1, last_attempt_at = now()
+        WHERE outbox_id IN (
+          SELECT outbox_id FROM ${OUTBOX_TABLE}
+           ORDER BY seq
+           LIMIT $1
+           FOR UPDATE SKIP LOCKED
+        )
+      RETURNING outbox_id, event_id, subject, payload, occurred_at`,
+      [batchSize]
+    );
+    if (rows.length === 0) {
+      return 0;
+    }
+    const js = nats.jetstream();
+    let published = 0;
+    for (const row of rows) {
+      const rec = rowToRecord(row);
+      try {
+        await publishRecord(js, rec);
+        await deleteOutboxRow(client, rec.outboxId);
+        recordOutboxPublished();
+        published += 1;
+      } catch (err) {
+        recordOutboxFailure();
+        await client
+          .query(`UPDATE ${OUTBOX_TABLE} SET last_error = $2 WHERE outbox_id = $1`, [
+            rec.outboxId,
+            err instanceof Error ? err.message : String(err),
+          ])
+          .catch(() => {
+            // The row stays pending regardless; a failed error-stamp is not
+            // worth surfacing.
+          });
+      }
+    }
+    return published;
+  } finally {
+    client.release();
+  }
+};
+
+export type OutboxRelayOptions = {
+  // How often to sweep for rows the inline path missed. Default 1s — the relay
+  // is a backstop (the inline path handles the happy path), so this only
+  // governs crash/outage recovery latency, and a gentle interval keeps idle DB
+  // load negligible.
+  intervalMs?: number;
+  // Max rows claimed per statement. The tick drains fully (loops until a short
+  // batch), so this just bounds each claim's lock set / memory.
+  batchSize?: number;
+};
+
+export type OutboxRelayHandle = {
+  stop: () => void;
+};
+
+const DEFAULT_INTERVAL_MS = 500;
+const DEFAULT_BATCH_SIZE = 100;
+
+// Start the background relay. Returns a handle whose stop() clears the timer.
+// The tick is re-entrancy-guarded (a slow sweep never overlaps the next) and
+// wraps everything so a transient DB/NATS error is logged, not fatal. The
+// timer is unref'd so the relay alone never keeps the process alive at
+// shutdown.
+export const startOutboxRelay = (
+  deps: OutboxRelayDeps,
+  options: OutboxRelayOptions = {}
+): OutboxRelayHandle => {
+  const intervalMs = options.intervalMs ?? DEFAULT_INTERVAL_MS;
+  const batchSize = options.batchSize ?? DEFAULT_BATCH_SIZE;
+  let ticking = false;
+
+  const tick = async (): Promise<void> => {
+    if (ticking) {
+      return;
+    }
+    ticking = true;
+    try {
+      let published = 0;
+      do {
+        published = await relayOutboxOnce(deps, batchSize);
+      } while (published === batchSize);
+      await updatePendingGauge(deps.pool);
+    } catch (err) {
+      deps.logger?.error?.('outbox relay tick failed', { err });
+    } finally {
+      ticking = false;
+    }
+  };
+
+  const timer = setInterval(() => {
+    void tick();
+  }, intervalMs);
+  timer.unref?.();
+
+  return {
+    stop: () => clearInterval(timer),
+  };
+};
+
+// --- Metrics ----------------------------------------------------------------
+//
+// Registered once on the shared observability registry so they appear on
+// /metrics next to the HTTP/gRPC and dead-letter series. The pending gauge is
+// the primary alert signal — a rising backlog means events are stuck (NATS
+// down, relay wedged); the counters give throughput and a failure rate.
+
+let _published: InstanceType<typeof Counter> | null = null;
+let _failures: InstanceType<typeof Counter> | null = null;
+let _pending: InstanceType<typeof Gauge> | null = null;
+
+const publishedCounter = (): InstanceType<typeof Counter> => {
+  if (!_published) {
+    _published = new Counter({
+      name: 'events_outbox_published_total',
+      help: 'Domain events published from the transactional outbox (inline + relay).',
+      registers: [getMetricsRegistry()],
+    });
+  }
+  return _published;
+};
+
+const failuresCounter = (): InstanceType<typeof Counter> => {
+  if (!_failures) {
+    _failures = new Counter({
+      name: 'events_outbox_publish_failures_total',
+      help: 'Outbox publish attempts that failed and left the row for a later relay sweep.',
+      registers: [getMetricsRegistry()],
+    });
+  }
+  return _failures;
+};
+
+const pendingGauge = (): InstanceType<typeof Gauge> => {
+  if (!_pending) {
+    _pending = new Gauge({
+      name: 'events_outbox_pending',
+      help: 'Rows currently waiting in the transactional outbox (unpublished backlog).',
+      registers: [getMetricsRegistry()],
+    });
+  }
+  return _pending;
+};
+
+const recordOutboxPublished = (): void => {
+  publishedCounter().inc();
+};
+
+const recordOutboxFailure = (): void => {
+  failuresCounter().inc();
+};
+
+const updatePendingGauge = async (pool: Pick<Pool, 'query'>): Promise<void> => {
+  try {
+    const { rows } = await pool.query<{ count: string }>(
+      `SELECT count(*)::text AS count FROM ${OUTBOX_TABLE}`
+    );
+    pendingGauge().set(Number(rows[0]?.count ?? 0));
+  } catch {
+    // A backlog-count blip must not crash the relay tick; the next tick retries.
+  }
+};
+
+// --- Test-only helper -------------------------------------------------------
+
+export const __resetOutboxMetricsForTest = (): void => {
+  _published = null;
+  _failures = null;
+  _pending = null;
+};

--- a/packages/events/src/outbox.ts
+++ b/packages/events/src/outbox.ts
@@ -147,6 +147,10 @@ export const flushInline = async (
       await deleteOutboxRow(executor, rec.outboxId);
       recordOutboxPublished();
     } catch (err) {
+      // Count it on the same failure metric the relay uses — an inline failure
+      // is non-fatal (the row waits for the relay) but it IS a publish failure,
+      // and hiding it would understate the true failure rate.
+      recordOutboxFailure();
       logger?.warn?.('outbox inline publish failed; relay will retry', {
         subject: rec.subject,
         err,
@@ -170,12 +174,25 @@ const rowToRecord = (row: {
   occurredAt: row.occurred_at,
 });
 
-// Claim a batch and publish it. The claim UPDATE bumps attempts and locks the
-// batch with FOR UPDATE SKIP LOCKED (so concurrent relays across replicas take
-// disjoint batches), then autocommits — releasing the locks BEFORE we do any
-// network I/O. Each row is published then DELETEd; a publish failure records
-// last_error and leaves the row for the next tick. Returns the count published
-// so the caller can drain until a short batch signals the backlog is empty.
+// Claim a batch and publish it, holding the claim lock through publish+delete.
+//
+// The whole sweep runs in ONE transaction: `SELECT ... FOR UPDATE SKIP LOCKED`
+// locks the batch, and the locks are held until COMMIT — so a second relay (a
+// sibling replica) skips these rows and picks up a disjoint batch instead of
+// re-claiming and re-publishing them. That matters because events published
+// with no id opt out of JetStream's Nats-Msg-Id de-dup, so a cross-replica
+// double-claim would be a genuine duplicate side-effect, not a deduped one.
+//
+// Holding a connection + row locks across the network publishes is acceptable
+// here where it would not be on the write hot-path: the relay is a background
+// backstop (the inline path handles the happy path), it runs on a bounded
+// batch, and it stops the batch at the first failure — so the hold is short.
+//
+// Each row is published then DELETEd (self-cleaning queue). A publish failure
+// stamps attempts/last_error, stops the batch (preserving per-subject order),
+// and COMMITs what already succeeded; the remaining rows wait for the next
+// sweep. Returns the count published so the caller can drain until a short
+// batch signals the backlog is empty.
 export const relayOutboxOnce = async (
   deps: Pick<OutboxRelayDeps, 'pool' | 'nats'>,
   batchSize: number
@@ -183,19 +200,17 @@ export const relayOutboxOnce = async (
   const { pool, nats } = deps;
   const client = await pool.connect();
   try {
+    await client.query('BEGIN');
     const { rows } = await client.query(
-      `UPDATE ${OUTBOX_TABLE}
-          SET attempts = attempts + 1, last_attempt_at = now()
-        WHERE outbox_id IN (
-          SELECT outbox_id FROM ${OUTBOX_TABLE}
-           ORDER BY seq
-           LIMIT $1
-           FOR UPDATE SKIP LOCKED
-        )
-      RETURNING outbox_id, event_id, subject, payload, occurred_at`,
+      `SELECT outbox_id, event_id, subject, payload, occurred_at
+         FROM ${OUTBOX_TABLE}
+        ORDER BY seq
+        LIMIT $1
+        FOR UPDATE SKIP LOCKED`,
       [batchSize]
     );
     if (rows.length === 0) {
+      await client.query('COMMIT');
       return 0;
     }
     const js = nats.jetstream();
@@ -209,18 +224,27 @@ export const relayOutboxOnce = async (
         published += 1;
       } catch (err) {
         recordOutboxFailure();
-        await client
-          .query(`UPDATE ${OUTBOX_TABLE} SET last_error = $2 WHERE outbox_id = $1`, [
-            rec.outboxId,
-            err instanceof Error ? err.message : String(err),
-          ])
-          .catch(() => {
-            // The row stays pending regardless; a failed error-stamp is not
-            // worth surfacing.
-          });
+        await client.query(
+          `UPDATE ${OUTBOX_TABLE}
+              SET attempts = attempts + 1, last_attempt_at = now(), last_error = $2
+            WHERE outbox_id = $1`,
+          [rec.outboxId, err instanceof Error ? err.message : String(err)]
+        );
+        // Stop at the first failure — the remaining rows keep their lock until
+        // COMMIT and are retried next sweep, in order.
+        break;
       }
     }
+    await client.query('COMMIT');
     return published;
+  } catch (err) {
+    try {
+      await client.query('ROLLBACK');
+    } catch {
+      // The original error is the one that matters; a failed rollback usually
+      // means the connection is already gone.
+    }
+    throw err;
   } finally {
     client.release();
   }
@@ -241,7 +265,7 @@ export type OutboxRelayHandle = {
   stop: () => void;
 };
 
-const DEFAULT_INTERVAL_MS = 500;
+const DEFAULT_INTERVAL_MS = 1_000;
 const DEFAULT_BATCH_SIZE = 100;
 
 // Start the background relay. Returns a handle whose stop() clears the timer.

--- a/packages/events/src/publish.test.ts
+++ b/packages/events/src/publish.test.ts
@@ -117,19 +117,64 @@ describe('withTransaction', () => {
     expect(mocks.clientMock.release).toHaveBeenCalledTimes(1);
   });
 
-  it('surfaces a JetStream publish failure to the caller (no silent fire-and-forget)', async () => {
+  it('does NOT fail the caller when the inline publish fails (the event is durably staged for the relay)', async () => {
+    // Post-commit publish failure is no longer lost — the event sits in the
+    // outbox and the relay delivers it — so withTransaction still resolves.
     mocks.jsPublish.mockRejectedValueOnce(new Error('no stream ack'));
 
     await expect(
       withTransaction({ pool: mocks.pool, nats: mocks.nats }, async ({ publish }) => {
         publish({ type: 'pets.created', id: 'evt-1', payload: {} });
+        return 'ok';
       })
-    ).rejects.toThrow('no stream ack');
+    ).resolves.toBe('ok');
 
-    // The commit already happened — we do NOT roll back on a publish failure.
+    // The commit happened; we do NOT roll back on a publish failure...
     expect(mocks.clientMock.query).toHaveBeenCalledWith('COMMIT');
     expect(mocks.clientMock.query).not.toHaveBeenCalledWith('ROLLBACK');
+    // ...and the row is left in the outbox (never DELETEd) for the relay.
+    const deleted = mocks.clientMock.query.mock.calls.some(([sql]: [string]) =>
+      String(sql).includes('DELETE FROM event_outbox')
+    );
+    expect(deleted).toBe(false);
     expect(mocks.clientMock.release).toHaveBeenCalledTimes(1);
+  });
+
+  it('stages events into the outbox inside the transaction (INSERT before COMMIT)', async () => {
+    const order: string[] = [];
+    mocks.clientMock.query.mockImplementation(async (sql: string) => {
+      order.push(sql.includes('INSERT INTO event_outbox') ? 'OUTBOX_INSERT' : sql);
+      return { rows: [] };
+    });
+
+    await withTransaction({ pool: mocks.pool, nats: mocks.nats }, async ({ publish }) => {
+      publish({ type: 'pets.created', id: 'evt-1', payload: { petId: 'p1' } });
+    });
+
+    const insertIdx = order.indexOf('OUTBOX_INSERT');
+    const commitIdx = order.indexOf('COMMIT');
+    expect(insertIdx).toBeGreaterThanOrEqual(0);
+    // The outbox row is written before COMMIT — atomic with the business write.
+    expect(insertIdx).toBeLessThan(commitIdx);
+  });
+
+  it('rolls back and never publishes when the outbox INSERT fails', async () => {
+    mocks.clientMock.query.mockImplementation(async (sql: string) => {
+      if (sql.includes('INSERT INTO event_outbox')) {
+        throw new Error('outbox table missing');
+      }
+      return { rows: [] };
+    });
+
+    await expect(
+      withTransaction({ pool: mocks.pool, nats: mocks.nats }, async ({ publish }) => {
+        publish({ type: 'pets.created', id: 'evt-1', payload: {} });
+      })
+    ).rejects.toThrow('outbox table missing');
+
+    expect(mocks.jsPublish).not.toHaveBeenCalled();
+    expect(mocks.clientMock.query).toHaveBeenCalledWith('ROLLBACK');
+    expect(mocks.clientMock.query).not.toHaveBeenCalledWith('COMMIT');
   });
 
   it('releases the client even when ROLLBACK also fails', async () => {

--- a/packages/events/src/publish.ts
+++ b/packages/events/src/publish.ts
@@ -1,6 +1,8 @@
 import type { NatsConnection } from 'nats';
 import type { Pool, PoolClient } from 'pg';
 
+import { flushInline, insertOutboxRecords, toOutboxRecord, type OutboxLogger } from './outbox.js';
+
 export type DomainEvent<T = unknown> = {
   // NATS subject the event publishes on. Convention: `<service>.<entity>.<verb>`,
   // e.g. `pets.unit.statusChanged`. Subscribers wildcard the prefix.
@@ -33,30 +35,49 @@ export type TransactionalScope = {
 export type WithTransactionDeps = {
   pool: Pool;
   nats: NatsConnection;
+  // Optional structured logger. When present, a failed inline publish (the
+  // best-effort fast-path — see below) is logged at warn; the relay still
+  // delivers the event regardless, so a logger is never required.
+  logger?: OutboxLogger;
 };
 
-// withTransaction runs `fn` inside a Postgres transaction and publishes any
-// events staged via `scope.publish(...)` only after the commit succeeds.
+// withTransaction runs `fn` inside a Postgres transaction and delivers any
+// events staged via `scope.publish(...)` through a transactional outbox
+// (ADS-1048).
 //
-// Publishing goes through JetStream (`nc.jetstream().publish()`), which
-// returns a server-side ACK — the event is durably stored in the
-// DOMAIN_EVENTS stream before this function resolves. A consumer that was
-// offline when the event fired still receives it on reconnect
-// (at-least-once), which is the point of the migration: no domain event is
-// lost to a subscriber being mid-deploy/restart.
+// Staged events are written as rows in the `event_outbox` table INSIDE the
+// same transaction as the business write, so the event is durable atomically
+// with the state change it describes. There is no dual-write window any more:
+// if we commit, the event is durably queued; if we roll back, it never
+// existed. This closes the old hole where a crash between COMMIT and the
+// JetStream ack lost a terminal event (a notification never sent, an audit row
+// never written) forever.
+//
+// Delivery is then two-phase:
+//   1. Inline fast-path — right after COMMIT we publish the just-staged rows
+//      and DELETE them on ack, preserving the low latency the old
+//      commit-then-publish had. This is BEST-EFFORT: a failure here is
+//      swallowed (logged if a logger was passed), because the row is still in
+//      the outbox and...
+//   2. The relay (`startOutboxRelay`, started once per service at boot) sweeps
+//      any rows the inline path did not clear and publishes them. This is the
+//      durability guarantee — the process can die anywhere in the inline path
+//      and the event is still delivered.
 //
 // Failure modes:
-//  - `fn` throws → ROLLBACK, no events fire, error re-thrown.
-//  - COMMIT throws → no events fire (we never reach the publish loop), error
-//    re-thrown. Transaction is effectively rolled back.
-//  - publish throws (no JetStream ack) → does NOT roll back (commit already
-//    happened) but the error bubbles. Callers should treat this as a transient
-//    infra issue; consumers will re-derive state from the next event.
+//  - `fn` throws → ROLLBACK, nothing staged, error re-thrown.
+//  - the outbox INSERT throws → ROLLBACK, error re-thrown. The business write
+//    is abandoned too, because we could not durably stage its event — that
+//    atomicity IS the fix.
+//  - COMMIT throws → ROLLBACK, error re-thrown; nothing was published.
+//  - inline publish throws → swallowed; the row stays in the outbox for the
+//    relay. The caller sees success, because the operation DID succeed and the
+//    event is durably queued.
 //
-// This is the CAD pattern that PR #29 / #35 codified: no phantom events on
-// rollback, ever.
+// This preserves the CAD discipline (no phantom events on rollback) and adds
+// the missing half: no committed event is ever lost.
 export async function withTransaction<R>(
-  { pool, nats }: WithTransactionDeps,
+  { pool, nats, logger }: WithTransactionDeps,
   fn: (scope: TransactionalScope) => Promise<R>
 ): Promise<R> {
   const client = await pool.connect();
@@ -70,13 +91,19 @@ export async function withTransaction<R>(
         staged.push(event);
       },
     });
+
+    // Persist the staged events in the SAME transaction as the business write.
+    // A failure here rolls the whole thing back — we never commit a state
+    // change whose event we could not durably queue.
+    const records = staged.map(toOutboxRecord);
+    await insertOutboxRecords(client, records);
+
     await client.query('COMMIT');
     committed = true;
-    // Publish AFTER commit. A failure here bubbles to the caller but must NOT
-    // trigger a rollback — the commit already happened, so the `committed`
-    // guard below skips the ROLLBACK. Consumers re-derive state from the next
-    // event in that (rare, transient) case.
-    await publishStaged(nats, staged);
+
+    // Best-effort inline delivery on the just-committed client. Never throws —
+    // anything left unpublished stays in the outbox for the relay to deliver.
+    await flushInline(nats, client, records, logger);
     return result;
   } catch (err) {
     if (!committed) {
@@ -92,26 +119,5 @@ export async function withTransaction<R>(
     throw err;
   } finally {
     client.release();
-  }
-}
-
-async function publishStaged(nats: NatsConnection, staged: readonly DomainEvent[]): Promise<void> {
-  if (staged.length === 0) {
-    return;
-  }
-  const js = nats.jetstream();
-  const encoder = new TextEncoder();
-  for (const event of staged) {
-    const envelope = {
-      id: event.id,
-      occurredAt: event.occurredAt ?? new Date(),
-      payload: event.payload,
-    };
-    // Await the PubAck so a publish failure surfaces to the caller rather
-    // than being fire-and-forget. `msgID` sets Nats-Msg-Id for broker-side
-    // de-dup within the stream's duplicate window.
-    await js.publish(event.type, encoder.encode(JSON.stringify(envelope)), {
-      ...(event.id ? { msgID: event.id } : {}),
-    });
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -784,6 +784,9 @@ importers:
       '@types/pg':
         specifier: ^8.15.5
         version: 8.20.0
+      node-pg-migrate:
+        specifier: ^8.0.4
+        version: 8.0.4(@types/pg@8.20.0)(pg@8.22.0)
       pg:
         specifier: ^8.22.0
         version: 8.22.0

--- a/services/applications/src/index.ts
+++ b/services/applications/src/index.ts
@@ -37,6 +37,12 @@ const main = async (): Promise<void> => {
       await ensureStream(nats);
     }
 
+    // Drain the transactional outbox (ADS-1048): the relay publishes any
+    // events the inline fast-path in withTransaction did not (a crash or NATS
+    // outage in the commit→publish window) so no committed event is lost.
+    const { startOutboxRelay } = await import('@adopt-dont-shop/events');
+    const outboxRelay = startOutboxRelay({ pool, nats, logger });
+
     grpc = await startGrpcServer({ config, pool, nats, logger });
     grpcReady = true;
     // GDPR erasure subscriber — drops the user's data in this schema.
@@ -67,8 +73,10 @@ const main = async (): Promise<void> => {
       environment: config.environment,
     });
 
-    const teardown = (): Promise<void> =>
-      runServiceShutdown({ httpServer, grpc, nats, pool, logger });
+    const teardown = (): Promise<void> => {
+      outboxRelay.stop();
+      return runServiceShutdown({ httpServer, grpc, nats, pool, logger });
+    };
 
     const shutdown = async (signal: string): Promise<void> => {
       logger.info('service.applications shutting down', { signal });

--- a/services/applications/src/migrations/011_create_event_outbox.ts
+++ b/services/applications/src/migrations/011_create_event_outbox.ts
@@ -1,0 +1,7 @@
+// event_outbox — the transactional outbox for this service's schema
+// (ADS-1048). The table DDL lives once in @adopt-dont-shop/events and is
+// re-exported here so its columns stay in lock-step with the relay/insert SQL
+// that reads them. `withTransaction` stages every domain event as a row in
+// this table inside the business transaction, and the outbox relay (started at
+// boot) drains it to JetStream. See packages/events/src/outbox-schema.ts.
+export { up, down } from '@adopt-dont-shop/events/outbox-schema';

--- a/services/applications/src/migrations/migrations.test.ts
+++ b/services/applications/src/migrations/migrations.test.ts
@@ -49,6 +49,7 @@ describe('applications migrations', () => {
     '008_create_application_documents.ts',
     '009_create_application_defaults.ts',
     '010_backfill_application_actioned_at.ts',
+    '011_create_event_outbox.ts',
   ])('%s exports `up` and `down` functions', async filename => {
     const mod = (await import(`./${filename}`)) as {
       up: unknown;

--- a/services/auth/src/grpc/admin-handlers.test.ts
+++ b/services/auth/src/grpc/admin-handlers.test.ts
@@ -81,6 +81,13 @@ function makeMocks() {
       if (op === 'BEGIN' || op === 'COMMIT' || op === 'ROLLBACK') {
         return { rows: [] };
       }
+      // The event_outbox INSERT/DELETE are framework infrastructure owned by
+      // withTransaction's transactional outbox, not queries the handler under
+      // test issues. Make them transparent so the scripted responses still line
+      // up with the handler's own business queries.
+      if (sql.includes('event_outbox')) {
+        return { rows: [] };
+      }
       const next = clientScript.shift();
       if (!next) {
         throw new Error(`client.query unscripted: ${sql.slice(0, 80)}`);

--- a/services/auth/src/grpc/handlers.test.ts
+++ b/services/auth/src/grpc/handlers.test.ts
@@ -393,6 +393,12 @@ describe('login', () => {
 
     const callOrder: string[] = [];
     mocks.clientMock.query.mockImplementation(async (sql: string) => {
+      // The event_outbox INSERT/DELETE are framework infrastructure from
+      // withTransaction's transactional outbox — skip them so the recorded
+      // order reflects only the handler's own business queries.
+      if (sql.includes('event_outbox')) {
+        return { rows: [] };
+      }
       const verb = sql.trim().split(/\s+/)[0];
       callOrder.push(verb);
       return { rows: [] };
@@ -909,6 +915,11 @@ describe('logout', () => {
 
     const callOrder: string[] = [];
     mocks.clientMock.query.mockImplementation(async (sql: string) => {
+      // Skip the event_outbox INSERT/DELETE — framework infrastructure from
+      // withTransaction's transactional outbox, not the handler's own queries.
+      if (sql.includes('event_outbox')) {
+        return { rows: [] };
+      }
       callOrder.push(sql.trim().split(/\s+/)[0]);
       return { rows: [] };
     });
@@ -1117,6 +1128,11 @@ describe('refreshToken', () => {
 
     const calls: string[] = [];
     mocks.clientMock.query.mockImplementation(async (sql: string) => {
+      // Skip the event_outbox INSERT/DELETE — framework infrastructure from
+      // withTransaction's transactional outbox, not the handler's own queries.
+      if (sql.includes('event_outbox')) {
+        return { rows: [], rowCount: 1 };
+      }
       calls.push(sql.trim().split(/\s+/)[0]);
       // The conditional revoke UPDATE must report a row was flipped so the
       // rotation proceeds.
@@ -1196,6 +1212,11 @@ describe('refreshToken', () => {
 
     const sqls: string[] = [];
     mocks.clientMock.query.mockImplementation(async (sql: string) => {
+      // Skip the event_outbox INSERT/DELETE — framework infrastructure from
+      // withTransaction's transactional outbox, not the handler's own queries.
+      if (sql.includes('event_outbox')) {
+        return { rows: [], rowCount: 1 };
+      }
       const verb = sql.trim().split(/\s+/)[0];
       sqls.push(verb);
       // The conditional revoke flips 0 rows — another request already rotated.
@@ -1335,6 +1356,11 @@ describe('refreshToken', () => {
 
     const clientCalls: Array<{ sql: string; params: unknown[] }> = [];
     mocks.clientMock.query.mockImplementation(async (sql: string, params: unknown[] = []) => {
+      // Skip the event_outbox INSERT/DELETE — framework infrastructure from
+      // withTransaction's transactional outbox, not the handler's own queries.
+      if (sql.includes('event_outbox')) {
+        return { rows: [], rowCount: 1 };
+      }
       const verb = sql.trim().split(/\s+/)[0];
       clientCalls.push({ sql, params });
       // First UPDATE is the rotation gate; return 0 rows to trigger concurrent-reuse path.
@@ -1616,6 +1642,11 @@ describe('assignRole', () => {
 
     const callOrder: string[] = [];
     mocks.clientMock.query.mockImplementation(async (sql: string) => {
+      // Skip the event_outbox INSERT/DELETE — framework infrastructure from
+      // withTransaction's transactional outbox, not the handler's own queries.
+      if (sql.includes('event_outbox')) {
+        return { rows: [] };
+      }
       callOrder.push(sql.trim().split(/\s+/)[0]);
       return { rows: [] };
     });

--- a/services/auth/src/grpc/privacy-handlers.test.ts
+++ b/services/auth/src/grpc/privacy-handlers.test.ts
@@ -38,6 +38,13 @@ function makeMocks() {
       if (op === 'BEGIN' || op === 'COMMIT' || op === 'ROLLBACK') {
         return { rows: [] };
       }
+      // The event_outbox INSERT/DELETE are framework infrastructure owned by
+      // withTransaction's transactional outbox, not queries the handler under
+      // test issues. Make them transparent so the scripted responses still line
+      // up with the handler's own business queries.
+      if (sql.includes('event_outbox')) {
+        return { rows: [] };
+      }
       const next = clientScript.shift();
       if (!next) {
         throw new Error(`client.query unscripted: ${sql.slice(0, 80)}`);

--- a/services/auth/src/grpc/privacy-prefs-handlers.test.ts
+++ b/services/auth/src/grpc/privacy-prefs-handlers.test.ts
@@ -48,6 +48,13 @@ function makeMocks() {
       if (op === 'BEGIN' || op === 'COMMIT' || op === 'ROLLBACK') {
         return { rows: [] };
       }
+      // The event_outbox INSERT/DELETE are framework infrastructure owned by
+      // withTransaction's transactional outbox, not queries the handler under
+      // test issues. Make them transparent so the scripted responses still line
+      // up with the handler's own business queries.
+      if (sql.includes('event_outbox')) {
+        return { rows: [] };
+      }
       const next = clientScript.shift();
       if (!next) {
         throw new Error(`client.query unscripted: ${sql.slice(0, 80)}`);

--- a/services/auth/src/grpc/session-handlers.test.ts
+++ b/services/auth/src/grpc/session-handlers.test.ts
@@ -61,7 +61,12 @@ function realQueries(mock: { mock: { calls: unknown[][] } }): string[] {
   return mock.mock.calls
     .filter(c => {
       const sql = String(c[0]);
-      return sql !== 'BEGIN' && sql !== 'COMMIT' && sql !== 'ROLLBACK';
+      // Exclude transaction control and the event_outbox INSERT/DELETE, which
+      // are framework infrastructure from withTransaction's transactional
+      // outbox rather than queries the handler under test issues.
+      return (
+        sql !== 'BEGIN' && sql !== 'COMMIT' && sql !== 'ROLLBACK' && !sql.includes('event_outbox')
+      );
     })
     .map(c => String(c[0]).trim().split(/\s+/)[0].toUpperCase());
 }

--- a/services/auth/src/index.ts
+++ b/services/auth/src/index.ts
@@ -36,6 +36,12 @@ const main = async (): Promise<void> => {
     const { ensureStream } = await import('@adopt-dont-shop/events');
     await ensureStream(nats);
 
+    // Drain the transactional outbox (ADS-1048): the relay publishes any
+    // events the inline fast-path in withTransaction did not (a crash or NATS
+    // outage in the commit→publish window) so no committed event is lost.
+    const { startOutboxRelay } = await import('@adopt-dont-shop/events');
+    const outboxRelay = startOutboxRelay({ pool, nats, logger });
+
     const passwordHasher = createBcryptPasswordHasher();
     const tokenIssuer = createJwtTokenIssuer({
       accessSecret: config.jwtSecret,
@@ -82,8 +88,10 @@ const main = async (): Promise<void> => {
       environment: config.environment,
     });
 
-    const teardown = (): Promise<void> =>
-      runServiceShutdown({ httpServer, grpc, nats, pool, logger });
+    const teardown = (): Promise<void> => {
+      outboxRelay.stop();
+      return runServiceShutdown({ httpServer, grpc, nats, pool, logger });
+    };
 
     const shutdown = async (signal: string): Promise<void> => {
       logger.info('service.auth shutting down', { signal });

--- a/services/auth/src/migrations/030_create_event_outbox.ts
+++ b/services/auth/src/migrations/030_create_event_outbox.ts
@@ -1,0 +1,7 @@
+// event_outbox — the transactional outbox for this service's schema
+// (ADS-1048). The table DDL lives once in @adopt-dont-shop/events and is
+// re-exported here so its columns stay in lock-step with the relay/insert SQL
+// that reads them. `withTransaction` stages every domain event as a row in
+// this table inside the business transaction, and the outbox relay (started at
+// boot) drains it to JetStream. See packages/events/src/outbox-schema.ts.
+export { up, down } from '@adopt-dont-shop/events/outbox-schema';

--- a/services/auth/src/migrations/migrations.test.ts
+++ b/services/auth/src/migrations/migrations.test.ts
@@ -48,6 +48,7 @@ describe('auth migrations', () => {
     '007_create_revoked_tokens.ts',
     '015_add_tokens_valid_from.ts',
     '027_encrypt_totp_secrets.ts',
+    '030_create_event_outbox.ts',
   ])('%s exports `up` and `down` functions', async filename => {
     const mod = (await import(`./${filename}`)) as {
       up: unknown;

--- a/services/chat/src/grpc/handlers.coverage.test.ts
+++ b/services/chat/src/grpc/handlers.coverage.test.ts
@@ -114,6 +114,12 @@ function makeMocks() {
       if (op === 'BEGIN' || op === 'COMMIT' || op === 'ROLLBACK') {
         return { rows: [] };
       }
+      // The transactional-outbox framework queries (INSERT/DELETE against
+      // event_outbox, emitted by withTransaction) are infrastructure, not
+      // business SQL — answer them transparently without consuming the script.
+      if (/event_outbox/i.test(sql)) {
+        return { rows: [], rowCount: 0 };
+      }
       const next = clientScript.shift();
       if (!next) {
         throw new Error(`client.query unscripted: ${sql.slice(0, 80)}`);

--- a/services/chat/src/grpc/handlers.test.ts
+++ b/services/chat/src/grpc/handlers.test.ts
@@ -105,6 +105,12 @@ function makeMocks() {
       if (op === 'BEGIN' || op === 'COMMIT' || op === 'ROLLBACK') {
         return { rows: [] };
       }
+      // The transactional-outbox framework queries (INSERT/DELETE against
+      // event_outbox, emitted by withTransaction) are infrastructure, not
+      // business SQL — answer them transparently without consuming the script.
+      if (/event_outbox/i.test(sql)) {
+        return { rows: [], rowCount: 0 };
+      }
       const next = clientScript.shift();
       if (!next) {
         throw new Error(`client.query unscripted: ${sql.slice(0, 80)}`);
@@ -140,7 +146,9 @@ function makeMocks() {
 
 const realClientQueries = (mocks: ReturnType<typeof makeMocks>): string[] =>
   (mocks.clientMock.query.mock.calls as Array<[string]>)
-    .map(([sql]) => sql.trim().split(/\s+/)[0].toUpperCase())
+    .map(([sql]) => sql)
+    .filter(sql => !/event_outbox/i.test(sql))
+    .map(sql => sql.trim().split(/\s+/)[0].toUpperCase())
     .filter(op => op !== 'BEGIN' && op !== 'COMMIT' && op !== 'ROLLBACK');
 
 // --- OpenChat -------------------------------------------------------

--- a/services/chat/src/index.ts
+++ b/services/chat/src/index.ts
@@ -34,6 +34,12 @@ const main = async (): Promise<void> => {
       await ensureStream(nats);
     }
 
+    // Drain the transactional outbox (ADS-1048): the relay publishes any
+    // events the inline fast-path in withTransaction did not (a crash or NATS
+    // outage in the commit→publish window) so no committed event is lost.
+    const { startOutboxRelay } = await import('@adopt-dont-shop/events');
+    const outboxRelay = startOutboxRelay({ pool, nats, logger });
+
     grpc = await startGrpcServer({ config, pool, nats, logger });
     grpcReady = true;
     // GDPR erasure subscriber — drops the user's data in this schema.
@@ -64,8 +70,10 @@ const main = async (): Promise<void> => {
       environment: config.environment,
     });
 
-    const teardown = (): Promise<void> =>
-      runServiceShutdown({ httpServer, grpc, nats, pool, logger });
+    const teardown = (): Promise<void> => {
+      outboxRelay.stop();
+      return runServiceShutdown({ httpServer, grpc, nats, pool, logger });
+    };
 
     const shutdown = async (signal: string): Promise<void> => {
       logger.info('service.chat shutting down', { signal });

--- a/services/chat/src/migrations/007_create_event_outbox.ts
+++ b/services/chat/src/migrations/007_create_event_outbox.ts
@@ -1,0 +1,7 @@
+// event_outbox — the transactional outbox for this service's schema
+// (ADS-1048). The table DDL lives once in @adopt-dont-shop/events and is
+// re-exported here so its columns stay in lock-step with the relay/insert SQL
+// that reads them. `withTransaction` stages every domain event as a row in
+// this table inside the business transaction, and the outbox relay (started at
+// boot) drains it to JetStream. See packages/events/src/outbox-schema.ts.
+export { up, down } from '@adopt-dont-shop/events/outbox-schema';

--- a/services/chat/src/migrations/migrations.test.ts
+++ b/services/chat/src/migrations/migrations.test.ts
@@ -46,6 +46,7 @@ describe('chat migrations', () => {
     '004_install_messages_search_vector_trigger.ts',
     '005_create_message_reactions.ts',
     '006_create_message_reads.ts',
+    '007_create_event_outbox.ts',
   ])('%s exports `up` and `down` functions', async filename => {
     const mod = (await import(`./${filename}`)) as {
       up: unknown;

--- a/services/cms/src/grpc/handlers.gaps.test.ts
+++ b/services/cms/src/grpc/handlers.gaps.test.ts
@@ -53,7 +53,10 @@ function makeMocks() {
   const client = {
     query: vi.fn(async (sql: string) => {
       const op = sql.trim().split(/\s+/)[0].toUpperCase();
-      if (op === 'BEGIN' || op === 'COMMIT' || op === 'ROLLBACK') {
+      // Treat outbox framework queries (transactional-outbox INSERT/DELETE that
+      // withTransaction now runs) like BEGIN/COMMIT/ROLLBACK: transparent, no
+      // script consumed.
+      if (op === 'BEGIN' || op === 'COMMIT' || op === 'ROLLBACK' || /event_outbox/i.test(sql)) {
         return { rows: [], rowCount: 0 };
       }
       const next = clientScript.shift();

--- a/services/cms/src/grpc/handlers.test.ts
+++ b/services/cms/src/grpc/handlers.test.ts
@@ -55,7 +55,10 @@ function makeMocks() {
   const client = {
     query: vi.fn(async (sql: string) => {
       const op = sql.trim().split(/\s+/)[0].toUpperCase();
-      if (op === 'BEGIN' || op === 'COMMIT' || op === 'ROLLBACK') {
+      // Treat outbox framework queries (transactional-outbox INSERT/DELETE that
+      // withTransaction now runs) like BEGIN/COMMIT/ROLLBACK: transparent, no
+      // script consumed.
+      if (op === 'BEGIN' || op === 'COMMIT' || op === 'ROLLBACK' || /event_outbox/i.test(sql)) {
         return { rows: [], rowCount: 0 };
       }
       const next = clientScript.shift();

--- a/services/cms/src/index.ts
+++ b/services/cms/src/index.ts
@@ -29,6 +29,12 @@ const main = async (): Promise<void> => {
       const { ensureStream } = await import('@adopt-dont-shop/events');
       await ensureStream(nats);
     }
+
+    // Drain the transactional outbox (ADS-1048): the relay publishes any
+    // events the inline fast-path in withTransaction did not (a crash or NATS
+    // outage in the commit→publish window) so no committed event is lost.
+    const { startOutboxRelay } = await import('@adopt-dont-shop/events');
+    const outboxRelay = startOutboxRelay({ pool, nats, logger });
     grpc = await startGrpcServer({ config, pool, nats, logger });
     grpcReady = true;
     // GDPR erasure subscriber — drops the user's data in this schema.
@@ -59,8 +65,10 @@ const main = async (): Promise<void> => {
       environment: config.environment,
     });
 
-    const teardown = (): Promise<void> =>
-      runServiceShutdown({ httpServer, grpc, nats, pool, logger });
+    const teardown = (): Promise<void> => {
+      outboxRelay.stop();
+      return runServiceShutdown({ httpServer, grpc, nats, pool, logger });
+    };
 
     const shutdown = async (signal: string): Promise<void> => {
       logger.info('service.cms shutting down', { signal });

--- a/services/cms/src/migrations/004_create_event_outbox.ts
+++ b/services/cms/src/migrations/004_create_event_outbox.ts
@@ -1,0 +1,7 @@
+// event_outbox — the transactional outbox for this service's schema
+// (ADS-1048). The table DDL lives once in @adopt-dont-shop/events and is
+// re-exported here so its columns stay in lock-step with the relay/insert SQL
+// that reads them. `withTransaction` stages every domain event as a row in
+// this table inside the business transaction, and the outbox relay (started at
+// boot) drains it to JetStream. See packages/events/src/outbox-schema.ts.
+export { up, down } from '@adopt-dont-shop/events/outbox-schema';

--- a/services/matching/src/index.ts
+++ b/services/matching/src/index.ts
@@ -37,6 +37,12 @@ const main = async (): Promise<void> => {
       await ensureStream(nats);
     }
 
+    // Drain the transactional outbox (ADS-1048): the relay publishes any
+    // events the inline fast-path in withTransaction did not (a crash or NATS
+    // outage in the commit→publish window) so no committed event is lost.
+    const { startOutboxRelay } = await import('@adopt-dont-shop/events');
+    const outboxRelay = startOutboxRelay({ pool, nats, logger });
+
     grpc = await startGrpcServer({ config, pool, nats, logger });
     grpcReady = true;
     // GDPR erasure subscriber — drops the user's data in this schema.
@@ -67,8 +73,10 @@ const main = async (): Promise<void> => {
       environment: config.environment,
     });
 
-    const teardown = (): Promise<void> =>
-      runServiceShutdown({ httpServer, grpc, nats, pool, logger });
+    const teardown = (): Promise<void> => {
+      outboxRelay.stop();
+      return runServiceShutdown({ httpServer, grpc, nats, pool, logger });
+    };
 
     const shutdown = async (signal: string): Promise<void> => {
       logger.info('service.matching shutting down', { signal });

--- a/services/matching/src/migrations/005_create_event_outbox.ts
+++ b/services/matching/src/migrations/005_create_event_outbox.ts
@@ -1,0 +1,7 @@
+// event_outbox — the transactional outbox for this service's schema
+// (ADS-1048). The table DDL lives once in @adopt-dont-shop/events and is
+// re-exported here so its columns stay in lock-step with the relay/insert SQL
+// that reads them. `withTransaction` stages every domain event as a row in
+// this table inside the business transaction, and the outbox relay (started at
+// boot) drains it to JetStream. See packages/events/src/outbox-schema.ts.
+export { up, down } from '@adopt-dont-shop/events/outbox-schema';

--- a/services/matching/src/migrations/migrations.test.ts
+++ b/services/matching/src/migrations/migrations.test.ts
@@ -38,6 +38,7 @@ describe('matching migrations', () => {
     '002_create_swipe_actions.ts',
     '003_create_adopter_match_profiles.ts',
     '004_swipe_actions_user_pet_recency_idx.ts',
+    '005_create_event_outbox.ts',
   ])('%s exports `up` and `down` functions', async filename => {
     const mod = (await import(`./${filename}`)) as {
       up: unknown;

--- a/services/moderation/src/index.ts
+++ b/services/moderation/src/index.ts
@@ -38,6 +38,12 @@ const main = async (): Promise<void> => {
       await ensureStream(nats);
     }
 
+    // Drain the transactional outbox (ADS-1048): the relay publishes any
+    // events the inline fast-path in withTransaction did not (a crash or NATS
+    // outage in the commit→publish window) so no committed event is lost.
+    const { startOutboxRelay } = await import('@adopt-dont-shop/events');
+    const outboxRelay = startOutboxRelay({ pool, nats, logger });
+
     grpc = await startGrpcServer({ config, pool, nats, logger });
     grpcReady = true;
     // GDPR erasure subscriber — drops the user's data in this schema.
@@ -74,8 +80,10 @@ const main = async (): Promise<void> => {
       environment: config.environment,
     });
 
-    const teardown = (): Promise<void> =>
-      runServiceShutdown({ httpServer, grpc, nats, pool, logger });
+    const teardown = (): Promise<void> => {
+      outboxRelay.stop();
+      return runServiceShutdown({ httpServer, grpc, nats, pool, logger });
+    };
 
     const shutdown = async (signal: string): Promise<void> => {
       logger.info('service.moderation shutting down', { signal });

--- a/services/moderation/src/migrations/013_create_event_outbox.ts
+++ b/services/moderation/src/migrations/013_create_event_outbox.ts
@@ -1,0 +1,7 @@
+// event_outbox — the transactional outbox for this service's schema
+// (ADS-1048). The table DDL lives once in @adopt-dont-shop/events and is
+// re-exported here so its columns stay in lock-step with the relay/insert SQL
+// that reads them. `withTransaction` stages every domain event as a row in
+// this table inside the business transaction, and the outbox relay (started at
+// boot) drains it to JetStream. See packages/events/src/outbox-schema.ts.
+export { up, down } from '@adopt-dont-shop/events/outbox-schema';

--- a/services/moderation/src/migrations/migrations.test.ts
+++ b/services/moderation/src/migrations/migrations.test.ts
@@ -50,6 +50,7 @@ describe('moderation migrations', () => {
     '009_add_system_autoreport_unique_index.ts',
     '010_make_reporter_id_nullable.ts',
     '011_add_sanction_acknowledged_at.ts',
+    '013_create_event_outbox.ts',
   ])('%s exports `up` and `down` functions', async filename => {
     const mod = (await import(`./${filename}`)) as {
       up: unknown;

--- a/services/notifications/src/grpc/broadcast-handlers.test.ts
+++ b/services/notifications/src/grpc/broadcast-handlers.test.ts
@@ -30,6 +30,11 @@ function makeMocks(authClient?: AuthCohortClient, logger?: Logger) {
       if (op === 'BEGIN' || op === 'COMMIT' || op === 'ROLLBACK') {
         return { rows: [] };
       }
+      // event_outbox INSERT/DELETE is withTransaction's outbox plumbing — let
+      // it pass through like BEGIN/COMMIT without consuming a scripted response.
+      if (sql.includes('event_outbox')) {
+        return { rows: [] };
+      }
       const next = clientScript.shift();
       if (!next) {
         throw new Error(`client.query unscripted: ${sql.slice(0, 80)}`);
@@ -201,6 +206,10 @@ describe('broadcast', () => {
       if (op === 'BEGIN' || op === 'COMMIT' || op === 'ROLLBACK') {
         return { rows: [] };
       }
+      // event_outbox writes are withTransaction's outbox plumbing.
+      if (sql.includes('event_outbox')) {
+        return { rows: [] };
+      }
       if (sql.includes('INSERT INTO notifications.notifications')) {
         insertCount++;
         if (insertCount === 1) {
@@ -246,6 +255,10 @@ describe('broadcast', () => {
     mocks.clientMock.query = vi.fn(async (sql: string) => {
       const op = sql.trim().split(/\s+/)[0].toUpperCase();
       if (op === 'BEGIN' || op === 'COMMIT' || op === 'ROLLBACK') {
+        return { rows: [] };
+      }
+      // event_outbox writes are withTransaction's outbox plumbing.
+      if (sql.includes('event_outbox')) {
         return { rows: [] };
       }
       if (sql.includes('INSERT INTO notifications.notifications')) {
@@ -297,6 +310,10 @@ describe('broadcast', () => {
     mocks.clientMock.query = vi.fn(async (sql: string) => {
       const op = sql.trim().split(/\s+/)[0].toUpperCase();
       if (op === 'BEGIN' || op === 'COMMIT' || op === 'ROLLBACK') {
+        return { rows: [] };
+      }
+      // event_outbox writes are withTransaction's outbox plumbing.
+      if (sql.includes('event_outbox')) {
         return { rows: [] };
       }
       if (sql.includes('INSERT INTO notifications.notifications')) {

--- a/services/notifications/src/grpc/email-handlers.test.ts
+++ b/services/notifications/src/grpc/email-handlers.test.ts
@@ -74,6 +74,11 @@ function makeMocks() {
       if (op === 'BEGIN' || op === 'COMMIT' || op === 'ROLLBACK') {
         return { rows: [] };
       }
+      // event_outbox INSERT/DELETE is withTransaction's outbox plumbing — let
+      // it pass through like BEGIN/COMMIT without consuming a scripted response.
+      if (sql.includes('event_outbox')) {
+        return { rows: [], rowCount: 0 };
+      }
       const next = clientScript.shift();
       if (!next) {
         throw new Error(`client.query called with no scripted response for: ${sql.slice(0, 80)}`);
@@ -115,6 +120,7 @@ function makeMocks() {
 // so assertions can match on the substantive queries.
 const realClientQueries = (mocks: ReturnType<typeof makeMocks>): string[] =>
   (mocks.clientMock.query.mock.calls as Array<[string]>)
+    .filter(([sql]) => !sql.includes('event_outbox'))
     .map(([sql]) => sql.trim().split(/\s+/)[0].toUpperCase())
     .filter(op => op !== 'BEGIN' && op !== 'COMMIT' && op !== 'ROLLBACK');
 

--- a/services/notifications/src/grpc/handlers.test.ts
+++ b/services/notifications/src/grpc/handlers.test.ts
@@ -152,6 +152,11 @@ describe('createNotification', () => {
     // Track call order so we can assert publish-after-commit.
     const calls: string[] = [];
     mocks.clientMock.query.mockImplementation(async (sql: string) => {
+      // event_outbox writes are withTransaction's outbox plumbing, not part of
+      // the handler's own query sequence — don't record them.
+      if (sql.includes('event_outbox')) {
+        return { rows: [] };
+      }
       calls.push(sql.trim().split(/\s+/)[0]);
       if (sql.trim().startsWith('INSERT')) {
         return { rows: [insertedRow] };
@@ -389,6 +394,11 @@ describe('dismissNotification', () => {
 
     const calls: string[] = [];
     mocks.clientMock.query.mockImplementation(async (sql: string) => {
+      // event_outbox writes are withTransaction's outbox plumbing, not part of
+      // the handler's own query sequence — don't record them.
+      if (sql.includes('event_outbox')) {
+        return { rows: [] };
+      }
       calls.push(sql.trim().split(/\s+/)[0]);
       if (sql.trim().startsWith('UPDATE')) {
         return { rows: [updated] };
@@ -434,6 +444,11 @@ describe('createNotification idempotency (dedup)', () => {
   // claim happens before the insert, inside the one transaction.
   const wireClient = (claimRowCount: number, calls: string[]): void => {
     mocks.clientMock.query.mockImplementation(async (sql: string) => {
+      // event_outbox writes are withTransaction's outbox plumbing, not part of
+      // the claim/insert sequence under test — don't record them.
+      if (sql.includes('event_outbox')) {
+        return { rowCount: 0, rows: [] };
+      }
       if (sql.includes('processed_events')) {
         calls.push('CLAIM');
         return { rowCount: claimRowCount, rows: [] };

--- a/services/notifications/src/grpc/notification-prefs-handlers.test.ts
+++ b/services/notifications/src/grpc/notification-prefs-handlers.test.ts
@@ -61,6 +61,11 @@ function makeMocks() {
       if (op === 'BEGIN' || op === 'COMMIT' || op === 'ROLLBACK') {
         return { rows: [] };
       }
+      // event_outbox INSERT/DELETE is withTransaction's outbox plumbing — let
+      // it pass through like BEGIN/COMMIT without consuming a scripted response.
+      if (sql.includes('event_outbox')) {
+        return { rows: [], rowCount: 0 };
+      }
       const next = clientScript.shift();
       if (!next) {
         throw new Error(`client.query unscripted: ${sql.slice(0, 80)}`);

--- a/services/notifications/src/index.ts
+++ b/services/notifications/src/index.ts
@@ -58,6 +58,12 @@ const main = async (): Promise<void> => {
       await ensureStream(nats);
     }
 
+    // Drain the transactional outbox (ADS-1048): the relay publishes any
+    // events the inline fast-path in withTransaction did not (a crash or NATS
+    // outage in the commit→publish window) so no committed event is lost.
+    const { startOutboxRelay } = await import('@adopt-dont-shop/events');
+    const outboxRelay = startOutboxRelay({ pool, nats, logger });
+
     // Auth-cohort client for the Broadcast RPC. Only created when the
     // AUTH_GRPC_URL env is set; without it, Broadcast returns INTERNAL.
     const authClient = config.authGrpcUrl
@@ -210,8 +216,10 @@ const main = async (): Promise<void> => {
       environment: config.environment,
     });
 
-    const teardown = (): Promise<void> =>
-      runServiceShutdown({ httpServer, grpc, nats, pool, logger });
+    const teardown = (): Promise<void> => {
+      outboxRelay.stop();
+      return runServiceShutdown({ httpServer, grpc, nats, pool, logger });
+    };
 
     const shutdown = async (signal: string): Promise<void> => {
       logger.info('service.notifications shutting down', { signal });

--- a/services/notifications/src/migrations/011_create_event_outbox.ts
+++ b/services/notifications/src/migrations/011_create_event_outbox.ts
@@ -1,0 +1,7 @@
+// event_outbox — the transactional outbox for this service's schema
+// (ADS-1048). The table DDL lives once in @adopt-dont-shop/events and is
+// re-exported here so its columns stay in lock-step with the relay/insert SQL
+// that reads them. `withTransaction` stages every domain event as a row in
+// this table inside the business transaction, and the outbox relay (started at
+// boot) drains it to JetStream. See packages/events/src/outbox-schema.ts.
+export { up, down } from '@adopt-dont-shop/events/outbox-schema';

--- a/services/notifications/src/migrations/migrations.test.ts
+++ b/services/notifications/src/migrations/migrations.test.ts
@@ -53,6 +53,7 @@ describe('notifications migrations', () => {
     '008_create_processed_events.ts',
     '009_device_token_global_unique.ts',
     '010_create_scheduled_job_runs.ts',
+    '011_create_event_outbox.ts',
   ])('%s exports `up` and `down` functions', async filename => {
     const mod = (await import(`./${filename}`)) as {
       up: unknown;

--- a/services/pets/src/grpc/handlers.test.ts
+++ b/services/pets/src/grpc/handlers.test.ts
@@ -186,7 +186,11 @@ describe('createPet', () => {
   it('inserts inside a transaction and publishes pets.created AFTER commit', async () => {
     const order: string[] = [];
     mocks.clientMock.query.mockImplementation(async (sql: string) => {
-      order.push(sql.trim().split(/\s+/)[0]);
+      // event_outbox queries are withTransaction's outbox plumbing, not the
+      // handler's own SQL — skip them so the verb order reflects the handler.
+      if (!sql.includes('event_outbox')) {
+        order.push(sql.trim().split(/\s+/)[0]);
+      }
       return { rows: [petRow()] };
     });
     mocks.natsMock.publish.mockImplementation(() => order.push('NATS_PUBLISH'));
@@ -472,7 +476,11 @@ describe('updatePet', () => {
     mocks.poolMock.query.mockResolvedValueOnce({ rows: [petRow()] });
     const order: string[] = [];
     mocks.clientMock.query.mockImplementation(async (sql: string) => {
-      order.push(sql.trim().split(/\s+/)[0]);
+      // event_outbox queries are withTransaction's outbox plumbing, not the
+      // handler's own SQL — skip them so the verb order reflects the handler.
+      if (!sql.includes('event_outbox')) {
+        order.push(sql.trim().split(/\s+/)[0]);
+      }
       return { rows: [petRow({ name: 'Rexy' })] };
     });
     mocks.natsMock.publish.mockImplementation(() => order.push('NATS_PUBLISH'));
@@ -543,7 +551,11 @@ describe('updatePetStatus', () => {
     mocks.poolMock.query.mockResolvedValueOnce({ rows: [petRow({ status: 'available' })] });
     const order: string[] = [];
     mocks.clientMock.query.mockImplementation(async (sql: string) => {
-      order.push(sql.trim().split(/\s+/)[0]);
+      // event_outbox queries are withTransaction's outbox plumbing, not the
+      // handler's own SQL — skip them so the verb order reflects the handler.
+      if (!sql.includes('event_outbox')) {
+        order.push(sql.trim().split(/\s+/)[0]);
+      }
       // The in-transaction lock read still sees `available`; the UPDATE
       // returns the post-write `pending` row.
       if (/FOR UPDATE/.test(sql)) {
@@ -636,7 +648,11 @@ describe('deletePet', () => {
     mocks.poolMock.query.mockResolvedValueOnce({ rows: [petRow()] });
     const order: string[] = [];
     mocks.clientMock.query.mockImplementation(async (sql: string) => {
-      order.push(sql.trim().split(/\s+/)[0]);
+      // event_outbox queries are withTransaction's outbox plumbing, not the
+      // handler's own SQL — skip them so the verb order reflects the handler.
+      if (!sql.includes('event_outbox')) {
+        order.push(sql.trim().split(/\s+/)[0]);
+      }
       return { rows: [] };
     });
     mocks.natsMock.publish.mockImplementation(() => order.push('NATS_PUBLISH'));

--- a/services/pets/src/index.ts
+++ b/services/pets/src/index.ts
@@ -36,6 +36,12 @@ const main = async (): Promise<void> => {
       await ensureStream(nats);
     }
 
+    // Drain the transactional outbox (ADS-1048): the relay publishes any
+    // events the inline fast-path in withTransaction did not (a crash or NATS
+    // outage in the commit→publish window) so no committed event is lost.
+    const { startOutboxRelay } = await import('@adopt-dont-shop/events');
+    const outboxRelay = startOutboxRelay({ pool, nats, logger });
+
     grpc = await startGrpcServer({ config, pool, nats, logger });
     grpcReady = true;
     // GDPR erasure subscriber — drops the user's data in this schema.
@@ -66,8 +72,10 @@ const main = async (): Promise<void> => {
       environment: config.environment,
     });
 
-    const teardown = (): Promise<void> =>
-      runServiceShutdown({ httpServer, grpc, nats, pool, logger });
+    const teardown = (): Promise<void> => {
+      outboxRelay.stop();
+      return runServiceShutdown({ httpServer, grpc, nats, pool, logger });
+    };
 
     const shutdown = async (signal: string): Promise<void> => {
       logger.info('service.pets shutting down', { signal });

--- a/services/pets/src/migrations/008_create_event_outbox.ts
+++ b/services/pets/src/migrations/008_create_event_outbox.ts
@@ -1,0 +1,7 @@
+// event_outbox — the transactional outbox for this service's schema
+// (ADS-1048). The table DDL lives once in @adopt-dont-shop/events and is
+// re-exported here so its columns stay in lock-step with the relay/insert SQL
+// that reads them. `withTransaction` stages every domain event as a row in
+// this table inside the business transaction, and the outbox relay (started at
+// boot) drains it to JetStream. See packages/events/src/outbox-schema.ts.
+export { up, down } from '@adopt-dont-shop/events/outbox-schema';

--- a/services/pets/src/migrations/migrations.test.ts
+++ b/services/pets/src/migrations/migrations.test.ts
@@ -46,6 +46,7 @@ describe('pets migrations', () => {
     '005_create_ratings.ts',
     '006_create_user_favorites.ts',
     '007_pets_list_keyset_index.ts',
+    '008_create_event_outbox.ts',
   ])('%s exports `up` and `down` functions', async filename => {
     const mod = (await import(`./${filename}`)) as {
       up: unknown;

--- a/services/rescue/src/grpc/handlers.test.ts
+++ b/services/rescue/src/grpc/handlers.test.ts
@@ -157,7 +157,9 @@ describe('createRescue', () => {
   it('inserts in a transaction and publishes rescue.created AFTER commit', async () => {
     const order: string[] = [];
     mocks.clientMock.query.mockImplementation(async (sql: string) => {
-      order.push(sql.trim().split(/\s+/)[0]);
+      // event_outbox INSERT/DELETE are withTransaction's outbox plumbing —
+      // not part of the handler's own query sequence, so keep them out of `order`.
+      if (!sql.includes('event_outbox')) order.push(sql.trim().split(/\s+/)[0]);
       return { rows: [rescueRow()] };
     });
     mocks.natsMock.publish.mockImplementation(() => order.push('NATS_PUBLISH'));
@@ -403,7 +405,9 @@ describe('updateRescue', () => {
     mocks.poolMock.query.mockResolvedValueOnce({ rows: [rescueRow()] });
     const order: string[] = [];
     mocks.clientMock.query.mockImplementation(async (sql: string) => {
-      order.push(sql.trim().split(/\s+/)[0]);
+      // event_outbox INSERT/DELETE are withTransaction's outbox plumbing —
+      // not part of the handler's own query sequence, so keep them out of `order`.
+      if (!sql.includes('event_outbox')) order.push(sql.trim().split(/\s+/)[0]);
       return { rows: [rescueRow({ name: 'Pawsome 2' })] };
     });
     mocks.natsMock.publish.mockImplementation(() => order.push('NATS_PUBLISH'));
@@ -527,7 +531,9 @@ describe('verifyRescue', () => {
     const order: string[] = [];
     const publishedSubjects: string[] = [];
     mocks.clientMock.query.mockImplementation(async (sql: string) => {
-      order.push(sql.trim().split(/\s+/)[0]);
+      // event_outbox INSERT/DELETE are withTransaction's outbox plumbing —
+      // not part of the handler's own query sequence, so keep them out of `order`.
+      if (!sql.includes('event_outbox')) order.push(sql.trim().split(/\s+/)[0]);
       return { rows: [rescueRow({ status: 'verified' })] };
     });
     mocks.natsMock.publish.mockImplementation((subject: string) => {
@@ -621,7 +627,9 @@ describe('inviteStaff', () => {
     mocks.poolMock.query.mockResolvedValueOnce({ rows: [rescueRow()] });
     const order: string[] = [];
     mocks.clientMock.query.mockImplementation(async (sql: string) => {
-      order.push(sql.trim().split(/\s+/)[0]);
+      // event_outbox INSERT/DELETE are withTransaction's outbox plumbing —
+      // not part of the handler's own query sequence, so keep them out of `order`.
+      if (!sql.includes('event_outbox')) order.push(sql.trim().split(/\s+/)[0]);
       return {
         rows: [
           {
@@ -655,7 +663,8 @@ describe('inviteStaff', () => {
     mocks.poolMock.query.mockResolvedValueOnce({ rows: [rescueRow()] });
     let insertSql = '';
     mocks.clientMock.query.mockImplementation(async (sql: string) => {
-      if (sql.trim().startsWith('INSERT')) {
+      // Skip withTransaction's event_outbox INSERT — capture the handler's own.
+      if (sql.trim().startsWith('INSERT') && !sql.includes('event_outbox')) {
         insertSql = sql;
       }
       return {
@@ -812,7 +821,9 @@ describe('updateRescuePlan', () => {
     const order: string[] = [];
     const publishedSubjects: string[] = [];
     mocks.clientMock.query.mockImplementation(async (sql: string) => {
-      order.push(sql.trim().split(/\s+/)[0]);
+      // event_outbox INSERT/DELETE are withTransaction's outbox plumbing —
+      // not part of the handler's own query sequence, so keep them out of `order`.
+      if (!sql.includes('event_outbox')) order.push(sql.trim().split(/\s+/)[0]);
       return { rows: [rescueRow({ plan: 'professional' })] };
     });
     mocks.natsMock.publish.mockImplementation((subject: string) => {

--- a/services/rescue/src/index.ts
+++ b/services/rescue/src/index.ts
@@ -36,6 +36,12 @@ const main = async (): Promise<void> => {
       await ensureStream(nats);
     }
 
+    // Drain the transactional outbox (ADS-1048): the relay publishes any
+    // events the inline fast-path in withTransaction did not (a crash or NATS
+    // outage in the commit→publish window) so no committed event is lost.
+    const { startOutboxRelay } = await import('@adopt-dont-shop/events');
+    const outboxRelay = startOutboxRelay({ pool, nats, logger });
+
     grpc = await startGrpcServer({ config, pool, nats, logger });
     grpcReady = true;
     // GDPR erasure subscriber — drops the user's data in this schema.
@@ -66,8 +72,10 @@ const main = async (): Promise<void> => {
       environment: config.environment,
     });
 
-    const teardown = (): Promise<void> =>
-      runServiceShutdown({ httpServer, grpc, nats, pool, logger });
+    const teardown = (): Promise<void> => {
+      outboxRelay.stop();
+      return runServiceShutdown({ httpServer, grpc, nats, pool, logger });
+    };
 
     const shutdown = async (signal: string): Promise<void> => {
       logger.info('service.rescue shutting down', { signal });

--- a/services/rescue/src/migrations/011_create_event_outbox.ts
+++ b/services/rescue/src/migrations/011_create_event_outbox.ts
@@ -1,0 +1,7 @@
+// event_outbox — the transactional outbox for this service's schema
+// (ADS-1048). The table DDL lives once in @adopt-dont-shop/events and is
+// re-exported here so its columns stay in lock-step with the relay/insert SQL
+// that reads them. `withTransaction` stages every domain event as a row in
+// this table inside the business transaction, and the outbox relay (started at
+// boot) drains it to JetStream. See packages/events/src/outbox-schema.ts.
+export { up, down } from '@adopt-dont-shop/events/outbox-schema';

--- a/services/rescue/src/migrations/migrations.test.ts
+++ b/services/rescue/src/migrations/migrations.test.ts
@@ -47,6 +47,7 @@ describe('rescue migrations', () => {
     '006_create_application_questions.ts',
     '007_invitation_pending_unique.ts',
     '008_add_rescue_plan.ts',
+    '011_create_event_outbox.ts',
   ])('%s exports `up` and `down` functions', async filename => {
     const mod = (await import(`./${filename}`)) as {
       up: unknown;


### PR DESCRIPTION
## Summary

- Fixes the commit-then-publish **dual-write** in `withTransaction`: a crash between `COMMIT` and the JetStream ack silently lost terminal events (e.g. `applications.approved` → notification never sent, `audit_events` row never written, moderation scan never run).
- Staged events are now written to an `event_outbox` row **inside the same transaction** as the business write, so the event is durable atomically with the state change — no dual-write window, no phantom events on rollback, **no lost events after commit**.
- Delivery is two-phase: an inline fast-path (keeps current latency) plus a per-service background **relay** that is the durability guarantee and doubles as the reconciliation job the ticket asks for.

## Changes

- **`packages/events`**
  - `src/outbox-schema.ts` — `event_outbox` table DDL (single source of truth), re-exported via the new `./outbox-schema` subpath for per-service migrations.
  - `src/outbox.ts` — outbox insert, `publishRecord`, `flushInline` (inline fast-path), `relayOutboxOnce` / `startOutboxRelay` (background relay + one-shot reconciliation), and metrics.
  - `src/publish.ts` — `withTransaction` now stages events into `event_outbox` in-transaction, then best-effort inline publish; a publish failure no longer fails the caller (the relay delivers). `WithTransactionDeps` gains an optional `logger`.
  - `src/index.ts`, `package.json` — export the relay API and the `./outbox-schema` subpath; add `node-pg-migrate` as an optional peer for the DDL.
  - `README.md` — documents the outbox, the two-phase delivery, and the metrics.
- **9 event-publishing services** (`auth`, `pets`, `rescue`, `applications`, `chat`, `notifications`, `moderation`, `matching`, `cms`)
  - `src/migrations/NNN_create_event_outbox.ts` — creates `event_outbox` in the service's own schema (re-exports the shared DDL).
  - `src/index.ts` — starts the relay after `ensureStream` and stops it in teardown.
- **Tests** — the outbox `INSERT`/`DELETE` are treated as `withTransaction` framework infrastructure and made transparent to handler-test mocks, so business and publish assertions are unchanged. New behaviour is covered in `packages/events` (`outbox.test.ts`, `publish.test.ts`).

Rows are deleted on publish, so `event_outbox` is a self-cleaning queue (no unbounded ledger). Redelivery is safe by construction — JetStream de-dups on `Nats-Msg-Id` and every consumer is idempotent on the event id. Metrics: `events_outbox_pending` (gauge, the primary backlog alert), `events_outbox_published_total`, `events_outbox_publish_failures_total`.

`audit` and `gateway` are intentionally excluded — they publish GDPR events directly via NATS and never stage events through `withTransaction`.

## Before requesting review

- [x] Ran the equivalent of `pnpm ci:local:quick` locally (per-package test + type-check + lint on all changed packages)
- [x] Tests for new behaviour added (TDD — outbox insert/relay/inline-flush covered in `packages/events`)
- [ ] If touching `.env` requirements, updated `.env.example`'s REQUIRED block — n/a (no env changes)
- [ ] If touching a `lib.*`, considered consumer impact — n/a (touches `packages/events` + services only)

## Test plan

- [x] Existing tests pass — all changed packages green: events (113), auth (396), pets (175), rescue (257), applications (309), chat (156), notifications (301), moderation (330), matching (178), cms (116)
- [x] New behaviour is covered by tests (`packages/events/src/outbox.test.ts`, `publish.test.ts`)
- [ ] Tested manually — not run against a live stack in this change; relies on the test suite. The migrations + relay wiring will be exercised end-to-end by the docker-compose stack smoke.
- [x] No TypeScript errors (`type-check` clean across all changed packages)
- [x] Lint passes (0 errors; only pre-existing warnings in unrelated files)

## Related

- Linear: [ADS-1048](https://linear.app/ideasquared/issue/ADS-1048/high-commit-then-publish-dual-write-with-no-outbox-terminal-events-can) (parent: ADS-1039 — Production Readiness Review)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PvrZqp1QuTcvFHKAy4AFFN)_