### PR TITLE
feat(lib.components): add DateRangePicker presets + restore rescue Analytics shortcuts (D5)

### DIFF
--- a/apps/rescue/src/pages/Analytics.test.tsx
+++ b/apps/rescue/src/pages/Analytics.test.tsx
@@ -50,6 +50,18 @@ describe('Analytics page', () => {
     await waitFor(() => expect(analyticsService.getAdoptionMetrics).toHaveBeenCalledTimes(2));
   });
 
+  // D5: preset shortcuts (restored from the old local picker) set the range and
+  // drive a refetch.
+  it('refetches analytics when a preset shortcut is clicked', async () => {
+    renderWithProviders(<Analytics />);
+
+    await waitFor(() => expect(analyticsService.getAdoptionMetrics).toHaveBeenCalledTimes(1));
+
+    fireEvent.click(screen.getByRole('button', { name: 'Last 7 days' }));
+
+    await waitFor(() => expect(analyticsService.getAdoptionMetrics).toHaveBeenCalledTimes(2));
+  });
+
   // D6: every data section uses the shared EmptyState when nothing is available.
   it('shows the shared empty state for each section when no data is available', async () => {
     renderWithProviders(<Analytics />);

--- a/apps/rescue/src/pages/Analytics.tsx
+++ b/apps/rescue/src/pages/Analytics.tsx
@@ -4,6 +4,7 @@ import {
   MetricCard,
   toast,
   DateRangePicker,
+  createDefaultDateRangePresets,
   EmptyState,
   type DateRangeValue,
 } from '@adopt-dont-shop/lib.components';
@@ -27,6 +28,11 @@ import ExportButton from '../components/analytics/ExportButton';
 // The shared DateRangePicker works in ISO `yyyy-mm-dd` strings, while the
 // analytics service reasons in `Date`s. Convert at the picker boundary only.
 const toIsoDate = (date: Date): string => date.toISOString().slice(0, 10);
+
+// Quick-select shortcuts restored from the previous local picker: Last 7/30/90
+// days, This month, Last month. `getRange` resolves against the current date on
+// each click.
+const dateRangePresets = createDefaultDateRangePresets();
 
 // Services
 import {
@@ -239,6 +245,7 @@ const Analytics: React.FC = () => {
             <DateRangePicker
               value={{ from: toIsoDate(dateRange.start), to: toIsoDate(dateRange.end) }}
               onChange={handleDateRangeChange}
+              presets={dateRangePresets}
             />
             <ExportButton
               onExportCSV={handleExportCSV}

--- a/apps/rescue/src/setup-tests.ts
+++ b/apps/rescue/src/setup-tests.ts
@@ -263,10 +263,19 @@ vi.mock('@adopt-dont-shop/lib.components', () => ({
     ),
   // ADS UX D5: shared date-range picker. Render labelled From/To date inputs
   // and mirror the real onChange semantics (each field patches its own side).
-  DateRangePicker: ({ value, onChange, fromLabel = 'From', toLabel = 'To' }: any) =>
+  DateRangePicker: ({ value, onChange, fromLabel = 'From', toLabel = 'To', presets }: any) =>
     React.createElement(
       'div',
       null,
+      ...(Array.isArray(presets)
+        ? presets.map((preset: any) =>
+            React.createElement(
+              'button',
+              { key: preset.label, type: 'button', onClick: () => onChange(preset.getRange()) },
+              preset.label
+            )
+          )
+        : []),
       React.createElement('label', { htmlFor: 'drp-from' }, fromLabel),
       React.createElement('input', {
         id: 'drp-from',
@@ -282,6 +291,15 @@ vi.mock('@adopt-dont-shop/lib.components', () => ({
         onChange: (e: any) => onChange({ from: value?.from ?? null, to: e.target.value || null }),
       })
     ),
+  // Deterministic stand-in for the shared preset builder — distinct fixed
+  // ranges so a preset click always changes the range and drives a refetch.
+  createDefaultDateRangePresets: () => [
+    { label: 'Last 7 days', getRange: () => ({ from: '2026-01-01', to: '2026-01-08' }) },
+    { label: 'Last 30 days', getRange: () => ({ from: '2026-01-01', to: '2026-01-31' }) },
+    { label: 'Last 90 days', getRange: () => ({ from: '2025-10-01', to: '2026-01-01' }) },
+    { label: 'This month', getRange: () => ({ from: '2026-01-01', to: '2026-01-31' }) },
+    { label: 'Last month', getRange: () => ({ from: '2025-12-01', to: '2025-12-31' }) },
+  ],
   // ADS UX D2: shared responsive DataTable. Mirror the real cell rendering
   // (col.render or stringified value) and empty handling so behaviour tests
   // for the migrated tables keep exercising rows, links and actions.

--- a/packages/lib.components/src/components/form/DateRangePicker/DateRangePicker.css.ts
+++ b/packages/lib.components/src/components/form/DateRangePicker/DateRangePicker.css.ts
@@ -9,6 +9,46 @@ export const container = style({
   alignItems: 'flex-end',
 });
 
+export const presets = style({
+  flexBasis: '100%',
+  display: 'flex',
+  flexWrap: 'wrap',
+  gap: vars.spacing['2'],
+});
+
+export const presetButton = style({
+  padding: `${vars.spacing['1']} ${vars.spacing['3']}`,
+  fontFamily: vars.typography.family.sans,
+  fontSize: vars.typography.size.sm,
+  fontWeight: vars.typography.weight.medium,
+  color: vars.colors.primaryTextEmphasis,
+  background: vars.colors.primaryBgSubtle,
+  border: `${vars.border.width.thin} solid ${vars.colors.primaryBorderSubtle}`,
+  borderRadius: vars.border.radius.pill,
+  cursor: 'pointer',
+  transition: `all ${vars.transitions.fast}`,
+  selectors: {
+    '&:hover:not(:disabled)': {
+      background: vars.colors.primary,
+      borderColor: vars.colors.primary,
+      color: vars.text.inverse,
+    },
+    '&:focus-visible': {
+      outline: 'none',
+      boxShadow: vars.shadows.focus,
+    },
+    '&:disabled': {
+      opacity: 0.6,
+      cursor: 'not-allowed',
+    },
+  },
+  '@media': {
+    '(prefers-reduced-motion: reduce)': {
+      transition: 'none',
+    },
+  },
+});
+
 export const field = style({
   display: 'flex',
   flexDirection: 'column',

--- a/packages/lib.components/src/components/form/DateRangePicker/DateRangePicker.stories.tsx
+++ b/packages/lib.components/src/components/form/DateRangePicker/DateRangePicker.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react';
 
 import { DateRangePicker } from './DateRangePicker';
+import { createDefaultDateRangePresets } from './presets';
 
 const meta: Meta<typeof DateRangePicker> = {
   title: 'Components/DateRangePicker',
@@ -21,4 +22,12 @@ export const Prefilled: Story = {
 
 export const InvalidRange: Story = {
   args: { value: { from: '2026-08-31', to: '2026-08-01' }, onChange: () => {} },
+};
+
+export const WithPresets: Story = {
+  args: {
+    value: { from: null, to: null },
+    onChange: () => {},
+    presets: createDefaultDateRangePresets(),
+  },
 };

--- a/packages/lib.components/src/components/form/DateRangePicker/DateRangePicker.test.tsx
+++ b/packages/lib.components/src/components/form/DateRangePicker/DateRangePicker.test.tsx
@@ -2,7 +2,8 @@ import '@testing-library/jest-dom';
 import { fireEvent, render, screen } from '@testing-library/react';
 import { vi } from 'vitest';
 
-import { DateRangePicker } from './DateRangePicker';
+import { DateRangePicker, type DateRangePreset } from './DateRangePicker';
+import { createDefaultDateRangePresets } from './presets';
 
 describe('DateRangePicker', () => {
   it('renders two labelled date fields', () => {
@@ -81,5 +82,104 @@ describe('DateRangePicker', () => {
 
     expect(screen.getByLabelText('From')).toBeDisabled();
     expect(screen.getByLabelText('To')).toBeDisabled();
+  });
+
+  describe('presets', () => {
+    const presets: DateRangePreset[] = [
+      { label: 'Last 7 days', getRange: () => ({ from: '2026-07-30', to: '2026-08-06' }) },
+      { label: 'This month', getRange: () => ({ from: '2026-08-01', to: '2026-08-31' }) },
+    ];
+
+    it('renders each preset as a button in a labelled group', () => {
+      render(
+        <DateRangePicker value={{ from: null, to: null }} onChange={() => {}} presets={presets} />
+      );
+
+      expect(screen.getByRole('group', { name: 'Quick date ranges' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Last 7 days' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'This month' })).toBeInTheDocument();
+    });
+
+    it('fires onChange with the preset range when a preset is clicked', () => {
+      const onChange = vi.fn();
+      render(
+        <DateRangePicker value={{ from: null, to: null }} onChange={onChange} presets={presets} />
+      );
+
+      fireEvent.click(screen.getByRole('button', { name: 'Last 7 days' }));
+      expect(onChange).toHaveBeenCalledWith({ from: '2026-07-30', to: '2026-08-06' });
+
+      fireEvent.click(screen.getByRole('button', { name: 'This month' }));
+      expect(onChange).toHaveBeenCalledWith({ from: '2026-08-01', to: '2026-08-31' });
+    });
+
+    it('renders no preset controls when presets are omitted', () => {
+      render(<DateRangePicker value={{ from: null, to: null }} onChange={() => {}} />);
+
+      expect(screen.queryByRole('group')).not.toBeInTheDocument();
+      expect(screen.queryByRole('button')).not.toBeInTheDocument();
+    });
+
+    it('renders no preset controls when presets is an empty array', () => {
+      render(<DateRangePicker value={{ from: null, to: null }} onChange={() => {}} presets={[]} />);
+
+      expect(screen.queryByRole('group')).not.toBeInTheDocument();
+    });
+
+    it('disables preset buttons when disabled', () => {
+      render(
+        <DateRangePicker
+          value={{ from: null, to: null }}
+          onChange={() => {}}
+          presets={presets}
+          disabled
+        />
+      );
+
+      expect(screen.getByRole('button', { name: 'Last 7 days' })).toBeDisabled();
+    });
+  });
+});
+
+describe('createDefaultDateRangePresets', () => {
+  // 6 August 2026, local time.
+  const now = () => new Date(2026, 7, 6);
+
+  it('offers the standard shortcut set', () => {
+    expect(createDefaultDateRangePresets(now).map(preset => preset.label)).toEqual([
+      'Last 7 days',
+      'Last 30 days',
+      'Last 90 days',
+      'This month',
+      'Last month',
+    ]);
+  });
+
+  it('computes relative day ranges ending today', () => {
+    const [sevenDays, thirtyDays, ninetyDays] = createDefaultDateRangePresets(now);
+
+    expect(sevenDays.getRange()).toEqual({ from: '2026-07-30', to: '2026-08-06' });
+    expect(thirtyDays.getRange()).toEqual({ from: '2026-07-07', to: '2026-08-06' });
+    expect(ninetyDays.getRange()).toEqual({ from: '2026-05-08', to: '2026-08-06' });
+  });
+
+  it('computes calendar-month ranges', () => {
+    const byLabel = new Map(
+      createDefaultDateRangePresets(now).map(preset => [preset.label, preset])
+    );
+
+    expect(byLabel.get('This month')?.getRange()).toEqual({
+      from: '2026-08-01',
+      to: '2026-08-31',
+    });
+    expect(byLabel.get('Last month')?.getRange()).toEqual({
+      from: '2026-07-01',
+      to: '2026-07-31',
+    });
+  });
+
+  it('defaults to the real clock when none is injected', () => {
+    const labels = createDefaultDateRangePresets().map(preset => preset.label);
+    expect(labels).toContain('Last 7 days');
   });
 });

--- a/packages/lib.components/src/components/form/DateRangePicker/DateRangePicker.tsx
+++ b/packages/lib.components/src/components/form/DateRangePicker/DateRangePicker.tsx
@@ -9,6 +9,16 @@ export type DateRangeValue = {
   to: string | null;
 };
 
+/**
+ * A quick-select shortcut. `getRange` is evaluated at click time, so relative
+ * ranges (e.g. "Last 7 days") always resolve against the current date without
+ * the component itself reaching for the clock.
+ */
+export type DateRangePreset = {
+  label: string;
+  getRange: () => DateRangeValue;
+};
+
 export type DateRangePickerProps = {
   value: DateRangeValue;
   onChange: (value: DateRangeValue) => void;
@@ -19,6 +29,7 @@ export type DateRangePickerProps = {
   disabled?: boolean;
   error?: string;
   required?: boolean;
+  presets?: DateRangePreset[];
   className?: string;
   'data-testid'?: string;
 };
@@ -32,6 +43,10 @@ const isInvalidRange = (from: string | null, to: string | null): boolean =>
  * user's locale — dd/mm/yyyy for en-GB). Values are ISO `yyyy-mm-dd` strings
  * (or `null`). Selecting a range where `to` precedes `from` surfaces an
  * accessible error, and each field constrains the other's min/max.
+ *
+ * Pass `presets` to render quick-select shortcuts above the fields — each sets
+ * the from/to value on click. Omit it and the component renders exactly as a
+ * plain from/to range control.
  */
 export const DateRangePicker = ({
   value,
@@ -43,6 +58,7 @@ export const DateRangePicker = ({
   disabled = false,
   error,
   required = false,
+  presets,
   className,
   'data-testid': testId,
 }: DateRangePickerProps) => {
@@ -63,6 +79,22 @@ export const DateRangePicker = ({
 
   return (
     <div className={clsx(styles.container, className)} data-testid={testId}>
+      {presets && presets.length > 0 ? (
+        <div className={styles.presets} role='group' aria-label='Quick date ranges'>
+          {presets.map(preset => (
+            <button
+              key={preset.label}
+              type='button'
+              className={styles.presetButton}
+              onClick={() => onChange(preset.getRange())}
+              disabled={disabled}
+            >
+              {preset.label}
+            </button>
+          ))}
+        </div>
+      ) : null}
+
       <div className={styles.field}>
         <label htmlFor={fromId} className={styles.label}>
           {fromLabel}

--- a/packages/lib.components/src/components/form/DateRangePicker/README.md
+++ b/packages/lib.components/src/components/form/DateRangePicker/README.md
@@ -18,19 +18,37 @@ const Example = () => {
 
 ## Props
 
-| Prop          | Type                                           | Default  | Description                                          |
-| ------------- | ---------------------------------------------- | -------- | ---------------------------------------------------- |
-| `value`       | `{ from: string \| null; to: string \| null }` | —        | The current range (ISO `yyyy-mm-dd`).                |
-| `onChange`    | `(value: DateRangeValue) => void`              | —        | Called with the merged range on any field change.    |
-| `fromLabel`   | `string`                                       | `'From'` | Label for the start field.                           |
-| `toLabel`     | `string`                                       | `'To'`   | Label for the end field.                             |
-| `min`         | `string`                                       | —        | Minimum selectable date (ISO).                       |
-| `max`         | `string`                                       | —        | Maximum selectable date (ISO).                       |
-| `disabled`    | `boolean`                                      | `false`  | Disables both fields.                                |
-| `error`       | `string`                                       | —        | Caller-supplied error; overrides the built-in check. |
-| `required`    | `boolean`                                      | `false`  | Renders a required marker on each label.             |
-| `className`   | `string`                                       | —        | Extra class on the container.                        |
-| `data-testid` | `string`                                       | —        | Test id on the container.                            |
+| Prop          | Type                                           | Default  | Description                                           |
+| ------------- | ---------------------------------------------- | -------- | ----------------------------------------------------- |
+| `value`       | `{ from: string \| null; to: string \| null }` | —        | The current range (ISO `yyyy-mm-dd`).                 |
+| `onChange`    | `(value: DateRangeValue) => void`              | —        | Called with the merged range on any field change.     |
+| `fromLabel`   | `string`                                       | `'From'` | Label for the start field.                            |
+| `toLabel`     | `string`                                       | `'To'`   | Label for the end field.                              |
+| `min`         | `string`                                       | —        | Minimum selectable date (ISO).                        |
+| `max`         | `string`                                       | —        | Maximum selectable date (ISO).                        |
+| `disabled`    | `boolean`                                      | `false`  | Disables both fields.                                 |
+| `error`       | `string`                                       | —        | Caller-supplied error; overrides the built-in check.  |
+| `required`    | `boolean`                                      | `false`  | Renders a required marker on each label.              |
+| `presets`     | `DateRangePreset[]`                            | —        | Quick-select shortcuts; omitted → no preset controls. |
+| `className`   | `string`                                       | —        | Extra class on the container.                         |
+| `data-testid` | `string`                                       | —        | Test id on the container.                             |
+
+## Presets
+
+Pass `presets` to render quick-select shortcut buttons above the fields. Each is
+`{ label: string; getRange: () => DateRangeValue }`, and `getRange` is evaluated
+on click — so relative ranges resolve against the current date and the component
+never reaches for the clock itself. Omitting `presets` renders (and behaves as) a
+plain from/to control, unchanged for existing consumers.
+
+`createDefaultDateRangePresets(now?)` builds the standard set — Last 7/30/90
+days, This month, Last month — with an optional injectable clock for tests:
+
+```tsx
+import { DateRangePicker, createDefaultDateRangePresets } from '@adopt-dont-shop/lib.components';
+
+<DateRangePicker value={range} onChange={setRange} presets={createDefaultDateRangePresets()} />;
+```
 
 ## Behaviour & accessibility
 

--- a/packages/lib.components/src/components/form/DateRangePicker/index.ts
+++ b/packages/lib.components/src/components/form/DateRangePicker/index.ts
@@ -1,2 +1,3 @@
 export { DateRangePicker } from './DateRangePicker';
-export type { DateRangePickerProps, DateRangeValue } from './DateRangePicker';
+export type { DateRangePickerProps, DateRangeValue, DateRangePreset } from './DateRangePicker';
+export { createDefaultDateRangePresets } from './presets';

--- a/packages/lib.components/src/components/form/DateRangePicker/presets.ts
+++ b/packages/lib.components/src/components/form/DateRangePicker/presets.ts
@@ -1,0 +1,44 @@
+import type { DateRangePreset, DateRangeValue } from './DateRangePicker';
+
+const pad = (value: number): string => String(value).padStart(2, '0');
+
+// Local-calendar ISO (`yyyy-mm-dd`). Built from local date parts rather than
+// `toISOString()` so the UK day never slips to UTC's near midnight (BST).
+const toIsoDate = (date: Date): string =>
+  `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}`;
+
+const daysBefore = (from: Date, days: number): Date => {
+  const result = new Date(from);
+  result.setDate(result.getDate() - days);
+  return result;
+};
+
+const relativeDays = (now: () => Date, days: number) => (): DateRangeValue => {
+  const today = now();
+  return { from: toIsoDate(daysBefore(today, days)), to: toIsoDate(today) };
+};
+
+const monthRange = (now: () => Date, monthOffset: number) => (): DateRangeValue => {
+  const today = now();
+  const first = new Date(today.getFullYear(), today.getMonth() + monthOffset, 1);
+  const last = new Date(today.getFullYear(), today.getMonth() + monthOffset + 1, 0);
+  return { from: toIsoDate(first), to: toIsoDate(last) };
+};
+
+/**
+ * The standard relative date-range shortcuts (Last 7/30/90 days, This month,
+ * Last month) — the set the rescue analytics picker historically offered. Each
+ * range is computed against `now` at click time, so pass the array straight to
+ * `DateRangePicker`'s `presets` prop and every selection reflects today's date.
+ *
+ * `now` is injectable purely for deterministic tests; production callers omit it.
+ */
+export const createDefaultDateRangePresets = (
+  now: () => Date = () => new Date()
+): DateRangePreset[] => [
+  { label: 'Last 7 days', getRange: relativeDays(now, 7) },
+  { label: 'Last 30 days', getRange: relativeDays(now, 30) },
+  { label: 'Last 90 days', getRange: relativeDays(now, 90) },
+  { label: 'This month', getRange: monthRange(now, 0) },
+  { label: 'Last month', getRange: monthRange(now, -1) },
+];

--- a/packages/lib.components/src/index.ts
+++ b/packages/lib.components/src/index.ts
@@ -68,8 +68,12 @@ export type {
   FormRowProps,
   FormSectionProps,
 } from './components/form/FormField';
-export { DateRangePicker } from './components/form/DateRangePicker';
-export type { DateRangePickerProps, DateRangeValue } from './components/form/DateRangePicker';
+export { DateRangePicker, createDefaultDateRangePresets } from './components/form/DateRangePicker';
+export type {
+  DateRangePickerProps,
+  DateRangeValue,
+  DateRangePreset,
+} from './components/form/DateRangePicker';
 
 // Feedback Components
 export { Alert } from './components/ui/Alert';


### PR DESCRIPTION
## Summary

- Closes the D5 item deferred by #1317: the shared `DateRangePicker` was from/to only, so adopting it in rescue Analytics dropped the local picker's quick-range shortcuts. This adds an **optional `presets` prop** to the shared component and restores the shortcuts.
- Presets are opt-in — **when `presets` is omitted the component is byte-for-byte identical to today**, so no existing consumer changes.

> ⚠️ **Stacked on #1317** (base branch = `claude/ux-review-component-plan-7iq3rz`). It builds on that PR's DateRangePicker adoption. Once #1317 merges I'll rebase this onto `main` and retarget the base.

## Changes

- **`packages/lib.components` — DateRangePicker:**
  - New optional `presets?: DateRangePreset[]` prop (`{ label, getRange }`); `getRange` is evaluated at click time so the component holds no clock. Presets render as real `<button type="button">`s inside a `role="group"` labelled "Quick date ranges", honouring `disabled`.
  - New pure, exported helper `createDefaultDateRangePresets(now = () => new Date())` → **Last 7 / 30 / 90 days, This month, Last month** (parity with the deleted local picker). `now` is injectable for deterministic tests only.
  - ISO `yyyy-mm-dd` values built from **local** calendar parts (not `toISOString()`), so the UK day doesn't slip to UTC under BST; the fields stay native `<input type="date">` (dd/mm/yyyy in en-GB).
  - Styles via `vars` tokens only; new story + README notes.
- **`app.rescue` — Analytics:** opt into `presets={dateRangePresets}` via the shared helper.

## Before requesting review

- [x] Tests for new behaviour added (TDD)
- [x] If touching a `lib.*`, considered consumer impact — the **only** consumer of `DateRangePicker` in the repo is rescue Analytics; `presets` is optional and the omitted-presets path is covered by a test proving no change
- [x] No `.env` requirement changes

## Test plan

- [x] Existing tests pass — `lib.components` **634** (DateRangePicker suite 8→17), `app.rescue` **557**
- [x] New behaviour covered (preset click sets from/to + fires onChange; omitting presets renders unchanged; helper range math)
- [x] No TypeScript errors (`turbo run type-check`)
- [x] Lint passes (`turbo run lint` — 0 errors)
- [ ] Tested manually — verified via the test suites; running stack not exercised in this environment

## Screenshots / recordings

N/A — verified via component tests. Worth a quick visual check of the preset button row on the Analytics page during review.

## Related

- Follow-up to #1317 (D5). `docs/UX-REVIEW-2026-08.md` (Epic D / T8).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q4fStLkBsaY3ncGig1fCaw)_