### PR TITLE
feat(app.admin): responsive card fallback for the admin DataTable (UX B6)

### DIFF
--- a/apps/admin/src/components/data/DataTable.css.ts
+++ b/apps/admin/src/components/data/DataTable.css.ts
@@ -127,6 +127,71 @@ globalStyle(`${emptyRow} td`, {
   color: '#6b7280',
 });
 
+/**
+ * ADS UX B6 — responsive card fallback. Below the mobile breakpoint every admin
+ * table row collapses into a stacked label/value card: the header row is
+ * visually hidden and each data cell shows its column label (from `data-label`)
+ * beside the value, so data-dense tables stay usable on small screens without
+ * horizontal scrolling. Applied to every admin table by default. The
+ * empty/error colspan row carries no `data-label`, so it keeps its centred
+ * message rather than becoming a label/value pair.
+ */
+const MOBILE_CARDS = 'screen and (max-width: 640px)';
+
+export const responsiveCards = style({});
+
+globalStyle(`${responsiveCards} thead`, {
+  '@media': {
+    [MOBILE_CARDS]: {
+      position: 'absolute',
+      width: '1px',
+      height: '1px',
+      padding: 0,
+      margin: '-1px',
+      overflow: 'hidden',
+      clip: 'rect(0, 0, 0, 0)',
+      whiteSpace: 'nowrap',
+      border: 0,
+    },
+  },
+});
+
+globalStyle(`${responsiveCards} tbody tr`, {
+  '@media': {
+    [MOBILE_CARDS]: {
+      display: 'block',
+      marginBottom: '12px',
+      border: '1px solid #e5e7eb',
+      borderRadius: '8px',
+      padding: '4px 8px',
+    },
+  },
+});
+
+globalStyle(`${responsiveCards} td[data-label]`, {
+  '@media': {
+    [MOBILE_CARDS]: {
+      display: 'flex',
+      justifyContent: 'space-between',
+      alignItems: 'baseline',
+      gap: '12px',
+      padding: '6px 4px',
+      textAlign: 'right',
+    },
+  },
+});
+
+globalStyle(`${responsiveCards} td[data-label]::before`, {
+  '@media': {
+    [MOBILE_CARDS]: {
+      content: 'attr(data-label)',
+      fontWeight: 600,
+      color: '#6b7280',
+      textAlign: 'left',
+    },
+  },
+});
+
 export const paginationContainer = style({
   display: 'flex',
   alignItems: 'center',

--- a/apps/admin/src/components/data/DataTable.test.tsx
+++ b/apps/admin/src/components/data/DataTable.test.tsx
@@ -162,3 +162,28 @@ describe('DataTable load-state differentiation', () => {
     expect(screen.queryByRole('alert')).not.toBeInTheDocument();
   });
 });
+
+describe('DataTable responsive card fallback (B6)', () => {
+  it('labels each data cell with its column header via data-label', () => {
+    // Below the mobile breakpoint the CSS turns rows into stacked label/value
+    // cards using these data-label attributes; assert the contract that drives it.
+    render(<DataTable columns={columns} data={rows} />);
+    expect(screen.getByText('Alice').closest('td')).toHaveAttribute('data-label', 'Name');
+    expect(screen.getByText('active').closest('td')).toHaveAttribute('data-label', 'Status');
+  });
+
+  it('labels the selection checkbox cell so the mobile card shows it clearly', () => {
+    render(
+      <DataTable
+        columns={columns}
+        data={rows}
+        selectable
+        selectedRows={new Set()}
+        onSelectionChange={vi.fn()}
+        getRowId={row => row.id}
+      />
+    );
+    const checkbox = screen.getByLabelText('Select row 1');
+    expect(checkbox.closest('td')).toHaveAttribute('data-label', 'Select');
+  });
+});

--- a/apps/admin/src/components/data/DataTable.tsx
+++ b/apps/admin/src/components/data/DataTable.tsx
@@ -145,7 +145,7 @@ export function DataTable<T extends object>({
   return (
     <div className={styles.tableContainer}>
       <div className={styles.tableWrapper}>
-        <table className={styles.table}>
+        <table className={`${styles.table} ${styles.responsiveCards}`}>
           <thead className={styles.thead}>
             <tr>
               {selectable && (
@@ -244,6 +244,7 @@ export function DataTable<T extends object>({
                     {selectable && (
                       <td
                         className={styles.td({ align: 'center' })}
+                        data-label='Select'
                         onClick={e => e.stopPropagation()}
                       >
                         <input
@@ -256,7 +257,11 @@ export function DataTable<T extends object>({
                       </td>
                     )}
                     {columns.map(column => (
-                      <td key={column.id} className={styles.td({ align: column.align ?? 'left' })}>
+                      <td
+                        key={column.id}
+                        className={styles.td({ align: column.align ?? 'left' })}
+                        data-label={column.header}
+                      >
                         {getCellValue(row, column)}
                       </td>
                     ))}


### PR DESCRIPTION
## Summary

- Closes **B6** (ADS-1085) from the UX review: admin's data-dense tables weren't usable on small screens (horizontal scroll only). Below the 640px breakpoint every admin table row now collapses into a stacked **label/value card**.
- Done by **enhancing admin's existing local `DataTable` in place** (one component change → all ~9 admin tables become responsive) rather than migrating the pages to the shared `DataTable`. See **Related** for why.

## Changes

- **`apps/admin/src/components/data/DataTable.tsx`** — each body cell now carries `data-label={column.header}` (and the selection cell `data-label="Select"`); the `<table>` gains the `responsiveCards` class.
- **`apps/admin/src/components/data/DataTable.css.ts`** — new `responsiveCards` style: below `max-width: 640px` the header row is visually hidden, rows become bordered cards, and each cell shows its column label (`content: attr(data-label)`) beside the value. Mirrors the shared `DataTable`'s `cardsTable` approach. The empty/error colspan row has no `data-label`, so it keeps its centred message.
- **`DataTable.test.tsx`** — assert the `data-label` contract that drives the card layout (data cells + selection cell).

## Before requesting review

- [x] Tests for new behaviour added (TDD)
- [ ] Ran `pnpm ci:local:quick` — ran the scoped gate instead: `turbo run type-check lint test --filter=@adopt-dont-shop/app.admin` (green)
- [x] No `lib.*` changes — the enhancement is local to app.admin's DataTable
- [x] No `.env` requirement changes

## Test plan

- [x] `app.admin` green — **712 tests** (69 files), incl. the 2 new `data-label` cases
- [x] No TypeScript errors (`turbo run type-check`)
- [x] Lint passes (`turbo run lint`)
- [ ] Tested manually — the card layout is a CSS media query (not exercisable in jsdom); worth a mobile-viewport check of Users/Pets/Applications/Audit during review

## Screenshots / recordings

N/A — verified via the `data-label` contract tests. The visual card layout is worth a manual check at ≤640px on a couple of admin list pages.

## Related

- **Epic B / B6** (ADS-1085). Applies to all admin tables: Users, Pets, Applications, Moderation, Audit, Rescues, Support, Messages, Inbox.
- **Why enhance, not migrate:** admin's local `DataTable` is typed (`Column<T>`) and already provides URL-sort persistence, skeleton loading, and error/empty states — all of which a migration to the (untyped) shared `DataTable` would lose across 9 complex pages. Enhancing in place achieves the responsive goal with one low-risk change.
- **B3** (FilterPanel adoption) is the last open Epic B item; it's blocked on a shared-lib decision (the barrel-exported `FilterPanel` is report-builder-specific and can't express general page filters) and is being handled separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q4fStLkBsaY3ncGig1fCaw)_