### PR TITLE
feat(observability): wire Discord alert delivery, remove redundant client health probe

### DIFF
--- a/apps/client/src/utils/offlineManager.test.ts
+++ b/apps/client/src/utils/offlineManager.test.ts
@@ -11,14 +11,6 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
-const apiFetch = vi.fn();
-
-vi.mock('@/services', () => ({
-  api: {
-    fetch: (...args: unknown[]) => apiFetch(...args),
-  },
-}));
-
 // Fake timers must be active before the module's singleton constructor runs.
 vi.useFakeTimers();
 

--- a/apps/client/src/utils/offlineManager.ts
+++ b/apps/client/src/utils/offlineManager.ts
@@ -3,8 +3,6 @@
  * Handles offline message queuing, connection monitoring, and sync capabilities
  */
 
-import { api } from '@/services';
-
 export interface QueuedMessage {
   id: string;
   conversationId: string;
@@ -38,8 +36,6 @@ class OfflineManager {
   private syncCallback: SyncCallback | null = null;
   private listeners: OfflineStateChangeListener[] = [];
   private syncInterval: ReturnType<typeof setInterval> | null = null;
-  private connectionCheckInterval: ReturnType<typeof setInterval> | null = null;
-  private consecutiveFailures: number = 0;
   // Bound listener refs stored so removeEventListener can remove the same function reference.
   private readonly boundHandleOnline: () => void;
   private readonly boundHandleOffline: () => void;
@@ -50,7 +46,6 @@ class OfflineManager {
     this.initializeNetworkListeners();
     this.loadPersistedData();
     this.startPeriodicSync();
-    this.startConnectionQualityCheck();
   }
 
   private initializeNetworkListeners() {
@@ -77,61 +72,6 @@ class OfflineManager {
         this.trySync();
       }
     }, 30000); // Sync every 30 seconds
-  }
-
-  private startConnectionQualityCheck() {
-    // Do an initial check after a short delay
-    setTimeout(() => this.checkConnectionQuality(), 2000);
-
-    // Check every 2 minutes in development to reduce log noise, or 30 seconds in production
-    // ADS-423: import.meta.env.DEV is statically replaced by Vite at build time.
-    const isDev = import.meta.env.DEV === true || window.location.hostname === 'localhost';
-    const interval = isDev ? 120000 : 30000; // 2 minutes for dev, 30 seconds for prod
-
-    this.connectionCheckInterval = setInterval(() => {
-      this.checkConnectionQuality();
-    }, interval);
-  }
-
-  private async checkConnectionQuality() {
-    if (!this.isOnline) {
-      this.connectionQuality = 'offline';
-      return;
-    }
-
-    try {
-      const startTime = Date.now();
-
-      // Use the simple health endpoint for quick connection quality checks
-      await api.fetch('/api/v1/health/simple', {
-        method: 'GET',
-        timeout: 3000, // Reduced timeout to 3 seconds
-      });
-
-      const endTime = Date.now();
-      const latency = endTime - startTime;
-
-      // If we got here without throwing, the response was successful
-      this.connectionQuality = latency < 1000 ? 'good' : 'poor';
-      this.consecutiveFailures = 0; // Reset on success
-    } catch (error) {
-      this.consecutiveFailures++;
-      // Only log connection errors occasionally to avoid spam
-      if (this.connectionQuality !== 'poor' && this.consecutiveFailures <= 3) {
-        console.warn('Health check failed, marking connection as poor:', error);
-      }
-      this.connectionQuality = 'poor';
-
-      // If there are 5 consecutive failures, back off the check interval to every 2 minutes
-      if (this.consecutiveFailures >= 5) {
-        clearInterval(this.connectionCheckInterval!);
-        this.connectionCheckInterval = setInterval(() => {
-          this.checkConnectionQuality();
-        }, 120000); // 2 minutes
-      }
-    }
-
-    this.notifyListeners();
   }
 
   private loadPersistedData() {
@@ -268,10 +208,6 @@ class OfflineManager {
     if (this.syncInterval) {
       clearInterval(this.syncInterval);
       this.syncInterval = null;
-    }
-    if (this.connectionCheckInterval) {
-      clearInterval(this.connectionCheckInterval);
-      this.connectionCheckInterval = null;
     }
     window.removeEventListener('online', this.boundHandleOnline);
     window.removeEventListener('offline', this.boundHandleOffline);

--- a/observability/alertmanager/alertmanager.yml
+++ b/observability/alertmanager/alertmanager.yml
@@ -42,35 +42,33 @@ inhibit_rules:
     equal: ['alertname', 'job']
 
 receivers:
-  # ---- CRITICAL → paging channel -----------------------------------------
-  # Inert until a notifier is added. Recommended: Slack (or PagerDuty/Opsgenie
-  # for true on-call escalation). To activate Slack, create the secret file
-  #   observability/alertmanager/secrets/slack_api_url   (the incoming-webhook URL)
-  # and uncomment:
-  - name: 'critical-pager'
-    # slack_configs:
-    #   - channel: '#alerts-critical'
-    #     api_url_file: /etc/alertmanager/secrets/slack_api_url
-    #     send_resolved: true
-    #     title: '[{{ .Status | toUpper }}] {{ .CommonLabels.alertname }}'
-    #     text: >-
-    #       {{ range .Alerts }}{{ .Annotations.summary }}
-    #       {{ .Annotations.description }}
-    #       Runbook: {{ .Annotations.runbook }}
-    #       {{ end }}
+  # Delivery goes to Discord via an incoming webhook (ADS-1041). The webhook
+  # URL is a secret: it lives in observability/alertmanager/secrets/discord_webhook_url
+  # on the host (gitignored, mounted read-only at /etc/alertmanager/secrets/),
+  # NOT in this file — webhook_url_file keeps it out of `docker inspect` too.
+  # Reload after editing: `docker compose kill -s HUP alertmanager`.
 
-  # ---- WARNING → chat channel --------------------------------------------
-  # Inert until a notifier is added. Slack example (create
-  #   observability/alertmanager/secrets/slack_api_url) or SMTP email:
+  # ---- CRITICAL → alerts channel -----------------------------------------
+  - name: 'critical-pager'
+    discord_configs:
+      - webhook_url_file: /etc/alertmanager/secrets/discord_webhook_url
+        send_resolved: true
+        title: '[{{ .Status | toUpper }}] {{ .CommonLabels.alertname }}'
+        message: >-
+          {{ range .Alerts }}{{ .Annotations.summary }}
+          {{ .Annotations.description }}
+          {{ if .Annotations.runbook }}Runbook: {{ .Annotations.runbook }}{{ end }}
+          {{ end }}
+
+  # ---- WARNING → alerts channel ------------------------------------------
+  # Same webhook for now (single channel). Point at a separate webhook secret
+  # if you split #alerts-critical from #alerts later.
   - name: 'warning-chat'
-    # slack_configs:
-    #   - channel: '#alerts'
-    #     api_url_file: /etc/alertmanager/secrets/slack_api_url
-    #     send_resolved: true
-    # email_configs:
-    #   - to: 'oncall@adoptdontshop.com'
-    #     from: 'alertmanager@adoptdontshop.com'
-    #     smarthost: 'smtp.example.com:587'
-    #     auth_username: 'alertmanager@adoptdontshop.com'
-    #     auth_password_file: /etc/alertmanager/secrets/smtp_password
-    #     send_resolved: true
+    discord_configs:
+      - webhook_url_file: /etc/alertmanager/secrets/discord_webhook_url
+        send_resolved: true
+        title: '[{{ .Status | toUpper }}] {{ .CommonLabels.alertname }}'
+        message: >-
+          {{ range .Alerts }}{{ .Annotations.summary }}
+          {{ .Annotations.description }}
+          {{ end }}


### PR DESCRIPTION
## What

Two related reliability fixes surfaced while debugging a dev-stack startup failure.

### 1. Wire Discord alert delivery (the real gap)
Alertmanager shipped **inert** — the 8 alert rules (incl. `ServiceDown` = `up==0 for 2m`) fired, grouped, and were then **dropped**. Detection worked; nobody was ever notified.

Both receivers (`critical-pager`, `warning-chat`) now deliver to Discord via native `discord_configs` + `webhook_url_file`:
- Webhook URL lives in the gitignored `observability/alertmanager/secrets/discord_webhook_url` (mounted read-only), kept out of `docker inspect` via `_file`.
- Alertmanager v0.28 → `discord_configs` is GA, no feature flag needed.

**Verified end-to-end:** `amtool check-config` SUCCESS · secret mounted + readable · HUP reload · synthetic critical alert routed `active` → `critical-pager` · no notify errors · direct webhook returned **HTTP 204** · resolved-path cleared.

### 2. Remove redundant client health probe
`offlineManager`'s connection-quality probe polled `GET /api/v1/health/simple` — a path the gateway never served (health is `/health/simple`, no `/api/v1`). So it 404'd every 2 min per client and **always** reported `poor`. It was also just per-browser UX, not observability.

Removed the probe entirely. `connectionQuality` is now driven purely by the browser `online`/`offline` events; the offline message/action queue is unchanged.

## Why
"Ensure we're up" needs *delivery*, not another dashboard. Detection was already solid — the missing link was routing a firing alert to a human. The client probe was noise (broken + redundant) hitting the gateway on a dead path.

## Testing
- `offlineManager` tests: 15/15 pass, no orphaned refs, type-check clean for the touched file.
- Alerting verified live against the running dev observability stack (see checks above).
- Confirmed no remaining wrong-path (`/api/v1/health`) callers or Docker healthchecks anywhere.

## Notes
- The Discord webhook secret is **not** committed (gitignored). If it leaks, regenerate in Discord and overwrite the secret file — no YAML change needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)