### PR TITLE
feat: route-audit Wave 3 — notifications bulk mark-read

### DIFF
--- a/packages/proto/proto/adopt_dont_shop/notifications/v1/notification.proto
+++ b/packages/proto/proto/adopt_dont_shop/notifications/v1/notification.proto
@@ -47,6 +47,12 @@ service NotificationService {
   // returns affected_count = 0.
   rpc MarkAllRead(MarkAllReadRequest) returns (MarkAllReadResponse);
 
+  // Mark a specific set of the calling principal's notifications as read.
+  // Ownership-scoped (ids belonging to another user are silently skipped)
+  // and idempotent (already-read ids contribute 0). Returns the number of
+  // rows actually flipped to read.
+  rpc MarkRead(MarkReadRequest) returns (MarkReadResponse);
+
   // Soft-delete a notification (deleted_at stamped). Ownership-scoped.
   // Idempotent: a second Delete on the same notification_id returns
   // the already-deleted row without error.
@@ -579,6 +585,14 @@ message GetUnreadCountResponse {
 message MarkAllReadRequest {}
 
 message MarkAllReadResponse {
+  uint32 affected_count = 1;
+}
+
+message MarkReadRequest {
+  repeated string notification_ids = 1;
+}
+
+message MarkReadResponse {
   uint32 affected_count = 1;
 }
 

--- a/packages/proto/src/generated/proto/adopt_dont_shop/notifications/v1/notification.ts
+++ b/packages/proto/src/generated/proto/adopt_dont_shop/notifications/v1/notification.ts
@@ -1300,6 +1300,14 @@ export interface MarkAllReadResponse {
   affectedCount: number;
 }
 
+export interface MarkReadRequest {
+  notificationIds: string[];
+}
+
+export interface MarkReadResponse {
+  affectedCount: number;
+}
+
 export interface DeleteNotificationRequest {
   notificationId: string;
 }
@@ -5345,6 +5353,134 @@ export const MarkAllReadResponse: MessageFns<MarkAllReadResponse> = {
   },
 };
 
+function createBaseMarkReadRequest(): MarkReadRequest {
+  return { notificationIds: [] };
+}
+
+export const MarkReadRequest: MessageFns<MarkReadRequest> = {
+  encode(message: MarkReadRequest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+    for (const v of message.notificationIds) {
+      writer.uint32(10).string(v!);
+    }
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): MarkReadRequest {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseMarkReadRequest();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1: {
+          if (tag !== 10) {
+            break;
+          }
+
+          message.notificationIds.push(reader.string());
+          continue;
+        }
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): MarkReadRequest {
+    return {
+      notificationIds: globalThis.Array.isArray(object?.notificationIds)
+        ? object.notificationIds.map((e: any) => globalThis.String(e))
+        : globalThis.Array.isArray(object?.notification_ids)
+        ? object.notification_ids.map((e: any) => globalThis.String(e))
+        : [],
+    };
+  },
+
+  toJSON(message: MarkReadRequest): unknown {
+    const obj: any = {};
+    if (message.notificationIds?.length) {
+      obj.notificationIds = message.notificationIds;
+    }
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<MarkReadRequest>, I>>(base?: I): MarkReadRequest {
+    return MarkReadRequest.fromPartial(base ?? ({} as any));
+  },
+  fromPartial<I extends Exact<DeepPartial<MarkReadRequest>, I>>(object: I): MarkReadRequest {
+    const message = createBaseMarkReadRequest();
+    message.notificationIds = object.notificationIds?.map((e) => e) || [];
+    return message;
+  },
+};
+
+function createBaseMarkReadResponse(): MarkReadResponse {
+  return { affectedCount: 0 };
+}
+
+export const MarkReadResponse: MessageFns<MarkReadResponse> = {
+  encode(message: MarkReadResponse, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+    if (message.affectedCount !== 0) {
+      writer.uint32(8).uint32(message.affectedCount);
+    }
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): MarkReadResponse {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseMarkReadResponse();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1: {
+          if (tag !== 8) {
+            break;
+          }
+
+          message.affectedCount = reader.uint32();
+          continue;
+        }
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): MarkReadResponse {
+    return {
+      affectedCount: isSet(object.affectedCount)
+        ? globalThis.Number(object.affectedCount)
+        : isSet(object.affected_count)
+        ? globalThis.Number(object.affected_count)
+        : 0,
+    };
+  },
+
+  toJSON(message: MarkReadResponse): unknown {
+    const obj: any = {};
+    if (message.affectedCount !== 0) {
+      obj.affectedCount = Math.round(message.affectedCount);
+    }
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<MarkReadResponse>, I>>(base?: I): MarkReadResponse {
+    return MarkReadResponse.fromPartial(base ?? ({} as any));
+  },
+  fromPartial<I extends Exact<DeepPartial<MarkReadResponse>, I>>(object: I): MarkReadResponse {
+    const message = createBaseMarkReadResponse();
+    message.affectedCount = object.affectedCount ?? 0;
+    return message;
+  },
+};
+
 function createBaseDeleteNotificationRequest(): DeleteNotificationRequest {
   return { notificationId: "" };
 }
@@ -8697,6 +8833,21 @@ export const NotificationServiceService = {
     responseDeserialize: (value: Buffer): MarkAllReadResponse => MarkAllReadResponse.decode(value),
   },
   /**
+   * Mark a specific set of the calling principal's notifications as read.
+   * Ownership-scoped (ids belonging to another user are silently skipped)
+   * and idempotent (already-read ids contribute 0). Returns the number of
+   * rows actually flipped to read.
+   */
+  markRead: {
+    path: "/adopt_dont_shop.notifications.v1.NotificationService/MarkRead" as const,
+    requestStream: false as const,
+    responseStream: false as const,
+    requestSerialize: (value: MarkReadRequest): Buffer => Buffer.from(MarkReadRequest.encode(value).finish()),
+    requestDeserialize: (value: Buffer): MarkReadRequest => MarkReadRequest.decode(value),
+    responseSerialize: (value: MarkReadResponse): Buffer => Buffer.from(MarkReadResponse.encode(value).finish()),
+    responseDeserialize: (value: Buffer): MarkReadResponse => MarkReadResponse.decode(value),
+  },
+  /**
    * Soft-delete a notification (deleted_at stamped). Ownership-scoped.
    * Idempotent: a second Delete on the same notification_id returns
    * the already-deleted row without error.
@@ -8998,6 +9149,13 @@ export interface NotificationServiceServer extends UntypedServiceImplementation 
    */
   markAllRead: handleUnaryCall<MarkAllReadRequest, MarkAllReadResponse>;
   /**
+   * Mark a specific set of the calling principal's notifications as read.
+   * Ownership-scoped (ids belonging to another user are silently skipped)
+   * and idempotent (already-read ids contribute 0). Returns the number of
+   * rows actually flipped to read.
+   */
+  markRead: handleUnaryCall<MarkReadRequest, MarkReadResponse>;
+  /**
    * Soft-delete a notification (deleted_at stamped). Ownership-scoped.
    * Idempotent: a second Delete on the same notification_id returns
    * the already-deleted row without error.
@@ -9202,6 +9360,27 @@ export interface NotificationServiceClient extends Client {
     metadata: Metadata,
     options: Partial<CallOptions>,
     callback: (error: ServiceError | null, response: MarkAllReadResponse) => void,
+  ): ClientUnaryCall;
+  /**
+   * Mark a specific set of the calling principal's notifications as read.
+   * Ownership-scoped (ids belonging to another user are silently skipped)
+   * and idempotent (already-read ids contribute 0). Returns the number of
+   * rows actually flipped to read.
+   */
+  markRead(
+    request: MarkReadRequest,
+    callback: (error: ServiceError | null, response: MarkReadResponse) => void,
+  ): ClientUnaryCall;
+  markRead(
+    request: MarkReadRequest,
+    metadata: Metadata,
+    callback: (error: ServiceError | null, response: MarkReadResponse) => void,
+  ): ClientUnaryCall;
+  markRead(
+    request: MarkReadRequest,
+    metadata: Metadata,
+    options: Partial<CallOptions>,
+    callback: (error: ServiceError | null, response: MarkReadResponse) => void,
   ): ClientUnaryCall;
   /**
    * Soft-delete a notification (deleted_at stamped). Ownership-scoped.

--- a/packages/proto/src/index.ts
+++ b/packages/proto/src/index.ts
@@ -58,6 +58,8 @@ export type {
   GetUnreadCountResponse,
   MarkAllReadRequest,
   MarkAllReadResponse,
+  MarkReadRequest as MarkNotificationsReadRequest,
+  MarkReadResponse as MarkNotificationsReadResponse,
   DeleteNotificationRequest,
   DeleteNotificationResponse,
   NotificationPreferences,

--- a/services/gateway/src/grpc-clients/notifications-client.ts
+++ b/services/gateway/src/grpc-clients/notifications-client.ts
@@ -32,6 +32,8 @@ import {
   type ListNotificationsResponse,
   type MarkAllReadRequest,
   type MarkAllReadResponse,
+  type MarkNotificationsReadRequest,
+  type MarkNotificationsReadResponse,
   type RegisterDeviceTokenRequest,
   type RegisterDeviceTokenResponse,
   type UnregisterDeviceTokenRequest,
@@ -85,6 +87,10 @@ export type NotificationsClient = {
   ): Promise<GetNotificationResponse>;
   getUnreadCount(req: GetUnreadCountRequest, metadata: Metadata): Promise<GetUnreadCountResponse>;
   markAllRead(req: MarkAllReadRequest, metadata: Metadata): Promise<MarkAllReadResponse>;
+  markRead(
+    req: MarkNotificationsReadRequest,
+    metadata: Metadata
+  ): Promise<MarkNotificationsReadResponse>;
   deleteNotification(
     req: DeleteNotificationRequest,
     metadata: Metadata
@@ -212,6 +218,7 @@ export const createNotificationsClient = (
     unregisterDeviceToken: (req, metadata) =>
       callUnary(stub.unregisterDeviceToken, req, metadata, false),
     markAllRead: (req, metadata) => callUnary(stub.markAllRead, req, metadata, false),
+    markRead: (req, metadata) => callUnary(stub.markRead, req, metadata, false),
     deleteNotification: (req, metadata) => callUnary(stub.deleteNotification, req, metadata, false),
     updateNotificationPreferences: (req, metadata) =>
       callUnary(stub.updateNotificationPreferences, req, metadata, false),

--- a/services/gateway/src/routes/notifications.test.ts
+++ b/services/gateway/src/routes/notifications.test.ts
@@ -39,6 +39,7 @@ function makeClient(): NotificationsClient & {
   getNotificationMock: ReturnType<typeof vi.fn>;
   getUnreadCountMock: ReturnType<typeof vi.fn>;
   markAllReadMock: ReturnType<typeof vi.fn>;
+  markReadMock: ReturnType<typeof vi.fn>;
   deleteNotificationMock: ReturnType<typeof vi.fn>;
   getNotificationPreferencesMock: ReturnType<typeof vi.fn>;
   updateNotificationPreferencesMock: ReturnType<typeof vi.fn>;
@@ -50,6 +51,7 @@ function makeClient(): NotificationsClient & {
   const getNotificationMock = vi.fn();
   const getUnreadCountMock = vi.fn();
   const markAllReadMock = vi.fn();
+  const markReadMock = vi.fn();
   const deleteNotificationMock = vi.fn();
   const getNotificationPreferencesMock = vi.fn();
   const updateNotificationPreferencesMock = vi.fn();
@@ -61,6 +63,7 @@ function makeClient(): NotificationsClient & {
     getNotification: getNotificationMock,
     getUnreadCount: getUnreadCountMock,
     markAllRead: markAllReadMock,
+    markRead: markReadMock,
     deleteNotification: deleteNotificationMock,
     getNotificationPreferences: getNotificationPreferencesMock,
     updateNotificationPreferences: updateNotificationPreferencesMock,
@@ -72,6 +75,7 @@ function makeClient(): NotificationsClient & {
     getNotificationMock,
     getUnreadCountMock,
     markAllReadMock,
+    markReadMock,
     deleteNotificationMock,
     getNotificationPreferencesMock,
     updateNotificationPreferencesMock,
@@ -417,6 +421,50 @@ describe('POST /api/v1/notifications/read-all', () => {
       success: true,
       data: { affectedCount: 3 },
     });
+  });
+});
+
+describe('PATCH /api/v1/notifications/mark-read', () => {
+  let app: FastifyInstance;
+  let client: ReturnType<typeof makeClient>;
+
+  beforeEach(async () => {
+    client = makeClient();
+    app = await buildApp(client);
+  });
+  afterEach(async () => {
+    await app.close();
+  });
+
+  it('forwards the id list and returns the updated count', async () => {
+    client.markReadMock.mockResolvedValueOnce({ affectedCount: 2 });
+
+    const res = await app.inject({
+      method: 'PATCH',
+      url: '/api/v1/notifications/mark-read',
+      headers: {
+        'x-user-id': 'usr-1',
+        'x-user-roles': 'adopter',
+        'content-type': 'application/json',
+      },
+      payload: { notificationIds: ['n-1', 'n-2'] },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toMatchObject({ success: true, data: { updated: 2 } });
+    expect(client.markReadMock.mock.calls[0][0]).toEqual({ notificationIds: ['n-1', 'n-2'] });
+  });
+
+  it('rejects an empty id list with 400 and does not call the service', async () => {
+    const res = await app.inject({
+      method: 'PATCH',
+      url: '/api/v1/notifications/mark-read',
+      headers: { 'x-user-id': 'usr-1', 'content-type': 'application/json' },
+      payload: { notificationIds: [] },
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(client.markReadMock).not.toHaveBeenCalled();
   });
 });
 

--- a/services/gateway/src/routes/notifications.ts
+++ b/services/gateway/src/routes/notifications.ts
@@ -238,6 +238,45 @@ export const registerNotificationsRoutes = async (
     }
   );
 
+  // PATCH /api/v1/notifications/mark-read — mark a specific set of the
+  // caller's notifications read. Static segment, so it wins over /:id.
+  app.patch<{ Body?: { notificationIds?: string[] } }>(
+    '/api/v1/notifications/mark-read',
+    {
+      schema: {
+        tags: ['notifications'],
+        summary: 'Mark specific notifications as read',
+        body: {
+          type: 'object',
+          properties: { notificationIds: { type: 'array', items: { type: 'string' } } },
+          required: ['notificationIds'],
+        },
+        response: {
+          200: {
+            type: 'object',
+            properties: {
+              success: { type: 'boolean' },
+              data: { type: 'object', properties: { updated: { type: 'integer' } } },
+            },
+          },
+          400: { type: 'object', properties: { error: { type: 'string' } } },
+        },
+      },
+    },
+    async (req, reply) => {
+      const ids = (req.body ?? {}).notificationIds ?? [];
+      if (ids.length === 0) {
+        return reply.code(400).send({ error: 'notificationIds is required' });
+      }
+      try {
+        const res = await client.markRead({ notificationIds: ids }, buildMetadata(req));
+        return reply.send({ success: true, data: { updated: res.affectedCount } });
+      } catch (err) {
+        return handleGrpcError(err, reply);
+      }
+    }
+  );
+
   // In-app notification preferences (user_notification_prefs).
   app.get(
     '/api/v1/notifications/preferences',

--- a/services/notifications/src/grpc/notification-prefs-handlers.test.ts
+++ b/services/notifications/src/grpc/notification-prefs-handlers.test.ts
@@ -13,6 +13,7 @@ import {
   getNotificationPreferences,
   getUnreadCount,
   markAllRead,
+  markRead,
   resetNotificationPreferences,
   updateNotificationPreferences,
 } from './notification-prefs-handlers.js';
@@ -273,6 +274,57 @@ describe('markAllRead', () => {
   it('returns 0 and skips publish when nothing to update', async () => {
     mocks.clientScript.push({ rows: [], rowCount: 0 });
     const res = await markAllRead(mocks.deps, ADOPTER, {});
+    expect(res.affectedCount).toBe(0);
+    expect(mocks.natsMock.publish).not.toHaveBeenCalled();
+  });
+});
+
+// --- markRead --------------------------------------------------------
+
+describe('markRead', () => {
+  let mocks: ReturnType<typeof makeMocks>;
+  beforeEach(() => {
+    mocks = makeMocks();
+  });
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('rejects principals without notifications.update', async () => {
+    await expect(
+      markRead(mocks.deps, NO_PERMS, { notificationIds: ['n-1'] })
+    ).rejects.toMatchObject({ code: 'PERMISSION_DENIED' });
+  });
+
+  it('rejects an empty id list', async () => {
+    await expect(markRead(mocks.deps, ADOPTER, { notificationIds: [] })).rejects.toMatchObject({
+      code: 'INVALID_ARGUMENT',
+    });
+  });
+
+  it('flips the supplied ids, scoped to the caller, and publishes once', async () => {
+    mocks.clientScript.push({
+      rows: [{ notification_id: 'n-1' }, { notification_id: 'n-2' }],
+      rowCount: 2,
+    });
+
+    const res = await markRead(mocks.deps, ADOPTER, { notificationIds: ['n-1', 'n-2', 'n-other'] });
+
+    expect(res.affectedCount).toBe(2);
+    expect(mocks.natsMock.publish).toHaveBeenCalledTimes(1);
+    expect(mocks.natsMock.publish.mock.calls[0][0]).toBe('notifications.read');
+    // The UPDATE is scoped by user_id AND the id set.
+    const updateCall = mocks.clientMock.query.mock.calls.find(([q]: [string]) =>
+      String(q).includes('UPDATE notifications.notifications')
+    ) as [string, unknown[]];
+    expect(updateCall[0]).toContain('user_id = $1');
+    expect(updateCall[1][0]).toBe('usr-adopter');
+    expect(updateCall[1][1]).toEqual(['n-1', 'n-2', 'n-other']);
+  });
+
+  it('returns 0 and skips publish when nothing matched', async () => {
+    mocks.clientScript.push({ rows: [], rowCount: 0 });
+    const res = await markRead(mocks.deps, ADOPTER, { notificationIds: ['n-x'] });
     expect(res.affectedCount).toBe(0);
     expect(mocks.natsMock.publish).not.toHaveBeenCalled();
   });

--- a/services/notifications/src/grpc/notification-prefs-handlers.ts
+++ b/services/notifications/src/grpc/notification-prefs-handlers.ts
@@ -24,6 +24,8 @@ import {
   type GetUnreadCountResponse,
   type MarkAllReadRequest,
   type MarkAllReadResponse,
+  type MarkNotificationsReadRequest,
+  type MarkNotificationsReadResponse,
   type NotificationPreferences as NotificationPreferencesProto,
   type ResetNotificationPreferencesRequest,
   type ResetNotificationPreferencesResponse,
@@ -203,6 +205,53 @@ export async function markAllRead(
       publish({
         type: 'notifications.allRead',
         id: `notifications.allRead.${principal.userId}.${Date.now()}`,
+        payload: { userId: principal.userId, affectedCount: affected },
+      });
+    }
+  });
+
+  return { affectedCount: affected };
+}
+
+// --- MarkRead (specific ids) -----------------------------------------
+//
+// Ownership-scoped by user_id so a caller can only ever flip its own
+// notifications, and idempotent (already-read / unknown ids contribute
+// 0). Mirrors markAllRead but narrowed to the supplied id set.
+
+export async function markRead(
+  deps: HandlerDeps,
+  principal: Principal,
+  req: MarkNotificationsReadRequest
+): Promise<MarkNotificationsReadResponse> {
+  if (!hasPermission(principal, NOTIFICATIONS_UPDATE)) {
+    throw new HandlerError('PERMISSION_DENIED', `'${NOTIFICATIONS_UPDATE}' required`);
+  }
+  const ids = req.notificationIds ?? [];
+  if (ids.length === 0) {
+    throw new HandlerError('INVALID_ARGUMENT', 'notification_ids is required');
+  }
+
+  let affected = 0;
+  await withTransaction(deps, async ({ client, publish }) => {
+    const result = await client.query<{ notification_id: string }>(
+      `
+      UPDATE notifications.notifications
+      SET status = 'read', read_at = now(), updated_at = now(), version = version + 1
+      WHERE user_id = $1
+        AND notification_id = ANY($2::uuid[])
+        AND deleted_at IS NULL
+        AND read_at IS NULL
+      RETURNING notification_id
+      `,
+      [principal.userId, ids]
+    );
+    affected = result.rowCount ?? 0;
+
+    if (affected > 0) {
+      publish({
+        type: 'notifications.read',
+        id: `notifications.read.${principal.userId}.${Date.now()}`,
         payload: { userId: principal.userId, affectedCount: affected },
       });
     }

--- a/services/notifications/src/grpc/server.ts
+++ b/services/notifications/src/grpc/server.ts
@@ -40,6 +40,7 @@ import {
   getNotificationPreferences,
   getUnreadCount,
   markAllRead,
+  markRead,
   resetNotificationPreferences,
   updateNotificationPreferences,
 } from './notification-prefs-handlers.js';
@@ -75,6 +76,7 @@ export const createGrpcServer = (opts: CreateGrpcServerOptions): Server => {
     getNotification: adapt(getNotification, { deps: { pool, nats }, logger }),
     getUnreadCount: adapt(getUnreadCount, { deps: { pool, nats }, logger }),
     markAllRead: adapt(markAllRead, { deps: { pool, nats }, logger }),
+    markRead: adapt(markRead, { deps: { pool, nats }, logger }),
     deleteNotification: adapt(deleteNotification, { deps: { pool, nats }, logger }),
     getNotificationPreferences: adapt(getNotificationPreferences, { deps: { pool, nats }, logger }),
     updateNotificationPreferences: adapt(updateNotificationPreferences, {


### PR DESCRIPTION
## Summary

Continues the API-route audit (`docs/backend/api-route-audit-findings.md`) after Waves 1 (#1341) and 2 (#1342) merged. Backs frontend calls that hit 404 / silently no-op'd because the endpoint was never built. More tickets will land on this branch as follow-up commits.

- **ADS-1152 (first slice — bulk mark-read):** the notification list's "mark selected as read" (`PATCH /api/v1/notifications/mark-read`) had no backing bulk endpoint — the gateway only had single `/:id/read` and mark-all, so the call silently did nothing.

## Changes

- **`notifications` — `MarkRead` RPC.** Flips a supplied set of notification ids to read for the calling principal only (ownership-scoped by `user_id`), idempotent (already-read / unknown / other-user ids contribute 0), publishing `notifications.read` when anything changed. Mirrors `MarkAllRead` narrowed to an id set.
- **Gateway** `PATCH /api/v1/notifications/mark-read` → `{ updated }` (static segment, wins over `/:id`). New notifications gRPC client method.
- `packages/proto` regenerated (notifications `MarkRead` messages exported as `MarkNotificationsRead*` to avoid the name clash with chat's `MarkRead`).

## Before requesting review

- [x] Ran the equivalent of `pnpm ci:local:quick` locally (type-check, lint, per-package coverage)
- [x] Tests for new behaviour added (TDD)
- [ ] `.env` requirements — n/a
- [ ] `lib.*` consumer impact — n/a (services + proto only)

## Test plan

- [x] New behaviour covered by handler + gateway route tests
- [x] Package suites pass with coverage thresholds met (notifications, gateway, proto)
- [x] No TypeScript errors; lint clean

## Related

- ADS-1152 (this is the bulk-mark-read slice; remaining sub-items — page-mode user list, nested preferences reconcile, audit-logs repoint, analytics custom-reports, home-visit update — are follow-ups)
- Still open from the audit backlog: ADS-1138, ADS-1139, ADS-1140, ADS-1142, ADS-1147, ADS-1149, ADS-1145 (attachments half), ADS-1153 (nanoid, separate dep PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xjak7otuKv2PaPcqV1mcgk)_