### PR TITLE
fix: attach idle db-pool error listeners and top-level exception handlers (ADS-1040)

### DIFF
--- a/packages/db/src/client.test.ts
+++ b/packages/db/src/client.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { createDbClient } from './client.js';
 
 describe('createDbClient', () => {
@@ -140,6 +140,71 @@ describe('createDbClient', () => {
 
       expect(pool.read.options.connectionTimeoutMillis).toBe(10_000);
       expect(pool.read.options.statement_timeout).toBe(30_000);
+
+      void pool.read.end();
+      void pool.end();
+    });
+  });
+
+  describe('idle-client pool errors (ADS-1040)', () => {
+    it('never lets a pool "error" event go unhandled', () => {
+      // pg re-throws an 'error' event with no listener as an unhandled
+      // Node error, crashing the process — this must never happen.
+      const pool = createDbClient({
+        schema: 'test',
+        connectionString: 'postgres://localhost/test',
+      });
+
+      expect(pool.listenerCount('error')).toBeGreaterThan(0);
+
+      void pool.end();
+    });
+
+    it('routes a pool error to the supplied onError callback instead of crashing', () => {
+      const onError = vi.fn();
+      const pool = createDbClient({
+        schema: 'test',
+        connectionString: 'postgres://localhost/test',
+        onError,
+      });
+
+      const err = new Error('connection terminated unexpectedly');
+      pool.emit('error', err);
+
+      expect(onError).toHaveBeenCalledWith(err);
+
+      void pool.end();
+    });
+
+    it('falls back to console.error when no onError is supplied', () => {
+      const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+      const pool = createDbClient({
+        schema: 'test',
+        connectionString: 'postgres://localhost/test',
+      });
+
+      const err = new Error('connection terminated unexpectedly');
+      pool.emit('error', err);
+
+      expect(consoleErrorSpy).toHaveBeenCalledWith(expect.stringContaining('test'), err);
+
+      consoleErrorSpy.mockRestore();
+      void pool.end();
+    });
+
+    it('routes the read-replica pool errors through the same onError callback', () => {
+      const onError = vi.fn();
+      const pool = createDbClient({
+        schema: 'pets',
+        connectionString: 'postgres://localhost/primary',
+        readUrl: 'postgres://replica.example.com/pets',
+        onError,
+      });
+
+      const err = new Error('replica connection dropped');
+      pool.read.emit('error', err);
+
+      expect(onError).toHaveBeenCalledWith(err);
 
       void pool.read.end();
       void pool.end();

--- a/packages/db/src/client.ts
+++ b/packages/db/src/client.ts
@@ -20,6 +20,14 @@ export type DbClientOptions = PoolConfig & {
   // every write and every transaction (withTransaction) stays on `pool`
   // (the primary). See docs/adr/0004-postgres-read-replica-routing.md.
   readUrl?: string;
+
+  // Called whenever the pool (or its read replica) emits an idle-client
+  // 'error' — e.g. Postgres failover/restart/idle-connection-reap dropping a
+  // pooled connection, all routine in production. Without a listener pg
+  // re-throws it as an unhandled 'error' event and crashes the process
+  // (ADS-1040); a listener is always attached, so this only controls where
+  // the error is reported. Defaults to console.error.
+  onError?: (err: Error) => void;
 };
 
 // A primary pool with a `read` pool for read-only routing. `read` is always
@@ -43,20 +51,21 @@ const TIMEOUT_DEFAULTS = {
 const SAFE_SCHEMA = /^[A-Za-z_][A-Za-z0-9_]*$/;
 
 // Build a single pool with the schema search_path wiring applied on connect.
-function buildPool(schema: string, config: PoolConfig): Pool {
+function buildPool(schema: string, config: PoolConfig, onError: (err: Error) => void): Pool {
   const pool = new Pool({ ...TIMEOUT_DEFAULTS, ...config });
+
+  // Always attach an 'error' listener — pg emits it on the pool whenever an
+  // idle pooled client's connection is dropped (Postgres failover, restart,
+  // idle-connection reap). With no listener, Node re-throws it as an
+  // unhandled error and crashes the process (ADS-1040).
+  pool.on('error', onError);
 
   pool.on('connect', client => {
     // A connection that fails to set its search_path would silently resolve
     // unqualified table refs to `public` (wrong rows / "relation does not
-    // exist") — surface the failure instead of swallowing it: via the pool's
-    // own error channel when a listener is attached, else stderr.
+    // exist") — surface the failure instead of swallowing it.
     client.query(`SET search_path TO "${schema}", public`).catch((err: unknown) => {
-      if (pool.listenerCount('error') > 0) {
-        pool.emit('error', err as Error, client);
-      } else {
-        console.error(`db: failed to set search_path for schema "${schema}":`, err);
-      }
+      pool.emit('error', err as Error, client);
     });
   });
 
@@ -64,12 +73,14 @@ function buildPool(schema: string, config: PoolConfig): Pool {
 }
 
 export function createDbClient(opts: DbClientOptions): DbClient {
-  const { schema, readUrl, ...config } = opts;
+  const { schema, readUrl, onError, ...config } = opts;
   if (!SAFE_SCHEMA.test(schema)) {
     throw new Error(`createDbClient: invalid schema name "${schema}" (must match ${SAFE_SCHEMA})`);
   }
+  const handleError =
+    onError ?? ((err: Error) => console.error(`db: pool error (schema "${schema}"):`, err));
 
-  const primary = buildPool(schema, config);
+  const primary = buildPool(schema, config, handleError);
 
   // No replica configured → `.read` falls back to the primary so read-only
   // call sites work unchanged in single-instance deploys.
@@ -80,6 +91,6 @@ export function createDbClient(opts: DbClientOptions): DbClient {
   // A replica IS configured: open a read-only pool against it. It inherits the
   // same timeout defaults and search_path wiring, but only the connection
   // string differs — credentials/host come from readUrl, never the primary's.
-  const read = buildPool(schema, { ...config, connectionString: readUrl });
+  const read = buildPool(schema, { ...config, connectionString: readUrl }, handleError);
   return Object.assign(primary, { read });
 }

--- a/packages/service-bootstrap/src/index.ts
+++ b/packages/service-bootstrap/src/index.ts
@@ -72,3 +72,5 @@ export type {
 
 export { runServiceShutdown } from './shutdown.js';
 export type { ShutdownDeps } from './shutdown.js';
+
+export { registerFatalErrorHandlers } from './process-handlers.js';

--- a/packages/service-bootstrap/src/process-handlers.test.ts
+++ b/packages/service-bootstrap/src/process-handlers.test.ts
@@ -1,0 +1,81 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { registerFatalErrorHandlers } from './process-handlers.js';
+
+describe('registerFatalErrorHandlers', () => {
+  afterEach(() => {
+    process.removeAllListeners('uncaughtException');
+    process.removeAllListeners('unhandledRejection');
+    vi.restoreAllMocks();
+  });
+
+  it('logs, runs the shutdown sequence, and exits 1 on uncaughtException', async () => {
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => undefined as never);
+    const httpServer = { close: vi.fn(async () => undefined) };
+    const pool = { end: vi.fn(async () => undefined) };
+    const logger = makeLogger();
+
+    registerFatalErrorHandlers({ httpServer, pool, logger });
+
+    const err = new Error('idle client error');
+    process.emit('uncaughtException', err);
+    await flushAsync();
+
+    expect(logger.errorCalls.some(([msg]) => msg.includes('uncaughtException'))).toBe(true);
+    expect(httpServer.close).toHaveBeenCalled();
+    expect(pool.end).toHaveBeenCalled();
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+
+  it('logs, runs the shutdown sequence, and exits 1 on unhandledRejection', async () => {
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => undefined as never);
+    const httpServer = { close: vi.fn(async () => undefined) };
+    const logger = makeLogger();
+
+    registerFatalErrorHandlers({ httpServer, logger });
+
+    process.emit(
+      'unhandledRejection',
+      new Error('boom'),
+      Promise.reject().catch(() => undefined)
+    );
+    await flushAsync();
+
+    expect(logger.errorCalls.some(([msg]) => msg.includes('unhandledRejection'))).toBe(true);
+    expect(httpServer.close).toHaveBeenCalled();
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+
+  it('still exits 1 even when a shutdown step throws', async () => {
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => undefined as never);
+    const httpServer = {
+      close: vi.fn(async () => {
+        throw new Error('already closed');
+      }),
+    };
+    const logger = makeLogger();
+
+    registerFatalErrorHandlers({ httpServer, logger });
+
+    process.emit('uncaughtException', new Error('boom'));
+    await flushAsync();
+
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+});
+
+function flushAsync(): Promise<void> {
+  return new Promise(resolve => setImmediate(resolve));
+}
+
+function makeLogger() {
+  const errorCalls: Array<[string, unknown]> = [];
+  const logger = {
+    info: () => undefined,
+    error: (msg: string, meta?: unknown) => errorCalls.push([msg, meta]),
+    warn: () => undefined,
+    debug: () => undefined,
+    silly: () => undefined,
+  } as unknown as ReturnType<typeof import('@adopt-dont-shop/observability').createLogger>;
+  return Object.assign(logger, { errorCalls });
+}

--- a/packages/service-bootstrap/src/process-handlers.ts
+++ b/packages/service-bootstrap/src/process-handlers.ts
@@ -1,0 +1,24 @@
+// Top-level process guards (ADS-1040) — no service registered
+// `uncaughtException` / `unhandledRejection` handlers, so any error that
+// escapes normal error handling (an idle pg.Pool 'error' event with no
+// listener was the concrete case, now fixed separately in
+// @adopt-dont-shop/db) terminates the process immediately: no logged cause,
+// no graceful drain of in-flight work. Under `restart: always` this becomes
+// a crash-loop on every transient error.
+//
+// registerFatalErrorHandlers logs the error with context, runs the same
+// graceful-shutdown sequence as SIGTERM/SIGINT, then exits non-zero.
+
+import { runServiceShutdown, type ShutdownDeps } from './shutdown.js';
+
+export const registerFatalErrorHandlers = (deps: ShutdownDeps): void => {
+  const handleFatal =
+    (kind: 'uncaughtException' | 'unhandledRejection') =>
+    (err: unknown): void => {
+      deps.logger.error(`${kind} — shutting down`, { err });
+      void runServiceShutdown(deps).finally(() => process.exit(1));
+    };
+
+  process.on('uncaughtException', handleFatal('uncaughtException'));
+  process.on('unhandledRejection', handleFatal('unhandledRejection'));
+};

--- a/services/applications/src/index.ts
+++ b/services/applications/src/index.ts
@@ -2,7 +2,7 @@ import { connect, type NatsConnection } from 'nats';
 
 import { createDbClient } from '@adopt-dont-shop/db';
 import { createLogger } from '@adopt-dont-shop/observability';
-import { runServiceShutdown } from '@adopt-dont-shop/service-bootstrap';
+import { registerFatalErrorHandlers, runServiceShutdown } from '@adopt-dont-shop/service-bootstrap';
 
 import { loadConfig } from './config.js';
 import { startGrpcServer, type RunningGrpcServer } from './grpc/server.js';
@@ -25,6 +25,7 @@ const main = async (): Promise<void> => {
     pool = createDbClient({
       connectionString: config.databaseUrl,
       schema: config.schema,
+      onError: err => logger.error('idle db pool error', { err }),
     });
     nats = await connect({ servers: config.natsUrl });
     // Create-or-update the JetStream DOMAIN_EVENTS stream before anything
@@ -67,6 +68,7 @@ const main = async (): Promise<void> => {
 
     process.once('SIGTERM', () => void shutdown('SIGTERM'));
     process.once('SIGINT', () => void shutdown('SIGINT'));
+    registerFatalErrorHandlers({ httpServer, grpc, nats, pool, logger });
   } catch (err) {
     logger.error('service.applications failed to start', { err });
     try {

--- a/services/audit/src/index.ts
+++ b/services/audit/src/index.ts
@@ -3,7 +3,7 @@ import { connect, type NatsConnection } from 'nats';
 import { createDbClient } from '@adopt-dont-shop/db';
 import { type SubscriptionHandle } from '@adopt-dont-shop/events';
 import { createLogger } from '@adopt-dont-shop/observability';
-import { runServiceShutdown } from '@adopt-dont-shop/service-bootstrap';
+import { registerFatalErrorHandlers, runServiceShutdown } from '@adopt-dont-shop/service-bootstrap';
 
 import { loadConfig } from './config.js';
 import { startGrpcServer, type RunningGrpcServer } from './grpc/server.js';
@@ -35,6 +35,7 @@ const main = async (): Promise<void> => {
     pool = createDbClient({
       connectionString: config.databaseUrl,
       schema: config.schema,
+      onError: err => logger.error('idle db pool error', { err }),
     });
     nats = await connect({ servers: config.natsUrl });
     // Create-or-update the JetStream DOMAIN_EVENTS stream before anything
@@ -117,6 +118,7 @@ const main = async (): Promise<void> => {
 
     process.once('SIGTERM', () => void shutdown('SIGTERM'));
     process.once('SIGINT', () => void shutdown('SIGINT'));
+    registerFatalErrorHandlers({ httpServer, grpc, nats, pool, logger });
   } catch (err) {
     logger.error('service.audit failed to start', { err });
     try {

--- a/services/auth/src/index.ts
+++ b/services/auth/src/index.ts
@@ -2,7 +2,7 @@ import { connect, type NatsConnection } from 'nats';
 
 import { createDbClient } from '@adopt-dont-shop/db';
 import { createLogger } from '@adopt-dont-shop/observability';
-import { runServiceShutdown } from '@adopt-dont-shop/service-bootstrap';
+import { registerFatalErrorHandlers, runServiceShutdown } from '@adopt-dont-shop/service-bootstrap';
 
 import { loadConfig } from './config.js';
 import { createBcryptPasswordHasher } from './grpc/password-hasher.js';
@@ -26,6 +26,7 @@ const main = async (): Promise<void> => {
     pool = createDbClient({
       connectionString: config.databaseUrl,
       schema: config.schema,
+      onError: err => logger.error('idle db pool error', { err }),
     });
     nats = await connect({ servers: config.natsUrl });
     // Create-or-update the JetStream DOMAIN_EVENTS stream before anything
@@ -82,6 +83,7 @@ const main = async (): Promise<void> => {
 
     process.once('SIGTERM', () => void shutdown('SIGTERM'));
     process.once('SIGINT', () => void shutdown('SIGINT'));
+    registerFatalErrorHandlers({ httpServer, grpc, nats, pool, logger });
   } catch (err) {
     logger.error('service.auth failed to start', { err });
     try {

--- a/services/chat/src/index.ts
+++ b/services/chat/src/index.ts
@@ -2,7 +2,7 @@ import { connect, type NatsConnection } from 'nats';
 
 import { createDbClient } from '@adopt-dont-shop/db';
 import { createLogger } from '@adopt-dont-shop/observability';
-import { runServiceShutdown } from '@adopt-dont-shop/service-bootstrap';
+import { registerFatalErrorHandlers, runServiceShutdown } from '@adopt-dont-shop/service-bootstrap';
 
 import { loadConfig } from './config.js';
 import { startGrpcServer, type RunningGrpcServer } from './grpc/server.js';
@@ -22,6 +22,7 @@ const main = async (): Promise<void> => {
     pool = createDbClient({
       connectionString: config.databaseUrl,
       schema: config.schema,
+      onError: err => logger.error('idle db pool error', { err }),
     });
     nats = await connect({ servers: config.natsUrl });
     // Create-or-update the JetStream DOMAIN_EVENTS stream before anything
@@ -64,6 +65,7 @@ const main = async (): Promise<void> => {
 
     process.once('SIGTERM', () => void shutdown('SIGTERM'));
     process.once('SIGINT', () => void shutdown('SIGINT'));
+    registerFatalErrorHandlers({ httpServer, grpc, nats, pool, logger });
   } catch (err) {
     logger.error('service.chat failed to start', { err });
     try {

--- a/services/cms/src/index.ts
+++ b/services/cms/src/index.ts
@@ -2,7 +2,7 @@ import { connect, type NatsConnection } from 'nats';
 
 import { createDbClient } from '@adopt-dont-shop/db';
 import { createLogger } from '@adopt-dont-shop/observability';
-import { runServiceShutdown } from '@adopt-dont-shop/service-bootstrap';
+import { registerFatalErrorHandlers, runServiceShutdown } from '@adopt-dont-shop/service-bootstrap';
 
 import { loadConfig } from './config.js';
 import { startGrpcServer, type RunningGrpcServer } from './grpc/server.js';
@@ -18,7 +18,11 @@ const main = async (): Promise<void> => {
 
   try {
     const config = loadConfig();
-    pool = createDbClient({ connectionString: config.databaseUrl, schema: config.schema });
+    pool = createDbClient({
+      connectionString: config.databaseUrl,
+      schema: config.schema,
+      onError: err => logger.error('idle db pool error', { err }),
+    });
     nats = await connect({ servers: config.natsUrl });
     // Create-or-update the JetStream DOMAIN_EVENTS stream before anything
     // publishes or subscribes. Idempotent across every service's boot.
@@ -59,6 +63,7 @@ const main = async (): Promise<void> => {
 
     process.once('SIGTERM', () => void shutdown('SIGTERM'));
     process.once('SIGINT', () => void shutdown('SIGINT'));
+    registerFatalErrorHandlers({ httpServer, grpc, nats, pool, logger });
   } catch (err) {
     logger.error('service.cms failed to start', { err });
     try {

--- a/services/matching/src/index.ts
+++ b/services/matching/src/index.ts
@@ -2,7 +2,7 @@ import { connect, type NatsConnection } from 'nats';
 
 import { createDbClient } from '@adopt-dont-shop/db';
 import { createLogger } from '@adopt-dont-shop/observability';
-import { runServiceShutdown } from '@adopt-dont-shop/service-bootstrap';
+import { registerFatalErrorHandlers, runServiceShutdown } from '@adopt-dont-shop/service-bootstrap';
 
 import { loadConfig } from './config.js';
 import { startGrpcServer, type RunningGrpcServer } from './grpc/server.js';
@@ -25,6 +25,7 @@ const main = async (): Promise<void> => {
     pool = createDbClient({
       connectionString: config.databaseUrl,
       schema: config.schema,
+      onError: err => logger.error('idle db pool error', { err }),
     });
     nats = await connect({ servers: config.natsUrl });
     // Create-or-update the JetStream DOMAIN_EVENTS stream before anything
@@ -67,6 +68,7 @@ const main = async (): Promise<void> => {
 
     process.once('SIGTERM', () => void shutdown('SIGTERM'));
     process.once('SIGINT', () => void shutdown('SIGINT'));
+    registerFatalErrorHandlers({ httpServer, grpc, nats, pool, logger });
   } catch (err) {
     logger.error('service.matching failed to start', { err });
     try {

--- a/services/moderation/src/index.ts
+++ b/services/moderation/src/index.ts
@@ -2,7 +2,7 @@ import { connect, type NatsConnection } from 'nats';
 
 import { createDbClient } from '@adopt-dont-shop/db';
 import { createLogger } from '@adopt-dont-shop/observability';
-import { runServiceShutdown } from '@adopt-dont-shop/service-bootstrap';
+import { registerFatalErrorHandlers, runServiceShutdown } from '@adopt-dont-shop/service-bootstrap';
 
 import { loadConfig } from './config.js';
 import { startGrpcServer, type RunningGrpcServer } from './grpc/server.js';
@@ -26,6 +26,7 @@ const main = async (): Promise<void> => {
     pool = createDbClient({
       connectionString: config.databaseUrl,
       schema: config.schema,
+      onError: err => logger.error('idle db pool error', { err }),
     });
     nats = await connect({ servers: config.natsUrl });
     // Create-or-update the JetStream DOMAIN_EVENTS stream before anything
@@ -74,6 +75,7 @@ const main = async (): Promise<void> => {
 
     process.once('SIGTERM', () => void shutdown('SIGTERM'));
     process.once('SIGINT', () => void shutdown('SIGINT'));
+    registerFatalErrorHandlers({ httpServer, grpc, nats, pool, logger });
   } catch (err) {
     logger.error('service.moderation failed to start', { err });
     try {

--- a/services/notifications/src/index.ts
+++ b/services/notifications/src/index.ts
@@ -2,7 +2,7 @@ import { connect, type NatsConnection } from 'nats';
 
 import { createDbClient } from '@adopt-dont-shop/db';
 import { createLogger } from '@adopt-dont-shop/observability';
-import { runServiceShutdown } from '@adopt-dont-shop/service-bootstrap';
+import { registerFatalErrorHandlers, runServiceShutdown } from '@adopt-dont-shop/service-bootstrap';
 
 import { loadConfig } from './config.js';
 import { createAuthCohortClient } from './grpc/auth-client.js';
@@ -45,6 +45,7 @@ const main = async (): Promise<void> => {
     pool = createDbClient({
       connectionString: config.databaseUrl,
       schema: config.schema,
+      onError: err => logger.error('idle db pool error', { err }),
     });
     nats = await connect({ servers: config.natsUrl });
     // Create-or-update the JetStream DOMAIN_EVENTS stream before anything
@@ -225,6 +226,7 @@ const main = async (): Promise<void> => {
 
     process.once('SIGTERM', () => void shutdown('SIGTERM'));
     process.once('SIGINT', () => void shutdown('SIGINT'));
+    registerFatalErrorHandlers({ httpServer, grpc, nats, pool, logger });
   } catch (err) {
     logger.error('service.notifications failed to start', { err });
     try {

--- a/services/pets/src/index.ts
+++ b/services/pets/src/index.ts
@@ -2,7 +2,7 @@ import { connect, type NatsConnection } from 'nats';
 
 import { createDbClient } from '@adopt-dont-shop/db';
 import { createLogger } from '@adopt-dont-shop/observability';
-import { runServiceShutdown } from '@adopt-dont-shop/service-bootstrap';
+import { registerFatalErrorHandlers, runServiceShutdown } from '@adopt-dont-shop/service-bootstrap';
 
 import { loadConfig } from './config.js';
 import { startGrpcServer, type RunningGrpcServer } from './grpc/server.js';
@@ -24,6 +24,7 @@ const main = async (): Promise<void> => {
     pool = createDbClient({
       connectionString: config.databaseUrl,
       schema: config.schema,
+      onError: err => logger.error('idle db pool error', { err }),
     });
     nats = await connect({ servers: config.natsUrl });
     // Create-or-update the JetStream DOMAIN_EVENTS stream before anything
@@ -66,6 +67,7 @@ const main = async (): Promise<void> => {
 
     process.once('SIGTERM', () => void shutdown('SIGTERM'));
     process.once('SIGINT', () => void shutdown('SIGINT'));
+    registerFatalErrorHandlers({ httpServer, grpc, nats, pool, logger });
   } catch (err) {
     logger.error('service.pets failed to start', { err });
     try {

--- a/services/rescue/src/index.ts
+++ b/services/rescue/src/index.ts
@@ -2,7 +2,7 @@ import { connect, type NatsConnection } from 'nats';
 
 import { createDbClient } from '@adopt-dont-shop/db';
 import { createLogger } from '@adopt-dont-shop/observability';
-import { runServiceShutdown } from '@adopt-dont-shop/service-bootstrap';
+import { registerFatalErrorHandlers, runServiceShutdown } from '@adopt-dont-shop/service-bootstrap';
 
 import { loadConfig } from './config.js';
 import { startGrpcServer, type RunningGrpcServer } from './grpc/server.js';
@@ -24,6 +24,7 @@ const main = async (): Promise<void> => {
     pool = createDbClient({
       connectionString: config.databaseUrl,
       schema: config.schema,
+      onError: err => logger.error('idle db pool error', { err }),
     });
     nats = await connect({ servers: config.natsUrl });
     // Create-or-update the JetStream DOMAIN_EVENTS stream before anything
@@ -66,6 +67,7 @@ const main = async (): Promise<void> => {
 
     process.once('SIGTERM', () => void shutdown('SIGTERM'));
     process.once('SIGINT', () => void shutdown('SIGINT'));
+    registerFatalErrorHandlers({ httpServer, grpc, nats, pool, logger });
   } catch (err) {
     logger.error('service.rescue failed to start', { err });
     try {


### PR DESCRIPTION
## Summary

- `pg.Pool` emits an `'error'` event on an **idle** pooled client whenever its connection drops (Postgres failover, restart, or idle-connection reap — all routine in production). With no listener attached, Node re-throws it as an unhandled error and crashes the process; under `restart: always` this becomes a crash-loop with no logged cause.
- No service had top-level `uncaughtException` / `unhandledRejection` handlers, so any error that escaped normal handling terminated the process with no graceful drain of in-flight work.

## Changes

- `packages/db/src/client.ts`: `buildPool` now always attaches a pool `'error'` listener (caller-supplied `onError`, defaulting to `console.error`). This alone fixes the crash risk for every service that calls `createDbClient`, since the fix lives in the one shared pool constructor. Removed the old listener-count fallback in the `search_path` failure path since a listener is now always present.
- `packages/service-bootstrap/src/process-handlers.ts` (new): `registerFatalErrorHandlers(deps)` wires `uncaughtException`/`unhandledRejection` to log with context, run the same graceful shutdown sequence as `SIGTERM`/`SIGINT` (`runServiceShutdown`), then exit non-zero.
- Wired both into all 10 data-owning services: `applications`, `audit`, `auth`, `chat`, `cms`, `matching`, `moderation`, `notifications`, `pets`, `rescue`. Each now passes `onError` into `createDbClient` (routing pool errors to its structured logger) and calls `registerFatalErrorHandlers` alongside its existing signal handlers.
- `service.gateway` is intentionally out of scope: it owns no DB pool, and its shutdown sequence has a different shape (Socket.IO, Redis adapters, 9 gRPC clients) that doesn't fit `ShutdownDeps` — tracked separately by ADS-1051 (gateway shutdown has no deadline).

## Before requesting review

- [x] Tests for new behaviour added (TDD)
- [ ] Ran `pnpm ci:local:quick` locally
- [ ] If touching `.env` requirements, updated `.env.example`'s REQUIRED block — n/a
- [ ] If touching a `lib.*`, considered consumer impact — n/a (packages/db, packages/service-bootstrap)

## Test plan

- [x] New behaviour is covered by tests (`packages/db/src/client.test.ts`, `packages/service-bootstrap/src/process-handlers.test.ts`)
- [x] `pnpm exec turbo test lint type-check` passes for `@adopt-dont-shop/db`, `@adopt-dont-shop/service-bootstrap`, and all 10 wired services
- [ ] Tested manually against a live Postgres (not available in this environment)

## Related

Linear: ADS-1040 — [Critical] Idle DB-pool errors crash every service; no top-level exception handlers


---
_Generated by [Claude Code](https://claude.ai/code/session_01N4RxVwpwvm8SKv1UyVXmgG)_