### PR TITLE
lint: flag raw form elements and deprecated TextInput (ADS-1075)

### DIFF
--- a/apps/admin/eslint.config.js
+++ b/apps/admin/eslint.config.js
@@ -20,4 +20,47 @@ export default [
       ],
     },
   },
+  {
+    // ADS-1075: prefer the shared FormField + Input/SelectInput/TextArea + Zod
+    // pattern over raw form elements and the deprecated TextInput. `warn`
+    // (not `error`) since existing raw-input usage predates this rule and is
+    // migrated incrementally by separate tickets — this only flags new debt.
+    rules: {
+      'react/forbid-elements': [
+        'warn',
+        {
+          forbid: [
+            {
+              element: 'input',
+              message:
+                'Use Input from @adopt-dont-shop/lib.components (via FormField) instead of a raw <input> — see ADS-1075.',
+            },
+            {
+              element: 'select',
+              message:
+                'Use SelectInput from @adopt-dont-shop/lib.components (via FormField) instead of a raw <select> — see ADS-1075.',
+            },
+            {
+              element: 'textarea',
+              message:
+                'Use TextArea from @adopt-dont-shop/lib.components (via FormField) instead of a raw <textarea> — see ADS-1075.',
+            },
+          ],
+        },
+      ],
+      'no-restricted-imports': [
+        'warn',
+        {
+          paths: [
+            {
+              name: '@adopt-dont-shop/lib.components',
+              importNames: ['TextInput'],
+              message:
+                'TextInput is deprecated — use Input (via FormField) instead — see ADS-1075.',
+            },
+          ],
+        },
+      ],
+    },
+  },
 ];

--- a/apps/client/eslint.config.js
+++ b/apps/client/eslint.config.js
@@ -20,4 +20,47 @@ export default [
       ],
     },
   },
+  {
+    // ADS-1075: prefer the shared FormField + Input/SelectInput/TextArea + Zod
+    // pattern over raw form elements and the deprecated TextInput. `warn`
+    // (not `error`) since existing raw-input usage predates this rule and is
+    // migrated incrementally by separate tickets — this only flags new debt.
+    rules: {
+      'react/forbid-elements': [
+        'warn',
+        {
+          forbid: [
+            {
+              element: 'input',
+              message:
+                'Use Input from @adopt-dont-shop/lib.components (via FormField) instead of a raw <input> — see ADS-1075.',
+            },
+            {
+              element: 'select',
+              message:
+                'Use SelectInput from @adopt-dont-shop/lib.components (via FormField) instead of a raw <select> — see ADS-1075.',
+            },
+            {
+              element: 'textarea',
+              message:
+                'Use TextArea from @adopt-dont-shop/lib.components (via FormField) instead of a raw <textarea> — see ADS-1075.',
+            },
+          ],
+        },
+      ],
+      'no-restricted-imports': [
+        'warn',
+        {
+          paths: [
+            {
+              name: '@adopt-dont-shop/lib.components',
+              importNames: ['TextInput'],
+              message:
+                'TextInput is deprecated — use Input (via FormField) instead — see ADS-1075.',
+            },
+          ],
+        },
+      ],
+    },
+  },
 ];

--- a/apps/rescue/eslint.config.js
+++ b/apps/rescue/eslint.config.js
@@ -20,4 +20,47 @@ export default [
       ],
     },
   },
+  {
+    // ADS-1075: prefer the shared FormField + Input/SelectInput/TextArea + Zod
+    // pattern over raw form elements and the deprecated TextInput. `warn`
+    // (not `error`) since existing raw-input usage predates this rule and is
+    // migrated incrementally by separate tickets — this only flags new debt.
+    rules: {
+      'react/forbid-elements': [
+        'warn',
+        {
+          forbid: [
+            {
+              element: 'input',
+              message:
+                'Use Input from @adopt-dont-shop/lib.components (via FormField) instead of a raw <input> — see ADS-1075.',
+            },
+            {
+              element: 'select',
+              message:
+                'Use SelectInput from @adopt-dont-shop/lib.components (via FormField) instead of a raw <select> — see ADS-1075.',
+            },
+            {
+              element: 'textarea',
+              message:
+                'Use TextArea from @adopt-dont-shop/lib.components (via FormField) instead of a raw <textarea> — see ADS-1075.',
+            },
+          ],
+        },
+      ],
+      'no-restricted-imports': [
+        'warn',
+        {
+          paths: [
+            {
+              name: '@adopt-dont-shop/lib.components',
+              importNames: ['TextInput'],
+              message:
+                'TextInput is deprecated — use Input (via FormField) instead — see ADS-1075.',
+            },
+          ],
+        },
+      ],
+    },
+  },
 ];


### PR DESCRIPTION
## Summary

- First increment of ADS-1075 (Epic A foundation): closes the remaining gap in the ticket's acceptance criteria by adding lint enforcement for the FormField + Input + Zod form standard.
- The other two acceptance criteria were already satisfied on `main` before this PR: the pattern is documented (`.claude/skills/forms`) and proven by a representative migrated form in each app (client auth/profile, admin `BroadcastNotifications`, rescue via #1315/#1317).

## Changes

- `apps/admin/eslint.config.js`, `apps/client/eslint.config.js`, `apps/rescue/eslint.config.js` — add a `warn`-level `react/forbid-elements` rule for raw `<input>`/`<select>`/`<textarea>`, and a `no-restricted-imports` rule for the deprecated `TextInput` export from `@adopt-dont-shop/lib.components`. Follows the existing per-app override pattern already used for the native-dialog ban (ADS-585/586/587).

`warn` is deliberate, not `error`: there's substantial pre-existing raw-input usage that predates this rule (~40 files in admin, ~14 in client, ~45 in rescue) and is migrated incrementally by separate tickets (largest: ADS-1092 for rescue). `error` would fail CI on the whole existing backlog; `warn` surfaces new debt going forward without blocking unrelated PRs.

## Before requesting review

- [x] Ran the equivalent gates locally (`turbo lint` + `turbo type-check` for the three apps)
- [ ] Tests for new behaviour added (TDD) — n/a, lint-config-only change; verified by reproducing the warnings (see Test plan)
- [ ] If touching `.env` requirements — n/a
- [ ] If touching a `lib.*` — n/a, only app-level eslint configs touched (deliberately not the shared `eslint-config-react`, since `lib.components`/`lib.chat` also consume it and implement the raw primitives internally)

## Test plan

- [x] `pnpm exec turbo lint --filter=@adopt-dont-shop/app.admin --filter=@adopt-dont-shop/app.client --filter=@adopt-dont-shop/app.rescue` — 3/3 successful, 0 errors; new `react/forbid-elements`/`no-restricted-imports` warnings appear across existing raw-input usage as expected, CI-passing
- [x] `pnpm exec turbo type-check` (same filter) — 27/27 successful
- [ ] Tested manually — n/a (lint config only)

## Related

- Linear: [ADS-1075](https://linear.app/ideasquared/issue/ADS-1075/uxa5-form-standard-formfield-input-zod-lint-raw-inputstextinput) — [UX][A5] Form standard: FormField + Input + Zod; lint raw inputs/TextInput
- Parent epic: [ADS-1067](https://linear.app/ideasquared/issue/ADS-1067/ux-epic-a-foundation-shared-components-and-design-system-adoption)

---
_Generated by [Claude Code](https://claude.ai/code/session_017CQj1cunz1jg8drsfQHuAq)_