### PR TITLE
fix(lib.components): FormField wires aria-describedby to its control (a11y)

### DIFF
--- a/packages/lib.components/src/components/form/FormField/FormField.test.tsx
+++ b/packages/lib.components/src/components/form/FormField/FormField.test.tsx
@@ -113,4 +113,17 @@ describe('FormField', () => {
     expect(input.getAttribute('aria-describedby')).toBe(description.id);
     expect(input).not.toHaveAttribute('aria-invalid', 'true');
   });
+
+  it('does not augment a fragment child (avoids invalid aria-* on a fragment)', () => {
+    render(
+      <FormField label='Email' error='Email is required'>
+        <>
+          <input aria-label='Email' />
+        </>
+      </FormField>
+    );
+
+    expect(screen.getByRole('alert')).toHaveTextContent('Email is required');
+    expect(screen.getByLabelText('Email')).not.toHaveAttribute('aria-describedby');
+  });
 });

--- a/packages/lib.components/src/components/form/FormField/FormField.test.tsx
+++ b/packages/lib.components/src/components/form/FormField/FormField.test.tsx
@@ -85,4 +85,32 @@ describe('FormField', () => {
 
     expect(screen.getByText('Email')).toBeInTheDocument();
   });
+
+  it('wires the error to the control via aria-describedby and aria-invalid', () => {
+    render(
+      <FormField label='Email' htmlFor='email' error='Email is required'>
+        <input id='email' />
+      </FormField>
+    );
+
+    const input = screen.getByLabelText('Email');
+    const alert = screen.getByRole('alert');
+    expect(alert.id).toBeTruthy();
+    expect(input).toHaveAttribute('aria-invalid', 'true');
+    expect(input.getAttribute('aria-describedby')).toBe(alert.id);
+  });
+
+  it('links the description to the control via aria-describedby when no error', () => {
+    render(
+      <FormField label='Email' htmlFor='email' description='Used for login'>
+        <input id='email' />
+      </FormField>
+    );
+
+    const input = screen.getByLabelText('Email');
+    const description = screen.getByText('Used for login');
+    expect(description.id).toBeTruthy();
+    expect(input.getAttribute('aria-describedby')).toBe(description.id);
+    expect(input).not.toHaveAttribute('aria-invalid', 'true');
+  });
 });

--- a/packages/lib.components/src/components/form/FormField/FormField.tsx
+++ b/packages/lib.components/src/components/form/FormField/FormField.tsx
@@ -45,6 +45,14 @@ export type FormFieldProps = {
   className?: string;
 };
 
+type ControlAriaProps = {
+  'aria-describedby'?: string;
+  'aria-invalid'?: boolean | 'true' | 'false';
+};
+
+const mergeDescribedBy = (existing: string | undefined, added: string): string =>
+  existing ? `${existing} ${added}` : added;
+
 export const FormField = ({
   label,
   htmlFor,
@@ -54,22 +62,46 @@ export const FormField = ({
   fullWidth = false,
   children,
   className,
-}: FormFieldProps) => (
-  <div className={clsx(styles.field, fullWidth && styles.fieldFullWidth, className)}>
-    {label && (
-      <label
-        htmlFor={htmlFor}
-        className={clsx(styles.fieldLabel, required && styles.fieldLabelRequired)}
-      >
-        {label}
-      </label>
-    )}
-    {children}
-    {description && !error && <span className={styles.fieldDescription}>{description}</span>}
-    {error && (
-      <span className={styles.fieldError} role='alert'>
-        {error}
-      </span>
-    )}
-  </div>
-);
+}: FormFieldProps) => {
+  const reactId = React.useId();
+  const errorId = `${reactId}-error`;
+  const descriptionId = `${reactId}-description`;
+  const showDescription = Boolean(description) && !error;
+  const describedById = error ? errorId : showDescription ? descriptionId : undefined;
+
+  // Wire the message to the control via aria-describedby so screen readers
+  // announce it when the field regains focus (role="alert" only fires when the
+  // error first appears). Only a single valid element child is augmented;
+  // anything else renders untouched.
+  const control =
+    describedById && React.isValidElement<ControlAriaProps>(children)
+      ? React.cloneElement(children, {
+          'aria-describedby': mergeDescribedBy(children.props['aria-describedby'], describedById),
+          'aria-invalid': error ? true : children.props['aria-invalid'],
+        })
+      : children;
+
+  return (
+    <div className={clsx(styles.field, fullWidth && styles.fieldFullWidth, className)}>
+      {label && (
+        <label
+          htmlFor={htmlFor}
+          className={clsx(styles.fieldLabel, required && styles.fieldLabelRequired)}
+        >
+          {label}
+        </label>
+      )}
+      {control}
+      {showDescription && (
+        <span id={descriptionId} className={styles.fieldDescription}>
+          {description}
+        </span>
+      )}
+      {error && (
+        <span id={errorId} className={styles.fieldError} role='alert'>
+          {error}
+        </span>
+      )}
+    </div>
+  );
+};

--- a/packages/lib.components/src/components/form/FormField/FormField.tsx
+++ b/packages/lib.components/src/components/form/FormField/FormField.tsx
@@ -74,7 +74,9 @@ export const FormField = ({
   // error first appears). Only a single valid element child is augmented;
   // anything else renders untouched.
   const control =
-    describedById && React.isValidElement<ControlAriaProps>(children)
+    describedById &&
+    React.isValidElement<ControlAriaProps>(children) &&
+    children.type !== React.Fragment
       ? React.cloneElement(children, {
           'aria-describedby': mergeDescribedBy(children.props['aria-describedby'], describedById),
           'aria-invalid': error ? true : children.props['aria-invalid'],


### PR DESCRIPTION
## Summary

Fixes an accessibility gap in the shared `FormField` surfaced by Copilot's review of the Epic C/D form migrations (#1314, #1315). Fixing it **centrally** resolves the regression for every form at once, rather than patching each call site.

## The problem

`FormField`'s documented contract — and the repo `forms` skill — states it "slots an error message with `aria-describedby` wired up" and that "every error must be linked to its input via `aria-describedby`… `FormField` handles this." But the implementation rendered the error / description `<span>`s with **no `id`** and never wired them to the control. So `role="alert"` announced the error when it first appeared, but a screen-reader user who focused the field afterwards heard nothing.

## The fix

- Give the error and description spans stable `id`s (via `useId`).
- Inject `aria-describedby` (and `aria-invalid` when there's an error) onto the single control child via `cloneElement`, merging with any existing `aria-describedby`.
- Non-element children render untouched.

This makes the component match its documented behaviour, so the `FormField` call sites in the Epic C (client) and Epic D (rescue) form migrations get correct input↔error association with no per-call-site changes.

## Test plan

- [x] `lib.components`: type-check + build + tests (624 pass, incl. 2 new FormField a11y tests asserting the `aria-describedby`/`aria-invalid` wiring)

## Related

- Resolves the `aria-describedby` review comments on #1314 and #1315 centrally. Part of the UX-review follow-up (`docs/UX-REVIEW-2026-08.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q4fStLkBsaY3ncGig1fCaw)_