### PR TITLE
feat(lib.components): land deferred DateRangePicker presets (D5) and DataTable extension (D2)

### DIFF
--- a/apps/rescue/src/components/applications/ApplicationList.tsx
+++ b/apps/rescue/src/components/applications/ApplicationList.tsx
@@ -149,8 +149,6 @@ const sortFieldForKey = (key: string): ApplicationSort['field'] | null => {
       return 'submittedAt';
     case 'status':
       return 'status';
-    case 'petName':
-      return 'petName';
     case 'applicantName':
       return 'applicantName';
     case 'priority':
@@ -575,6 +573,10 @@ const ApplicationList: React.FC<ApplicationListProps> = ({
             columns={columns}
             rows={tableRows}
             getRowId={row => String(row.id)}
+            getRowLabel={row => {
+              const app = byId.get(String(row.id));
+              return app ? `application from ${app.applicantName}` : 'application';
+            }}
             onRowClick={handleRowClick}
             rowClassName={() => styles.tableRow}
             selectable={selectionEnabled}

--- a/apps/rescue/src/components/applications/ApplicationList.tsx
+++ b/apps/rescue/src/components/applications/ApplicationList.tsx
@@ -1,5 +1,10 @@
-import React from 'react';
-import { EmptyState, ErrorState } from '@adopt-dont-shop/lib.components';
+import React, { useMemo } from 'react';
+import {
+  DataTable,
+  EmptyState,
+  ErrorState,
+  type DataTableColumn,
+} from '@adopt-dont-shop/lib.components';
 import StatusBadge from '../common/StatusBadge';
 import type {
   ApplicationListItem,
@@ -133,7 +138,44 @@ interface ApplicationListProps {
   onApplicationSelect: (application: ApplicationListItem) => void;
   selectedIds?: Set<string>;
   onSelectionChange?: (next: Set<string>) => void;
+  onPageChange?: (page: number) => void;
 }
+
+// Column keys that map 1:1 onto server-side sort fields. Used to translate a
+// DataTable header-sort click back into an ApplicationSort without a cast.
+const sortFieldForKey = (key: string): ApplicationSort['field'] | null => {
+  switch (key) {
+    case 'submittedAt':
+      return 'submittedAt';
+    case 'status':
+      return 'status';
+    case 'petName':
+      return 'petName';
+    case 'applicantName':
+      return 'applicantName';
+    case 'priority':
+      return 'priority';
+    default:
+      return null;
+  }
+};
+
+const priorityVariant = (
+  priority: string | undefined
+): 'urgent' | 'high' | 'medium' | 'low' | 'default' => {
+  switch (priority) {
+    case 'urgent':
+      return 'urgent';
+    case 'high':
+      return 'high';
+    case 'medium':
+      return 'medium';
+    case 'low':
+      return 'low';
+    default:
+      return 'default';
+  }
+};
 
 const ApplicationList: React.FC<ApplicationListProps> = ({
   applications,
@@ -147,32 +189,176 @@ const ApplicationList: React.FC<ApplicationListProps> = ({
   onApplicationSelect,
   selectedIds,
   onSelectionChange,
+  onPageChange,
 }) => {
   const selectionEnabled = selectedIds !== undefined && onSelectionChange !== undefined;
-  const toggleOne = (id: string) => {
-    if (!selectionEnabled) {
-      return;
-    }
-    const next = new Set(selectedIds);
-    if (next.has(id)) {
-      next.delete(id);
-    } else {
-      next.add(id);
-    }
-    onSelectionChange(next);
+
+  // Look up the full application by id from a DataTable row (rows are plain
+  // records; the render callbacks resolve the typed item here).
+  const byId = useMemo(() => new Map(applications.map(a => [a.id, a])), [applications]);
+
+  const handleSelectionChange = (ids: string[]) => {
+    onSelectionChange?.(new Set(ids));
   };
-  const allSelected =
-    selectionEnabled && applications.length > 0 && applications.every(a => selectedIds.has(a.id));
-  const toggleAll = () => {
-    if (!selectionEnabled) {
-      return;
-    }
-    if (allSelected) {
-      onSelectionChange(new Set());
-    } else {
-      onSelectionChange(new Set(applications.map(a => a.id)));
+
+  const handleColumnSort = (key: string, direction: 'asc' | 'desc') => {
+    const field = sortFieldForKey(key);
+    if (field) {
+      onSortChange({ field, direction });
     }
   };
+
+  const handleRowClick = (row: Record<string, unknown>) => {
+    const app = byId.get(String(row.id));
+    if (app) {
+      onApplicationSelect(app);
+    }
+  };
+
+  const columns: DataTableColumn[] = [
+    {
+      key: 'applicantName',
+      label: 'Applicant',
+      render: (_value, row) => {
+        const app = byId.get(String(row.id));
+        if (!app) {
+          return null;
+        }
+        return (
+          <div className={styles.applicantInfo}>
+            <div className={styles.applicantName}>{app.applicantName}</div>
+            <div className={styles.applicantEmail}>
+              {app.data?.personalInfo?.email || 'No email provided'}
+            </div>
+          </div>
+        );
+      },
+    },
+    {
+      key: 'petName',
+      label: 'Pet',
+      sortable: false,
+      render: (_value, row) => {
+        const app = byId.get(String(row.id));
+        if (!app) {
+          return null;
+        }
+        return (
+          <div className={styles.petInfo}>
+            <div className={styles.petName}>{app.petName || 'Unknown Pet'}</div>
+            <div className={styles.petDetails}>
+              {app.petType} • {app.petBreed}
+            </div>
+          </div>
+        );
+      },
+    },
+    {
+      key: 'status',
+      label: 'Status',
+      render: (_value, row) => {
+        const app = byId.get(String(row.id));
+        if (!app) {
+          return null;
+        }
+        return <StatusBadge status={app.status || 'unknown'} />;
+      },
+    },
+    {
+      key: 'priority',
+      label: 'Priority',
+      render: (_value, row) => {
+        const app = byId.get(String(row.id));
+        if (!app) {
+          return null;
+        }
+        return (
+          <span className={styles.priorityBadge({ priority: priorityVariant(app.priority) })}>
+            {app.priority}
+          </span>
+        );
+      },
+    },
+    {
+      key: 'submittedAt',
+      label: 'Submitted',
+      render: (_value, row) => {
+        const app = byId.get(String(row.id));
+        if (!app) {
+          return null;
+        }
+        return app.submittedDaysAgo === 0 ? 'Today' : `${app.submittedDaysAgo} days ago`;
+      },
+    },
+    {
+      key: 'progress',
+      label: 'Progress',
+      sortable: false,
+      render: (_value, row) => {
+        const app = byId.get(String(row.id));
+        if (!app) {
+          return null;
+        }
+        const progress = getApplicationProgress(app);
+        return (
+          <div className={styles.progressIndicators}>
+            <div className={styles.progressBar}>
+              {[0, 1, 2, 3, 4].map(stepIndex => {
+                const stepStatus = getStepStatus(
+                  stepIndex,
+                  progress.current,
+                  progress.stage,
+                  progress.finalOutcome
+                );
+                return (
+                  <div
+                    key={stepIndex}
+                    className={styles.progressStep({
+                      status: stepStatus,
+                      isLast: stepIndex === 4,
+                    })}
+                  />
+                );
+              })}
+            </div>
+            <span className={styles.progressLabel}>
+              {getStepLabel(progress.current, app.stage, app.finalOutcome)}
+            </span>
+          </div>
+        );
+      },
+    },
+    {
+      key: 'actions',
+      label: 'Actions',
+      sortable: false,
+      render: (_value, row) => {
+        const app = byId.get(String(row.id));
+        if (!app) {
+          return null;
+        }
+        return (
+          <div className={styles.actionsContainer}>
+            {getActionButtons(app, onApplicationSelect).map(action => (
+              <button
+                key={action.label}
+                className={styles.actionButton({ variant: action.variant })}
+                onClick={e => {
+                  e.stopPropagation();
+                  action.action();
+                }}
+              >
+                {action.label}
+              </button>
+            ))}
+          </div>
+        );
+      },
+    },
+  ];
+
+  const tableRows = applications.map(a => ({ id: a.id }));
+
   // Convert complex ApplicationFilter to simple string-based filters for UI
   const getDateRangeValue = () => {
     if (!filter.dateRange) {
@@ -328,21 +514,14 @@ const ApplicationList: React.FC<ApplicationListProps> = ({
           </div>
         ) : !loading && applications.length === 0 ? (
           <EmptyState title="No applications found matching your criteria." />
-        ) : (
+        ) : loading ? (
+          // Per-row skeleton loading is a bespoke affordance kept out of the
+          // shared DataTable; it mirrors the DataTable column layout below.
           <div className={styles.tableWrapper}>
             <table className={styles.table}>
               <thead className={styles.tableHead}>
                 <tr>
-                  {selectionEnabled && (
-                    <th className={styles.tableHeader}>
-                      <input
-                        type="checkbox"
-                        aria-label="Select all applications"
-                        checked={allSelected}
-                        onChange={toggleAll}
-                      />
-                    </th>
-                  )}
+                  {selectionEnabled && <th className={styles.tableHeader} />}
                   <th className={styles.tableHeader}>Applicant</th>
                   <th className={styles.tableHeader}>Pet</th>
                   <th className={styles.tableHeader}>Status</th>
@@ -353,149 +532,62 @@ const ApplicationList: React.FC<ApplicationListProps> = ({
                 </tr>
               </thead>
               <tbody className={styles.tableBody}>
-                {loading
-                  ? Array.from({ length: pagination.limit }, (_, i) => (
-                      <tr key={`skeleton-${i}`} className={styles.tableRow} aria-hidden="true">
-                        {selectionEnabled && (
-                          <td className={styles.tableCell}>
-                            <div className={styles.skeletonBlock} style={{ width: '1rem' }} />
-                          </td>
-                        )}
-                        <td className={styles.tableCell}>
-                          <div className={styles.skeletonBlock} style={{ width: '60%' }} />
-                          <div
-                            className={styles.skeletonBlock}
-                            style={{ width: '40%', marginTop: '0.25rem' }}
-                          />
-                        </td>
-                        <td className={styles.tableCell}>
-                          <div className={styles.skeletonBlock} style={{ width: '50%' }} />
-                        </td>
-                        <td className={styles.tableCell}>
-                          <div className={styles.skeletonBlock} style={{ width: '4rem' }} />
-                        </td>
-                        <td className={styles.tableCell}>
-                          <div className={styles.skeletonBlock} style={{ width: '3rem' }} />
-                        </td>
-                        <td className={styles.tableCell}>
-                          <div className={styles.skeletonBlock} style={{ width: '5rem' }} />
-                        </td>
-                        <td className={styles.tableCell}>
-                          <div className={styles.skeletonBlock} style={{ width: '80%' }} />
-                        </td>
-                        <td className={styles.tableCell}>
-                          <div className={styles.skeletonBlock} style={{ width: '5rem' }} />
-                        </td>
-                      </tr>
-                    ))
-                  : applications.map(application => (
-                      <tr
-                        key={application.id}
-                        className={styles.tableRow}
-                        onClick={() => onApplicationSelect(application)}
-                      >
-                        {selectionEnabled && (
-                          <td className={styles.tableCell} onClick={e => e.stopPropagation()}>
-                            <input
-                              type="checkbox"
-                              aria-label={`Select application ${application.id}`}
-                              checked={selectedIds.has(application.id)}
-                              onChange={() => toggleOne(application.id)}
-                            />
-                          </td>
-                        )}
-                        <td className={styles.tableCell}>
-                          <div className={styles.applicantInfo}>
-                            <div className={styles.applicantName}>{application.applicantName}</div>
-                            <div className={styles.applicantEmail}>
-                              {application.data?.personalInfo?.email || 'No email provided'}
-                            </div>
-                          </div>
-                        </td>
-                        <td className={styles.tableCell}>
-                          <div className={styles.petInfo}>
-                            <div className={styles.petName}>
-                              {application.petName || 'Unknown Pet'}
-                            </div>
-                            <div className={styles.petDetails}>
-                              {application.petType} • {application.petBreed}
-                            </div>
-                          </div>
-                        </td>
-                        <td className={styles.tableCell}>
-                          <StatusBadge status={application.status || 'unknown'} />
-                        </td>
-                        <td className={styles.tableCell}>
-                          <span
-                            className={styles.priorityBadge({
-                              priority: application.priority as
-                                | 'urgent'
-                                | 'high'
-                                | 'medium'
-                                | 'low'
-                                | 'default',
-                            })}
-                          >
-                            {application.priority}
-                          </span>
-                        </td>
-                        <td className={styles.tableCell}>
-                          {application.submittedDaysAgo === 0
-                            ? 'Today'
-                            : `${application.submittedDaysAgo} days ago`}
-                        </td>
-                        <td className={styles.tableCell}>
-                          <div className={styles.progressIndicators}>
-                            <div className={styles.progressBar}>
-                              {[0, 1, 2, 3, 4].map(stepIndex => {
-                                const progress = getApplicationProgress(application);
-                                const stepStatus = getStepStatus(
-                                  stepIndex,
-                                  progress.current,
-                                  progress.stage,
-                                  progress.finalOutcome
-                                );
-                                return (
-                                  <div
-                                    key={stepIndex}
-                                    className={styles.progressStep({
-                                      status: stepStatus,
-                                      isLast: stepIndex === 4,
-                                    })}
-                                  />
-                                );
-                              })}
-                            </div>
-                            <span className={styles.progressLabel}>
-                              {getStepLabel(
-                                getApplicationProgress(application).current,
-                                application.stage,
-                                application.finalOutcome
-                              )}
-                            </span>
-                          </div>
-                        </td>
-                        <td className={styles.tableCell} onClick={e => e.stopPropagation()}>
-                          <div className={styles.actionsContainer}>
-                            {getActionButtons(application, onApplicationSelect).map(action => (
-                              <button
-                                key={action.label}
-                                className={styles.actionButton({ variant: action.variant })}
-                                onClick={e => {
-                                  e.stopPropagation();
-                                  action.action();
-                                }}
-                              >
-                                {action.label}
-                              </button>
-                            ))}
-                          </div>
-                        </td>
-                      </tr>
-                    ))}
+                {Array.from({ length: pagination.limit }, (_, i) => (
+                  <tr key={`skeleton-${i}`} className={styles.tableRow} aria-hidden="true">
+                    {selectionEnabled && (
+                      <td className={styles.tableCell}>
+                        <div className={styles.skeletonBlock} style={{ width: '1rem' }} />
+                      </td>
+                    )}
+                    <td className={styles.tableCell}>
+                      <div className={styles.skeletonBlock} style={{ width: '60%' }} />
+                      <div
+                        className={styles.skeletonBlock}
+                        style={{ width: '40%', marginTop: '0.25rem' }}
+                      />
+                    </td>
+                    <td className={styles.tableCell}>
+                      <div className={styles.skeletonBlock} style={{ width: '50%' }} />
+                    </td>
+                    <td className={styles.tableCell}>
+                      <div className={styles.skeletonBlock} style={{ width: '4rem' }} />
+                    </td>
+                    <td className={styles.tableCell}>
+                      <div className={styles.skeletonBlock} style={{ width: '3rem' }} />
+                    </td>
+                    <td className={styles.tableCell}>
+                      <div className={styles.skeletonBlock} style={{ width: '5rem' }} />
+                    </td>
+                    <td className={styles.tableCell}>
+                      <div className={styles.skeletonBlock} style={{ width: '80%' }} />
+                    </td>
+                    <td className={styles.tableCell}>
+                      <div className={styles.skeletonBlock} style={{ width: '5rem' }} />
+                    </td>
+                  </tr>
+                ))}
               </tbody>
             </table>
           </div>
+        ) : (
+          <DataTable
+            frameless
+            columns={columns}
+            rows={tableRows}
+            getRowId={row => String(row.id)}
+            onRowClick={handleRowClick}
+            rowClassName={() => styles.tableRow}
+            selectable={selectionEnabled}
+            selectedIds={selectedIds}
+            onSelectionChange={handleSelectionChange}
+            sortBy={sort.field}
+            sortDirection={sort.direction}
+            onSortChange={handleColumnSort}
+            page={pagination.page}
+            pageSize={pagination.limit}
+            total={pagination.total}
+            onPageChange={onPageChange}
+          />
         )}
       </div>
     </div>

--- a/apps/rescue/src/components/pets/PetCsvImportModal.css.ts
+++ b/apps/rescue/src/components/pets/PetCsvImportModal.css.ts
@@ -61,26 +61,6 @@ export const select = style({
   width: '100%',
 });
 
-export const previewTable = style({
-  width: '100%',
-  borderCollapse: 'collapse',
-  fontSize: '0.85rem',
-});
-
-export const previewCell = style({
-  border: '1px solid #e5e7eb',
-  padding: '0.4rem 0.5rem',
-  verticalAlign: 'top',
-});
-
-export const rowOk = style({
-  background: '#f0fdf4',
-});
-
-export const rowError = style({
-  background: '#fef2f2',
-});
-
 export const errorList = style({
   margin: 0,
   paddingLeft: '1.25rem',

--- a/apps/rescue/src/components/pets/PetCsvImportModal.test.tsx
+++ b/apps/rescue/src/components/pets/PetCsvImportModal.test.tsx
@@ -52,6 +52,29 @@ vi.mock('@adopt-dont-shop/lib.components', () => ({
     error: (...args: unknown[]) => toastError(...args),
     success: (...args: unknown[]) => toastSuccess(...args),
   }),
+  DataTable: ({
+    columns,
+    rows,
+  }: {
+    columns: Array<{
+      key: string;
+      label: string;
+      render?: (value: unknown, row: Record<string, unknown>) => React.ReactNode;
+    }>;
+    rows: Record<string, unknown>[];
+  }) => (
+    <table>
+      <tbody>
+        {rows.map((row, i) => (
+          <tr key={i}>
+            {columns.map(c => (
+              <td key={c.key}>{c.render ? c.render(row[c.key], row) : String(row[c.key] ?? '')}</td>
+            ))}
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  ),
 }));
 
 vi.mock('@adopt-dont-shop/lib.pets', () => ({

--- a/apps/rescue/src/components/pets/PetCsvImportModal.tsx
+++ b/apps/rescue/src/components/pets/PetCsvImportModal.tsx
@@ -1,5 +1,12 @@
 import React, { useMemo, useRef, useState } from 'react';
-import { Button, Modal, toast } from '@adopt-dont-shop/lib.components';
+import {
+  Button,
+  DataTable,
+  Modal,
+  toast,
+  type DataTableColumn,
+  type DataTableRowVariant,
+} from '@adopt-dont-shop/lib.components';
 import {
   IMPORTABLE_FIELDS,
   type ColumnMapping,
@@ -54,6 +61,51 @@ type Props = {
   onClose: () => void;
   onImported: () => void;
 };
+
+// Row highlighting for the preview table: valid rows are tinted success, rows
+// that would be skipped as duplicates warning, and failing rows danger.
+const previewRowVariant = (row: Record<string, unknown>): DataTableRowVariant => {
+  if (row.ok === false) {
+    return 'danger';
+  }
+  if (row.isDup === true) {
+    return 'warning';
+  }
+  return 'success';
+};
+
+const previewColumns: DataTableColumn[] = [
+  { key: 'row', label: 'Row', sortable: false },
+  { key: 'name', label: 'Name', sortable: false },
+  { key: 'type', label: 'Type', sortable: false },
+  { key: 'breed', label: 'Breed', sortable: false },
+  {
+    key: 'status',
+    label: 'Status',
+    sortable: false,
+    render: (_value, row) => {
+      if (row.ok === false) {
+        const errors = Array.isArray(row.errors) ? row.errors : [];
+        return (
+          <ul className={styles.errorList}>
+            {errors.map((e, i) => (
+              <li key={i}>{String(e)}</li>
+            ))}
+          </ul>
+        );
+      }
+      if (row.isDup === true) {
+        return <span>Duplicate — will skip</span>;
+      }
+      return <span>OK</span>;
+    },
+  },
+];
+
+const failureColumns: DataTableColumn[] = [
+  { key: 'row', label: 'Row', sortable: false },
+  { key: 'reason', label: 'Reason', sortable: false },
+];
 
 const PetCsvImportModal: React.FC<Props> = ({ isOpen, rescueId, onClose, onImported }) => {
   const [step, setStep] = useState<Step>('upload');
@@ -123,6 +175,34 @@ const PetCsvImportModal: React.FC<Props> = ({ isOpen, rescueId, onClose, onImpor
     }
     return dupes;
   }, [validatedRows, previouslyImportedIds]);
+
+  const previewRows = useMemo<Record<string, unknown>[]>(() => {
+    if (!parsed) {
+      return [];
+    }
+    return validatedRows.map(r => {
+      const isDup = duplicateRowIndexes.has(r.rowIndex);
+      const rawRow = parsed.rows[r.rowIndex - 1];
+      const cellValue = (field: ImportableField): string => {
+        const header = mapping[field];
+        return header ? String(rawRow[header] ?? '') : '';
+      };
+      return {
+        row: r.rowIndex,
+        name: cellValue('name'),
+        type: cellValue('type'),
+        breed: cellValue('breed'),
+        ok: r.ok,
+        isDup,
+        errors: r.ok ? [] : r.errors,
+      };
+    });
+  }, [parsed, validatedRows, mapping, duplicateRowIndexes]);
+
+  const failureRows = useMemo<Record<string, unknown>[]>(
+    () => (summary ? summary.failed.map(f => ({ row: f.rowIndex, reason: f.reason })) : []),
+    [summary]
+  );
 
   const requiredFieldsMapped = IMPORTABLE_FIELDS.filter(f => f.required).every(f => mapping[f.key]);
 
@@ -320,45 +400,14 @@ const PetCsvImportModal: React.FC<Props> = ({ isOpen, rescueId, onClose, onImpor
               </div>
             )}
             <div className={styles.scrollableTable}>
-              <table className={styles.previewTable}>
-                <thead>
-                  <tr>
-                    <th className={styles.previewCell}>Row</th>
-                    <th className={styles.previewCell}>Name</th>
-                    <th className={styles.previewCell}>Type</th>
-                    <th className={styles.previewCell}>Breed</th>
-                    <th className={styles.previewCell}>Status</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {validatedRows.map(r => {
-                    const isDup = duplicateRowIndexes.has(r.rowIndex);
-                    const className = r.ok && !isDup ? styles.rowOk : styles.rowError;
-                    const rawRow = parsed.rows[r.rowIndex - 1];
-                    const cell = (field: ImportableField) =>
-                      mapping[field] ? rawRow[mapping[field]!] : '';
-                    return (
-                      <tr key={r.rowIndex} className={className}>
-                        <td className={styles.previewCell}>{r.rowIndex}</td>
-                        <td className={styles.previewCell}>{cell('name')}</td>
-                        <td className={styles.previewCell}>{cell('type')}</td>
-                        <td className={styles.previewCell}>{cell('breed')}</td>
-                        <td className={styles.previewCell}>
-                          {r.ok && !isDup && <span>OK</span>}
-                          {r.ok && isDup && <span>Duplicate — will skip</span>}
-                          {!r.ok && (
-                            <ul className={styles.errorList}>
-                              {r.errors.map((e, i) => (
-                                <li key={i}>{e}</li>
-                              ))}
-                            </ul>
-                          )}
-                        </td>
-                      </tr>
-                    );
-                  })}
-                </tbody>
-              </table>
+              <DataTable
+                frameless
+                columns={previewColumns}
+                rows={previewRows}
+                getRowId={row => String(row.row)}
+                getRowVariant={previewRowVariant}
+                pageSize={Math.max(previewRows.length, 1)}
+              />
             </div>
             <div className={styles.actionsRow}>
               <Button variant="outline" onClick={() => setStep('map')}>
@@ -391,22 +440,14 @@ const PetCsvImportModal: React.FC<Props> = ({ isOpen, rescueId, onClose, onImpor
             </div>
             {summary.failed.length > 0 && (
               <div className={styles.failureTable}>
-                <table className={styles.previewTable}>
-                  <thead>
-                    <tr>
-                      <th className={styles.previewCell}>Row</th>
-                      <th className={styles.previewCell}>Reason</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {summary.failed.map(f => (
-                      <tr key={f.rowIndex} className={styles.rowError}>
-                        <td className={styles.previewCell}>{f.rowIndex}</td>
-                        <td className={styles.previewCell}>{f.reason}</td>
-                      </tr>
-                    ))}
-                  </tbody>
-                </table>
+                <DataTable
+                  frameless
+                  columns={failureColumns}
+                  rows={failureRows}
+                  getRowId={row => String(row.row)}
+                  getRowVariant={() => 'danger'}
+                  pageSize={Math.max(failureRows.length, 1)}
+                />
               </div>
             )}
             <div className={styles.actionsRow}>

--- a/apps/rescue/src/pages/Analytics.test.tsx
+++ b/apps/rescue/src/pages/Analytics.test.tsx
@@ -50,6 +50,18 @@ describe('Analytics page', () => {
     await waitFor(() => expect(analyticsService.getAdoptionMetrics).toHaveBeenCalledTimes(2));
   });
 
+  // D5: preset shortcuts (restored from the old local picker) set the range and
+  // drive a refetch.
+  it('refetches analytics when a preset shortcut is clicked', async () => {
+    renderWithProviders(<Analytics />);
+
+    await waitFor(() => expect(analyticsService.getAdoptionMetrics).toHaveBeenCalledTimes(1));
+
+    fireEvent.click(screen.getByRole('button', { name: 'Last 7 days' }));
+
+    await waitFor(() => expect(analyticsService.getAdoptionMetrics).toHaveBeenCalledTimes(2));
+  });
+
   // D6: every data section uses the shared EmptyState when nothing is available.
   it('shows the shared empty state for each section when no data is available', async () => {
     renderWithProviders(<Analytics />);

--- a/apps/rescue/src/pages/Analytics.tsx
+++ b/apps/rescue/src/pages/Analytics.tsx
@@ -4,6 +4,7 @@ import {
   MetricCard,
   toast,
   DateRangePicker,
+  createDefaultDateRangePresets,
   EmptyState,
   type DateRangeValue,
 } from '@adopt-dont-shop/lib.components';
@@ -27,6 +28,11 @@ import ExportButton from '../components/analytics/ExportButton';
 // The shared DateRangePicker works in ISO `yyyy-mm-dd` strings, while the
 // analytics service reasons in `Date`s. Convert at the picker boundary only.
 const toIsoDate = (date: Date): string => date.toISOString().slice(0, 10);
+
+// Quick-select shortcuts restored from the previous local picker: Last 7/30/90
+// days, This month, Last month. `getRange` resolves against the current date on
+// each click.
+const dateRangePresets = createDefaultDateRangePresets();
 
 // Services
 import {
@@ -239,6 +245,7 @@ const Analytics: React.FC = () => {
             <DateRangePicker
               value={{ from: toIsoDate(dateRange.start), to: toIsoDate(dateRange.end) }}
               onChange={handleDateRangeChange}
+              presets={dateRangePresets}
             />
             <ExportButton
               onExportCSV={handleExportCSV}

--- a/apps/rescue/src/pages/Analytics.tsx
+++ b/apps/rescue/src/pages/Analytics.tsx
@@ -27,7 +27,12 @@ import ExportButton from '../components/analytics/ExportButton';
 
 // The shared DateRangePicker works in ISO `yyyy-mm-dd` strings, while the
 // analytics service reasons in `Date`s. Convert at the picker boundary only.
-const toIsoDate = (date: Date): string => date.toISOString().slice(0, 10);
+const toIsoDate = (date: Date): string => {
+  const pad = (value: number): string => String(value).padStart(2, '0');
+  // Build the ISO date from local calendar parts rather than `toISOString()`,
+  // so the visible/queried day never slips to UTC's around midnight (BST).
+  return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}`;
+};
 
 // Quick-select shortcuts restored from the previous local picker: Last 7/30/90
 // days, This month, Last month. `getRange` resolves against the current date on

--- a/apps/rescue/src/pages/Applications.tsx
+++ b/apps/rescue/src/pages/Applications.tsx
@@ -46,6 +46,7 @@ const Applications: React.FC = () => {
     pagination,
     updateFilter,
     updateSort,
+    changePage,
     updateApplicationStatus,
     refetch,
   } = useApplications();
@@ -234,6 +235,7 @@ const Applications: React.FC = () => {
         onApplicationSelect={handleApplicationSelect}
         selectedIds={selectedIds}
         onSelectionChange={updateSelection}
+        onPageChange={changePage}
       />
 
       {/* Application Review Modal */}

--- a/apps/rescue/src/setup-tests.ts
+++ b/apps/rescue/src/setup-tests.ts
@@ -263,10 +263,19 @@ vi.mock('@adopt-dont-shop/lib.components', () => ({
     ),
   // ADS UX D5: shared date-range picker. Render labelled From/To date inputs
   // and mirror the real onChange semantics (each field patches its own side).
-  DateRangePicker: ({ value, onChange, fromLabel = 'From', toLabel = 'To' }: any) =>
+  DateRangePicker: ({ value, onChange, fromLabel = 'From', toLabel = 'To', presets }: any) =>
     React.createElement(
       'div',
       null,
+      ...(Array.isArray(presets)
+        ? presets.map((preset: any) =>
+            React.createElement(
+              'button',
+              { key: preset.label, type: 'button', onClick: () => onChange(preset.getRange()) },
+              preset.label
+            )
+          )
+        : []),
       React.createElement('label', { htmlFor: 'drp-from' }, fromLabel),
       React.createElement('input', {
         id: 'drp-from',
@@ -282,6 +291,15 @@ vi.mock('@adopt-dont-shop/lib.components', () => ({
         onChange: (e: any) => onChange({ from: value?.from ?? null, to: e.target.value || null }),
       })
     ),
+  // Deterministic stand-in for the shared preset builder — distinct fixed
+  // ranges so a preset click always changes the range and drives a refetch.
+  createDefaultDateRangePresets: () => [
+    { label: 'Last 7 days', getRange: () => ({ from: '2026-01-01', to: '2026-01-08' }) },
+    { label: 'Last 30 days', getRange: () => ({ from: '2026-01-01', to: '2026-01-31' }) },
+    { label: 'Last 90 days', getRange: () => ({ from: '2025-10-01', to: '2026-01-01' }) },
+    { label: 'This month', getRange: () => ({ from: '2026-01-01', to: '2026-01-31' }) },
+    { label: 'Last month', getRange: () => ({ from: '2025-12-01', to: '2025-12-31' }) },
+  ],
   // ADS UX D2: shared responsive DataTable. Mirror the real cell rendering
   // (col.render or stringified value) and empty handling so behaviour tests
   // for the migrated tables keep exercising rows, links and actions.

--- a/packages/lib.components/src/components/charts/DataTable.css.ts
+++ b/packages/lib.components/src/components/charts/DataTable.css.ts
@@ -1,4 +1,7 @@
 import { globalStyle, style } from '@vanilla-extract/css';
+import { recipe } from '@vanilla-extract/recipes';
+
+import { vars } from '../../styles/theme.css';
 
 export const scrollContainer = style({
   height: '100%',
@@ -117,5 +120,81 @@ globalStyle(`${cardsTable} td::before`, {
       color: 'var(--color-text-muted, #6b7280)',
       textAlign: 'left',
     },
+  },
+});
+
+/* ─────────────────────────────────────────────────────────────────────────
+ * ADS UX D2 — opt-in additive styles for selection, non-sortable headers and
+ * per-row highlighting. These use the theme `vars` contract (design-tokens
+ * skill) and are only applied when the matching opt-in props are set, so the
+ * default table appearance is unchanged.
+ * ──────────────────────────────────────────────────────────────────────── */
+
+/** Leading checkbox column — kept narrow and vertically aligned with cells. */
+export const selectCell = style({
+  width: '1%',
+  padding: `${vars.spacing['2']} ${vars.spacing['2']}`,
+  textAlign: 'center',
+  borderBottom: `${vars.border.width.thin} solid var(--color-border, #e5e7eb)`,
+});
+
+export const selectHeaderCell = style([
+  selectCell,
+  {
+    position: 'sticky',
+    top: 0,
+    background: 'var(--color-surface-muted, #f9fafb)',
+  },
+]);
+
+export const checkbox = style({
+  cursor: 'pointer',
+  width: vars.spacing['3'],
+  height: vars.spacing['3'],
+  accentColor: vars.colors.primary,
+  selectors: {
+    '&:focus-visible': {
+      outline: `${vars.border.width.base} solid ${vars.colors.primary}`,
+      outlineOffset: vars.spacing['1'],
+    },
+  },
+});
+
+/** Non-sortable column header — plain label with the same padding as the sort button. */
+export const headerLabel = style({
+  display: 'block',
+  padding: `${vars.spacing['2']} ${vars.spacing['3']}`,
+});
+
+/** Frameless empty state used when the table is rendered without the ChartFrame chrome. */
+export const emptyFrameless = style({
+  padding: vars.spacing['4'],
+  textAlign: 'center',
+  color: vars.text.muted,
+  fontSize: vars.typography.size.sm,
+});
+
+/**
+ * Per-row highlighting. `variant` tints the row for valid / duplicate / invalid
+ * style states; `selected` highlights a row picked via the selection column.
+ * Token-based so it stays theme-aware in light / normal / dark.
+ */
+export const rowVariant = recipe({
+  base: {},
+  variants: {
+    variant: {
+      default: {},
+      success: { backgroundColor: vars.colors.successBgSubtle },
+      warning: { backgroundColor: vars.colors.warningBgSubtle },
+      danger: { backgroundColor: vars.colors.dangerBgSubtle },
+    },
+    selected: {
+      true: { backgroundColor: vars.colors.primaryBgSubtle },
+      false: {},
+    },
+  },
+  defaultVariants: {
+    variant: 'default',
+    selected: false,
   },
 });

--- a/packages/lib.components/src/components/charts/DataTable.test.tsx
+++ b/packages/lib.components/src/components/charts/DataTable.test.tsx
@@ -183,6 +183,40 @@ describe('DataTable row selection', () => {
     await user.click(rowCheckboxes[1]);
     expect(onSelectionChange).toHaveBeenCalledWith(['r1', 'r2']);
   });
+
+  it('gives each row checkbox a distinct accessible name (via row id by default)', () => {
+    renderWithTheme(
+      <DataTable
+        title='Pets'
+        columns={columns}
+        rows={idRows}
+        selectable
+        selectedIds={[]}
+        onSelectionChange={vi.fn()}
+      />
+    );
+
+    expect(screen.getByRole('checkbox', { name: 'Select row r1' })).toBeInTheDocument();
+    expect(screen.getByRole('checkbox', { name: 'Select row r2' })).toBeInTheDocument();
+    expect(screen.getByRole('checkbox', { name: 'Select row r3' })).toBeInTheDocument();
+  });
+
+  it('labels row checkboxes via getRowLabel when provided', () => {
+    renderWithTheme(
+      <DataTable
+        title='Pets'
+        columns={columns}
+        rows={idRows}
+        selectable
+        selectedIds={[]}
+        onSelectionChange={vi.fn()}
+        getRowLabel={row => `pet ${String(row.name)}`}
+      />
+    );
+
+    expect(screen.getByRole('checkbox', { name: 'Select pet Bea' })).toBeInTheDocument();
+    expect(screen.getByRole('checkbox', { name: 'Select pet Ada' })).toBeInTheDocument();
+  });
 });
 
 describe('DataTable controlled sort', () => {
@@ -296,6 +330,24 @@ describe('DataTable controlled pagination', () => {
 
     expect(screen.getByRole('button', { name: /prev/i })).toBeDisabled();
     expect(screen.getByRole('button', { name: /next/i })).toBeEnabled();
+  });
+
+  it('clamps an out-of-range controlled page to the last page for display and nav', () => {
+    renderWithTheme(
+      <DataTable
+        title='Pets'
+        columns={columns}
+        rows={idRows}
+        page={99}
+        pageSize={10}
+        total={25}
+        onPageChange={vi.fn()}
+      />
+    );
+
+    // ceil(25 / 10) === 3 pages; an out-of-range page 99 clamps to 3.
+    expect(screen.getByText('Page 3 of 3')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /next/i })).toBeDisabled();
   });
 });
 

--- a/packages/lib.components/src/components/charts/DataTable.test.tsx
+++ b/packages/lib.components/src/components/charts/DataTable.test.tsx
@@ -16,6 +16,13 @@ const rows = [
   { name: 'Cy', age: 2 },
 ];
 
+// Rows carrying stable ids for the selection / variant / pagination suites.
+const idRows = [
+  { id: 'r1', name: 'Bea', age: 4 },
+  { id: 'r2', name: 'Ada', age: 7 },
+  { id: 'r3', name: 'Cy', age: 2 },
+];
+
 describe('DataTable sortable headers', () => {
   it('reports aria-sort="none" on unsorted columns', () => {
     renderWithTheme(<DataTable title='Pets' columns={columns} rows={rows} />);
@@ -63,5 +70,273 @@ describe('DataTable responsive layout', () => {
     expect(screen.getByText('Ada')).toBeInTheDocument();
     expect(screen.getByText('Cy')).toBeInTheDocument();
     expect(screen.getByText('Bea').closest('td')).toHaveAttribute('data-label', 'Name');
+  });
+});
+
+describe('DataTable row selection', () => {
+  it('renders no checkboxes unless selection is enabled', () => {
+    renderWithTheme(<DataTable title='Pets' columns={columns} rows={idRows} />);
+    expect(screen.queryByRole('checkbox')).toBeNull();
+  });
+
+  it('renders a select-all header checkbox and one checkbox per row when selectable', () => {
+    renderWithTheme(
+      <DataTable
+        title='Pets'
+        columns={columns}
+        rows={idRows}
+        selectable
+        selectedIds={[]}
+        onSelectionChange={vi.fn()}
+      />
+    );
+
+    expect(screen.getByRole('checkbox', { name: /select all/i })).toBeInTheDocument();
+    expect(screen.getAllByRole('checkbox', { name: /select row/i })).toHaveLength(3);
+  });
+
+  it('select-all selects every visible row', async () => {
+    const user = userEvent.setup();
+    const onSelectionChange = vi.fn();
+    renderWithTheme(
+      <DataTable
+        title='Pets'
+        columns={columns}
+        rows={idRows}
+        selectable
+        selectedIds={[]}
+        onSelectionChange={onSelectionChange}
+      />
+    );
+
+    await user.click(screen.getByRole('checkbox', { name: /select all/i }));
+    expect(onSelectionChange).toHaveBeenCalledWith(['r1', 'r2', 'r3']);
+  });
+
+  it('select-all deselects every visible row when already fully selected', async () => {
+    const user = userEvent.setup();
+    const onSelectionChange = vi.fn();
+    renderWithTheme(
+      <DataTable
+        title='Pets'
+        columns={columns}
+        rows={idRows}
+        selectable
+        selectedIds={['r1', 'r2', 'r3']}
+        onSelectionChange={onSelectionChange}
+      />
+    );
+
+    await user.click(screen.getByRole('checkbox', { name: /select all/i }));
+    expect(onSelectionChange).toHaveBeenCalledWith([]);
+  });
+
+  it('shows an indeterminate select-all for a partial selection', () => {
+    renderWithTheme(
+      <DataTable
+        title='Pets'
+        columns={columns}
+        rows={idRows}
+        selectable
+        selectedIds={['r1']}
+        onSelectionChange={vi.fn()}
+      />
+    );
+
+    const selectAll = screen.getByRole('checkbox', { name: /select all/i });
+    expect(selectAll).not.toBeChecked();
+    expect(selectAll).toHaveProperty('indeterminate', true);
+  });
+
+  it('checks (and clears indeterminate on) the select-all when all rows are selected', () => {
+    renderWithTheme(
+      <DataTable
+        title='Pets'
+        columns={columns}
+        rows={idRows}
+        selectable
+        selectedIds={['r1', 'r2', 'r3']}
+        onSelectionChange={vi.fn()}
+      />
+    );
+
+    const selectAll = screen.getByRole('checkbox', { name: /select all/i });
+    expect(selectAll).toBeChecked();
+    expect(selectAll).toHaveProperty('indeterminate', false);
+  });
+
+  it('toggling one row adds it to the existing selection', async () => {
+    const user = userEvent.setup();
+    const onSelectionChange = vi.fn();
+    renderWithTheme(
+      <DataTable
+        title='Pets'
+        columns={columns}
+        rows={idRows}
+        selectable
+        selectedIds={['r1']}
+        onSelectionChange={onSelectionChange}
+      />
+    );
+
+    const rowCheckboxes = screen.getAllByRole('checkbox', { name: /select row/i });
+    await user.click(rowCheckboxes[1]);
+    expect(onSelectionChange).toHaveBeenCalledWith(['r1', 'r2']);
+  });
+});
+
+describe('DataTable controlled sort', () => {
+  it('reflects the controlled sortBy/sortDirection in aria-sort', () => {
+    renderWithTheme(
+      <DataTable
+        title='Pets'
+        columns={columns}
+        rows={idRows}
+        sortBy='age'
+        sortDirection='desc'
+        onSortChange={vi.fn()}
+      />
+    );
+
+    expect(screen.getByTestId('th-age')).toHaveAttribute('aria-sort', 'descending');
+    expect(screen.getByTestId('th-name')).toHaveAttribute('aria-sort', 'none');
+  });
+
+  it('calls onSortChange on header click and does NOT re-sort rows locally', async () => {
+    const user = userEvent.setup();
+    const onSortChange = vi.fn();
+    renderWithTheme(
+      <DataTable
+        title='Pets'
+        columns={columns}
+        rows={idRows}
+        sortBy='name'
+        sortDirection='asc'
+        onSortChange={onSortChange}
+      />
+    );
+
+    // Given order is Bea, Ada, Cy — a local asc sort would reorder to Ada first.
+    expect(screen.getAllByRole('row')[1]).toHaveTextContent('Bea');
+
+    await user.click(screen.getByRole('button', { name: /name/i }));
+
+    // Controlled: the parent is asked to flip direction; rows stay in given order.
+    expect(onSortChange).toHaveBeenCalledWith('name', 'desc');
+    expect(screen.getAllByRole('row')[1]).toHaveTextContent('Bea');
+  });
+
+  it('does not render a sort button for a non-sortable column', () => {
+    const cols: DataTableColumn[] = [
+      { key: 'name', label: 'Name' },
+      { key: 'actions', label: 'Actions', sortable: false },
+    ];
+    renderWithTheme(<DataTable title='Pets' columns={cols} rows={idRows} />);
+
+    expect(screen.getByRole('button', { name: /name/i })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /actions/i })).toBeNull();
+  });
+});
+
+describe('DataTable controlled pagination', () => {
+  it('shows the controlled page info and renders all given rows (no local slice)', () => {
+    renderWithTheme(
+      <DataTable
+        title='Pets'
+        columns={columns}
+        rows={idRows}
+        page={2}
+        pageSize={10}
+        total={25}
+        onPageChange={vi.fn()}
+      />
+    );
+
+    // ceil(25 / 10) === 3 pages.
+    expect(screen.getByText('Page 2 of 3')).toBeInTheDocument();
+    expect(screen.getByText('Bea')).toBeInTheDocument();
+    expect(screen.getByText('Ada')).toBeInTheDocument();
+    expect(screen.getByText('Cy')).toBeInTheDocument();
+  });
+
+  it('calls onPageChange for Next and Prev', async () => {
+    const user = userEvent.setup();
+    const onPageChange = vi.fn();
+    renderWithTheme(
+      <DataTable
+        title='Pets'
+        columns={columns}
+        rows={idRows}
+        page={2}
+        pageSize={10}
+        total={25}
+        onPageChange={onPageChange}
+      />
+    );
+
+    await user.click(screen.getByRole('button', { name: /next/i }));
+    expect(onPageChange).toHaveBeenCalledWith(3);
+
+    await user.click(screen.getByRole('button', { name: /prev/i }));
+    expect(onPageChange).toHaveBeenCalledWith(1);
+  });
+
+  it('disables Prev on the first page', () => {
+    renderWithTheme(
+      <DataTable
+        title='Pets'
+        columns={columns}
+        rows={idRows}
+        page={1}
+        pageSize={10}
+        total={25}
+        onPageChange={vi.fn()}
+      />
+    );
+
+    expect(screen.getByRole('button', { name: /prev/i })).toBeDisabled();
+    expect(screen.getByRole('button', { name: /next/i })).toBeEnabled();
+  });
+});
+
+describe('DataTable row highlighting', () => {
+  it('marks a row with the variant returned by getRowVariant', () => {
+    renderWithTheme(
+      <DataTable
+        title='Pets'
+        columns={columns}
+        rows={idRows}
+        getRowVariant={row => (row.id === 'r2' ? 'danger' : 'default')}
+      />
+    );
+
+    expect(screen.getByText('Ada').closest('tr')).toHaveAttribute('data-variant', 'danger');
+    // 'default' rows carry no variant marker.
+    expect(screen.getByText('Bea').closest('tr')).not.toHaveAttribute('data-variant');
+  });
+
+  it('applies a custom rowClassName to the matching row', () => {
+    renderWithTheme(
+      <DataTable
+        title='Pets'
+        columns={columns}
+        rows={idRows}
+        rowClassName={row => (row.id === 'r1' ? 'flagged-row' : undefined)}
+      />
+    );
+
+    expect(screen.getByText('Bea').closest('tr')?.className).toContain('flagged-row');
+    expect(screen.getByText('Ada').closest('tr')?.className).not.toContain('flagged-row');
+  });
+});
+
+describe('DataTable frameless mode', () => {
+  it('omits the ChartFrame chrome (no title heading, no frame test id)', () => {
+    renderWithTheme(<DataTable title='Pets' columns={columns} rows={idRows} frameless />);
+
+    expect(screen.queryByTestId('chart-frame')).toBeNull();
+    expect(screen.queryByRole('heading', { name: 'Pets' })).toBeNull();
+    // The table itself still renders.
+    expect(screen.getByText('Bea')).toBeInTheDocument();
   });
 });

--- a/packages/lib.components/src/components/charts/DataTable.tsx
+++ b/packages/lib.components/src/components/charts/DataTable.tsx
@@ -44,6 +44,12 @@ export type DataTableProps = Omit<ChartFrameProps, 'children' | 'isEmpty' | 'tit
   onSelectionChange?: (selectedIds: string[]) => void;
   /** Derives a stable id for a row (defaults to `row.id`, falling back to index). */
   getRowId?: (row: Record<string, unknown>, index: number) => string;
+  /**
+   * Accessible label for a row's selection checkbox. Defaults to
+   * `Select row <id>` so each checkbox has a distinct name; supply this for a
+   * human-friendly label (e.g. the row's name).
+   */
+  getRowLabel?: (row: Record<string, unknown>, index: number) => string;
 
   // ── Controlled (server-side) sort (opt-in) ─────────────────────────────
   /** When `onSortChange` is provided the table stops sorting locally. */
@@ -101,6 +107,7 @@ export const DataTable: React.FC<DataTableProps> = ({
   selectedIds,
   onSelectionChange,
   getRowId,
+  getRowLabel,
   sortBy,
   sortDirection,
   onSortChange,
@@ -139,7 +146,7 @@ export const DataTable: React.FC<DataTableProps> = ({
     ? Math.max(1, Math.ceil((total ?? 0) / pageSize))
     : Math.max(1, Math.ceil(sortedRows.length / pageSize));
   const currentPageIndex = controlledPagination
-    ? Math.max(0, (page ?? 1) - 1)
+    ? Math.min(pageCount - 1, Math.max(0, (page ?? 1) - 1))
     : Math.min(internalPage, pageCount - 1);
   const visibleRows = controlledPagination
     ? sortedRows
@@ -272,7 +279,9 @@ export const DataTable: React.FC<DataTableProps> = ({
                     <input
                       type='checkbox'
                       className={styles.checkbox}
-                      aria-label='Select row'
+                      aria-label={
+                        getRowLabel ? `Select ${getRowLabel(row, i)}` : `Select row ${rowId}`
+                      }
                       checked={selectedSet.has(rowId)}
                       onChange={() => toggleOne(rowId)}
                     />

--- a/packages/lib.components/src/components/charts/DataTable.tsx
+++ b/packages/lib.components/src/components/charts/DataTable.tsx
@@ -8,9 +8,21 @@ export type DataTableColumn = {
   label: string;
   /** Optional renderer for non-trivial cells. */
   render?: (value: unknown, row: Record<string, unknown>) => React.ReactNode;
+  /**
+   * Whether the header drives sorting. Defaults to `true`, preserving the
+   * original behaviour where every column header is a sort control.
+   */
+  sortable?: boolean;
 };
 
-export type DataTableProps = Omit<ChartFrameProps, 'children' | 'isEmpty'> & {
+export type SortDirection = 'asc' | 'desc';
+
+/** Highlight tone for a row, applied via a token-based recipe (not inline styles). */
+export type DataTableRowVariant = 'default' | 'success' | 'warning' | 'danger';
+
+export type DataTableProps = Omit<ChartFrameProps, 'children' | 'isEmpty' | 'title'> & {
+  /** Optional in frameless mode; otherwise shown as the ChartFrame heading. */
+  title?: string;
   columns: DataTableColumn[];
   rows: Record<string, unknown>[];
   pageSize?: number;
@@ -22,6 +34,38 @@ export type DataTableProps = Omit<ChartFrameProps, 'children' | 'isEmpty'> & {
    * label/value card below the mobile breakpoint.
    */
   responsive?: 'scroll' | 'cards';
+
+  // ── Row selection (opt-in, controlled) ─────────────────────────────────
+  /** Render a leading checkbox column + header select-all checkbox. */
+  selectable?: boolean;
+  /** The currently-selected row ids (controlled). */
+  selectedIds?: readonly string[] | ReadonlySet<string>;
+  /** Called with the next full selection whenever a checkbox toggles. */
+  onSelectionChange?: (selectedIds: string[]) => void;
+  /** Derives a stable id for a row (defaults to `row.id`, falling back to index). */
+  getRowId?: (row: Record<string, unknown>, index: number) => string;
+
+  // ── Controlled (server-side) sort (opt-in) ─────────────────────────────
+  /** When `onSortChange` is provided the table stops sorting locally. */
+  sortBy?: string | null;
+  sortDirection?: SortDirection;
+  onSortChange?: (key: string, direction: SortDirection) => void;
+
+  // ── Controlled (server-side) pagination (opt-in) ───────────────────────
+  /** 1-based page index; when provided with `total`/`onPageChange` the table
+   *  stops paginating locally and renders the given rows as the current page. */
+  page?: number;
+  total?: number;
+  onPageChange?: (page: number) => void;
+
+  // ── Per-row highlighting ───────────────────────────────────────────────
+  /** Tone applied to a row (valid / duplicate / invalid style states). */
+  getRowVariant?: (row: Record<string, unknown>, index: number) => DataTableRowVariant | undefined;
+  /** Escape hatch for an additional per-row class. */
+  rowClassName?: (row: Record<string, unknown>, index: number) => string | undefined;
+
+  /** Render the bare table without the ChartFrame chrome (title/border/states). */
+  frameless?: boolean;
 };
 
 const compareCells = (a: unknown, b: unknown): number => {
@@ -34,114 +78,250 @@ const compareCells = (a: unknown, b: unknown): number => {
   return String(a ?? '').localeCompare(String(b ?? ''));
 };
 
+const toIdSet = (ids?: readonly string[] | ReadonlySet<string>): Set<string> => {
+  if (!ids) {
+    return new Set<string>();
+  }
+  return new Set<string>(ids);
+};
+
+const defaultGetRowId = (row: Record<string, unknown>, index: number): string => {
+  const id = row.id;
+  return id === undefined || id === null ? String(index) : String(id);
+};
+
 export const DataTable: React.FC<DataTableProps> = ({
+  title,
   columns,
   rows,
   pageSize = 25,
   onRowClick,
   responsive = 'scroll',
+  selectable = false,
+  selectedIds,
+  onSelectionChange,
+  getRowId,
+  sortBy,
+  sortDirection,
+  onSortChange,
+  page,
+  total,
+  onPageChange,
+  getRowVariant,
+  rowClassName,
+  frameless = false,
   ...frame
 }) => {
-  const [sortKey, setSortKey] = useState<string | null>(null);
-  const [sortDir, setSortDir] = useState<'asc' | 'desc'>('asc');
-  const [page, setPage] = useState(0);
+  const [internalSortKey, setInternalSortKey] = useState<string | null>(null);
+  const [internalSortDir, setInternalSortDir] = useState<SortDirection>('asc');
+  const [internalPage, setInternalPage] = useState(0);
+
+  const controlledSort = onSortChange !== undefined;
+  const controlledPagination =
+    page !== undefined && total !== undefined && onPageChange !== undefined;
+
+  const activeSortKey = controlledSort ? (sortBy ?? null) : internalSortKey;
+  const activeSortDir: SortDirection = controlledSort ? (sortDirection ?? 'asc') : internalSortDir;
 
   const sortedRows = useMemo(() => {
-    if (!sortKey) {
+    if (controlledSort || !internalSortKey) {
       return rows;
     }
     const copy = [...rows];
     copy.sort((a, b) => {
-      const cmp = compareCells(a[sortKey], b[sortKey]);
-      return sortDir === 'asc' ? cmp : -cmp;
+      const cmp = compareCells(a[internalSortKey], b[internalSortKey]);
+      return internalSortDir === 'asc' ? cmp : -cmp;
     });
     return copy;
-  }, [rows, sortKey, sortDir]);
+  }, [rows, internalSortKey, internalSortDir, controlledSort]);
 
-  const totalPages = Math.max(1, Math.ceil(sortedRows.length / pageSize));
-  const safePage = Math.min(page, totalPages - 1);
-  const visibleRows = sortedRows.slice(safePage * pageSize, (safePage + 1) * pageSize);
+  const pageCount = controlledPagination
+    ? Math.max(1, Math.ceil((total ?? 0) / pageSize))
+    : Math.max(1, Math.ceil(sortedRows.length / pageSize));
+  const currentPageIndex = controlledPagination
+    ? Math.max(0, (page ?? 1) - 1)
+    : Math.min(internalPage, pageCount - 1);
+  const visibleRows = controlledPagination
+    ? sortedRows
+    : sortedRows.slice(currentPageIndex * pageSize, (currentPageIndex + 1) * pageSize);
+
+  const getRowIdFn = getRowId ?? defaultGetRowId;
+  const selectedSet = useMemo(() => toIdSet(selectedIds), [selectedIds]);
+  const visibleIds = visibleRows.map((row, i) => getRowIdFn(row, i));
+  const selectedVisibleCount = visibleIds.filter(id => selectedSet.has(id)).length;
+  const allVisibleSelected = visibleRows.length > 0 && selectedVisibleCount === visibleRows.length;
+  const someVisibleSelected = selectedVisibleCount > 0;
 
   const handleSort = (key: string): void => {
-    if (sortKey === key) {
-      setSortDir(d => (d === 'asc' ? 'desc' : 'asc'));
+    if (controlledSort) {
+      const nextDir: SortDirection =
+        activeSortKey === key && activeSortDir === 'asc' ? 'desc' : 'asc';
+      onSortChange?.(key, nextDir);
+      return;
+    }
+    if (internalSortKey === key) {
+      setInternalSortDir(d => (d === 'asc' ? 'desc' : 'asc'));
     } else {
-      setSortKey(key);
-      setSortDir('asc');
+      setInternalSortKey(key);
+      setInternalSortDir('asc');
     }
   };
 
-  return (
-    <ChartFrame {...frame} isEmpty={rows.length === 0}>
-      <div className={styles.scrollContainer}>
-        <table className={clsx(styles.table, responsive === 'cards' && styles.cardsTable)}>
-          <thead>
-            <tr>
-              {columns.map(col => {
-                const isSorted = sortKey === col.key;
-                const ariaSort: 'ascending' | 'descending' | 'none' = isSorted
-                  ? sortDir === 'asc'
-                    ? 'ascending'
-                    : 'descending'
-                  : 'none';
+  const toggleOne = (id: string): void => {
+    const next = new Set(selectedSet);
+    if (next.has(id)) {
+      next.delete(id);
+    } else {
+      next.add(id);
+    }
+    onSelectionChange?.(Array.from(next));
+  };
+
+  const toggleAll = (): void => {
+    const next = new Set(selectedSet);
+    if (allVisibleSelected) {
+      visibleIds.forEach(id => next.delete(id));
+    } else {
+      visibleIds.forEach(id => next.add(id));
+    }
+    onSelectionChange?.(Array.from(next));
+  };
+
+  const goToPage = (nextPage: number): void => {
+    if (controlledPagination) {
+      onPageChange?.(nextPage + 1);
+      return;
+    }
+    setInternalPage(nextPage);
+  };
+
+  const content = (
+    <div className={styles.scrollContainer}>
+      <table className={clsx(styles.table, responsive === 'cards' && styles.cardsTable)}>
+        <thead>
+          <tr>
+            {selectable ? (
+              <th className={styles.selectHeaderCell}>
+                <input
+                  type='checkbox'
+                  className={styles.checkbox}
+                  aria-label='Select all'
+                  checked={allVisibleSelected}
+                  ref={el => {
+                    if (el) {
+                      el.indeterminate = someVisibleSelected && !allVisibleSelected;
+                    }
+                  }}
+                  onChange={toggleAll}
+                />
+              </th>
+            ) : null}
+            {columns.map(col => {
+              const sortable = col.sortable ?? true;
+              if (!sortable) {
                 return (
-                  <th
-                    key={col.key}
-                    className={styles.th}
-                    data-testid={`th-${col.key}`}
-                    aria-sort={ariaSort}
-                  >
-                    <button
-                      type='button'
-                      className={styles.sortButton}
-                      onClick={() => handleSort(col.key)}
-                    >
-                      {col.label}
-                      {isSorted ? (sortDir === 'asc' ? ' ▲' : ' ▼') : ''}
-                    </button>
+                  <th key={col.key} className={styles.th} data-testid={`th-${col.key}`}>
+                    <span className={styles.headerLabel}>{col.label}</span>
                   </th>
                 );
-              })}
-            </tr>
-          </thead>
-          <tbody>
-            {visibleRows.map((row, i) => (
+              }
+              const isSorted = activeSortKey === col.key;
+              const ariaSort: 'ascending' | 'descending' | 'none' = isSorted
+                ? activeSortDir === 'asc'
+                  ? 'ascending'
+                  : 'descending'
+                : 'none';
+              return (
+                <th
+                  key={col.key}
+                  className={styles.th}
+                  data-testid={`th-${col.key}`}
+                  aria-sort={ariaSort}
+                >
+                  <button
+                    type='button'
+                    className={styles.sortButton}
+                    onClick={() => handleSort(col.key)}
+                  >
+                    {col.label}
+                    {isSorted ? (activeSortDir === 'asc' ? ' ▲' : ' ▼') : ''}
+                  </button>
+                </th>
+              );
+            })}
+          </tr>
+        </thead>
+        <tbody>
+          {visibleRows.map((row, i) => {
+            const rowId = getRowIdFn(row, i);
+            const isSelected = selectable && selectedSet.has(rowId);
+            const variant = getRowVariant?.(row, i) ?? 'default';
+            return (
               <tr
-                key={i}
-                onClick={() => onRowClick?.(row)}
-                className={onRowClick ? styles.rowClickable : styles.rowDefault}
+                key={rowId}
+                onClick={onRowClick ? () => onRowClick(row) : undefined}
+                data-variant={variant === 'default' ? undefined : variant}
+                className={clsx(
+                  onRowClick ? styles.rowClickable : styles.rowDefault,
+                  styles.rowVariant({ variant, selected: isSelected }),
+                  rowClassName?.(row, i)
+                )}
               >
+                {selectable ? (
+                  <td className={styles.selectCell} onClick={e => e.stopPropagation()}>
+                    <input
+                      type='checkbox'
+                      className={styles.checkbox}
+                      aria-label='Select row'
+                      checked={selectedSet.has(rowId)}
+                      onChange={() => toggleOne(rowId)}
+                    />
+                  </td>
+                ) : null}
                 {columns.map(col => (
                   <td key={col.key} className={styles.td} data-label={col.label}>
                     {col.render ? col.render(row[col.key], row) : String(row[col.key] ?? '')}
                   </td>
                 ))}
               </tr>
-            ))}
-          </tbody>
-        </table>
-        {totalPages > 1 ? (
-          <div className={styles.pagination}>
-            <button
-              type='button'
-              disabled={safePage === 0}
-              onClick={() => setPage(p => Math.max(0, p - 1))}
-            >
-              Prev
-            </button>
-            <span>
-              Page {safePage + 1} of {totalPages}
-            </span>
-            <button
-              type='button'
-              disabled={safePage >= totalPages - 1}
-              onClick={() => setPage(p => Math.min(totalPages - 1, p + 1))}
-            >
-              Next
-            </button>
-          </div>
-        ) : null}
-      </div>
+            );
+          })}
+        </tbody>
+      </table>
+      {pageCount > 1 ? (
+        <div className={styles.pagination}>
+          <button
+            type='button'
+            disabled={currentPageIndex === 0}
+            onClick={() => goToPage(Math.max(0, currentPageIndex - 1))}
+          >
+            Prev
+          </button>
+          <span>
+            Page {currentPageIndex + 1} of {pageCount}
+          </span>
+          <button
+            type='button'
+            disabled={currentPageIndex >= pageCount - 1}
+            onClick={() => goToPage(Math.min(pageCount - 1, currentPageIndex + 1))}
+          >
+            Next
+          </button>
+        </div>
+      ) : null}
+    </div>
+  );
+
+  if (frameless) {
+    if (rows.length === 0) {
+      return <div className={styles.emptyFrameless}>{frame.emptyMessage ?? 'No data'}</div>;
+    }
+    return content;
+  }
+
+  return (
+    <ChartFrame {...frame} title={title ?? ''} isEmpty={rows.length === 0}>
+      {content}
     </ChartFrame>
   );
 };

--- a/packages/lib.components/src/components/form/DateRangePicker/DateRangePicker.css.ts
+++ b/packages/lib.components/src/components/form/DateRangePicker/DateRangePicker.css.ts
@@ -9,6 +9,46 @@ export const container = style({
   alignItems: 'flex-end',
 });
 
+export const presets = style({
+  flexBasis: '100%',
+  display: 'flex',
+  flexWrap: 'wrap',
+  gap: vars.spacing['2'],
+});
+
+export const presetButton = style({
+  padding: `${vars.spacing['1']} ${vars.spacing['3']}`,
+  fontFamily: vars.typography.family.sans,
+  fontSize: vars.typography.size.sm,
+  fontWeight: vars.typography.weight.medium,
+  color: vars.colors.primaryTextEmphasis,
+  background: vars.colors.primaryBgSubtle,
+  border: `${vars.border.width.thin} solid ${vars.colors.primaryBorderSubtle}`,
+  borderRadius: vars.border.radius.pill,
+  cursor: 'pointer',
+  transition: `all ${vars.transitions.fast}`,
+  selectors: {
+    '&:hover:not(:disabled)': {
+      background: vars.colors.primary,
+      borderColor: vars.colors.primary,
+      color: vars.text.inverse,
+    },
+    '&:focus-visible': {
+      outline: 'none',
+      boxShadow: vars.shadows.focus,
+    },
+    '&:disabled': {
+      opacity: 0.6,
+      cursor: 'not-allowed',
+    },
+  },
+  '@media': {
+    '(prefers-reduced-motion: reduce)': {
+      transition: 'none',
+    },
+  },
+});
+
 export const field = style({
   display: 'flex',
   flexDirection: 'column',

--- a/packages/lib.components/src/components/form/DateRangePicker/DateRangePicker.stories.tsx
+++ b/packages/lib.components/src/components/form/DateRangePicker/DateRangePicker.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react';
 
 import { DateRangePicker } from './DateRangePicker';
+import { createDefaultDateRangePresets } from './presets';
 
 const meta: Meta<typeof DateRangePicker> = {
   title: 'Components/DateRangePicker',
@@ -21,4 +22,12 @@ export const Prefilled: Story = {
 
 export const InvalidRange: Story = {
   args: { value: { from: '2026-08-31', to: '2026-08-01' }, onChange: () => {} },
+};
+
+export const WithPresets: Story = {
+  args: {
+    value: { from: null, to: null },
+    onChange: () => {},
+    presets: createDefaultDateRangePresets(),
+  },
 };

--- a/packages/lib.components/src/components/form/DateRangePicker/DateRangePicker.test.tsx
+++ b/packages/lib.components/src/components/form/DateRangePicker/DateRangePicker.test.tsx
@@ -2,7 +2,8 @@ import '@testing-library/jest-dom';
 import { fireEvent, render, screen } from '@testing-library/react';
 import { vi } from 'vitest';
 
-import { DateRangePicker } from './DateRangePicker';
+import { DateRangePicker, type DateRangePreset } from './DateRangePicker';
+import { createDefaultDateRangePresets } from './presets';
 
 describe('DateRangePicker', () => {
   it('renders two labelled date fields', () => {
@@ -81,5 +82,104 @@ describe('DateRangePicker', () => {
 
     expect(screen.getByLabelText('From')).toBeDisabled();
     expect(screen.getByLabelText('To')).toBeDisabled();
+  });
+
+  describe('presets', () => {
+    const presets: DateRangePreset[] = [
+      { label: 'Last 7 days', getRange: () => ({ from: '2026-07-30', to: '2026-08-06' }) },
+      { label: 'This month', getRange: () => ({ from: '2026-08-01', to: '2026-08-31' }) },
+    ];
+
+    it('renders each preset as a button in a labelled group', () => {
+      render(
+        <DateRangePicker value={{ from: null, to: null }} onChange={() => {}} presets={presets} />
+      );
+
+      expect(screen.getByRole('group', { name: 'Quick date ranges' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Last 7 days' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'This month' })).toBeInTheDocument();
+    });
+
+    it('fires onChange with the preset range when a preset is clicked', () => {
+      const onChange = vi.fn();
+      render(
+        <DateRangePicker value={{ from: null, to: null }} onChange={onChange} presets={presets} />
+      );
+
+      fireEvent.click(screen.getByRole('button', { name: 'Last 7 days' }));
+      expect(onChange).toHaveBeenCalledWith({ from: '2026-07-30', to: '2026-08-06' });
+
+      fireEvent.click(screen.getByRole('button', { name: 'This month' }));
+      expect(onChange).toHaveBeenCalledWith({ from: '2026-08-01', to: '2026-08-31' });
+    });
+
+    it('renders no preset controls when presets are omitted', () => {
+      render(<DateRangePicker value={{ from: null, to: null }} onChange={() => {}} />);
+
+      expect(screen.queryByRole('group')).not.toBeInTheDocument();
+      expect(screen.queryByRole('button')).not.toBeInTheDocument();
+    });
+
+    it('renders no preset controls when presets is an empty array', () => {
+      render(<DateRangePicker value={{ from: null, to: null }} onChange={() => {}} presets={[]} />);
+
+      expect(screen.queryByRole('group')).not.toBeInTheDocument();
+    });
+
+    it('disables preset buttons when disabled', () => {
+      render(
+        <DateRangePicker
+          value={{ from: null, to: null }}
+          onChange={() => {}}
+          presets={presets}
+          disabled
+        />
+      );
+
+      expect(screen.getByRole('button', { name: 'Last 7 days' })).toBeDisabled();
+    });
+  });
+});
+
+describe('createDefaultDateRangePresets', () => {
+  // 6 August 2026, local time.
+  const now = () => new Date(2026, 7, 6);
+
+  it('offers the standard shortcut set', () => {
+    expect(createDefaultDateRangePresets(now).map(preset => preset.label)).toEqual([
+      'Last 7 days',
+      'Last 30 days',
+      'Last 90 days',
+      'This month',
+      'Last month',
+    ]);
+  });
+
+  it('computes relative day ranges ending today', () => {
+    const [sevenDays, thirtyDays, ninetyDays] = createDefaultDateRangePresets(now);
+
+    expect(sevenDays.getRange()).toEqual({ from: '2026-07-30', to: '2026-08-06' });
+    expect(thirtyDays.getRange()).toEqual({ from: '2026-07-07', to: '2026-08-06' });
+    expect(ninetyDays.getRange()).toEqual({ from: '2026-05-08', to: '2026-08-06' });
+  });
+
+  it('computes calendar-month ranges', () => {
+    const byLabel = new Map(
+      createDefaultDateRangePresets(now).map(preset => [preset.label, preset])
+    );
+
+    expect(byLabel.get('This month')?.getRange()).toEqual({
+      from: '2026-08-01',
+      to: '2026-08-31',
+    });
+    expect(byLabel.get('Last month')?.getRange()).toEqual({
+      from: '2026-07-01',
+      to: '2026-07-31',
+    });
+  });
+
+  it('defaults to the real clock when none is injected', () => {
+    const labels = createDefaultDateRangePresets().map(preset => preset.label);
+    expect(labels).toContain('Last 7 days');
   });
 });

--- a/packages/lib.components/src/components/form/DateRangePicker/DateRangePicker.tsx
+++ b/packages/lib.components/src/components/form/DateRangePicker/DateRangePicker.tsx
@@ -9,6 +9,16 @@ export type DateRangeValue = {
   to: string | null;
 };
 
+/**
+ * A quick-select shortcut. `getRange` is evaluated at click time, so relative
+ * ranges (e.g. "Last 7 days") always resolve against the current date without
+ * the component itself reaching for the clock.
+ */
+export type DateRangePreset = {
+  label: string;
+  getRange: () => DateRangeValue;
+};
+
 export type DateRangePickerProps = {
   value: DateRangeValue;
   onChange: (value: DateRangeValue) => void;
@@ -19,6 +29,7 @@ export type DateRangePickerProps = {
   disabled?: boolean;
   error?: string;
   required?: boolean;
+  presets?: DateRangePreset[];
   className?: string;
   'data-testid'?: string;
 };
@@ -32,6 +43,10 @@ const isInvalidRange = (from: string | null, to: string | null): boolean =>
  * user's locale — dd/mm/yyyy for en-GB). Values are ISO `yyyy-mm-dd` strings
  * (or `null`). Selecting a range where `to` precedes `from` surfaces an
  * accessible error, and each field constrains the other's min/max.
+ *
+ * Pass `presets` to render quick-select shortcuts above the fields — each sets
+ * the from/to value on click. Omit it and the component renders exactly as a
+ * plain from/to range control.
  */
 export const DateRangePicker = ({
   value,
@@ -43,6 +58,7 @@ export const DateRangePicker = ({
   disabled = false,
   error,
   required = false,
+  presets,
   className,
   'data-testid': testId,
 }: DateRangePickerProps) => {
@@ -63,6 +79,22 @@ export const DateRangePicker = ({
 
   return (
     <div className={clsx(styles.container, className)} data-testid={testId}>
+      {presets && presets.length > 0 ? (
+        <div className={styles.presets} role='group' aria-label='Quick date ranges'>
+          {presets.map(preset => (
+            <button
+              key={preset.label}
+              type='button'
+              className={styles.presetButton}
+              onClick={() => onChange(preset.getRange())}
+              disabled={disabled}
+            >
+              {preset.label}
+            </button>
+          ))}
+        </div>
+      ) : null}
+
       <div className={styles.field}>
         <label htmlFor={fromId} className={styles.label}>
           {fromLabel}

--- a/packages/lib.components/src/components/form/DateRangePicker/README.md
+++ b/packages/lib.components/src/components/form/DateRangePicker/README.md
@@ -18,19 +18,37 @@ const Example = () => {
 
 ## Props
 
-| Prop          | Type                                           | Default  | Description                                          |
-| ------------- | ---------------------------------------------- | -------- | ---------------------------------------------------- |
-| `value`       | `{ from: string \| null; to: string \| null }` | —        | The current range (ISO `yyyy-mm-dd`).                |
-| `onChange`    | `(value: DateRangeValue) => void`              | —        | Called with the merged range on any field change.    |
-| `fromLabel`   | `string`                                       | `'From'` | Label for the start field.                           |
-| `toLabel`     | `string`                                       | `'To'`   | Label for the end field.                             |
-| `min`         | `string`                                       | —        | Minimum selectable date (ISO).                       |
-| `max`         | `string`                                       | —        | Maximum selectable date (ISO).                       |
-| `disabled`    | `boolean`                                      | `false`  | Disables both fields.                                |
-| `error`       | `string`                                       | —        | Caller-supplied error; overrides the built-in check. |
-| `required`    | `boolean`                                      | `false`  | Renders a required marker on each label.             |
-| `className`   | `string`                                       | —        | Extra class on the container.                        |
-| `data-testid` | `string`                                       | —        | Test id on the container.                            |
+| Prop          | Type                                           | Default  | Description                                           |
+| ------------- | ---------------------------------------------- | -------- | ----------------------------------------------------- |
+| `value`       | `{ from: string \| null; to: string \| null }` | —        | The current range (ISO `yyyy-mm-dd`).                 |
+| `onChange`    | `(value: DateRangeValue) => void`              | —        | Called with the merged range on any field change.     |
+| `fromLabel`   | `string`                                       | `'From'` | Label for the start field.                            |
+| `toLabel`     | `string`                                       | `'To'`   | Label for the end field.                              |
+| `min`         | `string`                                       | —        | Minimum selectable date (ISO).                        |
+| `max`         | `string`                                       | —        | Maximum selectable date (ISO).                        |
+| `disabled`    | `boolean`                                      | `false`  | Disables both fields.                                 |
+| `error`       | `string`                                       | —        | Caller-supplied error; overrides the built-in check.  |
+| `required`    | `boolean`                                      | `false`  | Renders a required marker on each label.              |
+| `presets`     | `DateRangePreset[]`                            | —        | Quick-select shortcuts; omitted → no preset controls. |
+| `className`   | `string`                                       | —        | Extra class on the container.                         |
+| `data-testid` | `string`                                       | —        | Test id on the container.                             |
+
+## Presets
+
+Pass `presets` to render quick-select shortcut buttons above the fields. Each is
+`{ label: string; getRange: () => DateRangeValue }`, and `getRange` is evaluated
+on click — so relative ranges resolve against the current date and the component
+never reaches for the clock itself. Omitting `presets` renders (and behaves as) a
+plain from/to control, unchanged for existing consumers.
+
+`createDefaultDateRangePresets(now?)` builds the standard set — Last 7/30/90
+days, This month, Last month — with an optional injectable clock for tests:
+
+```tsx
+import { DateRangePicker, createDefaultDateRangePresets } from '@adopt-dont-shop/lib.components';
+
+<DateRangePicker value={range} onChange={setRange} presets={createDefaultDateRangePresets()} />;
+```
 
 ## Behaviour & accessibility
 

--- a/packages/lib.components/src/components/form/DateRangePicker/index.ts
+++ b/packages/lib.components/src/components/form/DateRangePicker/index.ts
@@ -1,2 +1,3 @@
 export { DateRangePicker } from './DateRangePicker';
-export type { DateRangePickerProps, DateRangeValue } from './DateRangePicker';
+export type { DateRangePickerProps, DateRangeValue, DateRangePreset } from './DateRangePicker';
+export { createDefaultDateRangePresets } from './presets';

--- a/packages/lib.components/src/components/form/DateRangePicker/presets.ts
+++ b/packages/lib.components/src/components/form/DateRangePicker/presets.ts
@@ -1,0 +1,44 @@
+import type { DateRangePreset, DateRangeValue } from './DateRangePicker';
+
+const pad = (value: number): string => String(value).padStart(2, '0');
+
+// Local-calendar ISO (`yyyy-mm-dd`). Built from local date parts rather than
+// `toISOString()` so the UK day never slips to UTC's near midnight (BST).
+const toIsoDate = (date: Date): string =>
+  `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}`;
+
+const daysBefore = (from: Date, days: number): Date => {
+  const result = new Date(from);
+  result.setDate(result.getDate() - days);
+  return result;
+};
+
+const relativeDays = (now: () => Date, days: number) => (): DateRangeValue => {
+  const today = now();
+  return { from: toIsoDate(daysBefore(today, days)), to: toIsoDate(today) };
+};
+
+const monthRange = (now: () => Date, monthOffset: number) => (): DateRangeValue => {
+  const today = now();
+  const first = new Date(today.getFullYear(), today.getMonth() + monthOffset, 1);
+  const last = new Date(today.getFullYear(), today.getMonth() + monthOffset + 1, 0);
+  return { from: toIsoDate(first), to: toIsoDate(last) };
+};
+
+/**
+ * The standard relative date-range shortcuts (Last 7/30/90 days, This month,
+ * Last month) — the set the rescue analytics picker historically offered. Each
+ * range is computed against `now` at click time, so pass the array straight to
+ * `DateRangePicker`'s `presets` prop and every selection reflects today's date.
+ *
+ * `now` is injectable purely for deterministic tests; production callers omit it.
+ */
+export const createDefaultDateRangePresets = (
+  now: () => Date = () => new Date()
+): DateRangePreset[] => [
+  { label: 'Last 7 days', getRange: relativeDays(now, 7) },
+  { label: 'Last 30 days', getRange: relativeDays(now, 30) },
+  { label: 'Last 90 days', getRange: relativeDays(now, 90) },
+  { label: 'This month', getRange: monthRange(now, 0) },
+  { label: 'Last month', getRange: monthRange(now, -1) },
+];

--- a/packages/lib.components/src/index.ts
+++ b/packages/lib.components/src/index.ts
@@ -68,8 +68,12 @@ export type {
   FormRowProps,
   FormSectionProps,
 } from './components/form/FormField';
-export { DateRangePicker } from './components/form/DateRangePicker';
-export type { DateRangePickerProps, DateRangeValue } from './components/form/DateRangePicker';
+export { DateRangePicker, createDefaultDateRangePresets } from './components/form/DateRangePicker';
+export type {
+  DateRangePickerProps,
+  DateRangeValue,
+  DateRangePreset,
+} from './components/form/DateRangePicker';
 
 // Feedback Components
 export { Alert } from './components/ui/Alert';

--- a/packages/lib.components/src/index.ts
+++ b/packages/lib.components/src/index.ts
@@ -148,7 +148,12 @@ export type { AreaChartProps } from './components/charts/AreaChart';
 export { MetricCard } from './components/charts/MetricCard';
 export type { MetricCardProps, MetricCardFormat } from './components/charts/MetricCard';
 export { DataTable } from './components/charts/DataTable';
-export type { DataTableProps, DataTableColumn } from './components/charts/DataTable';
+export type {
+  DataTableProps,
+  DataTableColumn,
+  DataTableRowVariant,
+  SortDirection,
+} from './components/charts/DataTable';
 export { PALETTE as ChartPalette } from './components/charts/types';
 export type { ChartSeries, ChartDatum } from './components/charts/types';
 


### PR DESCRIPTION
## Summary

- Re-lands two UX-review follow-ups (**D5**, **D2**) that were merged into #1317's feature branch instead of `main`, so their changes never actually reached `main` (see **Related**). This PR cherry-picks both commits cleanly onto current `main`.
- **D5:** optional `presets` prop on the shared `DateRangePicker`, restoring rescue Analytics' quick-range shortcuts that were dropped when it adopted the from/to-only shared picker.
- **D2:** extends the shared `DataTable` (row selection, controlled server sort/pagination, row variants, frameless) and migrates rescue `ApplicationList` + `PetCsvImportModal` off their bespoke tables.
- Both are **purely additive** — omitting the new props leaves every existing consumer byte-for-byte unchanged.

## Changes

- **`packages/lib.components` — DateRangePicker (D5):** new optional `presets?: DateRangePreset[]` (`{ label, getRange }`, evaluated at click time so the component holds no clock); new exported `createDefaultDateRangePresets(now?)` helper → Last 7/30/90 days, This month, Last month; ISO `yyyy-mm-dd` built from **local** calendar parts (BST-safe). Adds `presets.ts`, story, README, tests.
- **`packages/lib.components` — DataTable (D2):** opt-in `selectable`/`selectedIds`/`onSelectionChange`/`getRowId` (select-all with indeterminate, visible-rows-only union), controlled `sortBy`/`sortDirection`/`onSortChange`, controlled `page`/`total`/`onPageChange`, `getRowVariant`/`rowClassName` (token-based row tint + `data-variant`), `frameless`, per-column `sortable`. New barrel exports `DataTableRowVariant`, `SortDirection`.
- **`app.rescue`:** Analytics opts into `presets`; `ApplicationList` adopts DataTable selection + controlled server sort/pagination (bulk transitions, per-row skeleton branch, and #1317's error/empty logic preserved); `PetCsvImportModal` uses frameless DataTables with per-row valid→success / duplicate→warning / invalid→danger variants.

## Before requesting review

- [x] Tests for new behaviour added (TDD)
- [ ] Ran `pnpm ci:local:quick` — ran the equivalent scoped gates instead: `turbo run type-check lint test` for `lib.components` + `app.rescue` (all green — see Test plan)
- [x] If touching a `lib.*`, considered consumer impact — new props are all optional; `DataTable`'s other consumers (rescue `AttendeeList`/`FosterCoordination`, `lib.ReportRenderer`) and app.admin's separate local DataTable are unaffected and stay green
- [x] No `.env` requirement changes

## Test plan

- [x] Existing tests pass — `app.rescue` **557**, `lib.components` D5 + D2 suites; **25/25 turbo tasks green** across both packages
- [x] New behaviour covered (preset click sets from/to + fires onChange; omitting presets renders unchanged; helper range math; DataTable select-all/partial-indeterminate/per-row toggle, controlled sort fires callback without local reorder, controlled pagination page-info/next/prev/disabled, row-variant class + `data-variant`, frameless chrome removal)
- [x] No TypeScript errors (`turbo run type-check` — green)
- [x] Lint passes (`turbo run lint` — 0 errors)
- [ ] Tested manually — verified via the suites; the running stack was not exercised in this environment

## Screenshots / recordings

N/A — verified via component/behaviour tests. Worth a manual check of the Analytics preset-button row, `ApplicationList` selection + server sort/pagination, and the CSV-import row highlighting during review.

## Related

- **Re-lands #1318 (D5) and #1320 (D2).** Those PRs were stacked on #1317 and, because #1317 squash-merged to `main` first, their subsequent merges landed on the feature branch `claude/ux-review-component-plan-7iq3rz` rather than `main` — so the changes never reached `main`. This PR cherry-picks both commits (`4cb73733`, `b0584c66`) onto `main`; the combined result is verified green.
- Follows #1317 (Epics B5/C/D) and #1319 (C3). `docs/UX-REVIEW-2026-08.md` (Epic D / T6, T8).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q4fStLkBsaY3ncGig1fCaw)_