### PR TITLE
fix(docker): copy vite.shared.config.ts into app build stage

### DIFF
--- a/Dockerfile.app
+++ b/Dockerfile.app
@@ -117,9 +117,11 @@ COPY --from=pruner --chown=viteuser:nodejs /app/out/full/ ./
 # turbo prune --docker doesn't copy root-level config files into out/full/.
 # Workspace tsconfigs extend the root tier files (ADS-988: tsconfig.base.json
 # plus the lib/service tier bases; lib.types additionally extends
-# ../tsconfig.cjs.base.json for its dual ESM+CJS build).
-# Mirrors Dockerfile.service.
-COPY --chown=viteuser:nodejs tsconfig.base.json tsconfig.cjs.base.json tsconfig.lib.base.json tsconfig.service.base.json ./
+# ../tsconfig.cjs.base.json for its dual ESM+CJS build). The tsconfig copies
+# mirror Dockerfile.service.
+# vite.shared.config.ts is app-only (ADS-895): each app's vite.config.ts imports
+# getLibraryAliases from it, so `vite build` can't load its config without it.
+COPY --chown=viteuser:nodejs tsconfig.base.json tsconfig.cjs.base.json tsconfig.lib.base.json tsconfig.service.base.json vite.shared.config.ts ./
 
 # Build libraries first, then the specific app using Turbo
 # Use cache mount for Turbo cache


### PR DESCRIPTION
## Summary

- Fixes the app image build failure: `[UNRESOLVED_IMPORT] Could not resolve '../../vite.shared.config' in vite.config.ts`.
- Copies `vite.shared.config.ts` into the `build` stage of `Dockerfile.app` so `vite build` can load each app's config.
- Applies to all three app images (admin, client, rescue) — the Dockerfile is parameterized by `APP_NAME` and every app imports the file symmetrically.

## Changes

- `Dockerfile.app` — add `vite.shared.config.ts` to the existing root-config `COPY` in the `build` stage (alongside the tsconfig tier files), and update the adjacent comment to explain why.

## Root cause

The app image builds on `turbo prune --docker` output. `prune` carries each workspace's own files plus only a fixed set of root files (lockfile, `pnpm-workspace.yaml`, `.npmrc`, `turbo.json`) — it does **not** copy `vite.shared.config.ts`. Since ADS-895, every app's `vite.config.ts` does `import { getLibraryAliases } from '../../vite.shared.config'`, so config loading fails during `vite build`. The root tsconfig tier files were already copied in explicitly for the same class of reason; this change extends that `COPY` with the shared vite config.

The `development` stage is unaffected: the dev compose override bind-mounts the whole repo root (`.:/app`), so the file is already present there.

## Before requesting review

- [ ] Ran `pnpm ci:local:quick` locally (or installed the pre-push hook — see CONTRIBUTING.md)
- [x] Tests for new behaviour added (TDD) — n/a; Docker build config change, verified by reproducing the failing image build and confirming the fix (see Test plan)
- [ ] If touching `.env` requirements, updated `.env.example`'s REQUIRED block — n/a
- [ ] If touching a `lib.*`, considered consumer impact across `app.*` and `service.backend` — n/a

## Test plan

Reproduced the CI build path locally without Docker by reconstructing the exact pruned build context:

1. `turbo prune @adopt-dont-shop/app.admin --docker` → confirmed `vite.shared.config.ts` is absent from `out/full/` (only `.gitattributes`, `.gitignore`, `.npmrc`, `package.json`, `pnpm-workspace.yaml`, `turbo.json` at the root).
2. Assembled the context as the Dockerfile does (`out/json/` → install → `out/full/` → root tsconfigs).
3. **Red:** `turbo run build --filter=...@adopt-dont-shop/app.admin` reproduced the reported `[UNRESOLVED_IMPORT] Could not resolve '../../vite.shared.config'`.
4. **Green:** after copying in `vite.shared.config.ts` (what this change does), the build succeeded — `18 successful, 18 total`, exit code `0`, and `apps/admin/dist/` was produced.

- [x] Tested manually (described above)
- [ ] Existing tests pass (`pnpm test`) — no test surface changed
- [ ] No TypeScript errors (`pnpm type-check`)
- [ ] Lint passes (`pnpm lint`)

## Related

- ADS-895 (extraction of `vite.shared.config.ts` shared across the three apps)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HpRq1ZkRBbXA5B8SULbb6D

---
_Generated by [Claude Code](https://claude.ai/code/session_01HpRq1ZkRBbXA5B8SULbb6D)_