### PR TITLE
chore(review): record daily-code-review checkpoint at 823e28a

### DIFF
--- a/.claude/daily-code-review-checkpoint.json
+++ b/.claude/daily-code-review-checkpoint.json
@@ -1,0 +1,12 @@
+{
+  "description": "Checkpoint for the Daily Code Review routine. Records the last commit on the default branch (main) that has been reviewed. The next run diffs main from this SHA forward. Update after each run.",
+  "lastReviewedCommit": "823e28a7a20f5d84cc5ecc62db9139c2807759aa",
+  "lastReviewedDate": "2026-08-05",
+  "lastRun": {
+    "date": "2026-08-05",
+    "range": "b739507..823e28a",
+    "commitsReviewed": 23,
+    "ticketsFiled": ["ADS-1066"],
+    "notes": "First run of the routine. 23 commits merged 2026-08-05, almost all implementing already-tracked ADS tickets (production-readiness/Security/DevEx/Testing), most with a PR-review hardening round already applied. One new defect filed: ADS-1066 (cron claim quantised by wall-clock, not logical schedule)."
+  }
+}


### PR DESCRIPTION
## Summary

- Records the Daily Code Review routine's checkpoint so the next run diffs the default branch forward from the last-reviewed commit instead of re-scanning history.
- No production code changes — this PR only adds a state file for the automated review routine.

## Changes

- `.claude/daily-code-review-checkpoint.json` — new tracked checkpoint pinning `lastReviewedCommit` to `823e28a` (current `main` HEAD, 2026-08-05) plus a summary of the run.

## Before requesting review

- [ ] Ran `pnpm ci:local:quick` locally (or installed the pre-push hook — see CONTRIBUTING.md)
- [ ] Tests for new behaviour added (TDD) — n/a, data-only checkpoint file
- [ ] If touching `.env` requirements, updated `.env.example`'s REQUIRED block — n/a
- [ ] If touching a `lib.*`, considered consumer impact across `app.*` and `service.backend` — n/a

## Test plan

- [ ] Existing tests pass (`pnpm test`) — n/a, no code changed
- [ ] New behaviour is covered by tests — n/a
- [ ] Tested manually (describe how) — validated the JSON is well-formed
- [ ] No TypeScript errors (`pnpm type-check`) — n/a
- [ ] Lint passes (`pnpm lint`) — n/a

## Related

Daily Code Review run for `b739507..823e28a` (23 commits merged 2026-08-05). Findings filed:

- **ADS-1066** (Bug, Medium) — Cron claim slot is keyed on epoch-aligned wall-clock buckets, so multi-replica weekly-digest can still double-send. New defect in the ADS-1052 implementation (#1296).

---
_Generated by [Claude Code](https://claude.ai/code/session_01GVBJ4xJeR3nkVjp7GonEh2)_