### PR TITLE
chore: remove dead facetedSearch from lib.search

### DIFF
--- a/packages/lib.search/src/services/__tests__/search-service.test.ts
+++ b/packages/lib.search/src/services/__tests__/search-service.test.ts
@@ -5,8 +5,6 @@ import {
   MessageSearchOptions,
   MessageSearchResponse,
   SearchSuggestion,
-  AdvancedSearchOptions,
-  FacetedSearchResponse,
   PaginatedResponse,
 } from '../../types';
 
@@ -292,53 +290,6 @@ describe('SearchService', () => {
       await service.getSearchSuggestions('test', 'pets');
 
       expect(mockApiService.get).toHaveBeenCalledTimes(3);
-    });
-  });
-
-  describe('facetedSearch', () => {
-    it('should perform faceted search successfully', async () => {
-      const mockFacetedResponse: FacetedSearchResponse = {
-        results: [mockPetSearchResult],
-        facets: [
-          {
-            name: 'type',
-            values: [
-              { value: 'dog', count: 150 },
-              { value: 'cat', count: 100 },
-            ],
-          },
-        ],
-        total: 1,
-        page: 1,
-        totalPages: 1,
-        queryTime: 120,
-      };
-
-      const advancedOptions: AdvancedSearchOptions = {
-        includeTypes: ['pet'],
-        location: { lat: 40.7128, lng: -74.006, radius: 50 },
-        facets: ['type', 'size', 'age'],
-      };
-
-      mockApiService.post.mockResolvedValue(mockFacetedResponse);
-
-      const result = await service.facetedSearch('friendly dog', advancedOptions);
-
-      expect(mockApiService.post).toHaveBeenCalledWith('/api/v1/search/faceted', {
-        query: 'friendly dog',
-        ...advancedOptions,
-      });
-      expect(result).toEqual(mockFacetedResponse);
-    });
-
-    it('should return empty results on API failure', async () => {
-      mockApiService.post.mockRejectedValue(new Error('API Error'));
-
-      const result = await service.facetedSearch('test');
-
-      expect(result.results).toEqual([]);
-      expect(result.facets).toEqual([]);
-      expect(result.total).toBe(0);
     });
   });
 

--- a/packages/lib.search/src/services/search-service.ts
+++ b/packages/lib.search/src/services/search-service.ts
@@ -9,8 +9,6 @@ import {
   SearchSuggestion,
   SearchCacheEntry,
   SearchMetrics,
-  AdvancedSearchOptions,
-  FacetedSearchResponse,
   PaginatedResponse,
 } from '../types';
 
@@ -18,14 +16,13 @@ import {
  * Advanced Search Service
  *
  * Provides comprehensive search functionality for pets, messages, and other content
- * with intelligent caching, faceted search, and performance analytics.
+ * with intelligent caching and performance analytics.
  *
  * Features:
  * - Pet search with advanced filters
  * - Message search with conversation context
  * - Intelligent caching with TTL and LRU eviction
  * - Search suggestions and autocomplete
- * - Faceted search with filters
  * - Search analytics and performance tracking
  * - Geographic and proximity search
  * - Real-time search suggestions
@@ -237,49 +234,6 @@ export class SearchService {
         console.warn('Failed to get search suggestions:', error);
       }
       return [];
-    }
-  }
-
-  /**
-   * Perform faceted search with advanced filtering
-   *
-   * @param query - Search query
-   * @param advancedOptions - Advanced search options
-   * @returns Promise<FacetedSearchResponse> - Faceted search results
-   */
-  async facetedSearch(
-    query: string,
-    advancedOptions: AdvancedSearchOptions = {}
-  ): Promise<FacetedSearchResponse> {
-    const startTime = Date.now();
-
-    try {
-      const requestBody = {
-        query,
-        ...advancedOptions,
-      };
-
-      const response = await this.apiService.post<FacetedSearchResponse>(
-        `${this.API_BASE_URL}/faceted`,
-        requestBody
-      );
-
-      this.updateMetrics('faceted', startTime, false);
-      return response;
-    } catch (error) {
-      this.updateMetrics('faceted', startTime, false);
-      if (this.config.debug) {
-        console.warn('Faceted search failed:', error);
-      }
-
-      return {
-        results: [],
-        facets: [],
-        total: 0,
-        page: 1,
-        totalPages: 0,
-        queryTime: Date.now() - startTime,
-      };
     }
   }
 

--- a/packages/lib.search/src/types/index.ts
+++ b/packages/lib.search/src/types/index.ts
@@ -107,38 +107,3 @@ export interface SearchMetrics {
     slowQueries: number; // > 500ms
   };
 }
-
-export interface AdvancedSearchOptions {
-  includeTypes?: string[];
-  excludeTypes?: string[];
-  dateRange?: {
-    start: Date;
-    end: Date;
-  };
-  location?: {
-    lat: number;
-    lng: number;
-    radius: number;
-  };
-  customFilters?: Record<string, unknown>;
-  facets?: string[];
-  boost?: Record<string, number>;
-}
-
-export interface SearchFacet {
-  name: string;
-  values: {
-    value: string;
-    count: number;
-    selected?: boolean;
-  }[];
-}
-
-export interface FacetedSearchResponse {
-  results: SearchResult[];
-  facets: SearchFacet[];
-  total: number;
-  page: number;
-  totalPages: number;
-  queryTime: number;
-}


### PR DESCRIPTION
## Summary

- Removes the `facetedSearch` method from `@adopt-dont-shop/lib.search`. It had **zero callers anywhere in the monorepo** and hit `/search/faceted`, an endpoint that was never built (the ADS-1142 surface).

## Changes

- `packages/lib.search/src/services/search-service.ts` — remove the `facetedSearch` method (and its two `updateMetrics('faceted', …)` calls) and the now-false class-JSDoc lines advertising it.
- `packages/lib.search/src/types/index.ts` — remove the types that became orphaned by the removal (verified used nowhere else): `FacetedSearchResponse`, `SearchFacet` (used only inside it), and `AdvancedSearchOptions` (the method's parameter type). They were exported only via the wildcard `export *`, so this narrows the package's public type surface slightly.
- `packages/lib.search/src/services/__tests__/search-service.test.ts` — remove the `facetedSearch` test block.

## Before requesting review

- [x] Ran quick checks locally (type-check + lint + lib.search tests + consumer type-check)
- [x] Confirmed zero callers before removal (safety gate)
- [ ] If touching `.env` requirements — n/a
- [x] If touching a `lib.*`, considered consumer impact — `app.rescue`/`app.client` type-check against the trimmed API

## Test plan

- [x] `lib.search` type-check + tests pass (25 tests)
- [x] Consumers (`app.rescue`, `app.client`) type-check against the new API
- [x] No TypeScript errors
- [x] Lint passes

## Screenshots / recordings

n/a — library dead-code removal.

## Related

Post-route-audit cleanup. Sibling PRs remove the rescue response-time section and the never-wired `lib.analytics` analytics-platform methods.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xjak7otuKv2PaPcqV1mcgk

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xjak7otuKv2PaPcqV1mcgk)_