### PR TITLE
feat(lib.components): extend DataTable (selection, controlled sort/pagination, row variants) + adopt in rescue (D2)

### DIFF
--- a/apps/rescue/src/components/applications/ApplicationList.tsx
+++ b/apps/rescue/src/components/applications/ApplicationList.tsx
@@ -1,5 +1,10 @@
-import React from 'react';
-import { EmptyState, ErrorState } from '@adopt-dont-shop/lib.components';
+import React, { useMemo } from 'react';
+import {
+  DataTable,
+  EmptyState,
+  ErrorState,
+  type DataTableColumn,
+} from '@adopt-dont-shop/lib.components';
 import StatusBadge from '../common/StatusBadge';
 import type {
   ApplicationListItem,
@@ -133,7 +138,44 @@ interface ApplicationListProps {
   onApplicationSelect: (application: ApplicationListItem) => void;
   selectedIds?: Set<string>;
   onSelectionChange?: (next: Set<string>) => void;
+  onPageChange?: (page: number) => void;
 }
+
+// Column keys that map 1:1 onto server-side sort fields. Used to translate a
+// DataTable header-sort click back into an ApplicationSort without a cast.
+const sortFieldForKey = (key: string): ApplicationSort['field'] | null => {
+  switch (key) {
+    case 'submittedAt':
+      return 'submittedAt';
+    case 'status':
+      return 'status';
+    case 'petName':
+      return 'petName';
+    case 'applicantName':
+      return 'applicantName';
+    case 'priority':
+      return 'priority';
+    default:
+      return null;
+  }
+};
+
+const priorityVariant = (
+  priority: string | undefined
+): 'urgent' | 'high' | 'medium' | 'low' | 'default' => {
+  switch (priority) {
+    case 'urgent':
+      return 'urgent';
+    case 'high':
+      return 'high';
+    case 'medium':
+      return 'medium';
+    case 'low':
+      return 'low';
+    default:
+      return 'default';
+  }
+};
 
 const ApplicationList: React.FC<ApplicationListProps> = ({
   applications,
@@ -147,32 +189,176 @@ const ApplicationList: React.FC<ApplicationListProps> = ({
   onApplicationSelect,
   selectedIds,
   onSelectionChange,
+  onPageChange,
 }) => {
   const selectionEnabled = selectedIds !== undefined && onSelectionChange !== undefined;
-  const toggleOne = (id: string) => {
-    if (!selectionEnabled) {
-      return;
-    }
-    const next = new Set(selectedIds);
-    if (next.has(id)) {
-      next.delete(id);
-    } else {
-      next.add(id);
-    }
-    onSelectionChange(next);
+
+  // Look up the full application by id from a DataTable row (rows are plain
+  // records; the render callbacks resolve the typed item here).
+  const byId = useMemo(() => new Map(applications.map(a => [a.id, a])), [applications]);
+
+  const handleSelectionChange = (ids: string[]) => {
+    onSelectionChange?.(new Set(ids));
   };
-  const allSelected =
-    selectionEnabled && applications.length > 0 && applications.every(a => selectedIds.has(a.id));
-  const toggleAll = () => {
-    if (!selectionEnabled) {
-      return;
-    }
-    if (allSelected) {
-      onSelectionChange(new Set());
-    } else {
-      onSelectionChange(new Set(applications.map(a => a.id)));
+
+  const handleColumnSort = (key: string, direction: 'asc' | 'desc') => {
+    const field = sortFieldForKey(key);
+    if (field) {
+      onSortChange({ field, direction });
     }
   };
+
+  const handleRowClick = (row: Record<string, unknown>) => {
+    const app = byId.get(String(row.id));
+    if (app) {
+      onApplicationSelect(app);
+    }
+  };
+
+  const columns: DataTableColumn[] = [
+    {
+      key: 'applicantName',
+      label: 'Applicant',
+      render: (_value, row) => {
+        const app = byId.get(String(row.id));
+        if (!app) {
+          return null;
+        }
+        return (
+          <div className={styles.applicantInfo}>
+            <div className={styles.applicantName}>{app.applicantName}</div>
+            <div className={styles.applicantEmail}>
+              {app.data?.personalInfo?.email || 'No email provided'}
+            </div>
+          </div>
+        );
+      },
+    },
+    {
+      key: 'petName',
+      label: 'Pet',
+      sortable: false,
+      render: (_value, row) => {
+        const app = byId.get(String(row.id));
+        if (!app) {
+          return null;
+        }
+        return (
+          <div className={styles.petInfo}>
+            <div className={styles.petName}>{app.petName || 'Unknown Pet'}</div>
+            <div className={styles.petDetails}>
+              {app.petType} • {app.petBreed}
+            </div>
+          </div>
+        );
+      },
+    },
+    {
+      key: 'status',
+      label: 'Status',
+      render: (_value, row) => {
+        const app = byId.get(String(row.id));
+        if (!app) {
+          return null;
+        }
+        return <StatusBadge status={app.status || 'unknown'} />;
+      },
+    },
+    {
+      key: 'priority',
+      label: 'Priority',
+      render: (_value, row) => {
+        const app = byId.get(String(row.id));
+        if (!app) {
+          return null;
+        }
+        return (
+          <span className={styles.priorityBadge({ priority: priorityVariant(app.priority) })}>
+            {app.priority}
+          </span>
+        );
+      },
+    },
+    {
+      key: 'submittedAt',
+      label: 'Submitted',
+      render: (_value, row) => {
+        const app = byId.get(String(row.id));
+        if (!app) {
+          return null;
+        }
+        return app.submittedDaysAgo === 0 ? 'Today' : `${app.submittedDaysAgo} days ago`;
+      },
+    },
+    {
+      key: 'progress',
+      label: 'Progress',
+      sortable: false,
+      render: (_value, row) => {
+        const app = byId.get(String(row.id));
+        if (!app) {
+          return null;
+        }
+        const progress = getApplicationProgress(app);
+        return (
+          <div className={styles.progressIndicators}>
+            <div className={styles.progressBar}>
+              {[0, 1, 2, 3, 4].map(stepIndex => {
+                const stepStatus = getStepStatus(
+                  stepIndex,
+                  progress.current,
+                  progress.stage,
+                  progress.finalOutcome
+                );
+                return (
+                  <div
+                    key={stepIndex}
+                    className={styles.progressStep({
+                      status: stepStatus,
+                      isLast: stepIndex === 4,
+                    })}
+                  />
+                );
+              })}
+            </div>
+            <span className={styles.progressLabel}>
+              {getStepLabel(progress.current, app.stage, app.finalOutcome)}
+            </span>
+          </div>
+        );
+      },
+    },
+    {
+      key: 'actions',
+      label: 'Actions',
+      sortable: false,
+      render: (_value, row) => {
+        const app = byId.get(String(row.id));
+        if (!app) {
+          return null;
+        }
+        return (
+          <div className={styles.actionsContainer}>
+            {getActionButtons(app, onApplicationSelect).map(action => (
+              <button
+                key={action.label}
+                className={styles.actionButton({ variant: action.variant })}
+                onClick={e => {
+                  e.stopPropagation();
+                  action.action();
+                }}
+              >
+                {action.label}
+              </button>
+            ))}
+          </div>
+        );
+      },
+    },
+  ];
+
+  const tableRows = applications.map(a => ({ id: a.id }));
+
   // Convert complex ApplicationFilter to simple string-based filters for UI
   const getDateRangeValue = () => {
     if (!filter.dateRange) {
@@ -328,21 +514,14 @@ const ApplicationList: React.FC<ApplicationListProps> = ({
           </div>
         ) : !loading && applications.length === 0 ? (
           <EmptyState title="No applications found matching your criteria." />
-        ) : (
+        ) : loading ? (
+          // Per-row skeleton loading is a bespoke affordance kept out of the
+          // shared DataTable; it mirrors the DataTable column layout below.
           <div className={styles.tableWrapper}>
             <table className={styles.table}>
               <thead className={styles.tableHead}>
                 <tr>
-                  {selectionEnabled && (
-                    <th className={styles.tableHeader}>
-                      <input
-                        type="checkbox"
-                        aria-label="Select all applications"
-                        checked={allSelected}
-                        onChange={toggleAll}
-                      />
-                    </th>
-                  )}
+                  {selectionEnabled && <th className={styles.tableHeader} />}
                   <th className={styles.tableHeader}>Applicant</th>
                   <th className={styles.tableHeader}>Pet</th>
                   <th className={styles.tableHeader}>Status</th>
@@ -353,149 +532,62 @@ const ApplicationList: React.FC<ApplicationListProps> = ({
                 </tr>
               </thead>
               <tbody className={styles.tableBody}>
-                {loading
-                  ? Array.from({ length: pagination.limit }, (_, i) => (
-                      <tr key={`skeleton-${i}`} className={styles.tableRow} aria-hidden="true">
-                        {selectionEnabled && (
-                          <td className={styles.tableCell}>
-                            <div className={styles.skeletonBlock} style={{ width: '1rem' }} />
-                          </td>
-                        )}
-                        <td className={styles.tableCell}>
-                          <div className={styles.skeletonBlock} style={{ width: '60%' }} />
-                          <div
-                            className={styles.skeletonBlock}
-                            style={{ width: '40%', marginTop: '0.25rem' }}
-                          />
-                        </td>
-                        <td className={styles.tableCell}>
-                          <div className={styles.skeletonBlock} style={{ width: '50%' }} />
-                        </td>
-                        <td className={styles.tableCell}>
-                          <div className={styles.skeletonBlock} style={{ width: '4rem' }} />
-                        </td>
-                        <td className={styles.tableCell}>
-                          <div className={styles.skeletonBlock} style={{ width: '3rem' }} />
-                        </td>
-                        <td className={styles.tableCell}>
-                          <div className={styles.skeletonBlock} style={{ width: '5rem' }} />
-                        </td>
-                        <td className={styles.tableCell}>
-                          <div className={styles.skeletonBlock} style={{ width: '80%' }} />
-                        </td>
-                        <td className={styles.tableCell}>
-                          <div className={styles.skeletonBlock} style={{ width: '5rem' }} />
-                        </td>
-                      </tr>
-                    ))
-                  : applications.map(application => (
-                      <tr
-                        key={application.id}
-                        className={styles.tableRow}
-                        onClick={() => onApplicationSelect(application)}
-                      >
-                        {selectionEnabled && (
-                          <td className={styles.tableCell} onClick={e => e.stopPropagation()}>
-                            <input
-                              type="checkbox"
-                              aria-label={`Select application ${application.id}`}
-                              checked={selectedIds.has(application.id)}
-                              onChange={() => toggleOne(application.id)}
-                            />
-                          </td>
-                        )}
-                        <td className={styles.tableCell}>
-                          <div className={styles.applicantInfo}>
-                            <div className={styles.applicantName}>{application.applicantName}</div>
-                            <div className={styles.applicantEmail}>
-                              {application.data?.personalInfo?.email || 'No email provided'}
-                            </div>
-                          </div>
-                        </td>
-                        <td className={styles.tableCell}>
-                          <div className={styles.petInfo}>
-                            <div className={styles.petName}>
-                              {application.petName || 'Unknown Pet'}
-                            </div>
-                            <div className={styles.petDetails}>
-                              {application.petType} • {application.petBreed}
-                            </div>
-                          </div>
-                        </td>
-                        <td className={styles.tableCell}>
-                          <StatusBadge status={application.status || 'unknown'} />
-                        </td>
-                        <td className={styles.tableCell}>
-                          <span
-                            className={styles.priorityBadge({
-                              priority: application.priority as
-                                | 'urgent'
-                                | 'high'
-                                | 'medium'
-                                | 'low'
-                                | 'default',
-                            })}
-                          >
-                            {application.priority}
-                          </span>
-                        </td>
-                        <td className={styles.tableCell}>
-                          {application.submittedDaysAgo === 0
-                            ? 'Today'
-                            : `${application.submittedDaysAgo} days ago`}
-                        </td>
-                        <td className={styles.tableCell}>
-                          <div className={styles.progressIndicators}>
-                            <div className={styles.progressBar}>
-                              {[0, 1, 2, 3, 4].map(stepIndex => {
-                                const progress = getApplicationProgress(application);
-                                const stepStatus = getStepStatus(
-                                  stepIndex,
-                                  progress.current,
-                                  progress.stage,
-                                  progress.finalOutcome
-                                );
-                                return (
-                                  <div
-                                    key={stepIndex}
-                                    className={styles.progressStep({
-                                      status: stepStatus,
-                                      isLast: stepIndex === 4,
-                                    })}
-                                  />
-                                );
-                              })}
-                            </div>
-                            <span className={styles.progressLabel}>
-                              {getStepLabel(
-                                getApplicationProgress(application).current,
-                                application.stage,
-                                application.finalOutcome
-                              )}
-                            </span>
-                          </div>
-                        </td>
-                        <td className={styles.tableCell} onClick={e => e.stopPropagation()}>
-                          <div className={styles.actionsContainer}>
-                            {getActionButtons(application, onApplicationSelect).map(action => (
-                              <button
-                                key={action.label}
-                                className={styles.actionButton({ variant: action.variant })}
-                                onClick={e => {
-                                  e.stopPropagation();
-                                  action.action();
-                                }}
-                              >
-                                {action.label}
-                              </button>
-                            ))}
-                          </div>
-                        </td>
-                      </tr>
-                    ))}
+                {Array.from({ length: pagination.limit }, (_, i) => (
+                  <tr key={`skeleton-${i}`} className={styles.tableRow} aria-hidden="true">
+                    {selectionEnabled && (
+                      <td className={styles.tableCell}>
+                        <div className={styles.skeletonBlock} style={{ width: '1rem' }} />
+                      </td>
+                    )}
+                    <td className={styles.tableCell}>
+                      <div className={styles.skeletonBlock} style={{ width: '60%' }} />
+                      <div
+                        className={styles.skeletonBlock}
+                        style={{ width: '40%', marginTop: '0.25rem' }}
+                      />
+                    </td>
+                    <td className={styles.tableCell}>
+                      <div className={styles.skeletonBlock} style={{ width: '50%' }} />
+                    </td>
+                    <td className={styles.tableCell}>
+                      <div className={styles.skeletonBlock} style={{ width: '4rem' }} />
+                    </td>
+                    <td className={styles.tableCell}>
+                      <div className={styles.skeletonBlock} style={{ width: '3rem' }} />
+                    </td>
+                    <td className={styles.tableCell}>
+                      <div className={styles.skeletonBlock} style={{ width: '5rem' }} />
+                    </td>
+                    <td className={styles.tableCell}>
+                      <div className={styles.skeletonBlock} style={{ width: '80%' }} />
+                    </td>
+                    <td className={styles.tableCell}>
+                      <div className={styles.skeletonBlock} style={{ width: '5rem' }} />
+                    </td>
+                  </tr>
+                ))}
               </tbody>
             </table>
           </div>
+        ) : (
+          <DataTable
+            frameless
+            columns={columns}
+            rows={tableRows}
+            getRowId={row => String(row.id)}
+            onRowClick={handleRowClick}
+            rowClassName={() => styles.tableRow}
+            selectable={selectionEnabled}
+            selectedIds={selectedIds}
+            onSelectionChange={handleSelectionChange}
+            sortBy={sort.field}
+            sortDirection={sort.direction}
+            onSortChange={handleColumnSort}
+            page={pagination.page}
+            pageSize={pagination.limit}
+            total={pagination.total}
+            onPageChange={onPageChange}
+          />
         )}
       </div>
     </div>

--- a/apps/rescue/src/components/pets/PetCsvImportModal.css.ts
+++ b/apps/rescue/src/components/pets/PetCsvImportModal.css.ts
@@ -61,26 +61,6 @@ export const select = style({
   width: '100%',
 });
 
-export const previewTable = style({
-  width: '100%',
-  borderCollapse: 'collapse',
-  fontSize: '0.85rem',
-});
-
-export const previewCell = style({
-  border: '1px solid #e5e7eb',
-  padding: '0.4rem 0.5rem',
-  verticalAlign: 'top',
-});
-
-export const rowOk = style({
-  background: '#f0fdf4',
-});
-
-export const rowError = style({
-  background: '#fef2f2',
-});
-
 export const errorList = style({
   margin: 0,
   paddingLeft: '1.25rem',

--- a/apps/rescue/src/components/pets/PetCsvImportModal.test.tsx
+++ b/apps/rescue/src/components/pets/PetCsvImportModal.test.tsx
@@ -52,6 +52,29 @@ vi.mock('@adopt-dont-shop/lib.components', () => ({
     error: (...args: unknown[]) => toastError(...args),
     success: (...args: unknown[]) => toastSuccess(...args),
   }),
+  DataTable: ({
+    columns,
+    rows,
+  }: {
+    columns: Array<{
+      key: string;
+      label: string;
+      render?: (value: unknown, row: Record<string, unknown>) => React.ReactNode;
+    }>;
+    rows: Record<string, unknown>[];
+  }) => (
+    <table>
+      <tbody>
+        {rows.map((row, i) => (
+          <tr key={i}>
+            {columns.map(c => (
+              <td key={c.key}>{c.render ? c.render(row[c.key], row) : String(row[c.key] ?? '')}</td>
+            ))}
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  ),
 }));
 
 vi.mock('@adopt-dont-shop/lib.pets', () => ({

--- a/apps/rescue/src/components/pets/PetCsvImportModal.tsx
+++ b/apps/rescue/src/components/pets/PetCsvImportModal.tsx
@@ -1,5 +1,12 @@
 import React, { useMemo, useRef, useState } from 'react';
-import { Button, Modal, toast } from '@adopt-dont-shop/lib.components';
+import {
+  Button,
+  DataTable,
+  Modal,
+  toast,
+  type DataTableColumn,
+  type DataTableRowVariant,
+} from '@adopt-dont-shop/lib.components';
 import {
   IMPORTABLE_FIELDS,
   type ColumnMapping,
@@ -54,6 +61,51 @@ type Props = {
   onClose: () => void;
   onImported: () => void;
 };
+
+// Row highlighting for the preview table: valid rows are tinted success, rows
+// that would be skipped as duplicates warning, and failing rows danger.
+const previewRowVariant = (row: Record<string, unknown>): DataTableRowVariant => {
+  if (row.ok === false) {
+    return 'danger';
+  }
+  if (row.isDup === true) {
+    return 'warning';
+  }
+  return 'success';
+};
+
+const previewColumns: DataTableColumn[] = [
+  { key: 'row', label: 'Row', sortable: false },
+  { key: 'name', label: 'Name', sortable: false },
+  { key: 'type', label: 'Type', sortable: false },
+  { key: 'breed', label: 'Breed', sortable: false },
+  {
+    key: 'status',
+    label: 'Status',
+    sortable: false,
+    render: (_value, row) => {
+      if (row.ok === false) {
+        const errors = Array.isArray(row.errors) ? row.errors : [];
+        return (
+          <ul className={styles.errorList}>
+            {errors.map((e, i) => (
+              <li key={i}>{String(e)}</li>
+            ))}
+          </ul>
+        );
+      }
+      if (row.isDup === true) {
+        return <span>Duplicate — will skip</span>;
+      }
+      return <span>OK</span>;
+    },
+  },
+];
+
+const failureColumns: DataTableColumn[] = [
+  { key: 'row', label: 'Row', sortable: false },
+  { key: 'reason', label: 'Reason', sortable: false },
+];
 
 const PetCsvImportModal: React.FC<Props> = ({ isOpen, rescueId, onClose, onImported }) => {
   const [step, setStep] = useState<Step>('upload');
@@ -123,6 +175,34 @@ const PetCsvImportModal: React.FC<Props> = ({ isOpen, rescueId, onClose, onImpor
     }
     return dupes;
   }, [validatedRows, previouslyImportedIds]);
+
+  const previewRows = useMemo<Record<string, unknown>[]>(() => {
+    if (!parsed) {
+      return [];
+    }
+    return validatedRows.map(r => {
+      const isDup = duplicateRowIndexes.has(r.rowIndex);
+      const rawRow = parsed.rows[r.rowIndex - 1];
+      const cellValue = (field: ImportableField): string => {
+        const header = mapping[field];
+        return header ? String(rawRow[header] ?? '') : '';
+      };
+      return {
+        row: r.rowIndex,
+        name: cellValue('name'),
+        type: cellValue('type'),
+        breed: cellValue('breed'),
+        ok: r.ok,
+        isDup,
+        errors: r.ok ? [] : r.errors,
+      };
+    });
+  }, [parsed, validatedRows, mapping, duplicateRowIndexes]);
+
+  const failureRows = useMemo<Record<string, unknown>[]>(
+    () => (summary ? summary.failed.map(f => ({ row: f.rowIndex, reason: f.reason })) : []),
+    [summary]
+  );
 
   const requiredFieldsMapped = IMPORTABLE_FIELDS.filter(f => f.required).every(f => mapping[f.key]);
 
@@ -320,45 +400,14 @@ const PetCsvImportModal: React.FC<Props> = ({ isOpen, rescueId, onClose, onImpor
               </div>
             )}
             <div className={styles.scrollableTable}>
-              <table className={styles.previewTable}>
-                <thead>
-                  <tr>
-                    <th className={styles.previewCell}>Row</th>
-                    <th className={styles.previewCell}>Name</th>
-                    <th className={styles.previewCell}>Type</th>
-                    <th className={styles.previewCell}>Breed</th>
-                    <th className={styles.previewCell}>Status</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {validatedRows.map(r => {
-                    const isDup = duplicateRowIndexes.has(r.rowIndex);
-                    const className = r.ok && !isDup ? styles.rowOk : styles.rowError;
-                    const rawRow = parsed.rows[r.rowIndex - 1];
-                    const cell = (field: ImportableField) =>
-                      mapping[field] ? rawRow[mapping[field]!] : '';
-                    return (
-                      <tr key={r.rowIndex} className={className}>
-                        <td className={styles.previewCell}>{r.rowIndex}</td>
-                        <td className={styles.previewCell}>{cell('name')}</td>
-                        <td className={styles.previewCell}>{cell('type')}</td>
-                        <td className={styles.previewCell}>{cell('breed')}</td>
-                        <td className={styles.previewCell}>
-                          {r.ok && !isDup && <span>OK</span>}
-                          {r.ok && isDup && <span>Duplicate — will skip</span>}
-                          {!r.ok && (
-                            <ul className={styles.errorList}>
-                              {r.errors.map((e, i) => (
-                                <li key={i}>{e}</li>
-                              ))}
-                            </ul>
-                          )}
-                        </td>
-                      </tr>
-                    );
-                  })}
-                </tbody>
-              </table>
+              <DataTable
+                frameless
+                columns={previewColumns}
+                rows={previewRows}
+                getRowId={row => String(row.row)}
+                getRowVariant={previewRowVariant}
+                pageSize={Math.max(previewRows.length, 1)}
+              />
             </div>
             <div className={styles.actionsRow}>
               <Button variant="outline" onClick={() => setStep('map')}>
@@ -391,22 +440,14 @@ const PetCsvImportModal: React.FC<Props> = ({ isOpen, rescueId, onClose, onImpor
             </div>
             {summary.failed.length > 0 && (
               <div className={styles.failureTable}>
-                <table className={styles.previewTable}>
-                  <thead>
-                    <tr>
-                      <th className={styles.previewCell}>Row</th>
-                      <th className={styles.previewCell}>Reason</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {summary.failed.map(f => (
-                      <tr key={f.rowIndex} className={styles.rowError}>
-                        <td className={styles.previewCell}>{f.rowIndex}</td>
-                        <td className={styles.previewCell}>{f.reason}</td>
-                      </tr>
-                    ))}
-                  </tbody>
-                </table>
+                <DataTable
+                  frameless
+                  columns={failureColumns}
+                  rows={failureRows}
+                  getRowId={row => String(row.row)}
+                  getRowVariant={() => 'danger'}
+                  pageSize={Math.max(failureRows.length, 1)}
+                />
               </div>
             )}
             <div className={styles.actionsRow}>

--- a/apps/rescue/src/pages/Applications.tsx
+++ b/apps/rescue/src/pages/Applications.tsx
@@ -46,6 +46,7 @@ const Applications: React.FC = () => {
     pagination,
     updateFilter,
     updateSort,
+    changePage,
     updateApplicationStatus,
     refetch,
   } = useApplications();
@@ -234,6 +235,7 @@ const Applications: React.FC = () => {
         onApplicationSelect={handleApplicationSelect}
         selectedIds={selectedIds}
         onSelectionChange={updateSelection}
+        onPageChange={changePage}
       />
 
       {/* Application Review Modal */}

--- a/packages/lib.components/src/components/charts/DataTable.css.ts
+++ b/packages/lib.components/src/components/charts/DataTable.css.ts
@@ -1,4 +1,7 @@
 import { globalStyle, style } from '@vanilla-extract/css';
+import { recipe } from '@vanilla-extract/recipes';
+
+import { vars } from '../../styles/theme.css';
 
 export const scrollContainer = style({
   height: '100%',
@@ -117,5 +120,81 @@ globalStyle(`${cardsTable} td::before`, {
       color: 'var(--color-text-muted, #6b7280)',
       textAlign: 'left',
     },
+  },
+});
+
+/* ─────────────────────────────────────────────────────────────────────────
+ * ADS UX D2 — opt-in additive styles for selection, non-sortable headers and
+ * per-row highlighting. These use the theme `vars` contract (design-tokens
+ * skill) and are only applied when the matching opt-in props are set, so the
+ * default table appearance is unchanged.
+ * ──────────────────────────────────────────────────────────────────────── */
+
+/** Leading checkbox column — kept narrow and vertically aligned with cells. */
+export const selectCell = style({
+  width: '1%',
+  padding: `${vars.spacing['2']} ${vars.spacing['2']}`,
+  textAlign: 'center',
+  borderBottom: `${vars.border.width.thin} solid var(--color-border, #e5e7eb)`,
+});
+
+export const selectHeaderCell = style([
+  selectCell,
+  {
+    position: 'sticky',
+    top: 0,
+    background: 'var(--color-surface-muted, #f9fafb)',
+  },
+]);
+
+export const checkbox = style({
+  cursor: 'pointer',
+  width: vars.spacing['3'],
+  height: vars.spacing['3'],
+  accentColor: vars.colors.primary,
+  selectors: {
+    '&:focus-visible': {
+      outline: `${vars.border.width.base} solid ${vars.colors.primary}`,
+      outlineOffset: vars.spacing['1'],
+    },
+  },
+});
+
+/** Non-sortable column header — plain label with the same padding as the sort button. */
+export const headerLabel = style({
+  display: 'block',
+  padding: `${vars.spacing['2']} ${vars.spacing['3']}`,
+});
+
+/** Frameless empty state used when the table is rendered without the ChartFrame chrome. */
+export const emptyFrameless = style({
+  padding: vars.spacing['4'],
+  textAlign: 'center',
+  color: vars.text.muted,
+  fontSize: vars.typography.size.sm,
+});
+
+/**
+ * Per-row highlighting. `variant` tints the row for valid / duplicate / invalid
+ * style states; `selected` highlights a row picked via the selection column.
+ * Token-based so it stays theme-aware in light / normal / dark.
+ */
+export const rowVariant = recipe({
+  base: {},
+  variants: {
+    variant: {
+      default: {},
+      success: { backgroundColor: vars.colors.successBgSubtle },
+      warning: { backgroundColor: vars.colors.warningBgSubtle },
+      danger: { backgroundColor: vars.colors.dangerBgSubtle },
+    },
+    selected: {
+      true: { backgroundColor: vars.colors.primaryBgSubtle },
+      false: {},
+    },
+  },
+  defaultVariants: {
+    variant: 'default',
+    selected: false,
   },
 });

--- a/packages/lib.components/src/components/charts/DataTable.test.tsx
+++ b/packages/lib.components/src/components/charts/DataTable.test.tsx
@@ -16,6 +16,13 @@ const rows = [
   { name: 'Cy', age: 2 },
 ];
 
+// Rows carrying stable ids for the selection / variant / pagination suites.
+const idRows = [
+  { id: 'r1', name: 'Bea', age: 4 },
+  { id: 'r2', name: 'Ada', age: 7 },
+  { id: 'r3', name: 'Cy', age: 2 },
+];
+
 describe('DataTable sortable headers', () => {
   it('reports aria-sort="none" on unsorted columns', () => {
     renderWithTheme(<DataTable title='Pets' columns={columns} rows={rows} />);
@@ -63,5 +70,273 @@ describe('DataTable responsive layout', () => {
     expect(screen.getByText('Ada')).toBeInTheDocument();
     expect(screen.getByText('Cy')).toBeInTheDocument();
     expect(screen.getByText('Bea').closest('td')).toHaveAttribute('data-label', 'Name');
+  });
+});
+
+describe('DataTable row selection', () => {
+  it('renders no checkboxes unless selection is enabled', () => {
+    renderWithTheme(<DataTable title='Pets' columns={columns} rows={idRows} />);
+    expect(screen.queryByRole('checkbox')).toBeNull();
+  });
+
+  it('renders a select-all header checkbox and one checkbox per row when selectable', () => {
+    renderWithTheme(
+      <DataTable
+        title='Pets'
+        columns={columns}
+        rows={idRows}
+        selectable
+        selectedIds={[]}
+        onSelectionChange={vi.fn()}
+      />
+    );
+
+    expect(screen.getByRole('checkbox', { name: /select all/i })).toBeInTheDocument();
+    expect(screen.getAllByRole('checkbox', { name: /select row/i })).toHaveLength(3);
+  });
+
+  it('select-all selects every visible row', async () => {
+    const user = userEvent.setup();
+    const onSelectionChange = vi.fn();
+    renderWithTheme(
+      <DataTable
+        title='Pets'
+        columns={columns}
+        rows={idRows}
+        selectable
+        selectedIds={[]}
+        onSelectionChange={onSelectionChange}
+      />
+    );
+
+    await user.click(screen.getByRole('checkbox', { name: /select all/i }));
+    expect(onSelectionChange).toHaveBeenCalledWith(['r1', 'r2', 'r3']);
+  });
+
+  it('select-all deselects every visible row when already fully selected', async () => {
+    const user = userEvent.setup();
+    const onSelectionChange = vi.fn();
+    renderWithTheme(
+      <DataTable
+        title='Pets'
+        columns={columns}
+        rows={idRows}
+        selectable
+        selectedIds={['r1', 'r2', 'r3']}
+        onSelectionChange={onSelectionChange}
+      />
+    );
+
+    await user.click(screen.getByRole('checkbox', { name: /select all/i }));
+    expect(onSelectionChange).toHaveBeenCalledWith([]);
+  });
+
+  it('shows an indeterminate select-all for a partial selection', () => {
+    renderWithTheme(
+      <DataTable
+        title='Pets'
+        columns={columns}
+        rows={idRows}
+        selectable
+        selectedIds={['r1']}
+        onSelectionChange={vi.fn()}
+      />
+    );
+
+    const selectAll = screen.getByRole('checkbox', { name: /select all/i });
+    expect(selectAll).not.toBeChecked();
+    expect(selectAll).toHaveProperty('indeterminate', true);
+  });
+
+  it('checks (and clears indeterminate on) the select-all when all rows are selected', () => {
+    renderWithTheme(
+      <DataTable
+        title='Pets'
+        columns={columns}
+        rows={idRows}
+        selectable
+        selectedIds={['r1', 'r2', 'r3']}
+        onSelectionChange={vi.fn()}
+      />
+    );
+
+    const selectAll = screen.getByRole('checkbox', { name: /select all/i });
+    expect(selectAll).toBeChecked();
+    expect(selectAll).toHaveProperty('indeterminate', false);
+  });
+
+  it('toggling one row adds it to the existing selection', async () => {
+    const user = userEvent.setup();
+    const onSelectionChange = vi.fn();
+    renderWithTheme(
+      <DataTable
+        title='Pets'
+        columns={columns}
+        rows={idRows}
+        selectable
+        selectedIds={['r1']}
+        onSelectionChange={onSelectionChange}
+      />
+    );
+
+    const rowCheckboxes = screen.getAllByRole('checkbox', { name: /select row/i });
+    await user.click(rowCheckboxes[1]);
+    expect(onSelectionChange).toHaveBeenCalledWith(['r1', 'r2']);
+  });
+});
+
+describe('DataTable controlled sort', () => {
+  it('reflects the controlled sortBy/sortDirection in aria-sort', () => {
+    renderWithTheme(
+      <DataTable
+        title='Pets'
+        columns={columns}
+        rows={idRows}
+        sortBy='age'
+        sortDirection='desc'
+        onSortChange={vi.fn()}
+      />
+    );
+
+    expect(screen.getByTestId('th-age')).toHaveAttribute('aria-sort', 'descending');
+    expect(screen.getByTestId('th-name')).toHaveAttribute('aria-sort', 'none');
+  });
+
+  it('calls onSortChange on header click and does NOT re-sort rows locally', async () => {
+    const user = userEvent.setup();
+    const onSortChange = vi.fn();
+    renderWithTheme(
+      <DataTable
+        title='Pets'
+        columns={columns}
+        rows={idRows}
+        sortBy='name'
+        sortDirection='asc'
+        onSortChange={onSortChange}
+      />
+    );
+
+    // Given order is Bea, Ada, Cy — a local asc sort would reorder to Ada first.
+    expect(screen.getAllByRole('row')[1]).toHaveTextContent('Bea');
+
+    await user.click(screen.getByRole('button', { name: /name/i }));
+
+    // Controlled: the parent is asked to flip direction; rows stay in given order.
+    expect(onSortChange).toHaveBeenCalledWith('name', 'desc');
+    expect(screen.getAllByRole('row')[1]).toHaveTextContent('Bea');
+  });
+
+  it('does not render a sort button for a non-sortable column', () => {
+    const cols: DataTableColumn[] = [
+      { key: 'name', label: 'Name' },
+      { key: 'actions', label: 'Actions', sortable: false },
+    ];
+    renderWithTheme(<DataTable title='Pets' columns={cols} rows={idRows} />);
+
+    expect(screen.getByRole('button', { name: /name/i })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /actions/i })).toBeNull();
+  });
+});
+
+describe('DataTable controlled pagination', () => {
+  it('shows the controlled page info and renders all given rows (no local slice)', () => {
+    renderWithTheme(
+      <DataTable
+        title='Pets'
+        columns={columns}
+        rows={idRows}
+        page={2}
+        pageSize={10}
+        total={25}
+        onPageChange={vi.fn()}
+      />
+    );
+
+    // ceil(25 / 10) === 3 pages.
+    expect(screen.getByText('Page 2 of 3')).toBeInTheDocument();
+    expect(screen.getByText('Bea')).toBeInTheDocument();
+    expect(screen.getByText('Ada')).toBeInTheDocument();
+    expect(screen.getByText('Cy')).toBeInTheDocument();
+  });
+
+  it('calls onPageChange for Next and Prev', async () => {
+    const user = userEvent.setup();
+    const onPageChange = vi.fn();
+    renderWithTheme(
+      <DataTable
+        title='Pets'
+        columns={columns}
+        rows={idRows}
+        page={2}
+        pageSize={10}
+        total={25}
+        onPageChange={onPageChange}
+      />
+    );
+
+    await user.click(screen.getByRole('button', { name: /next/i }));
+    expect(onPageChange).toHaveBeenCalledWith(3);
+
+    await user.click(screen.getByRole('button', { name: /prev/i }));
+    expect(onPageChange).toHaveBeenCalledWith(1);
+  });
+
+  it('disables Prev on the first page', () => {
+    renderWithTheme(
+      <DataTable
+        title='Pets'
+        columns={columns}
+        rows={idRows}
+        page={1}
+        pageSize={10}
+        total={25}
+        onPageChange={vi.fn()}
+      />
+    );
+
+    expect(screen.getByRole('button', { name: /prev/i })).toBeDisabled();
+    expect(screen.getByRole('button', { name: /next/i })).toBeEnabled();
+  });
+});
+
+describe('DataTable row highlighting', () => {
+  it('marks a row with the variant returned by getRowVariant', () => {
+    renderWithTheme(
+      <DataTable
+        title='Pets'
+        columns={columns}
+        rows={idRows}
+        getRowVariant={row => (row.id === 'r2' ? 'danger' : 'default')}
+      />
+    );
+
+    expect(screen.getByText('Ada').closest('tr')).toHaveAttribute('data-variant', 'danger');
+    // 'default' rows carry no variant marker.
+    expect(screen.getByText('Bea').closest('tr')).not.toHaveAttribute('data-variant');
+  });
+
+  it('applies a custom rowClassName to the matching row', () => {
+    renderWithTheme(
+      <DataTable
+        title='Pets'
+        columns={columns}
+        rows={idRows}
+        rowClassName={row => (row.id === 'r1' ? 'flagged-row' : undefined)}
+      />
+    );
+
+    expect(screen.getByText('Bea').closest('tr')?.className).toContain('flagged-row');
+    expect(screen.getByText('Ada').closest('tr')?.className).not.toContain('flagged-row');
+  });
+});
+
+describe('DataTable frameless mode', () => {
+  it('omits the ChartFrame chrome (no title heading, no frame test id)', () => {
+    renderWithTheme(<DataTable title='Pets' columns={columns} rows={idRows} frameless />);
+
+    expect(screen.queryByTestId('chart-frame')).toBeNull();
+    expect(screen.queryByRole('heading', { name: 'Pets' })).toBeNull();
+    // The table itself still renders.
+    expect(screen.getByText('Bea')).toBeInTheDocument();
   });
 });

--- a/packages/lib.components/src/components/charts/DataTable.tsx
+++ b/packages/lib.components/src/components/charts/DataTable.tsx
@@ -8,9 +8,21 @@ export type DataTableColumn = {
   label: string;
   /** Optional renderer for non-trivial cells. */
   render?: (value: unknown, row: Record<string, unknown>) => React.ReactNode;
+  /**
+   * Whether the header drives sorting. Defaults to `true`, preserving the
+   * original behaviour where every column header is a sort control.
+   */
+  sortable?: boolean;
 };
 
-export type DataTableProps = Omit<ChartFrameProps, 'children' | 'isEmpty'> & {
+export type SortDirection = 'asc' | 'desc';
+
+/** Highlight tone for a row, applied via a token-based recipe (not inline styles). */
+export type DataTableRowVariant = 'default' | 'success' | 'warning' | 'danger';
+
+export type DataTableProps = Omit<ChartFrameProps, 'children' | 'isEmpty' | 'title'> & {
+  /** Optional in frameless mode; otherwise shown as the ChartFrame heading. */
+  title?: string;
   columns: DataTableColumn[];
   rows: Record<string, unknown>[];
   pageSize?: number;
@@ -22,6 +34,38 @@ export type DataTableProps = Omit<ChartFrameProps, 'children' | 'isEmpty'> & {
    * label/value card below the mobile breakpoint.
    */
   responsive?: 'scroll' | 'cards';
+
+  // ── Row selection (opt-in, controlled) ─────────────────────────────────
+  /** Render a leading checkbox column + header select-all checkbox. */
+  selectable?: boolean;
+  /** The currently-selected row ids (controlled). */
+  selectedIds?: readonly string[] | ReadonlySet<string>;
+  /** Called with the next full selection whenever a checkbox toggles. */
+  onSelectionChange?: (selectedIds: string[]) => void;
+  /** Derives a stable id for a row (defaults to `row.id`, falling back to index). */
+  getRowId?: (row: Record<string, unknown>, index: number) => string;
+
+  // ── Controlled (server-side) sort (opt-in) ─────────────────────────────
+  /** When `onSortChange` is provided the table stops sorting locally. */
+  sortBy?: string | null;
+  sortDirection?: SortDirection;
+  onSortChange?: (key: string, direction: SortDirection) => void;
+
+  // ── Controlled (server-side) pagination (opt-in) ───────────────────────
+  /** 1-based page index; when provided with `total`/`onPageChange` the table
+   *  stops paginating locally and renders the given rows as the current page. */
+  page?: number;
+  total?: number;
+  onPageChange?: (page: number) => void;
+
+  // ── Per-row highlighting ───────────────────────────────────────────────
+  /** Tone applied to a row (valid / duplicate / invalid style states). */
+  getRowVariant?: (row: Record<string, unknown>, index: number) => DataTableRowVariant | undefined;
+  /** Escape hatch for an additional per-row class. */
+  rowClassName?: (row: Record<string, unknown>, index: number) => string | undefined;
+
+  /** Render the bare table without the ChartFrame chrome (title/border/states). */
+  frameless?: boolean;
 };
 
 const compareCells = (a: unknown, b: unknown): number => {
@@ -34,114 +78,250 @@ const compareCells = (a: unknown, b: unknown): number => {
   return String(a ?? '').localeCompare(String(b ?? ''));
 };
 
+const toIdSet = (ids?: readonly string[] | ReadonlySet<string>): Set<string> => {
+  if (!ids) {
+    return new Set<string>();
+  }
+  return new Set<string>(ids);
+};
+
+const defaultGetRowId = (row: Record<string, unknown>, index: number): string => {
+  const id = row.id;
+  return id === undefined || id === null ? String(index) : String(id);
+};
+
 export const DataTable: React.FC<DataTableProps> = ({
+  title,
   columns,
   rows,
   pageSize = 25,
   onRowClick,
   responsive = 'scroll',
+  selectable = false,
+  selectedIds,
+  onSelectionChange,
+  getRowId,
+  sortBy,
+  sortDirection,
+  onSortChange,
+  page,
+  total,
+  onPageChange,
+  getRowVariant,
+  rowClassName,
+  frameless = false,
   ...frame
 }) => {
-  const [sortKey, setSortKey] = useState<string | null>(null);
-  const [sortDir, setSortDir] = useState<'asc' | 'desc'>('asc');
-  const [page, setPage] = useState(0);
+  const [internalSortKey, setInternalSortKey] = useState<string | null>(null);
+  const [internalSortDir, setInternalSortDir] = useState<SortDirection>('asc');
+  const [internalPage, setInternalPage] = useState(0);
+
+  const controlledSort = onSortChange !== undefined;
+  const controlledPagination =
+    page !== undefined && total !== undefined && onPageChange !== undefined;
+
+  const activeSortKey = controlledSort ? (sortBy ?? null) : internalSortKey;
+  const activeSortDir: SortDirection = controlledSort ? (sortDirection ?? 'asc') : internalSortDir;
 
   const sortedRows = useMemo(() => {
-    if (!sortKey) {
+    if (controlledSort || !internalSortKey) {
       return rows;
     }
     const copy = [...rows];
     copy.sort((a, b) => {
-      const cmp = compareCells(a[sortKey], b[sortKey]);
-      return sortDir === 'asc' ? cmp : -cmp;
+      const cmp = compareCells(a[internalSortKey], b[internalSortKey]);
+      return internalSortDir === 'asc' ? cmp : -cmp;
     });
     return copy;
-  }, [rows, sortKey, sortDir]);
+  }, [rows, internalSortKey, internalSortDir, controlledSort]);
 
-  const totalPages = Math.max(1, Math.ceil(sortedRows.length / pageSize));
-  const safePage = Math.min(page, totalPages - 1);
-  const visibleRows = sortedRows.slice(safePage * pageSize, (safePage + 1) * pageSize);
+  const pageCount = controlledPagination
+    ? Math.max(1, Math.ceil((total ?? 0) / pageSize))
+    : Math.max(1, Math.ceil(sortedRows.length / pageSize));
+  const currentPageIndex = controlledPagination
+    ? Math.max(0, (page ?? 1) - 1)
+    : Math.min(internalPage, pageCount - 1);
+  const visibleRows = controlledPagination
+    ? sortedRows
+    : sortedRows.slice(currentPageIndex * pageSize, (currentPageIndex + 1) * pageSize);
+
+  const getRowIdFn = getRowId ?? defaultGetRowId;
+  const selectedSet = useMemo(() => toIdSet(selectedIds), [selectedIds]);
+  const visibleIds = visibleRows.map((row, i) => getRowIdFn(row, i));
+  const selectedVisibleCount = visibleIds.filter(id => selectedSet.has(id)).length;
+  const allVisibleSelected = visibleRows.length > 0 && selectedVisibleCount === visibleRows.length;
+  const someVisibleSelected = selectedVisibleCount > 0;
 
   const handleSort = (key: string): void => {
-    if (sortKey === key) {
-      setSortDir(d => (d === 'asc' ? 'desc' : 'asc'));
+    if (controlledSort) {
+      const nextDir: SortDirection =
+        activeSortKey === key && activeSortDir === 'asc' ? 'desc' : 'asc';
+      onSortChange?.(key, nextDir);
+      return;
+    }
+    if (internalSortKey === key) {
+      setInternalSortDir(d => (d === 'asc' ? 'desc' : 'asc'));
     } else {
-      setSortKey(key);
-      setSortDir('asc');
+      setInternalSortKey(key);
+      setInternalSortDir('asc');
     }
   };
 
-  return (
-    <ChartFrame {...frame} isEmpty={rows.length === 0}>
-      <div className={styles.scrollContainer}>
-        <table className={clsx(styles.table, responsive === 'cards' && styles.cardsTable)}>
-          <thead>
-            <tr>
-              {columns.map(col => {
-                const isSorted = sortKey === col.key;
-                const ariaSort: 'ascending' | 'descending' | 'none' = isSorted
-                  ? sortDir === 'asc'
-                    ? 'ascending'
-                    : 'descending'
-                  : 'none';
+  const toggleOne = (id: string): void => {
+    const next = new Set(selectedSet);
+    if (next.has(id)) {
+      next.delete(id);
+    } else {
+      next.add(id);
+    }
+    onSelectionChange?.(Array.from(next));
+  };
+
+  const toggleAll = (): void => {
+    const next = new Set(selectedSet);
+    if (allVisibleSelected) {
+      visibleIds.forEach(id => next.delete(id));
+    } else {
+      visibleIds.forEach(id => next.add(id));
+    }
+    onSelectionChange?.(Array.from(next));
+  };
+
+  const goToPage = (nextPage: number): void => {
+    if (controlledPagination) {
+      onPageChange?.(nextPage + 1);
+      return;
+    }
+    setInternalPage(nextPage);
+  };
+
+  const content = (
+    <div className={styles.scrollContainer}>
+      <table className={clsx(styles.table, responsive === 'cards' && styles.cardsTable)}>
+        <thead>
+          <tr>
+            {selectable ? (
+              <th className={styles.selectHeaderCell}>
+                <input
+                  type='checkbox'
+                  className={styles.checkbox}
+                  aria-label='Select all'
+                  checked={allVisibleSelected}
+                  ref={el => {
+                    if (el) {
+                      el.indeterminate = someVisibleSelected && !allVisibleSelected;
+                    }
+                  }}
+                  onChange={toggleAll}
+                />
+              </th>
+            ) : null}
+            {columns.map(col => {
+              const sortable = col.sortable ?? true;
+              if (!sortable) {
                 return (
-                  <th
-                    key={col.key}
-                    className={styles.th}
-                    data-testid={`th-${col.key}`}
-                    aria-sort={ariaSort}
-                  >
-                    <button
-                      type='button'
-                      className={styles.sortButton}
-                      onClick={() => handleSort(col.key)}
-                    >
-                      {col.label}
-                      {isSorted ? (sortDir === 'asc' ? ' ▲' : ' ▼') : ''}
-                    </button>
+                  <th key={col.key} className={styles.th} data-testid={`th-${col.key}`}>
+                    <span className={styles.headerLabel}>{col.label}</span>
                   </th>
                 );
-              })}
-            </tr>
-          </thead>
-          <tbody>
-            {visibleRows.map((row, i) => (
+              }
+              const isSorted = activeSortKey === col.key;
+              const ariaSort: 'ascending' | 'descending' | 'none' = isSorted
+                ? activeSortDir === 'asc'
+                  ? 'ascending'
+                  : 'descending'
+                : 'none';
+              return (
+                <th
+                  key={col.key}
+                  className={styles.th}
+                  data-testid={`th-${col.key}`}
+                  aria-sort={ariaSort}
+                >
+                  <button
+                    type='button'
+                    className={styles.sortButton}
+                    onClick={() => handleSort(col.key)}
+                  >
+                    {col.label}
+                    {isSorted ? (activeSortDir === 'asc' ? ' ▲' : ' ▼') : ''}
+                  </button>
+                </th>
+              );
+            })}
+          </tr>
+        </thead>
+        <tbody>
+          {visibleRows.map((row, i) => {
+            const rowId = getRowIdFn(row, i);
+            const isSelected = selectable && selectedSet.has(rowId);
+            const variant = getRowVariant?.(row, i) ?? 'default';
+            return (
               <tr
-                key={i}
-                onClick={() => onRowClick?.(row)}
-                className={onRowClick ? styles.rowClickable : styles.rowDefault}
+                key={rowId}
+                onClick={onRowClick ? () => onRowClick(row) : undefined}
+                data-variant={variant === 'default' ? undefined : variant}
+                className={clsx(
+                  onRowClick ? styles.rowClickable : styles.rowDefault,
+                  styles.rowVariant({ variant, selected: isSelected }),
+                  rowClassName?.(row, i)
+                )}
               >
+                {selectable ? (
+                  <td className={styles.selectCell} onClick={e => e.stopPropagation()}>
+                    <input
+                      type='checkbox'
+                      className={styles.checkbox}
+                      aria-label='Select row'
+                      checked={selectedSet.has(rowId)}
+                      onChange={() => toggleOne(rowId)}
+                    />
+                  </td>
+                ) : null}
                 {columns.map(col => (
                   <td key={col.key} className={styles.td} data-label={col.label}>
                     {col.render ? col.render(row[col.key], row) : String(row[col.key] ?? '')}
                   </td>
                 ))}
               </tr>
-            ))}
-          </tbody>
-        </table>
-        {totalPages > 1 ? (
-          <div className={styles.pagination}>
-            <button
-              type='button'
-              disabled={safePage === 0}
-              onClick={() => setPage(p => Math.max(0, p - 1))}
-            >
-              Prev
-            </button>
-            <span>
-              Page {safePage + 1} of {totalPages}
-            </span>
-            <button
-              type='button'
-              disabled={safePage >= totalPages - 1}
-              onClick={() => setPage(p => Math.min(totalPages - 1, p + 1))}
-            >
-              Next
-            </button>
-          </div>
-        ) : null}
-      </div>
+            );
+          })}
+        </tbody>
+      </table>
+      {pageCount > 1 ? (
+        <div className={styles.pagination}>
+          <button
+            type='button'
+            disabled={currentPageIndex === 0}
+            onClick={() => goToPage(Math.max(0, currentPageIndex - 1))}
+          >
+            Prev
+          </button>
+          <span>
+            Page {currentPageIndex + 1} of {pageCount}
+          </span>
+          <button
+            type='button'
+            disabled={currentPageIndex >= pageCount - 1}
+            onClick={() => goToPage(Math.min(pageCount - 1, currentPageIndex + 1))}
+          >
+            Next
+          </button>
+        </div>
+      ) : null}
+    </div>
+  );
+
+  if (frameless) {
+    if (rows.length === 0) {
+      return <div className={styles.emptyFrameless}>{frame.emptyMessage ?? 'No data'}</div>;
+    }
+    return content;
+  }
+
+  return (
+    <ChartFrame {...frame} title={title ?? ''} isEmpty={rows.length === 0}>
+      {content}
     </ChartFrame>
   );
 };

--- a/packages/lib.components/src/index.ts
+++ b/packages/lib.components/src/index.ts
@@ -144,7 +144,12 @@ export type { AreaChartProps } from './components/charts/AreaChart';
 export { MetricCard } from './components/charts/MetricCard';
 export type { MetricCardProps, MetricCardFormat } from './components/charts/MetricCard';
 export { DataTable } from './components/charts/DataTable';
-export type { DataTableProps, DataTableColumn } from './components/charts/DataTable';
+export type {
+  DataTableProps,
+  DataTableColumn,
+  DataTableRowVariant,
+  SortDirection,
+} from './components/charts/DataTable';
 export { PALETTE as ChartPalette } from './components/charts/types';
 export type { ChartSeries, ChartDatum } from './components/charts/types';
 


### PR DESCRIPTION
## Summary

- Closes the D2 items #1317 deferred: rescue's `ApplicationList` and `PetCsvImportModal` stayed on bespoke `<table>`s because the shared `DataTable` couldn't express row selection, server-side sort/pagination, or per-row highlighting. This **extends `DataTable` additively** (every existing usage unchanged) and migrates both.
- No new table abstraction — the shared component gains opt-in props, per the approved approach.

> ⚠️ **Stacked on #1317** (base = `claude/ux-review-component-plan-7iq3rz`); builds on that PR's rescue D-work. I'll rebase onto `main` and retarget once #1317 merges.

## Changes

**`packages/lib.components` — DataTable (all props opt-in; omitting them = today's behaviour):**

| Prop | Effect |
|---|---|
| `selectable` + `selectedIds` / `onSelectionChange` / `getRowId` | Controlled selection: leading checkbox column + select-all header with indeterminate state (aria-labelled). Select-all unions/removes **only visible rows**, so off-page selection survives. |
| `sortBy` / `sortDirection` / `onSortChange` | Controlled server sort — disables local client-sort when a handler is supplied; `aria-sort` reflected. |
| `page` / `total` / `onPageChange` (+ existing `pageSize`) | Controlled server pagination — disables local pagination when all supplied. |
| `getRowVariant` → `default\|success\|warning\|danger` / `rowClassName` | Per-row tint via vanilla-extract token recipe (`vars.*BgSubtle`) + `data-variant`. |
| `frameless`, per-column `sortable` | Bare table with no `ChartFrame`/title chrome (modals/pages); non-sortable columns render a plain header. |

New barrel exports: `DataTableRowVariant`, `SortDirection`.

**`app.rescue`:**
- `ApplicationList` → `<DataTable frameless>` with selection, controlled server sort, and controlled pagination. Bulk stage transitions, the per-row **skeleton-loading** branch, and #1317's error/empty logic are all preserved; render callbacks resolve typed items via a `byId` Map (no `as`/`any`).
- `PetCsvImportModal` → both tables become frameless `DataTable`s; `getRowVariant` upgrades highlighting to three distinct states (valid→success, duplicate→warning, invalid→danger).

## Before requesting review

- [x] Tests for new behaviour added (TDD)
- [x] If touching a `lib.*`, considered consumer impact — shared `DataTable` consumers (rescue `AttendeeList`/`FosterCoordination`, lib `ReportRenderer`) unchanged; **app.admin uses its own local DataTable**, not this one, and its suite stays green
- [x] No `.env` requirement changes

## Test plan

- [x] Existing tests pass — `lib.components` **641** (DataTable spec 5→21), `app.rescue` **556**, `app.admin` **710** (no regression)
- [x] New behaviour covered (select-all/partial-indeterminate/per-row toggle; controlled sort fires callback and does not reorder locally; controlled pagination page-info/next/prev/disabled; row-variant class + `data-variant`; frameless chrome removal)
- [x] No TypeScript errors (`turbo run type-check`)
- [x] Lint passes (`turbo run lint` — 0 errors)
- [ ] Tested manually — verified via the suites; running stack not exercised in this environment

## Screenshots / recordings

N/A — verified via component tests. Worth a manual check of the ApplicationList selection + server sort/pagination and the CSV-import row highlighting during review.

## Related

- Follow-up to #1317 (D2). `docs/UX-REVIEW-2026-08.md` (Epic D / T6).

### Known limitations (called out for review)
- `ApplicationList`'s per-row skeleton-loading stays a small bespoke branch — skeleton rendering isn't one of the four added `DataTable` capabilities.
- `ApplicationList` keeps its existing sort `<select>` alongside the now-clickable sortable headers (both drive the same server sort); the dropdown can cosmetically desync from a header-driven direction it doesn't list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q4fStLkBsaY3ncGig1fCaw)_