### PR TITLE
feat: analytics PDF export + email-report, and dead-code cleanup

### DIFF
--- a/apps/rescue/src/services/analyticsService.test.ts
+++ b/apps/rescue/src/services/analyticsService.test.ts
@@ -156,48 +156,5 @@ describe('AnalyticsService', () => {
       apiServiceMock.post.mockRejectedValue(new Error('x'));
       await expect(service.emailReport('r', {}, [])).rejects.toThrow('x');
     });
-
-    it('saves a custom report and returns it', async () => {
-      const report = { name: 'My Report', metrics: [], visualizations: [], filters: {} };
-      apiServiceMock.post.mockResolvedValue({ success: true, data: { ...report, id: 'cr1' } });
-
-      const result = await service.saveCustomReport(report);
-
-      expect(apiServiceMock.post).toHaveBeenCalledWith('/api/v1/analytics/custom-reports', report);
-      expect(result.id).toBe('cr1');
-    });
-
-    it('propagates save failures', async () => {
-      apiServiceMock.post.mockRejectedValue(new Error('x'));
-      await expect(
-        service.saveCustomReport({ name: 'r', metrics: [], visualizations: [], filters: {} })
-      ).rejects.toThrow('x');
-    });
-
-    it('lists custom reports', async () => {
-      apiServiceMock.get.mockResolvedValue({ success: true, data: [{ name: 'r1' }] });
-
-      const result = await service.getCustomReports();
-
-      expect(result).toHaveLength(1);
-    });
-
-    it('returns an empty list when fetching custom reports fails', async () => {
-      apiServiceMock.get.mockRejectedValue(new Error('x'));
-      await expect(service.getCustomReports()).resolves.toEqual([]);
-    });
-
-    it('deletes a custom report', async () => {
-      apiServiceMock.delete.mockResolvedValue(undefined);
-
-      await service.deleteCustomReport('cr1');
-
-      expect(apiServiceMock.delete).toHaveBeenCalledWith('/api/v1/analytics/custom-reports/cr1');
-    });
-
-    it('propagates delete failures', async () => {
-      apiServiceMock.delete.mockRejectedValue(new Error('x'));
-      await expect(service.deleteCustomReport('cr1')).rejects.toThrow('x');
-    });
   });
 });

--- a/apps/rescue/src/services/analyticsService.ts
+++ b/apps/rescue/src/services/analyticsService.ts
@@ -73,18 +73,6 @@ export interface ReportFilters {
   staffMemberId?: string;
 }
 
-export interface CustomReport {
-  id?: string;
-  name: string;
-  metrics: string[];
-  visualizations: string[];
-  filters: ReportFilters;
-  schedule?: {
-    frequency: 'daily' | 'weekly' | 'monthly';
-    recipients: string[];
-  };
-}
-
 export class AnalyticsService {
   /**
    * Get adoption metrics for the specified date range
@@ -241,51 +229,6 @@ export class AnalyticsService {
       });
     } catch (error) {
       console.error('Failed to email report:', error);
-      throw error;
-    }
-  }
-
-  /**
-   * Save a custom report template
-   */
-  async saveCustomReport(report: CustomReport): Promise<CustomReport> {
-    try {
-      const response = await apiService.post<{ success: boolean; data: CustomReport }>(
-        '/api/v1/analytics/custom-reports',
-        report
-      );
-
-      return response.data;
-    } catch (error) {
-      console.error('Failed to save custom report:', error);
-      throw error;
-    }
-  }
-
-  /**
-   * Get saved custom reports
-   */
-  async getCustomReports(): Promise<CustomReport[]> {
-    try {
-      const response = await apiService.get<{ success: boolean; data: CustomReport[] }>(
-        '/api/v1/analytics/custom-reports'
-      );
-
-      return response.data;
-    } catch (error) {
-      console.error('Failed to fetch custom reports:', error);
-      return [];
-    }
-  }
-
-  /**
-   * Delete a custom report
-   */
-  async deleteCustomReport(reportId: string): Promise<void> {
-    try {
-      await apiService.delete(`/api/v1/analytics/custom-reports/${reportId}`);
-    } catch (error) {
-      console.error('Failed to delete custom report:', error);
       throw error;
     }
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1962,6 +1962,12 @@ importers:
       ioredis:
         specifier: ^5.11.1
         version: 5.11.1
+      jspdf:
+        specifier: 4.2.1
+        version: 4.2.1
+      jspdf-autotable:
+        specifier: 5.0.8
+        version: 5.0.8(jspdf@4.2.1)
       nats:
         specifier: ^2.29.3
         version: 2.29.3

--- a/services/gateway/package.json
+++ b/services/gateway/package.json
@@ -55,6 +55,8 @@
     "fastify": "^5.8.5",
     "file-type": "^22.0.1",
     "ioredis": "^5.11.1",
+    "jspdf": "4.2.1",
+    "jspdf-autotable": "5.0.8",
     "nats": "^2.29.3",
     "pg": "^8.22.0",
     "prom-client": "^15.1.3",

--- a/services/gateway/src/grpc-clients/notifications-client.ts
+++ b/services/gateway/src/grpc-clients/notifications-client.ts
@@ -58,6 +58,8 @@ import {
   type DeleteEmailTemplateResponse,
   type PreviewEmailTemplateRequest,
   type PreviewEmailTemplateResponse,
+  type SendEmailRequest,
+  type SendEmailResponse,
 } from '@adopt-dont-shop/proto';
 
 import { startGrpcTimer } from '@adopt-dont-shop/observability';
@@ -141,6 +143,7 @@ export type NotificationsClient = {
     req: PreviewEmailTemplateRequest,
     metadata: Metadata
   ): Promise<PreviewEmailTemplateResponse>;
+  sendEmail(req: SendEmailRequest, metadata: Metadata): Promise<SendEmailResponse>;
   broadcast(
     req: import('@adopt-dont-shop/proto').BroadcastRequest,
     metadata: Metadata
@@ -252,6 +255,7 @@ export const createNotificationsClient = (
     getEmailTemplate: (req, metadata) => callUnary(stub.getEmailTemplate, req, metadata, true),
     previewEmailTemplate: (req, metadata) =>
       callUnary(stub.previewEmailTemplate, req, metadata, true),
+    sendEmail: (req, metadata) => callUnary(stub.sendEmail, req, metadata, false),
     close: () => stub.close(),
   };
 };

--- a/services/gateway/src/routes/analytics-metrics.test.ts
+++ b/services/gateway/src/routes/analytics-metrics.test.ts
@@ -3,6 +3,7 @@ import Fastify, { type FastifyInstance } from 'fastify';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { ApplicationsClient } from '../grpc-clients/applications-client.js';
+import type { NotificationsClient } from '../grpc-clients/notifications-client.js';
 import type { PetsClient } from '../grpc-clients/pets-client.js';
 
 import { registerAnalyticsMetricsRoutes } from './analytics-metrics.js';
@@ -27,6 +28,14 @@ function makeApplicationsClient(): {
   return { applicationsClient: mocks as unknown as ApplicationsClient, mocks };
 }
 
+function makeNotificationsClient(): {
+  notificationsClient: NotificationsClient;
+  mocks: { sendEmail: ReturnType<typeof vi.fn> };
+} {
+  const mocks = { sendEmail: vi.fn() };
+  return { notificationsClient: mocks as unknown as NotificationsClient, mocks };
+}
+
 // Mutually-exclusive per-status counts (each application has exactly one
 // current status) that sum to `total`.
 const APP_STATS_FIXTURE = {
@@ -46,14 +55,21 @@ describe('/api/v1/analytics gateway routes', () => {
   let app: FastifyInstance;
   let petsMocks: ReturnType<typeof makePetsClient>['mocks'];
   let applicationsMocks: ReturnType<typeof makeApplicationsClient>['mocks'];
+  let notificationsMocks: ReturnType<typeof makeNotificationsClient>['mocks'];
 
   beforeEach(async () => {
     app = Fastify({ logger: false });
     const { petsClient, mocks: pm } = makePetsClient();
     const { applicationsClient, mocks: am } = makeApplicationsClient();
+    const { notificationsClient, mocks: nm } = makeNotificationsClient();
     petsMocks = pm;
     applicationsMocks = am;
-    await registerAnalyticsMetricsRoutes(app, { petsClient, applicationsClient });
+    notificationsMocks = nm;
+    await registerAnalyticsMetricsRoutes(app, {
+      petsClient,
+      applicationsClient,
+      notificationsClient,
+    });
   });
 
   afterEach(async () => {
@@ -322,6 +338,134 @@ describe('/api/v1/analytics gateway routes', () => {
         method: 'POST',
         url: '/api/v1/analytics/export/csv',
         payload: validPayload,
+      });
+      expect(res.statusCode).toBe(403);
+    });
+  });
+
+  describe('POST /api/v1/analytics/export/pdf', () => {
+    const validPayload = {
+      reportType: 'full-analytics',
+      filters: {
+        dateRange: { start: '2026-01-08T00:00:00.000Z', end: '2026-01-15T00:00:00.000Z' },
+      },
+    };
+
+    const primeReads = (): void => {
+      petsMocks.getAdoptionTrend
+        .mockResolvedValueOnce({ points: [{ date: '2026-01-08', count: 3 }] })
+        .mockResolvedValueOnce({ points: [] });
+      petsMocks.getStats.mockResolvedValue({ averageDaysToAdoption: 14 });
+      petsMocks.getTopBreedsByAdoptions.mockResolvedValue({
+        breeds: [{ breed: 'Labrador', count: 24, averageAdoptionDays: 13 }],
+      });
+      applicationsMocks.getStats.mockResolvedValue(APP_STATS_FIXTURE);
+    };
+
+    it('returns 400 when the date range is missing', async () => {
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/v1/analytics/export/pdf',
+        payload: { filters: {} },
+      });
+      expect(res.statusCode).toBe(400);
+    });
+
+    it('renders a real PDF document from the composed figures', async () => {
+      primeReads();
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/v1/analytics/export/pdf',
+        payload: validPayload,
+      });
+      expect(res.statusCode).toBe(200);
+      expect(res.headers['content-type']).toBe('application/pdf');
+      expect(res.headers['content-disposition']).toContain(
+        'attachment; filename="analytics-2026-01-08-to-2026-01-15.pdf"'
+      );
+      // A real PDF payload begins with the %PDF- signature and is non-trivial.
+      expect(res.rawPayload.subarray(0, 5).toString('latin1')).toBe('%PDF-');
+      expect(res.rawPayload.length).toBeGreaterThan(500);
+    });
+
+    it('maps an upstream error to its HTTP status', async () => {
+      petsMocks.getAdoptionTrend.mockRejectedValue({ code: grpcStatus.PERMISSION_DENIED });
+      petsMocks.getStats.mockResolvedValue({ averageDaysToAdoption: 0 });
+      petsMocks.getTopBreedsByAdoptions.mockResolvedValue({ breeds: [] });
+      applicationsMocks.getStats.mockResolvedValue(APP_STATS_FIXTURE);
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/v1/analytics/export/pdf',
+        payload: validPayload,
+      });
+      expect(res.statusCode).toBe(403);
+    });
+  });
+
+  describe('POST /api/v1/analytics/email-report', () => {
+    const base = {
+      reportType: 'full-analytics',
+      filters: {
+        dateRange: { start: '2026-01-08T00:00:00.000Z', end: '2026-01-15T00:00:00.000Z' },
+      },
+    };
+
+    const primeReads = (): void => {
+      petsMocks.getAdoptionTrend
+        .mockResolvedValueOnce({ points: [{ date: '2026-01-08', count: 3 }] })
+        .mockResolvedValueOnce({ points: [] });
+      petsMocks.getStats.mockResolvedValue({ averageDaysToAdoption: 14 });
+      petsMocks.getTopBreedsByAdoptions.mockResolvedValue({
+        breeds: [{ breed: 'Labrador', count: 24, averageAdoptionDays: 13 }],
+      });
+      applicationsMocks.getStats.mockResolvedValue(APP_STATS_FIXTURE);
+    };
+
+    it('returns 400 when the date range is missing', async () => {
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/v1/analytics/email-report',
+        payload: { recipients: ['a@rescue.org'], filters: {} },
+      });
+      expect(res.statusCode).toBe(400);
+    });
+
+    it('returns 400 when no recipients are given', async () => {
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/v1/analytics/email-report',
+        payload: { ...base, recipients: [] },
+      });
+      expect(res.statusCode).toBe(400);
+    });
+
+    it('emails the composed HTML report to each recipient', async () => {
+      primeReads();
+      notificationsMocks.sendEmail.mockResolvedValue({});
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/v1/analytics/email-report',
+        payload: { ...base, recipients: ['a@rescue.org', 'b@rescue.org'] },
+      });
+      expect(res.statusCode).toBe(200);
+      expect(res.json()).toEqual({ success: true, sent: 2 });
+      expect(notificationsMocks.sendEmail).toHaveBeenCalledTimes(2);
+      const firstArg = notificationsMocks.sendEmail.mock.calls[0][0];
+      expect(firstArg.toEmail).toBe('a@rescue.org');
+      expect(firstArg.subject).toContain('2026-01-08');
+      expect(firstArg.htmlContent).toContain('Adoption Metrics');
+      expect(firstArg.htmlContent).toContain('Labrador');
+    });
+
+    it('maps an upstream error to its HTTP status', async () => {
+      petsMocks.getAdoptionTrend.mockRejectedValue({ code: grpcStatus.PERMISSION_DENIED });
+      petsMocks.getStats.mockResolvedValue({ averageDaysToAdoption: 0 });
+      petsMocks.getTopBreedsByAdoptions.mockResolvedValue({ breeds: [] });
+      applicationsMocks.getStats.mockResolvedValue(APP_STATS_FIXTURE);
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/v1/analytics/email-report',
+        payload: { ...base, recipients: ['a@rescue.org'] },
       });
       expect(res.statusCode).toBe(403);
     });

--- a/services/gateway/src/routes/analytics-metrics.ts
+++ b/services/gateway/src/routes/analytics-metrics.ts
@@ -18,20 +18,28 @@
 //                                                  current-snapshot per-stage counts
 //
 //   POST /api/v1/analytics/export/csv           → the four reads above, composed
-//                                                  into one CSV download (no new
-//                                                  data — a faithful serialisation
-//                                                  of what the dashboard shows)
+//   POST /api/v1/analytics/export/pdf              into one download (CSV / PDF)
+//   POST /api/v1/analytics/email-report            or emailed via notifications.
+//                                                  No new data — a faithful
+//                                                  serialisation of what the
+//                                                  dashboard already shows.
 //
 // Known gaps (no backing RPC exists, so these fields are dropped rather
 // than half-built): per-species adoption rates/average-time, per-stage
-// average duration + bottleneck detection, response-time/SLA/staff
-// metrics, PDF export, email-report, custom-reports.
+// average duration + bottleneck detection, response-time/SLA/staff metrics
+// (the SPA's ResponseTimeChart degrades gracefully), custom-reports.
 
+import jsPDF from 'jspdf';
+import autoTable from 'jspdf-autotable';
 import type { FastifyInstance } from 'fastify';
 
-import type { GetStatsResponse as ApplicationsGetStatsResponse } from '@adopt-dont-shop/proto';
+import {
+  NotificationsV1,
+  type GetStatsResponse as ApplicationsGetStatsResponse,
+} from '@adopt-dont-shop/proto';
 
 import type { ApplicationsClient } from '../grpc-clients/applications-client.js';
+import type { NotificationsClient } from '../grpc-clients/notifications-client.js';
 import type { PetsClient } from '../grpc-clients/pets-client.js';
 import { buildMetadata } from '../middleware/metadata.js';
 import { handleGrpcError } from '../middleware/grpc-error.js';
@@ -39,6 +47,10 @@ import { handleGrpcError } from '../middleware/grpc-error.js';
 export type AnalyticsMetricsRoutesOptions = {
   petsClient: PetsClient;
   applicationsClient: ApplicationsClient;
+  // Optional: when present the report can be emailed via service.notifications.
+  // Absent (e.g. a gateway configured without notifications) → the email-report
+  // route is not registered and the request falls through to the catch-all.
+  notificationsClient?: NotificationsClient;
 };
 
 const rate = (numerator: number, denominator: number): number =>
@@ -235,11 +247,147 @@ function renderAnalyticsCsv(
   return rows.join('\r\n') + '\r\n';
 }
 
+// --- PDF serialisation. jsPDF + jsPDF-AutoTable run headless in Node (no DOM
+// is touched for text/table output), so the gateway renders the same composed
+// figures the CSV export uses into a printable one-page report.
+const PDF_SECTIONS = (
+  adoption: AdoptionShape,
+  applications: ApplicationShape,
+  performance: PerformanceShape,
+  stages: StageShape
+): ReadonlyArray<{ title: string; head: string[]; body: (string | number)[][] }> => [
+  {
+    title: 'Adoption Metrics',
+    head: ['Metric', 'Value'],
+    body: [
+      ['Total Adoptions', adoption.totalAdoptions],
+      ['Success Rate (%)', round2(adoption.successRate)],
+      ['Average Time to Adoption (days)', adoption.averageTimeToAdoption],
+    ],
+  },
+  {
+    title: 'Application Funnel',
+    head: ['Stage', 'Applications', 'Conversion Rate (%)'],
+    body: applications.conversionRateByStage.map(s => [
+      s.stage,
+      s.applicationsCount,
+      round2(s.conversionRate),
+    ]),
+  },
+  {
+    title: 'Most Popular Breeds',
+    head: ['Breed', 'Adoptions', 'Average Adoption Time (days)'],
+    body: performance.mostPopularBreeds.map(b => [b.breed, b.count, b.averageAdoptionTime]),
+  },
+  {
+    title: 'Stage Distribution (current)',
+    head: ['Stage', 'Count', 'Percentage (%)'],
+    body: stages.map(s => [s.stage, s.count, round2(s.percentage)]),
+  },
+];
+
+function renderAnalyticsPdf(
+  range: { startDate: string; endDate: string },
+  adoption: AdoptionShape,
+  applications: ApplicationShape,
+  performance: PerformanceShape,
+  stages: StageShape
+): Buffer {
+  const doc = new jsPDF();
+  doc.setFontSize(16);
+  doc.text("Adopt Don't Shop — Analytics Report", 14, 18);
+  doc.setFontSize(10);
+  doc.text(`Period: ${range.startDate} to ${range.endDate}`, 14, 26);
+
+  let cursorY = 34;
+  for (const section of PDF_SECTIONS(adoption, applications, performance, stages)) {
+    autoTable(doc, {
+      startY: cursorY,
+      head: [[section.title, ...Array(section.head.length - 1).fill('')]],
+      body: [section.head, ...section.body.map(r => r.map(String))],
+      theme: 'striped',
+      headStyles: { fillColor: [59, 130, 246] },
+    });
+    // jsPDF-AutoTable stashes the y-cursor of the last drawn table on the doc.
+    const lastTable = (doc as unknown as { lastAutoTable?: { finalY: number } }).lastAutoTable;
+    cursorY = (lastTable?.finalY ?? cursorY) + 8;
+  }
+  return Buffer.from(doc.output('arraybuffer'));
+}
+
+// --- Email body. A compact HTML report emailed via service.notifications;
+// mirrors the CSV/PDF figures so the three exports tell the same story.
+const htmlEscape = (value: string | number): string =>
+  String(value).replace(/[&<>"']/g, c =>
+    c === '&' ? '&amp;' : c === '<' ? '&lt;' : c === '>' ? '&gt;' : c === '"' ? '&quot;' : '&#39;'
+  );
+
+function renderAnalyticsEmailHtml(
+  range: { startDate: string; endDate: string },
+  adoption: AdoptionShape,
+  applications: ApplicationShape,
+  performance: PerformanceShape,
+  stages: StageShape
+): string {
+  const table = (title: string, head: string[], body: (string | number)[][]): string =>
+    `<h3>${htmlEscape(title)}</h3><table border="1" cellpadding="6" cellspacing="0">` +
+    `<thead><tr>${head.map(h => `<th>${htmlEscape(h)}</th>`).join('')}</tr></thead>` +
+    `<tbody>${body
+      .map(r => `<tr>${r.map(c => `<td>${htmlEscape(c)}</td>`).join('')}</tr>`)
+      .join('')}</tbody></table>`;
+  return (
+    `<h2>Adopt Don't Shop — Analytics Report</h2>` +
+    `<p>Period: ${htmlEscape(range.startDate)} to ${htmlEscape(range.endDate)}</p>` +
+    PDF_SECTIONS(adoption, applications, performance, stages)
+      .map(s => table(s.title, s.head, s.body))
+      .join('')
+  );
+}
+
+// One place that fans out to the four upstream reads and reshapes them, so the
+// CSV / PDF / email exports all serialise identical figures. Rescue-staff
+// scoping stays server-side in the upstream handlers via the principal.
+type ReportMetadata = ReturnType<typeof buildMetadata>;
+
+async function composeDashboard(
+  petsClient: PetsClient,
+  applicationsClient: ApplicationsClient,
+  metadata: ReportMetadata,
+  start: string,
+  end: string
+): Promise<{
+  adoption: AdoptionShape;
+  applications: ApplicationShape;
+  performance: PerformanceShape;
+  stages: StageShape;
+}> {
+  const prior = previousPeriod(start, end);
+  const [currentTrend, priorTrend, petStats, currentApps, priorApps, topBreeds, snapshot] =
+    await Promise.all([
+      petsClient.getAdoptionTrend({ startDate: start, endDate: end }, metadata),
+      petsClient.getAdoptionTrend({ startDate: prior.start, endDate: prior.end }, metadata),
+      petsClient.getStats({}, metadata),
+      applicationsClient.getStats({ createdAfter: start, createdBefore: end }, metadata),
+      applicationsClient.getStats(
+        { createdAfter: prior.start, createdBefore: prior.end },
+        metadata
+      ),
+      petsClient.getTopBreedsByAdoptions({ startDate: start, endDate: end, limit: 5 }, metadata),
+      applicationsClient.getStats({}, metadata),
+    ]);
+  return {
+    adoption: shapeAdoptionMetrics(currentTrend, priorTrend, petStats, currentApps, priorApps),
+    applications: shapeApplicationAnalytics(currentApps),
+    performance: shapePetPerformance(topBreeds),
+    stages: shapeStageDistribution(snapshot),
+  };
+}
+
 export const registerAnalyticsMetricsRoutes = async (
   app: FastifyInstance,
   opts: AnalyticsMetricsRoutesOptions
 ): Promise<void> => {
-  const { petsClient, applicationsClient } = opts;
+  const { petsClient, applicationsClient, notificationsClient } = opts;
 
   app.get(
     '/api/v1/analytics/adoption-metrics',
@@ -466,31 +614,15 @@ export const registerAnalyticsMetricsRoutes = async (
           error: 'filters.dateRange.start and filters.dateRange.end are required',
         });
       }
-      const prior = previousPeriod(start, end);
       const metadata = buildMetadata(req);
       try {
-        const [currentTrend, priorTrend, petStats, currentApps, priorApps, topBreeds, snapshot] =
-          await Promise.all([
-            petsClient.getAdoptionTrend({ startDate: start, endDate: end }, metadata),
-            petsClient.getAdoptionTrend({ startDate: prior.start, endDate: prior.end }, metadata),
-            petsClient.getStats({}, metadata),
-            applicationsClient.getStats({ createdAfter: start, createdBefore: end }, metadata),
-            applicationsClient.getStats(
-              { createdAfter: prior.start, createdBefore: prior.end },
-              metadata
-            ),
-            petsClient.getTopBreedsByAdoptions(
-              { startDate: start, endDate: end, limit: 5 },
-              metadata
-            ),
-            applicationsClient.getStats({}, metadata),
-          ]);
+        const report = await composeDashboard(petsClient, applicationsClient, metadata, start, end);
         const csv = renderAnalyticsCsv(
           { startDate: start, endDate: end },
-          shapeAdoptionMetrics(currentTrend, priorTrend, petStats, currentApps, priorApps),
-          shapeApplicationAnalytics(currentApps),
-          shapePetPerformance(topBreeds),
-          shapeStageDistribution(snapshot)
+          report.adoption,
+          report.applications,
+          report.performance,
+          report.stages
         );
         return reply
           .header('Content-Type', 'text/csv; charset=utf-8')
@@ -504,4 +636,186 @@ export const registerAnalyticsMetricsRoutes = async (
       }
     }
   );
+
+  // POST /api/v1/analytics/export/pdf — the dashboard's "Export PDF" button.
+  // Same composed figures as the CSV export, rendered to a one-page PDF via
+  // jsPDF (headless in Node). No 200 response schema so Fastify streams the
+  // Buffer untouched.
+  app.post(
+    '/api/v1/analytics/export/pdf',
+    {
+      schema: {
+        tags: ['analytics'],
+        summary: 'Download the rescue Analytics dashboard as a PDF report',
+        produces: ['application/pdf'],
+        body: {
+          type: 'object',
+          properties: {
+            reportType: { type: 'string' },
+            filters: {
+              type: 'object',
+              properties: {
+                dateRange: {
+                  type: 'object',
+                  properties: { start: { type: 'string' }, end: { type: 'string' } },
+                },
+              },
+              additionalProperties: true,
+            },
+          },
+          additionalProperties: true,
+        },
+        response: {
+          400: {
+            type: 'object',
+            properties: { success: { type: 'boolean' }, error: { type: 'string' } },
+          },
+        },
+      },
+    },
+    async (req, reply) => {
+      const body = (req.body ?? {}) as {
+        filters?: { dateRange?: { start?: string; end?: string } };
+      };
+      const start = body.filters?.dateRange?.start;
+      const end = body.filters?.dateRange?.end;
+      if (!start || !end) {
+        return reply.code(400).send({
+          success: false,
+          error: 'filters.dateRange.start and filters.dateRange.end are required',
+        });
+      }
+      try {
+        const report = await composeDashboard(
+          petsClient,
+          applicationsClient,
+          buildMetadata(req),
+          start,
+          end
+        );
+        const pdf = renderAnalyticsPdf(
+          { startDate: start, endDate: end },
+          report.adoption,
+          report.applications,
+          report.performance,
+          report.stages
+        );
+        return reply
+          .header('Content-Type', 'application/pdf')
+          .header(
+            'Content-Disposition',
+            `attachment; filename="analytics-${start.slice(0, 10)}-to-${end.slice(0, 10)}.pdf"`
+          )
+          .send(pdf);
+      } catch (err) {
+        return handleGrpcError(err, reply);
+      }
+    }
+  );
+
+  // POST /api/v1/analytics/email-report — the dashboard's "Email report" flow.
+  // Composes the same figures into an HTML email and hands it to
+  // service.notifications. Only registered when a notifications client is
+  // configured; otherwise the request falls through to the catch-all.
+  if (notificationsClient) {
+    app.post(
+      '/api/v1/analytics/email-report',
+      {
+        schema: {
+          tags: ['analytics'],
+          summary: 'Email the rescue Analytics report to one or more recipients',
+          body: {
+            type: 'object',
+            properties: {
+              reportType: { type: 'string' },
+              recipients: { type: 'array', items: { type: 'string' } },
+              filters: {
+                type: 'object',
+                properties: {
+                  dateRange: {
+                    type: 'object',
+                    properties: { start: { type: 'string' }, end: { type: 'string' } },
+                  },
+                },
+                additionalProperties: true,
+              },
+            },
+            additionalProperties: true,
+          },
+          response: {
+            200: {
+              type: 'object',
+              properties: { success: { type: 'boolean' }, sent: { type: 'integer' } },
+            },
+            400: {
+              type: 'object',
+              properties: { success: { type: 'boolean' }, error: { type: 'string' } },
+            },
+          },
+        },
+      },
+      async (req, reply) => {
+        const body = (req.body ?? {}) as {
+          recipients?: unknown;
+          filters?: { dateRange?: { start?: string; end?: string } };
+        };
+        const start = body.filters?.dateRange?.start;
+        const end = body.filters?.dateRange?.end;
+        const recipients = Array.isArray(body.recipients)
+          ? body.recipients.filter((r): r is string => typeof r === 'string' && r.length > 0)
+          : [];
+        if (!start || !end) {
+          return reply.code(400).send({
+            success: false,
+            error: 'filters.dateRange.start and filters.dateRange.end are required',
+          });
+        }
+        if (recipients.length === 0) {
+          return reply
+            .code(400)
+            .send({ success: false, error: 'at least one recipient is required' });
+        }
+        const metadata = buildMetadata(req);
+        try {
+          const report = await composeDashboard(
+            petsClient,
+            applicationsClient,
+            metadata,
+            start,
+            end
+          );
+          const htmlContent = renderAnalyticsEmailHtml(
+            { startDate: start, endDate: end },
+            report.adoption,
+            report.applications,
+            report.performance,
+            report.stages
+          );
+          const subject = `Analytics report: ${start.slice(0, 10)} to ${end.slice(0, 10)}`;
+          await Promise.all(
+            recipients.map(toEmail =>
+              notificationsClient.sendEmail(
+                {
+                  toEmail,
+                  subject,
+                  htmlContent,
+                  ccEmails: [],
+                  bccEmails: [],
+                  templateDataJson: '',
+                  type: NotificationsV1.EmailType.EMAIL_TYPE_NOTIFICATION,
+                  priority: NotificationsV1.EmailPriority.EMAIL_PRIORITY_NORMAL,
+                  metadataJson: '',
+                  tags: ['analytics-report'],
+                },
+                metadata
+              )
+            )
+          );
+          return reply.code(200).send({ success: true, sent: recipients.length });
+        } catch (err) {
+          return handleGrpcError(err, reply);
+        }
+      }
+    );
+  }
 };

--- a/services/gateway/src/server.ts
+++ b/services/gateway/src/server.ts
@@ -770,6 +770,8 @@ export const createServer = async (opts: CreateServerOptions): Promise<FastifyIn
     await registerAnalyticsMetricsRoutes(server, {
       petsClient: opts.petsClient,
       applicationsClient: opts.applicationsClient,
+      // Optional — enables POST /analytics/email-report when configured.
+      notificationsClient: opts.notificationsClient,
     });
   }
 


### PR DESCRIPTION
## Summary

Closes the remaining live gaps on the rescue Analytics dashboard and removes confirmed dead code, following the CSV export in #1347.

- **`POST /api/v1/analytics/export/pdf`** — renders the composed dashboard figures to a one-page PDF (jsPDF + jsPDF-AutoTable, both headless in Node), same Blob contract as the CSV route. Backs the dashboard's "Export PDF" button, which previously 404'd through to the catch-all.
- **`POST /api/v1/analytics/email-report`** — composes the same figures into an HTML email and sends it to each recipient via `service.notifications` (`SendEmail`). Backs the dashboard's "Email report" flow.
- **Cleanup** — removes the dead `saveCustomReport` / `getCustomReports` / `deleteCustomReport` methods (+ `CustomReport` type) from the rescue analytics service; they had zero callers anywhere.

Both new routes reuse the existing `pets`/`applications` aggregation RPCs — **no new data, nothing fabricated**, rescue-scoped server-side by the principal exactly like the sibling GET routes. The CSV/PDF/email exports now share one `composeDashboard` + `shape*` source of truth.

## Changes

- `services/gateway/src/routes/analytics-metrics.ts` — new `export/pdf` and `email-report` routes; extracted `composeDashboard` + PDF/HTML renderers; CSV route refactored onto the shared helper.
- `services/gateway/src/grpc-clients/notifications-client.ts` — wire the previously-unimplemented `sendEmail` onto the gateway client.
- `services/gateway/src/server.ts` — thread the optional notifications client into the analytics-metrics registration.
- `services/gateway/package.json` / `pnpm-lock.yaml` — add `jspdf@4.2.1` + `jspdf-autotable@5.0.8` (same versions already used by `app.admin`).
- `apps/rescue/src/services/analyticsService.ts` (+ test) — remove the dead custom-report methods and type.

## Scope notes (deliberately out)

- **`response-time` metric** — left as-is (the `ResponseTimeChart` degrades gracefully). Its expected shape embeds real product decisions (SLA threshold, per-staff attribution, per-stage correlation) and needs a proper spec + a new `chat` aggregation RPC, not a rushed build or a destructive teardown.
- **`lib.analytics` unused methods / `lib.search` `facetedSearch`** — confirmed to have no callers, but they are shared-library API surface; left for a separate deliberate audit rather than piecemeal deletion.
- **Per-permission endpoints** (`/permissions/check`, `/grant`, …) — the frontend never calls these; no action needed.

## Before requesting review

- [x] Ran quick checks locally (type-check + lint + gateway & rescue tests)
- [x] Tests for new behaviour added (TDD)
- [ ] If touching `.env` requirements, updated `.env.example`'s REQUIRED block — n/a
- [ ] If touching a `lib.*`, considered consumer impact — n/a (no `lib.*` changed)

## Test plan

- [x] Existing tests pass — full gateway suite green (1263 tests), rescue analytics tests green (18)
- [x] New behaviour covered by tests — PDF route asserts a real `%PDF-` payload; email route asserts per-recipient `SendEmail` calls with the composed subject/HTML; both cover 400s and upstream-error → HTTP mapping
- [ ] Tested manually — not run against a live stack; covered by route-level injection tests
- [x] No TypeScript errors (`type-check` on `service.gateway` + `app.rescue`)
- [x] Lint passes

## Screenshots / recordings

n/a — backend routes + a frontend dead-code removal; the PDF/email are produced server-side and consumed by the existing dashboard controls.

## Related

Follows #1347 (CSV export). Completes the rescue Analytics export/reporting surface (CSV + PDF + email).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xjak7otuKv2PaPcqV1mcgk

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xjak7otuKv2PaPcqV1mcgk)_