### PR TITLE
fix(ci): make Storybook build cache key deterministic across jobs

### DIFF
--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -44,16 +44,25 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
       - name: Setup workspace (Node + pnpm)
         uses: ./.github/actions/setup-workspace
-      # ADS-909: cache the built output, keyed on every file that can affect
-      # it (component source, stories, theme, Storybook config). A doc-only
-      # PR under packages/lib.components/** (this workflow's own path
-      # filter) still triggers the job but skips the rebuild on a hit.
+      # ADS-909: cache the built output, keyed on every source file that can
+      # affect it — component source, stories, theme (src/**), Storybook and
+      # Vite config, the package manifest, tsconfig and the lockfile. A
+      # doc-only change still triggers the job (via the path filter) but
+      # restores on a hit.
+      #
+      # The key MUST be source-only. A broad `packages/lib.components/**` glob
+      # also hashes node_modules, which is present here (after setup-workspace
+      # installs it) but absent in the deploy-storybook job below (which has no
+      # setup-workspace). The two jobs would then compute different keys, the
+      # deploy restore would miss, and `cp -r storybook-static` would fail with
+      # "No such file or directory". This mirrors the source-only lib-dist key
+      # shared across jobs in ci.yml — keep the two keys byte-identical.
       - name: Restore Storybook build cache
         id: cache-storybook
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
         with:
           path: packages/lib.components/storybook-static
-          key: storybook-${{ runner.os }}-${{ hashFiles('packages/lib.components/**') }}
+          key: storybook-${{ runner.os }}-${{ hashFiles('packages/lib.components/src/**', 'packages/lib.components/.storybook/**', 'packages/lib.components/package.json', 'packages/lib.components/tsconfig*.json', 'packages/lib.components/vite*.config.ts', 'pnpm-lock.yaml') }}
       - run: pnpm build-storybook
         if: steps.cache-storybook.outputs.cache-hit != 'true'
         working-directory: packages/lib.components
@@ -78,11 +87,13 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
 
       # Restore the storybook-static directory built (or cache-hit) above.
+      # Key MUST match build-storybook's exactly (source-only — see the note
+      # there) so this cross-job restore hits.
       - name: Restore Storybook build
         uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
         with:
           path: packages/lib.components/storybook-static
-          key: storybook-${{ runner.os }}-${{ hashFiles('packages/lib.components/**') }}
+          key: storybook-${{ runner.os }}-${{ hashFiles('packages/lib.components/src/**', 'packages/lib.components/.storybook/**', 'packages/lib.components/package.json', 'packages/lib.components/tsconfig*.json', 'packages/lib.components/vite*.config.ts', 'pnpm-lock.yaml') }}
 
       - name: Push Storybook to gh-pages branch
         run: |

--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -46,9 +46,10 @@ jobs:
         uses: ./.github/actions/setup-workspace
       # ADS-909: cache the built output, keyed on every source file that can
       # affect it — component source, stories, theme (src/**), Storybook and
-      # Vite config, the package manifest, tsconfig and the lockfile. A
-      # doc-only change still triggers the job (via the path filter) but
-      # restores on a hit.
+      # Vite config, the package manifest, tsconfig and the lockfile. The
+      # workflow's path filter (packages/lib.components/**) is broader than
+      # this key, so a change outside these inputs (e.g. the package-level
+      # README) still triggers the job but restores on a hit.
       #
       # The key MUST be source-only. A broad `packages/lib.components/**` glob
       # also hashes node_modules, which is present here (after setup-workspace


### PR DESCRIPTION
## Summary

- Fixes the broken **Storybook** workflow on `main`, which failed the `Deploy Storybook to GitHub Pages` job with `cp: cannot stat 'packages/lib.components/storybook-static': No such file or directory`.
- Root cause: the `build-storybook` and `deploy-storybook` jobs computed **different** `actions/cache` keys, so the deploy job's cross-job cache restore missed and `storybook-static` was never present when the deploy script tried to copy it.
- Makes the cache key **source-only** and byte-identical across both jobs so the restore reliably hits.

## Changes

- `.github/workflows/storybook.yml`
  - Changed both Storybook cache keys (`build-storybook` save + `deploy-storybook` restore) from `hashFiles('packages/lib.components/**')` to a source-only glob: `src/**`, `.storybook/**`, `package.json`, `tsconfig*.json`, `vite*.config.ts`, `pnpm-lock.yaml`.
  - Added comments explaining why the key must be source-only and byte-identical between the two jobs.

### Why this was failing

`hashFiles('packages/lib.components/**')` also hashes `packages/lib.components/node_modules/**`. In `build-storybook` the key is computed **after** `setup-workspace` runs `pnpm install` (node_modules present → hashed). `deploy-storybook` has **no** `setup-workspace` step, so it computes the key with node_modules absent. The two hashes differed, the deploy `actions/cache/restore` missed, `storybook-static` was never restored, and `cp -r "$STORYBOOK" /tmp/storybook-build` failed.

Excluding node_modules from the key (and keeping the two keys identical) makes both jobs derive the same hash, so the deploy job restores the artifact the build job produced. This mirrors the existing source-only `lib-dist` cache key shared across jobs in `ci.yml` (ADS-909 / ADS-390).

## Before requesting review

- [ ] Ran `pnpm ci:local:quick` locally — N/A, this is a CI workflow YAML change only (no application code)
- [ ] Tests for new behaviour added (TDD) — N/A, workflow config change
- [ ] If touching `.env` requirements, updated `.env.example`'s REQUIRED block — N/A
- [ ] If touching a `lib.*`, considered consumer impact across `app.*` and `service.backend` — N/A

## Test plan

- [x] Validated `storybook.yml` still parses as YAML
- [x] Verified the two cache keys are byte-identical (required for the cross-job restore to hit)
- [x] Verified every glob in the new key resolves to real files (`src/**`, `.storybook/**`, `package.json`, `tsconfig*.json`, `vite*.config.ts`, `pnpm-lock.yaml`), so the key is not degenerate
- [ ] End-to-end deploy path only exercises on `main` (the `deploy-storybook` job is gated on `github.ref == 'refs/heads/main'`, and the workflow's `packages/lib.components/**` path filter means this workflow-only PR won't trigger it) — full verification happens on merge

## Related

- Storybook deploy pipeline (ADS-909); mirrors the `lib-dist` cross-job cache convention (ADS-390) in `ci.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EaKidnk3LmUyZk95Mzo2bP

---
_Generated by [Claude Code](https://claude.ai/code/session_01EaKidnk3LmUyZk95Mzo2bP)_