### PR TITLE
feat: server-side analytics CSV export for the rescue dashboard

### DIFF
--- a/services/gateway/src/routes/analytics-metrics.test.ts
+++ b/services/gateway/src/routes/analytics-metrics.test.ts
@@ -242,4 +242,88 @@ describe('/api/v1/analytics gateway routes', () => {
       expect(applicationsMocks.getStats.mock.calls[0][0]).toEqual({});
     });
   });
+
+  describe('POST /api/v1/analytics/export/csv', () => {
+    const validPayload = {
+      reportType: 'full-analytics',
+      filters: {
+        dateRange: { start: '2026-01-08T00:00:00.000Z', end: '2026-01-15T00:00:00.000Z' },
+      },
+    };
+
+    it('returns 400 when the date range is missing', async () => {
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/v1/analytics/export/csv',
+        payload: { reportType: 'full-analytics', filters: {} },
+      });
+      expect(res.statusCode).toBe(400);
+    });
+
+    it('composes the four reads into a CSV download with the dashboard figures', async () => {
+      petsMocks.getAdoptionTrend
+        .mockResolvedValueOnce({
+          points: [
+            { date: '2026-01-08', count: 3 },
+            { date: '2026-01-09', count: 5 },
+          ],
+        })
+        .mockResolvedValueOnce({ points: [{ date: '2026-01-01', count: 4 }] });
+      petsMocks.getStats.mockResolvedValue({ averageDaysToAdoption: 14 });
+      petsMocks.getTopBreedsByAdoptions.mockResolvedValue({
+        breeds: [
+          { breed: 'Labrador', count: 24, averageAdoptionDays: 13 },
+          { breed: 'Siamese', count: 12, averageAdoptionDays: 14 },
+        ],
+      });
+      applicationsMocks.getStats
+        .mockResolvedValueOnce(APP_STATS_FIXTURE) // current range → success rate + funnel
+        .mockResolvedValueOnce({ ...APP_STATS_FIXTURE, total: 80, adopted: 20 }) // prior range
+        .mockResolvedValueOnce(APP_STATS_FIXTURE); // snapshot → stage distribution
+
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/v1/analytics/export/csv',
+        payload: validPayload,
+      });
+
+      expect(res.statusCode).toBe(200);
+      expect(res.headers['content-type']).toContain('text/csv');
+      expect(res.headers['content-disposition']).toContain(
+        'attachment; filename="analytics-2026-01-08-to-2026-01-15.csv"'
+      );
+
+      const csv = res.body;
+      // Adoption section: 3 + 5 = 8 total; rate(94,156) = 60.26; avg days 14.
+      expect(csv).toContain('Total Adoptions,8');
+      expect(csv).toContain('Success Rate (%),60.26');
+      expect(csv).toContain('Average Time to Adoption (days),14');
+      // Adoption trend rows.
+      expect(csv).toContain('2026-01-08,3');
+      expect(csv).toContain('2026-01-09,5');
+      // Funnel: Submitted anchors at 137 (100%), Adopted at 94 ((94/137)*100 = 68.61).
+      expect(csv).toContain('Submitted,137,100');
+      expect(csv).toContain('Adopted,94,68.61');
+      // Breeds passed straight through.
+      expect(csv).toContain('Labrador,24,13');
+      expect(csv).toContain('Siamese,12,14');
+      // Stage distribution (current snapshot): Adopted 94 of 156 = 60.26%.
+      expect(csv).toContain('Stage Distribution (current)');
+      expect(csv).toContain('Adopted,94,60.26');
+    });
+
+    it('maps an upstream error to its HTTP status', async () => {
+      petsMocks.getAdoptionTrend.mockRejectedValue({ code: grpcStatus.PERMISSION_DENIED });
+      petsMocks.getStats.mockResolvedValue({ averageDaysToAdoption: 0 });
+      petsMocks.getTopBreedsByAdoptions.mockResolvedValue({ breeds: [] });
+      applicationsMocks.getStats.mockResolvedValue(APP_STATS_FIXTURE);
+
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/v1/analytics/export/csv',
+        payload: validPayload,
+      });
+      expect(res.statusCode).toBe(403);
+    });
+  });
 });

--- a/services/gateway/src/routes/analytics-metrics.ts
+++ b/services/gateway/src/routes/analytics-metrics.ts
@@ -17,11 +17,15 @@
 //   GET /api/v1/analytics/stage-distribution    → applications.getStats, reshaped into
 //                                                  current-snapshot per-stage counts
 //
+//   POST /api/v1/analytics/export/csv           → the four reads above, composed
+//                                                  into one CSV download (no new
+//                                                  data — a faithful serialisation
+//                                                  of what the dashboard shows)
+//
 // Known gaps (no backing RPC exists, so these fields are dropped rather
 // than half-built): per-species adoption rates/average-time, per-stage
 // average duration + bottleneck detection, response-time/SLA/staff
-// metrics, CSV/PDF export, email-report, custom-reports. None of these
-// are read by Analytics.tsx today.
+// metrics, PDF export, email-report, custom-reports.
 
 import type { FastifyInstance } from 'fastify';
 
@@ -108,6 +112,129 @@ const STAGE_DISTRIBUTION_STAGES: ReadonlyArray<{
   { stage: 'Adopted', field: 'adopted', color: '#EF4444' },
 ];
 
+// Structural shapes of the upstream RPC responses this file reshapes — kept
+// local so the pure shaping functions below stay decoupled from the generated
+// proto client types (they only touch the fields used here).
+type TrendResponse = { points: ReadonlyArray<{ date: string; count: number }> };
+type PetStatsResponse = { averageDaysToAdoption: number };
+type TopBreedsResponse = {
+  breeds: ReadonlyArray<{ breed: string; count: number; averageAdoptionDays: number }>;
+};
+
+// The four pure reshapers. Each turns an upstream RPC response into the SPA's
+// documented contract; the GET routes and the CSV export both compose them so
+// there is exactly one source of truth for the shaping.
+function shapeAdoptionMetrics(
+  currentTrend: TrendResponse,
+  priorTrend: TrendResponse,
+  petStats: PetStatsResponse,
+  currentApps: ApplicationsGetStatsResponse,
+  priorApps: ApplicationsGetStatsResponse
+) {
+  const totalAdoptions = sumCounts(currentTrend.points);
+  const totalAdoptionsPrior = sumCounts(priorTrend.points);
+  const percentageChange =
+    totalAdoptionsPrior > 0
+      ? ((totalAdoptions - totalAdoptionsPrior) / totalAdoptionsPrior) * 100
+      : 0;
+  return {
+    totalAdoptions,
+    successRate: rate(currentApps.adopted, currentApps.total),
+    averageTimeToAdoption: petStats.averageDaysToAdoption,
+    adoptionTrends: currentTrend.points.map(p => ({ date: p.date, count: p.count })),
+    comparisonPeriod: {
+      totalAdoptions: totalAdoptionsPrior,
+      successRate: rate(priorApps.adopted, priorApps.total),
+      percentageChange,
+    },
+  };
+}
+
+function shapeApplicationAnalytics(res: ApplicationsGetStatsResponse) {
+  const submittedTotal = FUNNEL_STAGES[0].fields.reduce((sum, f) => sum + res[f], 0);
+  return {
+    totalApplications: res.total,
+    conversionRateByStage: FUNNEL_STAGES.map(({ stage, fields }) => {
+      const applicationsCount = fields.reduce((sum, f) => sum + res[f], 0);
+      return { stage, conversionRate: rate(applicationsCount, submittedTotal), applicationsCount };
+    }),
+  };
+}
+
+function shapePetPerformance(res: TopBreedsResponse) {
+  return {
+    mostPopularBreeds: res.breeds.map(b => ({
+      breed: b.breed,
+      count: b.count,
+      averageAdoptionTime: b.averageAdoptionDays,
+    })),
+  };
+}
+
+function shapeStageDistribution(res: ApplicationsGetStatsResponse) {
+  return STAGE_DISTRIBUTION_STAGES.map(({ stage, field, color }) => ({
+    stage,
+    count: res[field],
+    percentage: rate(res[field], res.total),
+    color,
+  }));
+}
+
+// --- CSV serialisation (no dependency — a report is a handful of small
+// sections). RFC-4180 quoting: wrap in quotes and double any embedded quote
+// when a field contains a comma, quote or newline. Percentages are rounded to
+// two places for a readable export; counts stay exact.
+const round2 = (n: number): number => Math.round(n * 100) / 100;
+
+const csvEscape = (value: string | number): string => {
+  const s = String(value);
+  return /[",\n\r]/.test(s) ? `"${s.replace(/"/g, '""')}"` : s;
+};
+
+const csvRow = (fields: ReadonlyArray<string | number>): string => fields.map(csvEscape).join(',');
+
+type AdoptionShape = ReturnType<typeof shapeAdoptionMetrics>;
+type ApplicationShape = ReturnType<typeof shapeApplicationAnalytics>;
+type PerformanceShape = ReturnType<typeof shapePetPerformance>;
+type StageShape = ReturnType<typeof shapeStageDistribution>;
+
+function renderAnalyticsCsv(
+  range: { startDate: string; endDate: string },
+  adoption: AdoptionShape,
+  applications: ApplicationShape,
+  performance: PerformanceShape,
+  stages: StageShape
+): string {
+  const rows: string[] = [
+    csvRow(["Adopt Don't Shop — Analytics Report"]),
+    csvRow(['Period', range.startDate, range.endDate]),
+    '',
+    csvRow(['Adoption Metrics']),
+    csvRow(['Total Adoptions', adoption.totalAdoptions]),
+    csvRow(['Success Rate (%)', round2(adoption.successRate)]),
+    csvRow(['Average Time to Adoption (days)', adoption.averageTimeToAdoption]),
+    '',
+    csvRow(['Adoption Trend']),
+    csvRow(['Date', 'Adoptions']),
+    ...adoption.adoptionTrends.map(p => csvRow([p.date, p.count])),
+    '',
+    csvRow(['Application Funnel']),
+    csvRow(['Stage', 'Applications', 'Conversion Rate (%)']),
+    ...applications.conversionRateByStage.map(s =>
+      csvRow([s.stage, s.applicationsCount, round2(s.conversionRate)])
+    ),
+    '',
+    csvRow(['Most Popular Breeds']),
+    csvRow(['Breed', 'Adoptions', 'Average Adoption Time (days)']),
+    ...performance.mostPopularBreeds.map(b => csvRow([b.breed, b.count, b.averageAdoptionTime])),
+    '',
+    csvRow(['Stage Distribution (current)']),
+    csvRow(['Stage', 'Count', 'Percentage (%)']),
+    ...stages.map(s => csvRow([s.stage, s.count, round2(s.percentage)])),
+  ];
+  return rows.join('\r\n') + '\r\n';
+}
+
 export const registerAnalyticsMetricsRoutes = async (
   app: FastifyInstance,
   opts: AnalyticsMetricsRoutesOptions
@@ -163,25 +290,9 @@ export const registerAnalyticsMetricsRoutes = async (
             metadata
           ),
         ]);
-        const totalAdoptions = sumCounts(currentTrend.points);
-        const totalAdoptionsPrior = sumCounts(priorTrend.points);
-        const percentageChange =
-          totalAdoptionsPrior > 0
-            ? ((totalAdoptions - totalAdoptionsPrior) / totalAdoptionsPrior) * 100
-            : 0;
         return reply.send({
           success: true,
-          data: {
-            totalAdoptions,
-            successRate: rate(currentApps.adopted, currentApps.total),
-            averageTimeToAdoption: petStats.averageDaysToAdoption,
-            adoptionTrends: currentTrend.points.map(p => ({ date: p.date, count: p.count })),
-            comparisonPeriod: {
-              totalAdoptions: totalAdoptionsPrior,
-              successRate: rate(priorApps.adopted, priorApps.total),
-              percentageChange,
-            },
-          },
+          data: shapeAdoptionMetrics(currentTrend, priorTrend, petStats, currentApps, priorApps),
         });
       } catch (err) {
         return handleGrpcError(err, reply);
@@ -226,21 +337,7 @@ export const registerAnalyticsMetricsRoutes = async (
           { createdAfter: range.startDate, createdBefore: range.endDate },
           buildMetadata(req)
         );
-        const submittedTotal = FUNNEL_STAGES[0].fields.reduce((sum, f) => sum + res[f], 0);
-        return reply.send({
-          success: true,
-          data: {
-            totalApplications: res.total,
-            conversionRateByStage: FUNNEL_STAGES.map(({ stage, fields }) => {
-              const applicationsCount = fields.reduce((sum, f) => sum + res[f], 0);
-              return {
-                stage,
-                conversionRate: rate(applicationsCount, submittedTotal),
-                applicationsCount,
-              };
-            }),
-          },
-        });
+        return reply.send({ success: true, data: shapeApplicationAnalytics(res) });
       } catch (err) {
         return handleGrpcError(err, reply);
       }
@@ -284,16 +381,7 @@ export const registerAnalyticsMetricsRoutes = async (
           { startDate: range.startDate, endDate: range.endDate, limit: 5 },
           buildMetadata(req)
         );
-        return reply.send({
-          success: true,
-          data: {
-            mostPopularBreeds: res.breeds.map(b => ({
-              breed: b.breed,
-              count: b.count,
-              averageAdoptionTime: b.averageAdoptionDays,
-            })),
-          },
-        });
+        return reply.send({ success: true, data: shapePetPerformance(res) });
       } catch (err) {
         return handleGrpcError(err, reply);
       }
@@ -320,13 +408,97 @@ export const registerAnalyticsMetricsRoutes = async (
     async (req, reply) => {
       try {
         const res = await applicationsClient.getStats({}, buildMetadata(req));
-        const data = STAGE_DISTRIBUTION_STAGES.map(({ stage, field, color }) => ({
-          stage,
-          count: res[field],
-          percentage: rate(res[field], res.total),
-          color,
-        }));
-        return reply.send({ success: true, data });
+        return reply.send({ success: true, data: shapeStageDistribution(res) });
+      } catch (err) {
+        return handleGrpcError(err, reply);
+      }
+    }
+  );
+
+  // POST /api/v1/analytics/export/csv — the dashboard's "Export CSV" button.
+  // Composes the same four upstream reads (rescue-scoped server-side by the
+  // principal, exactly as the GET routes) into a single CSV download. No 200
+  // response schema is declared so Fastify sends the raw CSV string untouched.
+  app.post(
+    '/api/v1/analytics/export/csv',
+    {
+      schema: {
+        tags: ['analytics'],
+        summary: 'Download the rescue Analytics dashboard as a CSV report',
+        produces: ['text/csv'],
+        body: {
+          type: 'object',
+          properties: {
+            reportType: { type: 'string' },
+            filters: {
+              type: 'object',
+              properties: {
+                dateRange: {
+                  type: 'object',
+                  properties: {
+                    start: { type: 'string' },
+                    end: { type: 'string' },
+                  },
+                },
+              },
+              additionalProperties: true,
+            },
+          },
+          additionalProperties: true,
+        },
+        response: {
+          400: {
+            type: 'object',
+            properties: { success: { type: 'boolean' }, error: { type: 'string' } },
+          },
+        },
+      },
+    },
+    async (req, reply) => {
+      const body = (req.body ?? {}) as {
+        filters?: { dateRange?: { start?: string; end?: string } };
+      };
+      const start = body.filters?.dateRange?.start;
+      const end = body.filters?.dateRange?.end;
+      if (!start || !end) {
+        return reply.code(400).send({
+          success: false,
+          error: 'filters.dateRange.start and filters.dateRange.end are required',
+        });
+      }
+      const prior = previousPeriod(start, end);
+      const metadata = buildMetadata(req);
+      try {
+        const [currentTrend, priorTrend, petStats, currentApps, priorApps, topBreeds, snapshot] =
+          await Promise.all([
+            petsClient.getAdoptionTrend({ startDate: start, endDate: end }, metadata),
+            petsClient.getAdoptionTrend({ startDate: prior.start, endDate: prior.end }, metadata),
+            petsClient.getStats({}, metadata),
+            applicationsClient.getStats({ createdAfter: start, createdBefore: end }, metadata),
+            applicationsClient.getStats(
+              { createdAfter: prior.start, createdBefore: prior.end },
+              metadata
+            ),
+            petsClient.getTopBreedsByAdoptions(
+              { startDate: start, endDate: end, limit: 5 },
+              metadata
+            ),
+            applicationsClient.getStats({}, metadata),
+          ]);
+        const csv = renderAnalyticsCsv(
+          { startDate: start, endDate: end },
+          shapeAdoptionMetrics(currentTrend, priorTrend, petStats, currentApps, priorApps),
+          shapeApplicationAnalytics(currentApps),
+          shapePetPerformance(topBreeds),
+          shapeStageDistribution(snapshot)
+        );
+        return reply
+          .header('Content-Type', 'text/csv; charset=utf-8')
+          .header(
+            'Content-Disposition',
+            `attachment; filename="analytics-${start.slice(0, 10)}-to-${end.slice(0, 10)}.csv"`
+          )
+          .send(csv);
       } catch (err) {
         return handleGrpcError(err, reply);
       }


### PR DESCRIPTION
## Summary

- Adds `POST /api/v1/analytics/export/csv`, backing the rescue Analytics dashboard's **Export CSV** button (`apps/rescue` `Analytics.tsx` → `analyticsService.exportToCSV`), which previously had no gateway route and 404'd through to the strangler-fig proxy.
- The route composes the **same four aggregation reads** the dashboard's existing GET routes already use and serialises them into one CSV download — no new data model, no new metric, no fabricated backend: a faithful serialisation of exactly what the dashboard displays.
- Extracts the four inline reshapers into pure functions so the GET routes and the CSV export share one source of truth for the shaping.

## Changes

- `services/gateway/src/routes/analytics-metrics.ts`
  - New `POST /api/v1/analytics/export/csv` route. Fans out to `pets.getAdoptionTrend` / `pets.getStats` / `pets.getTopBreedsByAdoptions` and `applications.getStats` (current range, prior-equal-length period, and current snapshot), exactly as the sibling GET routes do. Rescue-staff scoping stays server-side in the upstream handlers via the principal.
  - Reads the SPA's existing request contract (`{ reportType, filters: { dateRange: { start, end } } }`); returns `text/csv` with a `Content-Disposition: attachment` filename matching the client's download name. Missing date range → `400`; upstream gRPC errors map to HTTP via `handleGrpcError`.
  - Refactor: the four inline reshapers become `shapeAdoptionMetrics` / `shapeApplicationAnalytics` / `shapePetPerformance` / `shapeStageDistribution`, reused by both the GET routes and the export. Behaviour of the existing routes is unchanged (their tests are untouched and green).
  - CSV quoting follows RFC 4180 (no dependency added); percentages rounded to two places for readability, counts exact.
- `services/gateway/src/routes/analytics-metrics.test.ts`
  - New coverage for the export route: `400` on missing date range, faithful CSV composition across all four sections (asserting the real figures), and upstream-error → HTTP-status mapping.

## Before requesting review

- [x] Ran quick checks locally (type-check + lint + gateway tests)
- [x] Tests for new behaviour added (TDD)
- [ ] If touching `.env` requirements, updated `.env.example`'s REQUIRED block — n/a
- [ ] If touching a `lib.*`, considered consumer impact — n/a (gateway route only)

## Test plan

- [x] Existing tests pass — full gateway suite green (1256 tests)
- [x] New behaviour is covered by tests (3 new cases in `analytics-metrics.test.ts`)
- [ ] Tested manually — not run against a live stack; covered by route-level injection tests
- [x] No TypeScript errors (`type-check` on `service.gateway`)
- [x] Lint passes

## Screenshots / recordings

n/a — backend route; the CSV is generated server-side and downloaded by the existing dashboard button.

## Related

Follow-up to the route-audit waves (PR #1345). Closes the CSV-export gap on the rescue Analytics dashboard. Remaining live gaps on that page (`response-time`, PDF export, `email-report`) each require a product/architecture decision and are intentionally out of scope here — see the `Known gaps` note kept in `analytics-metrics.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xjak7otuKv2PaPcqV1mcgk

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xjak7otuKv2PaPcqV1mcgk)_