### PR TITLE
feat(lib.components): extend shared DataTable toward the canonical table (consolidation 1a)

### DIFF
--- a/packages/lib.components/src/components/charts/DataTable.test.tsx
+++ b/packages/lib.components/src/components/charts/DataTable.test.tsx
@@ -392,3 +392,18 @@ describe('DataTable frameless mode', () => {
     expect(screen.getByText('Bea')).toBeInTheDocument();
   });
 });
+
+describe('DataTable loading state', () => {
+  it('renders skeleton rows while loading, so a load reads as loading not empty', () => {
+    renderWithTheme(<DataTable title='Pets' columns={columns} rows={[]} loading />);
+    expect(screen.getAllByTestId('skeleton-row')).toHaveLength(5);
+    // No empty state while loading.
+    expect(screen.queryByTestId('chart-empty')).not.toBeInTheDocument();
+  });
+
+  it('shows real rows (no skeletons) once loaded', () => {
+    renderWithTheme(<DataTable title='Pets' columns={columns} rows={idRows} />);
+    expect(screen.queryAllByTestId('skeleton-row')).toHaveLength(0);
+    expect(screen.getByText('Bea')).toBeInTheDocument();
+  });
+});

--- a/packages/lib.components/src/components/charts/DataTable.test.tsx
+++ b/packages/lib.components/src/components/charts/DataTable.test.tsx
@@ -406,17 +406,39 @@ describe('DataTable loading state', () => {
     expect(screen.queryAllByTestId('skeleton-row')).toHaveLength(0);
     expect(screen.getByText('Bea')).toBeInTheDocument();
   });
+
+  it('prefers skeleton rows over ChartFrame isLoading when both are set', () => {
+    renderWithTheme(<DataTable title='Pets' columns={columns} rows={[]} loading isLoading />);
+    expect(screen.getAllByTestId('skeleton-row')).toHaveLength(5);
+    // ChartFrame's own "Loading…" state is suppressed so the skeleton table shows.
+    expect(screen.queryByTestId('chart-loading')).not.toBeInTheDocument();
+  });
 });
 
 describe('DataTable column width + alignment', () => {
-  it('applies per-column width and alignment to the header cell', () => {
+  it('applies per-column width + alignment to the header and body cells', () => {
     renderWithTheme(
       <DataTable
         title='Pets'
-        columns={[{ key: 'name', label: 'Name', width: '200px', align: 'center' }]}
+        columns={[{ key: 'name', label: 'Name', width: '200px', align: 'center', sortable: false }]}
         rows={idRows}
       />
     );
     expect(screen.getByTestId('th-name')).toHaveStyle({ width: '200px', textAlign: 'center' });
+    expect(screen.getByText('Bea').closest('td')).toHaveStyle({
+      width: '200px',
+      textAlign: 'center',
+    });
+  });
+
+  it('aligns a sortable header label via its sort button (not just the th)', () => {
+    renderWithTheme(
+      <DataTable
+        title='Pets'
+        columns={[{ key: 'name', label: 'Name', align: 'right', sortable: true }]}
+        rows={idRows}
+      />
+    );
+    expect(screen.getByRole('button', { name: /name/i })).toHaveStyle({ textAlign: 'right' });
   });
 });

--- a/packages/lib.components/src/components/charts/DataTable.test.tsx
+++ b/packages/lib.components/src/components/charts/DataTable.test.tsx
@@ -407,3 +407,16 @@ describe('DataTable loading state', () => {
     expect(screen.getByText('Bea')).toBeInTheDocument();
   });
 });
+
+describe('DataTable column width + alignment', () => {
+  it('applies per-column width and alignment to the header cell', () => {
+    renderWithTheme(
+      <DataTable
+        title='Pets'
+        columns={[{ key: 'name', label: 'Name', width: '200px', align: 'center' }]}
+        rows={idRows}
+      />
+    );
+    expect(screen.getByTestId('th-name')).toHaveStyle({ width: '200px', textAlign: 'center' });
+  });
+});

--- a/packages/lib.components/src/components/charts/DataTable.tsx
+++ b/packages/lib.components/src/components/charts/DataTable.tsx
@@ -14,6 +14,10 @@ export type DataTableColumn = {
    * original behaviour where every column header is a sort control.
    */
   sortable?: boolean;
+  /** Fixed column width (any CSS length), applied to the header cell. */
+  width?: string;
+  /** Horizontal alignment for the column's header and cells. Defaults to left. */
+  align?: 'left' | 'center' | 'right';
 };
 
 export type SortDirection = 'asc' | 'desc';
@@ -237,7 +241,12 @@ export const DataTable: React.FC<DataTableProps> = ({
               const sortable = col.sortable ?? true;
               if (!sortable) {
                 return (
-                  <th key={col.key} className={styles.th} data-testid={`th-${col.key}`}>
+                  <th
+                    key={col.key}
+                    className={styles.th}
+                    data-testid={`th-${col.key}`}
+                    style={{ width: col.width, textAlign: col.align }}
+                  >
                     <span className={styles.headerLabel}>{col.label}</span>
                   </th>
                 );
@@ -254,6 +263,7 @@ export const DataTable: React.FC<DataTableProps> = ({
                   className={styles.th}
                   data-testid={`th-${col.key}`}
                   aria-sort={ariaSort}
+                  style={{ width: col.width, textAlign: col.align }}
                 >
                   <button
                     type='button'
@@ -306,7 +316,12 @@ export const DataTable: React.FC<DataTableProps> = ({
                       </td>
                     ) : null}
                     {columns.map(col => (
-                      <td key={col.key} className={styles.td} data-label={col.label}>
+                      <td
+                        key={col.key}
+                        className={styles.td}
+                        data-label={col.label}
+                        style={{ textAlign: col.align }}
+                      >
                         {col.render ? col.render(row[col.key], row) : String(row[col.key] ?? '')}
                       </td>
                     ))}

--- a/packages/lib.components/src/components/charts/DataTable.tsx
+++ b/packages/lib.components/src/components/charts/DataTable.tsx
@@ -1,6 +1,7 @@
 import React, { useMemo, useState } from 'react';
 import clsx from 'clsx';
 import { ChartFrame, type ChartFrameProps } from './ChartFrame';
+import { SkeletonTableRow } from '../ui/Skeleton';
 import * as styles from './DataTable.css';
 
 export type DataTableColumn = {
@@ -26,6 +27,12 @@ export type DataTableProps = Omit<ChartFrameProps, 'children' | 'isEmpty' | 'tit
   columns: DataTableColumn[];
   rows: Record<string, unknown>[];
   pageSize?: number;
+  /**
+   * When true, the body renders skeleton rows instead of data (initial load),
+   * so a load in progress reads as "loading" rather than "empty". Works in
+   * frameless mode too, unlike ChartFrame's framed `isLoading` text state.
+   */
+  loading?: boolean;
   /** Optional callback when a row is clicked (used for drill-down). */
   onRowClick?: (row: Record<string, unknown>) => void;
   /**
@@ -96,11 +103,14 @@ const defaultGetRowId = (row: Record<string, unknown>, index: number): string =>
   return id === undefined || id === null ? String(index) : String(id);
 };
 
+const SKELETON_ROW_COUNT = 5;
+
 export const DataTable: React.FC<DataTableProps> = ({
   title,
   columns,
   rows,
   pageSize = 25,
+  loading = false,
   onRowClick,
   responsive = 'scroll',
   selectable = false,
@@ -259,42 +269,50 @@ export const DataTable: React.FC<DataTableProps> = ({
           </tr>
         </thead>
         <tbody>
-          {visibleRows.map((row, i) => {
-            const rowId = getRowIdFn(row, i);
-            const isSelected = selectable && selectedSet.has(rowId);
-            const variant = getRowVariant?.(row, i) ?? 'default';
-            return (
-              <tr
-                key={rowId}
-                onClick={onRowClick ? () => onRowClick(row) : undefined}
-                data-variant={variant === 'default' ? undefined : variant}
-                className={clsx(
-                  onRowClick ? styles.rowClickable : styles.rowDefault,
-                  styles.rowVariant({ variant, selected: isSelected }),
-                  rowClassName?.(row, i)
-                )}
-              >
-                {selectable ? (
-                  <td className={styles.selectCell} onClick={e => e.stopPropagation()}>
-                    <input
-                      type='checkbox'
-                      className={styles.checkbox}
-                      aria-label={
-                        getRowLabel ? `Select ${getRowLabel(row, i)}` : `Select row ${rowId}`
-                      }
-                      checked={selectedSet.has(rowId)}
-                      onChange={() => toggleOne(rowId)}
-                    />
-                  </td>
-                ) : null}
-                {columns.map(col => (
-                  <td key={col.key} className={styles.td} data-label={col.label}>
-                    {col.render ? col.render(row[col.key], row) : String(row[col.key] ?? '')}
-                  </td>
-                ))}
-              </tr>
-            );
-          })}
+          {loading
+            ? Array.from({ length: SKELETON_ROW_COUNT }, (_, i) => (
+                <SkeletonTableRow
+                  key={`skeleton-${i}`}
+                  columnCount={columns.length}
+                  hasCheckbox={selectable}
+                />
+              ))
+            : visibleRows.map((row, i) => {
+                const rowId = getRowIdFn(row, i);
+                const isSelected = selectable && selectedSet.has(rowId);
+                const variant = getRowVariant?.(row, i) ?? 'default';
+                return (
+                  <tr
+                    key={rowId}
+                    onClick={onRowClick ? () => onRowClick(row) : undefined}
+                    data-variant={variant === 'default' ? undefined : variant}
+                    className={clsx(
+                      onRowClick ? styles.rowClickable : styles.rowDefault,
+                      styles.rowVariant({ variant, selected: isSelected }),
+                      rowClassName?.(row, i)
+                    )}
+                  >
+                    {selectable ? (
+                      <td className={styles.selectCell} onClick={e => e.stopPropagation()}>
+                        <input
+                          type='checkbox'
+                          className={styles.checkbox}
+                          aria-label={
+                            getRowLabel ? `Select ${getRowLabel(row, i)}` : `Select row ${rowId}`
+                          }
+                          checked={selectedSet.has(rowId)}
+                          onChange={() => toggleOne(rowId)}
+                        />
+                      </td>
+                    ) : null}
+                    {columns.map(col => (
+                      <td key={col.key} className={styles.td} data-label={col.label}>
+                        {col.render ? col.render(row[col.key], row) : String(row[col.key] ?? '')}
+                      </td>
+                    ))}
+                  </tr>
+                );
+              })}
         </tbody>
       </table>
       {pageCount > 1 ? (
@@ -322,14 +340,14 @@ export const DataTable: React.FC<DataTableProps> = ({
   );
 
   if (frameless) {
-    if (rows.length === 0) {
+    if (!loading && rows.length === 0) {
       return <div className={styles.emptyFrameless}>{frame.emptyMessage ?? 'No data'}</div>;
     }
     return content;
   }
 
   return (
-    <ChartFrame {...frame} title={title ?? ''} isEmpty={rows.length === 0}>
+    <ChartFrame {...frame} title={title ?? ''} isEmpty={!loading && rows.length === 0}>
       {content}
     </ChartFrame>
   );

--- a/packages/lib.components/src/components/charts/DataTable.tsx
+++ b/packages/lib.components/src/components/charts/DataTable.tsx
@@ -269,6 +269,7 @@ export const DataTable: React.FC<DataTableProps> = ({
                     type='button'
                     className={styles.sortButton}
                     onClick={() => handleSort(col.key)}
+                    style={{ textAlign: col.align }}
                   >
                     {col.label}
                     {isSorted ? (activeSortDir === 'asc' ? ' ▲' : ' ▼') : ''}
@@ -320,7 +321,7 @@ export const DataTable: React.FC<DataTableProps> = ({
                         key={col.key}
                         className={styles.td}
                         data-label={col.label}
-                        style={{ textAlign: col.align }}
+                        style={{ width: col.width, textAlign: col.align }}
                       >
                         {col.render ? col.render(row[col.key], row) : String(row[col.key] ?? '')}
                       </td>
@@ -362,7 +363,12 @@ export const DataTable: React.FC<DataTableProps> = ({
   }
 
   return (
-    <ChartFrame {...frame} title={title ?? ''} isEmpty={!loading && rows.length === 0}>
+    <ChartFrame
+      {...frame}
+      title={title ?? ''}
+      isLoading={loading ? false : frame.isLoading}
+      isEmpty={!loading && rows.length === 0}
+    >
       {content}
     </ChartFrame>
   );


### PR DESCRIPTION
## Summary

- **Phase 1a** of the component consolidation ([ADS-1136](https://linear.app/ideasquared/issue/ADS-1136)): converge the two DataTable implementations (`app.admin`'s local typed `DataTable<T>` and the shared `lib.components` `DataTable`) onto one extensible shared component, and retire the duplicate.
- This PR **extends the shared `DataTable` additively** so it can faithfully supersede admin's local one, without touching any current consumer. The admin-page migration + deletion of the local component follows in Phase 1b.

## Changes

- **`loading`** prop — renders `SkeletonTableRow` rows in the body during initial load, so a load reads as "loading" not "empty". Unlike `ChartFrame`'s framed `isLoading` text state, it **works in frameless mode** (which the admin list tables use).
- **Per-column `width` + `align`** on `DataTableColumn` — applied to header and body cells, so the shared component can express admin's fixed-width / centred columns.

Both are opt-in and backward-compatible — omitting them leaves every existing consumer (rescue's 4 tables, `ReportRenderer`) byte-for-byte unchanged.

## Before requesting review

- [x] Tests for new behaviour added (TDD)
- [x] If touching a `lib.*`, considered consumer impact — additive only; rescue + ReportRenderer unaffected
- [x] No `.env` changes

## Test plan

- [x] `lib.components` green — **656 tests** (new: skeleton-rows loading state, loaded-state has no skeletons, per-column width/align on the header)
- [x] No TypeScript errors; lint passes

## Related — consolidation roadmap ([ADS-1136](https://linear.app/ideasquared/issue/ADS-1136))

Supersedes **B6** (ADS-1085, responsive delivered via the shared table) and **B3** (ADS-1082, filter unification).

1. **1a (this PR)** — extend the shared DataTable (loading + width/align).
2. **1b** — migrate admin's 9 DataTable pages + 4 raw-`<table>` pages onto the shared component; delete `apps/admin/src/components/data/DataTable.tsx`. (URL-sort persistence, where actually wired, becomes an app-level hook on `onSortChange`.)
3. **2** — filter consolidation: one config-driven filter primitive + `SearchToolbar` composition; migrate admin Analytics/Audit/Messages; retire `FilterBar`/`FilterGroup` and the duplicate lib filter pieces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q4fStLkBsaY3ncGig1fCaw)_