### PR TITLE
feat(lib.components): make SearchToolbar search field optional (consolidation 2a)

### DIFF
--- a/packages/lib.components/src/components/data/SearchToolbar/README.md
+++ b/packages/lib.components/src/components/data/SearchToolbar/README.md
@@ -34,21 +34,21 @@ function PetsList() {
 
 ## Props
 
-| Prop                | Type                                                       | Default    | Description                                                                 |
-| ------------------- | ---------------------------------------------------------- | ---------- | --------------------------------------------------------------------------- |
-| `searchValue`       | `string`                                                   | -          | Controlled value of the search field (required)                             |
-| `onSearchChange`    | `(value: string) => void`                                  | -          | Called with the new value on every keystroke — debounce upstream (required) |
-| `searchPlaceholder` | `string`                                                   | -          | Placeholder text for the search field                                       |
-| `searchLabel`       | `string`                                                   | `'Search'` | Accessible label rendered above the search field                            |
-| `filterConfig`      | `FilterConfig[]`                                           | -          | Passed straight through to the shared `FilterPanel`                         |
-| `filters`           | `Record<string, string \| boolean \| number \| undefined>` | -          | Current filter values for `FilterPanel`                                     |
-| `onFilterChange`    | `(name: string, value: string \| boolean) => void`         | -          | Called by `FilterPanel` when a filter changes                               |
-| `activeFilters`     | `SearchToolbarActiveFilter[]`                              | `[]`       | Renders one removable chip per entry                                        |
-| `onRemoveFilter`    | `(name: string) => void`                                   | -          | Called with the filter name when a chip's remove button is activated        |
-| `resultCount`       | `number`                                                   | -          | Renders a polite live-region summary (e.g. `3 results`); `0` is honoured    |
-| `resultNoun`        | `string`                                                   | `'result'` | Singular noun for the summary; pluralised automatically                     |
-| `className`         | `string`                                                   | -          | Extra class on the container                                                |
-| `data-testid`       | `string`                                                   | -          | Test id on the container                                                    |
+| Prop                | Type                                                       | Default    | Description                                                                                                                                         |
+| ------------------- | ---------------------------------------------------------- | ---------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `searchValue`       | `string`                                                   | -          | Controlled value of the search field                                                                                                                |
+| `onSearchChange`    | `(value: string) => void`                                  | -          | Called with the new value on every keystroke — debounce upstream. Omit both this and `searchValue` to render a filter-only bar with no search field |
+| `searchPlaceholder` | `string`                                                   | -          | Placeholder text for the search field                                                                                                               |
+| `searchLabel`       | `string`                                                   | `'Search'` | Accessible label rendered above the search field                                                                                                    |
+| `filterConfig`      | `FilterConfig[]`                                           | -          | Passed straight through to the shared `FilterPanel`                                                                                                 |
+| `filters`           | `Record<string, string \| boolean \| number \| undefined>` | -          | Current filter values for `FilterPanel`                                                                                                             |
+| `onFilterChange`    | `(name: string, value: string \| boolean) => void`         | -          | Called by `FilterPanel` when a filter changes                                                                                                       |
+| `activeFilters`     | `SearchToolbarActiveFilter[]`                              | `[]`       | Renders one removable chip per entry                                                                                                                |
+| `onRemoveFilter`    | `(name: string) => void`                                   | -          | Called with the filter name when a chip's remove button is activated                                                                                |
+| `resultCount`       | `number`                                                   | -          | Renders a polite live-region summary (e.g. `3 results`); `0` is honoured                                                                            |
+| `resultNoun`        | `string`                                                   | `'result'` | Singular noun for the summary; pluralised automatically                                                                                             |
+| `className`         | `string`                                                   | -          | Extra class on the container                                                                                                                        |
+| `data-testid`       | `string`                                                   | -          | Test id on the container                                                                                                                            |
 
 The filter panel only renders when `filterConfig`, `filters` and `onFilterChange` are all provided.
 

--- a/packages/lib.components/src/components/data/SearchToolbar/SearchToolbar.stories.tsx
+++ b/packages/lib.components/src/components/data/SearchToolbar/SearchToolbar.stories.tsx
@@ -78,3 +78,12 @@ export const CustomNoun: Story = {
     resultNoun: 'application',
   },
 };
+
+export const FilterOnly: Story = {
+  args: {
+    searchValue: undefined,
+    onSearchChange: undefined,
+    filterConfig,
+    filters: { species: '', status: 'available' },
+  },
+};

--- a/packages/lib.components/src/components/data/SearchToolbar/SearchToolbar.test.tsx
+++ b/packages/lib.components/src/components/data/SearchToolbar/SearchToolbar.test.tsx
@@ -148,6 +148,28 @@ describe('SearchToolbar', () => {
     expect(screen.queryByRole('button')).not.toBeInTheDocument();
   });
 
+  it('renders as a filter-only bar with no search field when onSearchChange is omitted', () => {
+    renderToolbar(
+      <SearchToolbar
+        filterConfig={[{ name: 'range', label: 'Date range', type: 'text' }]}
+        filters={{ range: '' }}
+        onFilterChange={vi.fn()}
+        data-testid='toolbar'
+      />
+    );
+
+    expect(screen.getByTestId('toolbar')).toBeInTheDocument();
+    expect(screen.queryByRole('searchbox')).not.toBeInTheDocument();
+    expect(screen.getByLabelText('Date range')).toBeInTheDocument();
+  });
+
+  it('still renders the result count when there is no search field', () => {
+    renderToolbar(<SearchToolbar resultCount={5} />);
+
+    expect(screen.getByText('5 results')).toBeInTheDocument();
+    expect(screen.queryByRole('searchbox')).not.toBeInTheDocument();
+  });
+
   it('applies a custom className to the container', () => {
     renderToolbar(
       <SearchToolbar

--- a/packages/lib.components/src/components/data/SearchToolbar/SearchToolbar.tsx
+++ b/packages/lib.components/src/components/data/SearchToolbar/SearchToolbar.tsx
@@ -17,8 +17,8 @@ export type SearchToolbarActiveFilter = {
 type FilterValues = Record<string, string | boolean | number | undefined>;
 
 export type SearchToolbarProps = {
-  searchValue: string;
-  onSearchChange: (value: string) => void;
+  searchValue?: string;
+  onSearchChange?: (value: string) => void;
   searchPlaceholder?: string;
   searchLabel?: string;
   filterConfig?: FilterConfig[];
@@ -57,8 +57,10 @@ export const SearchToolbar = ({
   'data-testid': testId,
 }: SearchToolbarProps) => {
   const handleSearchChange = (event: ChangeEvent<HTMLInputElement>) => {
-    onSearchChange(event.target.value);
+    onSearchChange?.(event.target.value);
   };
+
+  const showSearchField = onSearchChange !== undefined;
 
   return (
     <div
@@ -67,23 +69,27 @@ export const SearchToolbar = ({
       aria-label='Search and filter'
       data-testid={testId}
     >
-      <div className={styles.searchRow}>
-        <div className={styles.searchField}>
-          <Input
-            type='search'
-            label={searchLabel}
-            value={searchValue}
-            onChange={handleSearchChange}
-            placeholder={searchPlaceholder}
-          />
-        </div>
+      {(showSearchField || resultCount !== undefined) && (
+        <div className={styles.searchRow}>
+          {showSearchField && (
+            <div className={styles.searchField}>
+              <Input
+                type='search'
+                label={searchLabel}
+                value={searchValue ?? ''}
+                onChange={handleSearchChange}
+                placeholder={searchPlaceholder}
+              />
+            </div>
+          )}
 
-        {resultCount !== undefined && (
-          <p className={styles.resultSummary} role='status' aria-live='polite'>
-            {formatCount(resultCount, resultNoun)}
-          </p>
-        )}
-      </div>
+          {resultCount !== undefined && (
+            <p className={styles.resultSummary} role='status' aria-live='polite'>
+              {formatCount(resultCount, resultNoun)}
+            </p>
+          )}
+        </div>
+      )}
 
       {filterConfig && filters !== undefined && onFilterChange && (
         <FilterPanel


### PR DESCRIPTION
## Summary

- **Phase 2a** of the component consolidation ([ADS-1136](https://linear.app/ideasquared/issue/ADS-1136)): converge admin's filter bars (`FilterBar`/`FilterGroup`, reports `FilterPanel`, `GenericFilters`) onto the shared, config-driven `SearchToolbar` primitive.
- This PR **extends `SearchToolbar` additively** so it can render as a filter-only bar (no search field) — needed for pages like admin's Analytics, which has a header filter select but no search box. No existing consumer is affected.

## Changes

- `packages/lib.components/src/components/data/SearchToolbar/SearchToolbar.tsx`: `searchValue` / `onSearchChange` are now optional. The search field (and its row) renders only when `onSearchChange` is provided; the result-count summary still renders on its own when there's no search field.
- Tests, README, and a new `FilterOnly` Storybook story added for the filter-only mode.

## Before requesting review

- [x] Tests for new behaviour added (TDD)
- [x] If touching a `lib.*`, considered consumer impact — additive only; `SearchToolbar` currently has no app consumers, so nothing to migrate yet
- [x] No `.env` changes

## Test plan

- [x] `lib.components` green — **626 tests** passing (2 new: filter-only rendering, result count without a search field)
- [x] `pnpm type-check` — no errors
- [x] `pnpm lint` — 0 errors (pre-existing warnings only, none in touched files)

## Related — consolidation roadmap ([ADS-1136](https://linear.app/ideasquared/issue/ADS-1136))

Builds on the merged DataTable consolidation (#1329, #1332). Filter-consolidation phasing:

1. **2a (this PR)** — extend the shared `SearchToolbar` (optional search field) so it can serve every current filter-bar use case.
2. **2b** — migrate admin's `Audit`, `Analytics`, and `Messages` pages off `FilterBar`/`FilterGroup` onto `SearchToolbar` (or the underlying config-driven filter primitive for filter-only bars); retire `FilterBar`/`FilterGroup`, `GenericFilters`'s duplicate wiring, and the ad-hoc per-page `<Select>` filters.

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01USAvC5ZhaZxJzVxqwDRFTb)_