### PR TITLE
feat(app.client): migrate SettingsForm to shared FormField + inputs (C3)

### DIFF
--- a/apps/client/src/components/profile/SettingsForm.css.ts
+++ b/apps/client/src/components/profile/SettingsForm.css.ts
@@ -68,65 +68,6 @@ export const settingControl = style({
   gap: '1rem',
 });
 
-export const switchLabel = style({
-  position: 'relative',
-  display: 'inline-block',
-  width: '50px',
-  height: '24px',
-});
-
-globalStyle(`${switchLabel} input`, {
-  opacity: 0,
-  width: 0,
-  height: 0,
-});
-
-globalStyle(`${switchLabel} span`, {
-  position: 'absolute',
-  cursor: 'pointer',
-  top: 0,
-  left: 0,
-  right: 0,
-  bottom: 0,
-  backgroundColor: vars.border.color.default,
-  transition: '0.3s',
-  borderRadius: '24px',
-});
-
-globalStyle(`${switchLabel} span:before`, {
-  position: 'absolute',
-  content: '""',
-  height: '18px',
-  width: '18px',
-  left: '3px',
-  bottom: '3px',
-  backgroundColor: 'white',
-  transition: '0.3s',
-  borderRadius: '50%',
-});
-
-globalStyle(`${switchLabel} input:checked + span`, {
-  backgroundColor: vars.colors.primary,
-});
-
-globalStyle(`${switchLabel} input:checked + span:before`, {
-  transform: 'translateX(26px)',
-});
-
-export const select = style({
-  padding: '0.5rem',
-  border: `1px solid ${vars.border.color.default}`,
-  borderRadius: '6px',
-  background: vars.background.body,
-  color: vars.text.primary,
-  fontSize: '0.875rem',
-  minWidth: '150px',
-  ':focus-visible': {
-    outline: 'none',
-    borderColor: vars.colors.primary,
-  },
-});
-
 export const buttonGroup = style({
   display: 'flex',
   gap: '1rem',

--- a/apps/client/src/components/profile/SettingsForm.test.tsx
+++ b/apps/client/src/components/profile/SettingsForm.test.tsx
@@ -1,0 +1,139 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@/test-utils/render';
+import userEvent from '@testing-library/user-event';
+import { createMockUser } from '@adopt-dont-shop/lib.dev-tools';
+import type { NotificationPreferences } from '@/services/notificationService';
+import { SettingsForm } from './SettingsForm';
+
+const getPreferencesMock = vi.fn();
+const updatePreferencesMock = vi.fn();
+
+vi.mock('@/services/notificationService', () => ({
+  default: {
+    getPreferences: () => getPreferencesMock(),
+    updatePreferences: (...args: unknown[]) => updatePreferencesMock(...args),
+  },
+}));
+
+vi.mock('@adopt-dont-shop/lib.auth', async () => {
+  const actual = await vi.importActual<typeof import('@adopt-dont-shop/lib.auth')>(
+    '@adopt-dont-shop/lib.auth'
+  );
+  return {
+    ...actual,
+    TwoFactorSettings: () => <div data-testid='two-factor-settings' />,
+  };
+});
+
+const defaultPreferences: NotificationPreferences = {
+  email: true,
+  push: false,
+  sms: false,
+  applications: true,
+  messages: true,
+  system: true,
+  marketing: false,
+  reminders: true,
+  quietHoursStart: '22:00',
+  quietHoursEnd: '08:00',
+};
+
+const baseUser = createMockUser({
+  userId: 'user-1',
+  email: 'ada@example.com',
+  firstName: 'Ada',
+  lastName: 'Lovelace',
+});
+
+describe('SettingsForm', () => {
+  beforeEach(() => {
+    getPreferencesMock.mockReset();
+    updatePreferencesMock.mockReset();
+    getPreferencesMock.mockResolvedValue(defaultPreferences);
+    updatePreferencesMock.mockResolvedValue(undefined);
+  });
+
+  it('renders each setting with an accessible label', async () => {
+    render(<SettingsForm user={baseUser} onSave={vi.fn()} />);
+
+    // Notification toggles are exposed as labelled checkboxes.
+    expect(await screen.findByLabelText(/email notifications/i)).toHaveProperty('type', 'checkbox');
+    expect(screen.getByLabelText(/push notifications/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/marketing & promotions/i)).toBeInTheDocument();
+
+    // Privacy + preference dropdowns are labelled comboboxes.
+    expect(screen.getByLabelText(/profile visibility/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/search radius/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/quiet hours start/i)).toBeInTheDocument();
+
+    // Descriptions remain as accessible help text.
+    expect(
+      screen.getByText(/receive updates about your applications and new pet matches/i)
+    ).toBeInTheDocument();
+  });
+
+  it('reflects the notification preferences loaded from the service', async () => {
+    getPreferencesMock.mockResolvedValue({
+      ...defaultPreferences,
+      email: false,
+      push: true,
+    });
+
+    render(<SettingsForm user={baseUser} onSave={vi.fn()} />);
+
+    await waitFor(() => {
+      expect(screen.getByLabelText(/email notifications/i)).not.toBeChecked();
+    });
+    expect(screen.getByLabelText(/push notifications/i)).toBeChecked();
+  });
+
+  it('renders each dropdown showing its current value', async () => {
+    render(<SettingsForm user={baseUser} onSave={vi.fn()} />);
+
+    await screen.findByLabelText(/profile visibility/i);
+    // Defaults: public profile, 25 mile radius.
+    expect(screen.getByText('Public')).toBeInTheDocument();
+    expect(screen.getByText('25 miles')).toBeInTheDocument();
+  });
+
+  it('reveals the save controls only after a setting changes', async () => {
+    const user = userEvent.setup();
+    render(<SettingsForm user={baseUser} onSave={vi.fn()} />);
+
+    await screen.findByLabelText(/show email address/i);
+    expect(screen.queryByRole('button', { name: /save settings/i })).not.toBeInTheDocument();
+
+    await user.click(screen.getByLabelText(/show email address/i));
+
+    expect(screen.getByRole('button', { name: /save settings/i })).toBeInTheDocument();
+  });
+
+  it('saves the changed settings through the service and onSave prop', async () => {
+    const user = userEvent.setup();
+    const onSave = vi.fn().mockResolvedValue(undefined);
+    render(<SettingsForm user={baseUser} onSave={onSave} />);
+
+    await screen.findByLabelText(/show email address/i);
+
+    await user.click(screen.getByLabelText(/show email address/i));
+    await user.click(screen.getByRole('button', { name: /save settings/i }));
+
+    await waitFor(() => {
+      expect(updatePreferencesMock).toHaveBeenCalledTimes(1);
+    });
+    expect(updatePreferencesMock.mock.calls[0][0]).toMatchObject({
+      email: true,
+      push: false,
+    });
+
+    expect(onSave).toHaveBeenCalledTimes(1);
+    const saved = onSave.mock.calls[0][0] as {
+      privacy: { showEmail: boolean };
+      preferences: { maxDistance: number };
+      notifications: { email: boolean };
+    };
+    expect(saved.privacy.showEmail).toBe(true);
+    expect(saved.preferences.maxDistance).toBe(25);
+    expect(saved.notifications.email).toBe(true);
+  });
+});

--- a/apps/client/src/components/profile/SettingsForm.tsx
+++ b/apps/client/src/components/profile/SettingsForm.tsx
@@ -1,6 +1,13 @@
 import notificationService from '@/services/notificationService';
 import { User } from '@/types';
-import { Button, ThemeToggle } from '@adopt-dont-shop/lib.components';
+import {
+  Button,
+  CheckboxInput,
+  FormField,
+  SelectInput,
+  ThemeToggle,
+  type SelectOption,
+} from '@adopt-dont-shop/lib.components';
 import { TwoFactorSettings } from '@adopt-dont-shop/lib.auth';
 import React, { useEffect, useState } from 'react';
 import * as styles from './SettingsForm.css';
@@ -36,6 +43,29 @@ interface SettingsFormProps {
   onDeleteAccount?: () => void;
   isLoading?: boolean;
 }
+
+const profileVisibilityOptions: SelectOption[] = [
+  { value: 'public', label: 'Public' },
+  { value: 'private', label: 'Private' },
+];
+
+const searchRadiusOptions: SelectOption[] = [
+  { value: '10', label: '10 miles' },
+  { value: '25', label: '25 miles' },
+  { value: '50', label: '50 miles' },
+  { value: '100', label: '100 miles' },
+  { value: '250', label: '250 miles' },
+  { value: '500', label: '500+ miles' },
+];
+
+const hourOptions: SelectOption[] = Array.from({ length: 24 }, (_, i) => {
+  const hour = i.toString().padStart(2, '0');
+  return { value: `${hour}:00`, label: `${hour}:00` };
+});
+
+// SelectInput yields `string | string[]`; every select here is single-value.
+const singleValue = (value: string | string[]): string =>
+  Array.isArray(value) ? (value[0] ?? '') : value;
 
 export const SettingsForm: React.FC<SettingsFormProps> = ({
   user,
@@ -193,147 +223,91 @@ export const SettingsForm: React.FC<SettingsFormProps> = ({
           <h3 className={styles.sectionTitle}>Notification Preferences</h3>
 
           <div className={styles.settingItem}>
-            <div className={styles.settingLabel}>
-              <h4>Email Notifications</h4>
-              <p>Receive updates about your applications and new pet matches</p>
-            </div>
-            <div className={styles.settingControl}>
-              <label className={styles.switchLabel} aria-label='Email Notifications'>
-                <input
-                  type='checkbox'
-                  checked={settings.notifications.email}
-                  onChange={() => handleToggle('notifications', 'email')}
-                  disabled={isLoading}
-                />
-                <span />
-              </label>
-            </div>
+            <FormField description='Receive updates about your applications and new pet matches'>
+              <CheckboxInput
+                label='Email Notifications'
+                checked={settings.notifications.email}
+                onChange={() => handleToggle('notifications', 'email')}
+                disabled={isLoading}
+              />
+            </FormField>
           </div>
 
           <div className={styles.settingItem}>
-            <div className={styles.settingLabel}>
-              <h4>Push Notifications</h4>
-              <p>Get instant updates on your device</p>
-            </div>
-            <div className={styles.settingControl}>
-              <label className={styles.switchLabel} aria-label='Push Notifications'>
-                <input
-                  type='checkbox'
-                  checked={settings.notifications.push}
-                  onChange={() => handleToggle('notifications', 'push')}
-                  disabled={isLoading}
-                />
-                <span />
-              </label>
-            </div>
+            <FormField description='Get instant updates on your device'>
+              <CheckboxInput
+                label='Push Notifications'
+                checked={settings.notifications.push}
+                onChange={() => handleToggle('notifications', 'push')}
+                disabled={isLoading}
+              />
+            </FormField>
           </div>
 
           <div className={styles.settingItem}>
-            <div className={styles.settingLabel}>
-              <h4>SMS Notifications</h4>
-              <p>Receive text messages for urgent updates</p>
-            </div>
-            <div className={styles.settingControl}>
-              <label className={styles.switchLabel} aria-label='SMS Notifications'>
-                <input
-                  type='checkbox'
-                  checked={settings.notifications.sms}
-                  onChange={() => handleToggle('notifications', 'sms')}
-                  disabled={isLoading}
-                />
-                <span />
-              </label>
-            </div>
+            <FormField description='Receive text messages for urgent updates'>
+              <CheckboxInput
+                label='SMS Notifications'
+                checked={settings.notifications.sms}
+                onChange={() => handleToggle('notifications', 'sms')}
+                disabled={isLoading}
+              />
+            </FormField>
           </div>
 
           <div className={styles.settingItem}>
-            <div className={styles.settingLabel}>
-              <h4>Application Updates</h4>
-              <p>Get notified when your adoption applications change status</p>
-            </div>
-            <div className={styles.settingControl}>
-              <label className={styles.switchLabel} aria-label='Application Updates'>
-                <input
-                  type='checkbox'
-                  checked={settings.notifications.applications}
-                  onChange={() => handleToggle('notifications', 'applications')}
-                  disabled={isLoading}
-                />
-                <span />
-              </label>
-            </div>
+            <FormField description='Get notified when your adoption applications change status'>
+              <CheckboxInput
+                label='Application Updates'
+                checked={settings.notifications.applications}
+                onChange={() => handleToggle('notifications', 'applications')}
+                disabled={isLoading}
+              />
+            </FormField>
           </div>
 
           <div className={styles.settingItem}>
-            <div className={styles.settingLabel}>
-              <h4>Messages</h4>
-              <p>Receive notifications for new messages from rescue organizations</p>
-            </div>
-            <div className={styles.settingControl}>
-              <label className={styles.switchLabel} aria-label='Messages'>
-                <input
-                  type='checkbox'
-                  checked={settings.notifications.messages}
-                  onChange={() => handleToggle('notifications', 'messages')}
-                  disabled={isLoading}
-                />
-                <span />
-              </label>
-            </div>
+            <FormField description='Receive notifications for new messages from rescue organizations'>
+              <CheckboxInput
+                label='Messages'
+                checked={settings.notifications.messages}
+                onChange={() => handleToggle('notifications', 'messages')}
+                disabled={isLoading}
+              />
+            </FormField>
           </div>
 
           <div className={styles.settingItem}>
-            <div className={styles.settingLabel}>
-              <h4>System Notifications</h4>
-              <p>Important system updates and announcements</p>
-            </div>
-            <div className={styles.settingControl}>
-              <label className={styles.switchLabel} aria-label='System Notifications'>
-                <input
-                  type='checkbox'
-                  checked={settings.notifications.system}
-                  onChange={() => handleToggle('notifications', 'system')}
-                  disabled={isLoading}
-                />
-                <span />
-              </label>
-            </div>
+            <FormField description='Important system updates and announcements'>
+              <CheckboxInput
+                label='System Notifications'
+                checked={settings.notifications.system}
+                onChange={() => handleToggle('notifications', 'system')}
+                disabled={isLoading}
+              />
+            </FormField>
           </div>
 
           <div className={styles.settingItem}>
-            <div className={styles.settingLabel}>
-              <h4>Marketing &amp; Promotions</h4>
-              <p>Receive updates about special events and adoption promotions</p>
-            </div>
-            <div className={styles.settingControl}>
-              <label className={styles.switchLabel} aria-label='Marketing &amp; Promotions'>
-                <input
-                  type='checkbox'
-                  checked={settings.notifications.marketing}
-                  onChange={() => handleToggle('notifications', 'marketing')}
-                  disabled={isLoading}
-                />
-                <span />
-              </label>
-            </div>
+            <FormField description='Receive updates about special events and adoption promotions'>
+              <CheckboxInput
+                label='Marketing & Promotions'
+                checked={settings.notifications.marketing}
+                onChange={() => handleToggle('notifications', 'marketing')}
+                disabled={isLoading}
+              />
+            </FormField>
           </div>
 
           <div className={styles.settingItem}>
-            <div className={styles.settingLabel}>
-              <h4>Reminders</h4>
-              <p>Get reminders about incomplete applications and follow-ups</p>
-            </div>
-            <div className={styles.settingControl}>
-              <label className={styles.switchLabel} aria-label='Reminders'>
-                <input
-                  type='checkbox'
-                  checked={settings.notifications.reminders}
-                  onChange={() => handleToggle('notifications', 'reminders')}
-                  disabled={isLoading}
-                />
-                <span />
-              </label>
-            </div>
+            <FormField description='Get reminders about incomplete applications and follow-ups'>
+              <CheckboxInput
+                label='Reminders'
+                checked={settings.notifications.reminders}
+                onChange={() => handleToggle('notifications', 'reminders')}
+                disabled={isLoading}
+              />
+            </FormField>
           </div>
         </div>
 
@@ -341,57 +315,40 @@ export const SettingsForm: React.FC<SettingsFormProps> = ({
           <h3 className={styles.sectionTitle}>Privacy Settings</h3>
 
           <div className={styles.settingItem}>
-            <div className={styles.settingLabel}>
-              <h4>Profile Visibility</h4>
-              <p>Control who can see your profile information</p>
-            </div>
-            <div className={styles.settingControl}>
-              <select
-                className={styles.select}
-                value={settings.privacy.profileVisibility}
-                onChange={e => handleSelectChange('privacy', 'profileVisibility', e.target.value)}
+            <SelectInput
+              label='Profile Visibility'
+              helperText='Control who can see your profile information'
+              value={settings.privacy.profileVisibility}
+              onChange={value =>
+                handleSelectChange('privacy', 'profileVisibility', singleValue(value))
+              }
+              options={profileVisibilityOptions}
+              disabled={isLoading}
+              data-testid='setting-profile-visibility'
+              fullWidth
+            />
+          </div>
+
+          <div className={styles.settingItem}>
+            <FormField description='Allow rescue organizations to see your email'>
+              <CheckboxInput
+                label='Show Email Address'
+                checked={settings.privacy.showEmail}
+                onChange={() => handleToggle('privacy', 'showEmail')}
                 disabled={isLoading}
-              >
-                <option value='public'>Public</option>
-                <option value='private'>Private</option>
-              </select>
-            </div>
+              />
+            </FormField>
           </div>
 
           <div className={styles.settingItem}>
-            <div className={styles.settingLabel}>
-              <h4>Show Email Address</h4>
-              <p>Allow rescue organizations to see your email</p>
-            </div>
-            <div className={styles.settingControl}>
-              <label className={styles.switchLabel} aria-label='Show Email Address'>
-                <input
-                  type='checkbox'
-                  checked={settings.privacy.showEmail}
-                  onChange={() => handleToggle('privacy', 'showEmail')}
-                  disabled={isLoading}
-                />
-                <span />
-              </label>
-            </div>
-          </div>
-
-          <div className={styles.settingItem}>
-            <div className={styles.settingLabel}>
-              <h4>Show Phone Number</h4>
-              <p>Allow rescue organizations to see your phone number</p>
-            </div>
-            <div className={styles.settingControl}>
-              <label className={styles.switchLabel} aria-label='Show Phone Number'>
-                <input
-                  type='checkbox'
-                  checked={settings.privacy.showPhone}
-                  onChange={() => handleToggle('privacy', 'showPhone')}
-                  disabled={isLoading}
-                />
-                <span />
-              </label>
-            </div>
+            <FormField description='Allow rescue organizations to see your phone number'>
+              <CheckboxInput
+                label='Show Phone Number'
+                checked={settings.privacy.showPhone}
+                onChange={() => handleToggle('privacy', 'showPhone')}
+                disabled={isLoading}
+              />
+            </FormField>
           </div>
         </div>
 
@@ -399,45 +356,29 @@ export const SettingsForm: React.FC<SettingsFormProps> = ({
           <h3 className={styles.sectionTitle}>Pet Preferences</h3>
 
           <div className={styles.settingItem}>
-            <div className={styles.settingLabel}>
-              <h4>Newsletter Subscription</h4>
-              <p>Receive weekly updates about new pets and adoption stories</p>
-            </div>
-            <div className={styles.settingControl}>
-              <label className={styles.switchLabel} aria-label='Newsletter Subscription'>
-                <input
-                  type='checkbox'
-                  checked={settings.preferences.newsletterOptIn}
-                  onChange={() => handleToggle('preferences', 'newsletterOptIn')}
-                  disabled={isLoading}
-                />
-                <span />
-              </label>
-            </div>
+            <FormField description='Receive weekly updates about new pets and adoption stories'>
+              <CheckboxInput
+                label='Newsletter Subscription'
+                checked={settings.preferences.newsletterOptIn}
+                onChange={() => handleToggle('preferences', 'newsletterOptIn')}
+                disabled={isLoading}
+              />
+            </FormField>
           </div>
 
           <div className={styles.settingItem}>
-            <div className={styles.settingLabel}>
-              <h4>Search Radius</h4>
-              <p>Maximum distance to search for pets (miles)</p>
-            </div>
-            <div className={styles.settingControl}>
-              <select
-                className={styles.select}
-                value={settings.preferences.maxDistance.toString()}
-                onChange={e =>
-                  handleNumberChange('preferences', 'maxDistance', parseInt(e.target.value))
-                }
-                disabled={isLoading}
-              >
-                <option value='10'>10 miles</option>
-                <option value='25'>25 miles</option>
-                <option value='50'>50 miles</option>
-                <option value='100'>100 miles</option>
-                <option value='250'>250 miles</option>
-                <option value='500'>500+ miles</option>
-              </select>
-            </div>
+            <SelectInput
+              label='Search Radius'
+              helperText='Maximum distance to search for pets (miles)'
+              value={settings.preferences.maxDistance.toString()}
+              onChange={value =>
+                handleNumberChange('preferences', 'maxDistance', parseInt(singleValue(value), 10))
+              }
+              options={searchRadiusOptions}
+              disabled={isLoading}
+              data-testid='setting-search-radius'
+              fullWidth
+            />
           </div>
         </div>
 
@@ -445,53 +386,33 @@ export const SettingsForm: React.FC<SettingsFormProps> = ({
           <h3 className={styles.sectionTitle}>Quiet Hours</h3>
 
           <div className={styles.settingItem}>
-            <div className={styles.settingLabel}>
-              <h4>Quiet Hours Start</h4>
-              <p>Time when non-urgent notifications will be paused</p>
-            </div>
-            <div className={styles.settingControl}>
-              <select
-                className={styles.select}
-                value={settings.notifications.quietHoursStart || '22:00'}
-                onChange={e =>
-                  handleSelectChange('notifications', 'quietHoursStart', e.target.value)
-                }
-                disabled={isLoading}
-              >
-                {Array.from({ length: 24 }, (_, i) => {
-                  const hour = i.toString().padStart(2, '0');
-                  return (
-                    <option key={hour} value={`${hour}:00`}>
-                      {hour}:00
-                    </option>
-                  );
-                })}
-              </select>
-            </div>
+            <SelectInput
+              label='Quiet Hours Start'
+              helperText='Time when non-urgent notifications will be paused'
+              value={settings.notifications.quietHoursStart || '22:00'}
+              onChange={value =>
+                handleSelectChange('notifications', 'quietHoursStart', singleValue(value))
+              }
+              options={hourOptions}
+              disabled={isLoading}
+              data-testid='setting-quiet-hours-start'
+              fullWidth
+            />
           </div>
 
           <div className={styles.settingItem}>
-            <div className={styles.settingLabel}>
-              <h4>Quiet Hours End</h4>
-              <p>Time when notifications will resume</p>
-            </div>
-            <div className={styles.settingControl}>
-              <select
-                className={styles.select}
-                value={settings.notifications.quietHoursEnd || '08:00'}
-                onChange={e => handleSelectChange('notifications', 'quietHoursEnd', e.target.value)}
-                disabled={isLoading}
-              >
-                {Array.from({ length: 24 }, (_, i) => {
-                  const hour = i.toString().padStart(2, '0');
-                  return (
-                    <option key={hour} value={`${hour}:00`}>
-                      {hour}:00
-                    </option>
-                  );
-                })}
-              </select>
-            </div>
+            <SelectInput
+              label='Quiet Hours End'
+              helperText='Time when notifications will resume'
+              value={settings.notifications.quietHoursEnd || '08:00'}
+              onChange={value =>
+                handleSelectChange('notifications', 'quietHoursEnd', singleValue(value))
+              }
+              options={hourOptions}
+              disabled={isLoading}
+              data-testid='setting-quiet-hours-end'
+              fullWidth
+            />
           </div>
         </div>
 

--- a/apps/client/src/setup-tests.ts
+++ b/apps/client/src/setup-tests.ts
@@ -288,6 +288,15 @@ vi.mock('@adopt-dont-shop/lib.components', () => ({
     value,
     onChange,
     options = [],
+    helperText,
+    error,
+    required,
+    disabled,
+    'data-testid': testId,
+    // Absorbed so they don't leak onto the DOM <select> as unknown attributes.
+    fullWidth: _fullWidth,
+    state: _state,
+    placeholder: _placeholder,
     ...props
   }: {
     label?: string;
@@ -295,22 +304,89 @@ vi.mock('@adopt-dont-shop/lib.components', () => ({
     value?: string;
     onChange?: (v: string) => void;
     options?: Array<{ value: string; label: string }>;
+    helperText?: string;
+    error?: string;
+    required?: boolean;
+    disabled?: boolean;
+    'data-testid'?: string;
+    fullWidth?: boolean;
+    state?: string;
+    placeholder?: string;
   }) => {
-    const inputId = id ?? (label ? label.toLowerCase().replace(/\s+/g, '-') : undefined);
+    const inputId = id ?? testId ?? (label ? label.toLowerCase().replace(/\s+/g, '-') : undefined);
     return React.createElement(
       'div',
-      null,
-      label && React.createElement('label', { htmlFor: inputId }, label),
+      { 'data-testid': testId },
+      label && React.createElement('label', { htmlFor: inputId }, label, required ? ' *' : null),
       React.createElement(
         'select',
         {
           id: inputId,
           value,
+          disabled,
           onChange: (e: React.ChangeEvent<HTMLSelectElement>) => onChange?.(e.target.value),
           ...props,
         },
         options.map(o => React.createElement('option', { key: o.value, value: o.value }, o.label))
-      )
+      ),
+      error
+        ? React.createElement('span', { role: 'alert' }, error)
+        : helperText
+          ? React.createElement('span', null, helperText)
+          : null
+    );
+  },
+  CheckboxInput: ({
+    label,
+    checked,
+    defaultChecked,
+    description,
+    disabled,
+    id,
+    onChange,
+    required,
+    error,
+    helperText,
+    'data-testid': testId,
+    ...props
+  }: {
+    label?: string;
+    checked?: boolean;
+    defaultChecked?: boolean;
+    description?: string;
+    disabled?: boolean;
+    id?: string;
+    onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
+    required?: boolean;
+    error?: string;
+    helperText?: string;
+    'data-testid'?: string;
+    [key: string]: unknown;
+  }) => {
+    const inputId =
+      id ?? (label ? `checkbox-${label.toLowerCase().replace(/\s+/g, '-')}` : undefined);
+    return React.createElement(
+      'div',
+      null,
+      React.createElement('input', {
+        type: 'checkbox',
+        id: inputId,
+        checked,
+        defaultChecked,
+        disabled,
+        required,
+        'aria-required': required ? true : undefined,
+        'data-testid': testId,
+        onChange,
+        ...props,
+      }),
+      label && React.createElement('label', { htmlFor: inputId }, label),
+      description ? React.createElement('p', null, description) : null,
+      error
+        ? React.createElement('span', { role: 'alert' }, error)
+        : helperText
+          ? React.createElement('span', null, helperText)
+          : null
     );
   },
   // ADS-C3: FormField label + error scaffolding (mirrors the real component).


### PR DESCRIPTION
## Summary

- Closes the C3 item deferred by #1317: the profile `SettingsForm` was a bespoke preferences panel (toggle switches + native `<select>`s). It now uses the shared `CheckboxInput` / `SelectInput` (+ `FormField`), reusing each setting's existing heading as the single field label so nothing is duplicated.
- Independent of the D2/D5 PRs — based on `main`, touches only `app.client`.

## Changes

- **`SettingsForm.tsx`** — all 15 setting rows migrated:
  - 11 boolean toggles → `CheckboxInput` inside `FormField` (heading as label, old help text as the `FormField` description, associated via `aria-describedby`).
  - 4 dropdowns → `SelectInput` with its own label + `helperText`, mirroring the `ProfileEditForm` idiom from #1314; a small `singleValue` helper adapts `SelectInput`'s `string | string[]` onChange to the existing handlers.
  - Save/submit behaviour (`updatePreferences`, `onSave`, `hasChanges`/Cancel) preserved byte-for-byte. Appearance (`ThemeToggle`), Security (`TwoFactorSettings`) and Danger-Zone sections are not form controls — left untouched.
- **`SettingsForm.css.ts`** — removed the now-orphaned `switchLabel` (+ its `globalStyle` rules) and `select` styles; kept the styles still used by the untouched rows.
- **`setup-tests.ts`** — added a faithful `CheckboxInput` mock (the global lib.components mock lacked it) and taught the `SelectInput` mock to render `helperText` / absorb extra props.

**No Zod validation added — deliberately:** every migrated control is a boolean or a bounded fixed-option select, so there is no free-text/unbounded value to guard; a schema here would be dead code.

**Visual change (pre-approved):** rows move from a two-column (heading left / control right) layout to stacked fields (label above, help text below); the toggle switches render as standard checkboxes. All heading/help text is preserved verbatim.

## Before requesting review

- [x] Tests for new behaviour added (TDD)
- [x] If touching a `lib.*`, considered consumer impact — **no `lib.*` changes** (only the app-local test mock was extended)
- [x] No `.env` requirement changes

## Test plan

- [x] Existing tests pass — `app.client` **565** (SettingsForm suite 0→5; ProfilePage still green)
- [x] New behaviour covered (accessible labels render; loaded prefs reflected in control state; changing a control reveals Save; saving calls `updatePreferences` + `onSave` with expected values)
- [x] No TypeScript errors (`turbo run type-check`)
- [x] Lint passes (`turbo run lint` — 0 errors)
- [ ] Tested manually — verified via the test suite; running stack not exercised in this environment

## Screenshots / recordings

N/A — verified via component tests. The stacked-field restyle of the settings rows is worth a visual check during review.

## Related

- Follow-up to #1317 (C3). `docs/UX-REVIEW-2026-08.md` (Epic C / T1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q4fStLkBsaY3ncGig1fCaw)_