### PR TITLE
feat(lib.components): add shared ErrorState component (ADS-1072, part 1)

### DIFF
--- a/packages/lib.components/src/components/ui/ErrorState/ErrorState.css.ts
+++ b/packages/lib.components/src/components/ui/ErrorState/ErrorState.css.ts
@@ -1,0 +1,51 @@
+import { style } from '@vanilla-extract/css';
+
+import { vars } from '../../../styles/theme.css';
+
+export const container = style({
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'center',
+  justifyContent: 'center',
+  textAlign: 'center',
+  padding: vars.spacing['5'],
+  gap: vars.spacing['2'],
+});
+
+export const title = style({
+  margin: 0,
+  fontSize: vars.typography.size.lg,
+  fontWeight: vars.typography.weight.semibold,
+  color: vars.colors.dangerTextEmphasis,
+});
+
+export const message = style({
+  margin: 0,
+  fontSize: vars.typography.size.base,
+  lineHeight: '1.5',
+  color: vars.text.muted,
+  maxWidth: '400px',
+});
+
+export const retryButton = style({
+  marginTop: vars.spacing['2'],
+  padding: `${vars.spacing['2']} ${vars.spacing['4']}`,
+  borderRadius: vars.border.radius.base,
+  fontWeight: vars.typography.weight.medium,
+  fontSize: vars.typography.size.sm,
+  cursor: 'pointer',
+  border: `1px solid ${vars.colors.primary}`,
+  backgroundColor: vars.colors.primary,
+  color: vars.background.body,
+  transition: `all ${vars.transitions.fast}`,
+  selectors: {
+    '&:hover': {
+      backgroundColor: vars.colors.primaryActive,
+      borderColor: vars.colors.primaryActive,
+    },
+    '&:focus': {
+      outline: `2px solid ${vars.colors.primary}`,
+      outlineOffset: '2px',
+    },
+  },
+});

--- a/packages/lib.components/src/components/ui/ErrorState/ErrorState.test.tsx
+++ b/packages/lib.components/src/components/ui/ErrorState/ErrorState.test.tsx
@@ -1,0 +1,65 @@
+import '@testing-library/jest-dom';
+import { fireEvent, render, screen } from '@testing-library/react';
+import React from 'react';
+import { ErrorState } from './ErrorState';
+
+describe('ErrorState', () => {
+  it('renders the message', () => {
+    render(<ErrorState message='Failed to load pets' />);
+
+    expect(screen.getByText('Failed to load pets')).toBeInTheDocument();
+  });
+
+  it('renders a default title when none is provided', () => {
+    render(<ErrorState message='Failed to load pets' />);
+
+    expect(screen.getByText('Something went wrong')).toBeInTheDocument();
+  });
+
+  it('renders a custom title', () => {
+    render(<ErrorState title='Could not load applications' message='Please try again later' />);
+
+    expect(screen.getByText('Could not load applications')).toBeInTheDocument();
+  });
+
+  it('is announced to assistive technology as an alert', () => {
+    render(<ErrorState message='Failed to load pets' data-testid='error-state' />);
+
+    expect(screen.getByTestId('error-state')).toHaveAttribute('role', 'alert');
+  });
+
+  it('does not render a retry button when onRetry is omitted', () => {
+    render(<ErrorState message='Failed to load pets' />);
+
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+  });
+
+  it('renders a retry button that calls onRetry when clicked', () => {
+    const handleRetry = vi.fn();
+
+    render(<ErrorState message='Failed to load pets' onRetry={handleRetry} />);
+
+    const retryButton = screen.getByRole('button', { name: 'Try again' });
+    fireEvent.click(retryButton);
+
+    expect(handleRetry).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders a custom retry label', () => {
+    render(<ErrorState message='Failed to load pets' onRetry={vi.fn()} retryLabel='Retry now' />);
+
+    expect(screen.getByRole('button', { name: 'Retry now' })).toBeInTheDocument();
+  });
+
+  it('applies custom className', () => {
+    render(
+      <ErrorState
+        message='Failed to load pets'
+        className='custom-error-state'
+        data-testid='error-state'
+      />
+    );
+
+    expect(screen.getByTestId('error-state')).toHaveClass('custom-error-state');
+  });
+});

--- a/packages/lib.components/src/components/ui/ErrorState/ErrorState.test.tsx
+++ b/packages/lib.components/src/components/ui/ErrorState/ErrorState.test.tsx
@@ -25,7 +25,9 @@ describe('ErrorState', () => {
   it('is announced to assistive technology as an alert', () => {
     render(<ErrorState message='Failed to load pets' data-testid='error-state' />);
 
-    expect(screen.getByTestId('error-state')).toHaveAttribute('role', 'alert');
+    const errorState = screen.getByTestId('error-state');
+    expect(errorState).toHaveAttribute('role', 'alert');
+    expect(errorState).toHaveAttribute('aria-live', 'assertive');
   });
 
   it('does not render a retry button when onRetry is omitted', () => {

--- a/packages/lib.components/src/components/ui/ErrorState/ErrorState.tsx
+++ b/packages/lib.components/src/components/ui/ErrorState/ErrorState.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import clsx from 'clsx';
+
+import * as styles from './ErrorState.css';
+
+export type ErrorStateProps = {
+  title?: string;
+  message: string;
+  onRetry?: () => void;
+  retryLabel?: string;
+  className?: string;
+  'data-testid'?: string;
+};
+
+export const ErrorState: React.FC<ErrorStateProps> = ({
+  title = 'Something went wrong',
+  message,
+  onRetry,
+  retryLabel = 'Try again',
+  className,
+  'data-testid': testId,
+}) => {
+  return (
+    <div className={clsx(styles.container, className)} data-testid={testId} role='alert'>
+      <h3 className={styles.title}>{title}</h3>
+      <p className={styles.message}>{message}</p>
+      {onRetry && (
+        <button type='button' className={styles.retryButton} onClick={onRetry}>
+          {retryLabel}
+        </button>
+      )}
+    </div>
+  );
+};

--- a/packages/lib.components/src/components/ui/ErrorState/ErrorState.tsx
+++ b/packages/lib.components/src/components/ui/ErrorState/ErrorState.tsx
@@ -21,7 +21,12 @@ export const ErrorState: React.FC<ErrorStateProps> = ({
   'data-testid': testId,
 }) => {
   return (
-    <div className={clsx(styles.container, className)} data-testid={testId} role='alert'>
+    <div
+      className={clsx(styles.container, className)}
+      data-testid={testId}
+      role='alert'
+      aria-live='assertive'
+    >
       <h3 className={styles.title}>{title}</h3>
       <p className={styles.message}>{message}</p>
       {onRetry && (

--- a/packages/lib.components/src/components/ui/ErrorState/index.ts
+++ b/packages/lib.components/src/components/ui/ErrorState/index.ts
@@ -1,0 +1,2 @@
+export { ErrorState } from './ErrorState';
+export type { ErrorStateProps } from './ErrorState';

--- a/packages/lib.components/src/index.ts
+++ b/packages/lib.components/src/index.ts
@@ -77,6 +77,7 @@ export * from './components/form/FileUpload';
 
 // UI components
 export * from './components/ui/EmptyState';
+export * from './components/ui/ErrorState';
 export { Toast, ToastContainer } from './components/ui/Toast';
 export type { ToastContainerProps, ToastPosition, ToastProps } from './components/ui/Toast';
 


### PR DESCRIPTION
## Summary

- First increment of ADS-1072 (Epic A foundation): adds a standalone, accessible `ErrorState` component to `packages/lib.components`.
- Provides an accessible error message (`role="alert"`) with an optional retry action, matching the ad-hoc error banners currently hand-rolled across `app.admin`, `app.client`, and `app.rescue`.
- `QueryBoundary` (which will compose `ErrorState` for the error branch, alongside loading/empty/success branches) is the next increment on this ticket — not included in this PR.

## Changes

- `packages/lib.components/src/components/ui/ErrorState/ErrorState.tsx` — new component
- `packages/lib.components/src/components/ui/ErrorState/ErrorState.css.ts` — vanilla-extract styles using existing theme tokens
- `packages/lib.components/src/components/ui/ErrorState/ErrorState.test.tsx` — behaviour-driven tests (message, title, retry action, `role="alert"`, className)
- `packages/lib.components/src/components/ui/ErrorState/index.ts` — barrel export
- `packages/lib.components/src/index.ts` — export `ErrorState` from the package root

## Before requesting review

- [x] Ran tests/lint locally for the touched package
- [x] Tests for new behaviour added (TDD)
- [ ] If touching `.env` requirements, updated `.env.example`'s REQUIRED block — n/a
- [x] If touching a `lib.*`, considered consumer impact across `app.*` and `service.backend` — additive-only export, no existing consumers affected

## Test plan

- [x] `pnpm --filter @adopt-dont-shop/lib.components exec vitest run` — 541/541 tests pass (52 files), including the 8 new `ErrorState` tests
- [x] `pnpm --filter @adopt-dont-shop/lib.components exec eslint src/components/ui/ErrorState src/index.ts` — clean
- [ ] `pnpm type-check` — not run repo-wide in this pass; `lib.components`'s own `tsc --noEmit` fails only on a pre-existing, unrelated issue (unbuilt `@adopt-dont-shop/lib.types` declarations, resolved by Turbo's normal `build:libs` ordering)
- [ ] Tested manually — n/a (non-visual primitive change; no consumer wiring yet)

## Related

- Linear: [ADS-1072](https://linear.app/ideasquared/issue/ADS-1072/uxa2-add-shared-queryboundary-errorstate) — this PR covers the `ErrorState` half only; `QueryBoundary` follows in a subsequent PR/commit.
- Parent epic: [ADS-1067](https://linear.app/ideasquared/issue/ADS-1067/ux-epic-a-foundation-shared-components-and-design-system-adoption)


---
_Generated by [Claude Code](https://claude.ai/code/session_01HshKFax13gVFgYgqBCu6Fo)_