### PR TITLE
feat: back the homepage featured-pets rail + repoint health to served paths

### DIFF
--- a/packages/lib.notifications/src/services/__tests__/notifications-service.test.ts
+++ b/packages/lib.notifications/src/services/__tests__/notifications-service.test.ts
@@ -382,7 +382,7 @@ describe('NotificationsService', () => {
 
       const result = await service.healthCheck();
 
-      expect(mockApiService.get).toHaveBeenCalledWith('/api/v1/health');
+      expect(mockApiService.get).toHaveBeenCalledWith('/health/simple');
       expect(result).toBe(true);
     });
 

--- a/packages/lib.notifications/src/services/notifications-service.ts
+++ b/packages/lib.notifications/src/services/notifications-service.ts
@@ -437,7 +437,7 @@ export class NotificationsService {
    */
   public async healthCheck(): Promise<boolean> {
     try {
-      await this.apiService.get('/api/v1/health');
+      await this.apiService.get('/health/simple');
       return true;
     } catch (error) {
       if (this.config.debug) {

--- a/packages/lib.pets/src/constants/endpoints.ts
+++ b/packages/lib.pets/src/constants/endpoints.ts
@@ -8,8 +8,7 @@ export const PETS_ENDPOINTS = {
   PETS: '/api/v1/pets',
   PET_BY_ID: (id: string) => `/api/v1/pets/${id}`,
 
-  // Featured and recent pets
-  FEATURED_PETS: '/api/v1/pets/featured',
+  // Recent pets (featured pets are served by PETS with a ?featured=true query)
   RECENT_PETS: '/api/v1/pets/recent',
 
   // Pets by rescue (rescue-scoped list is served by PETS with a ?rescueId=
@@ -41,7 +40,6 @@ export const PETS_ENDPOINTS = {
 export const {
   PETS,
   PET_BY_ID,
-  FEATURED_PETS,
   RECENT_PETS,
   MY_RESCUE_PETS,
   PET_BREEDS,

--- a/packages/lib.pets/src/services/__tests__/pets-service.test.ts
+++ b/packages/lib.pets/src/services/__tests__/pets-service.test.ts
@@ -241,7 +241,10 @@ describe('PetsService', () => {
       const result = await service.getFeaturedPets(12);
 
       expect(result).toEqual(mockPets);
-      expect(mockApiService.get).toHaveBeenCalledWith('/api/v1/pets/featured', { limit: 12 });
+      expect(mockApiService.get).toHaveBeenCalledWith('/api/v1/pets', {
+        limit: 12,
+        featured: true,
+      });
     });
   });
 

--- a/packages/lib.pets/src/services/pets-service.ts
+++ b/packages/lib.pets/src/services/pets-service.ts
@@ -213,10 +213,10 @@ export class PetsService {
    */
   async getFeaturedPets(limit: number = 12): Promise<Pet[]> {
     try {
-      const response = await this.apiService.get<ApiResponse<unknown[]>>(
-        PETS_ENDPOINTS.FEATURED_PETS,
-        { limit }
-      );
+      const response = await this.apiService.get<ApiResponse<unknown[]>>(PETS_ENDPOINTS.PETS, {
+        limit,
+        featured: true,
+      });
       return (response.data || []).map((p) => normalisePet(p));
     } catch (error) {
       if (this.config.debug) {

--- a/packages/proto/proto/adopt_dont_shop/pets/v1/pet.proto
+++ b/packages/proto/proto/adopt_dont_shop/pets/v1/pet.proto
@@ -282,6 +282,9 @@ message ListPetsRequest {
   PetSize size_filter = 5;
   // Scope to a single rescue's pets (rescue staff dashboards).
   optional string rescue_id_filter = 6;
+  // Restrict to featured pets only (the public "featured" homepage rail).
+  // false / unset = no featured filter.
+  optional bool featured_filter = 7;
 }
 
 message ListPetsResponse {

--- a/packages/proto/src/generated/proto/adopt_dont_shop/pets/v1/pet.ts
+++ b/packages/proto/src/generated/proto/adopt_dont_shop/pets/v1/pet.ts
@@ -434,7 +434,14 @@ export interface ListPetsRequest {
   typeFilter: PetType;
   sizeFilter: PetSize;
   /** Scope to a single rescue's pets (rescue staff dashboards). */
-  rescueIdFilter?: string | undefined;
+  rescueIdFilter?:
+    | string
+    | undefined;
+  /**
+   * Restrict to featured pets only (the public "featured" homepage rail).
+   * false / unset = no featured filter.
+   */
+  featuredFilter?: boolean | undefined;
 }
 
 export interface ListPetsResponse {
@@ -2213,7 +2220,15 @@ export const GetPetResponse: MessageFns<GetPetResponse> = {
 };
 
 function createBaseListPetsRequest(): ListPetsRequest {
-  return { cursor: undefined, limit: 0, statusFilter: 0, typeFilter: 0, sizeFilter: 0, rescueIdFilter: undefined };
+  return {
+    cursor: undefined,
+    limit: 0,
+    statusFilter: 0,
+    typeFilter: 0,
+    sizeFilter: 0,
+    rescueIdFilter: undefined,
+    featuredFilter: undefined,
+  };
 }
 
 export const ListPetsRequest: MessageFns<ListPetsRequest> = {
@@ -2235,6 +2250,9 @@ export const ListPetsRequest: MessageFns<ListPetsRequest> = {
     }
     if (message.rescueIdFilter !== undefined) {
       writer.uint32(50).string(message.rescueIdFilter);
+    }
+    if (message.featuredFilter !== undefined) {
+      writer.uint32(56).bool(message.featuredFilter);
     }
     return writer;
   },
@@ -2294,6 +2312,14 @@ export const ListPetsRequest: MessageFns<ListPetsRequest> = {
           message.rescueIdFilter = reader.string();
           continue;
         }
+        case 7: {
+          if (tag !== 56) {
+            break;
+          }
+
+          message.featuredFilter = reader.bool();
+          continue;
+        }
       }
       if ((tag & 7) === 4 || tag === 0) {
         break;
@@ -2327,6 +2353,11 @@ export const ListPetsRequest: MessageFns<ListPetsRequest> = {
         : isSet(object.rescue_id_filter)
         ? globalThis.String(object.rescue_id_filter)
         : undefined,
+      featuredFilter: isSet(object.featuredFilter)
+        ? globalThis.Boolean(object.featuredFilter)
+        : isSet(object.featured_filter)
+        ? globalThis.Boolean(object.featured_filter)
+        : undefined,
     };
   },
 
@@ -2350,6 +2381,9 @@ export const ListPetsRequest: MessageFns<ListPetsRequest> = {
     if (message.rescueIdFilter !== undefined) {
       obj.rescueIdFilter = message.rescueIdFilter;
     }
+    if (message.featuredFilter !== undefined) {
+      obj.featuredFilter = message.featuredFilter;
+    }
     return obj;
   },
 
@@ -2364,6 +2398,7 @@ export const ListPetsRequest: MessageFns<ListPetsRequest> = {
     message.typeFilter = object.typeFilter ?? 0;
     message.sizeFilter = object.sizeFilter ?? 0;
     message.rescueIdFilter = object.rescueIdFilter ?? undefined;
+    message.featuredFilter = object.featuredFilter ?? undefined;
     return message;
   },
 };

--- a/services/gateway/src/routes/pets.test.ts
+++ b/services/gateway/src/routes/pets.test.ts
@@ -158,6 +158,28 @@ describe('GET /api/v1/pets', () => {
     expect(metadata.get('x-user-id')[0]).toBe('usr-1');
   });
 
+  it('forwards featured=true as featuredFilter (the homepage featured rail)', async () => {
+    listMock.mockResolvedValueOnce({ pets: [PET_FIXTURE], nextCursor: undefined });
+    await app.inject({
+      method: 'GET',
+      url: '/api/v1/pets?featured=true&limit=8',
+      headers: { 'x-user-id': 'usr-1', 'x-user-roles': 'adopter' },
+    });
+    const [req] = listMock.mock.calls[0];
+    expect(req.featuredFilter).toBe(true);
+  });
+
+  it('leaves featuredFilter false when featured is not requested', async () => {
+    listMock.mockResolvedValueOnce({ pets: [], nextCursor: undefined });
+    await app.inject({
+      method: 'GET',
+      url: '/api/v1/pets?limit=8',
+      headers: { 'x-user-id': 'usr-1', 'x-user-roles': 'adopter' },
+    });
+    const [req] = listMock.mock.calls[0];
+    expect(req.featuredFilter).toBe(false);
+  });
+
   it('coerces an unknown status to UNSPECIFIED (service returns 400)', async () => {
     listMock.mockResolvedValueOnce({ pets: [] });
     await app.inject({ method: 'GET', url: '/api/v1/pets?status=not_a_status' });

--- a/services/gateway/src/routes/pets.ts
+++ b/services/gateway/src/routes/pets.ts
@@ -153,6 +153,7 @@ export const registerPetsRoutes = async (
             type: { type: 'string' },
             size: { type: 'string' },
             rescueId: { type: 'string' },
+            featured: { type: 'string' },
           },
         },
         response: {
@@ -196,6 +197,7 @@ export const registerPetsRoutes = async (
         typeFilter: parseType(query.type),
         sizeFilter: parseSize(query.size),
         rescueIdFilter: query.rescueId,
+        featuredFilter: query.featured === 'true',
       };
       try {
         const res = await client.list(grpcReq, buildMetadata(req));

--- a/services/pets/src/grpc/handlers.test.ts
+++ b/services/pets/src/grpc/handlers.test.ts
@@ -336,6 +336,24 @@ describe('listPets', () => {
     expect(params).toContain(RESCUE_ID);
   });
 
+  it('restricts to featured pets when featuredFilter is set', async () => {
+    mocks.poolMock.query.mockResolvedValueOnce({ rows: [] });
+    await listPets(mocks.deps, ADOPTER, { limit: 0, featuredFilter: true } as never);
+    const sql = mocks.poolMock.query.mock.calls[0][0] as string;
+    const params = mocks.poolMock.query.mock.calls[0][1] as unknown[];
+    expect(sql).toMatch(/featured = \$/);
+    expect(params).toContain(true);
+  });
+
+  it('does not filter on featured when featuredFilter is false/unset', async () => {
+    mocks.poolMock.query.mockResolvedValueOnce({ rows: [] });
+    await listPets(mocks.deps, ADOPTER, { limit: 0, featuredFilter: false } as never);
+    const sql = mocks.poolMock.query.mock.calls[0][0] as string;
+    const params = mocks.poolMock.query.mock.calls[0][1] as unknown[];
+    expect(sql).not.toMatch(/featured = /);
+    expect(params).not.toContain(true);
+  });
+
   it('pins rescue staff to their own rescue, ignoring a foreign rescueIdFilter', async () => {
     mocks.poolMock.query.mockResolvedValueOnce({ rows: [] });
     // STAFF is scoped to rsc-1 but asks for rsc-2's pets.

--- a/services/pets/src/grpc/handlers.ts
+++ b/services/pets/src/grpc/handlers.ts
@@ -406,6 +406,11 @@ export async function listPets(
     params.push(rescueScope);
     n++;
   }
+  if (req.featuredFilter) {
+    where.push(`featured = $${n}`);
+    params.push(true);
+    n++;
+  }
   if (!privileged) {
     const placeholders = PUBLIC_HIDDEN_STATUSES.map(() => `$${n++}`).join(', ');
     where.push(`status NOT IN (${placeholders})`);


### PR DESCRIPTION
## Summary

- Repoints two frontend calls off legacy paths (that only resolved via the strangler-fig proxy) onto native gateway paths, and **wires featured-pets filtering end-to-end** so the repoint is actually functional.
- `lib.pets` `getFeaturedPets`: `GET /api/v1/pets/featured` → `GET /api/v1/pets?featured=true`.
- `lib.notifications` `healthCheck`: `GET /api/v1/health` → `GET /health/simple`.

## Changes

**Frontend repoints**
- `packages/lib.pets/src/services/pets-service.ts` — `getFeaturedPets` now calls `/api/v1/pets?featured=true` (limit preserved); removed the orphaned `FEATURED_PETS` constant.
- `packages/lib.notifications/src/services/notifications-service.ts` — `healthCheck` → `/health/simple`.

**Featured filter, backed by real data** (the pets table already has an indexed `featured` boolean column — no schema change, nothing fabricated)
- `packages/proto/.../pet.proto` — add `optional bool featured_filter` to `ListPetsRequest`.
- `services/pets/src/grpc/handlers.ts` — `listPets` applies `WHERE featured = true` when set; unset/false keeps the prior behaviour, so every other `pets.List` caller is unaffected.
- `services/gateway/src/routes/pets.ts` — map `?featured=true` onto `featuredFilter`.

**Left unchanged (with reasons)**
- `pets/rescue/:id` and `lib.api` `healthCheck` already used the served paths (`/pets?rescueId`, `/health/simple`).
- `pets/rescue/my` — its method has no rescue id to pass (it relied on server-side scoping); repointing would need the caller to supply a `rescueId`, so it's left as-is.

## Before requesting review

- [x] Ran quick checks locally (type-check + lint + affected tests)
- [x] Tests for new behaviour added (TDD)
- [x] Considered consumer impact — `lib.pets`/`lib.notifications` consumers type-check; the featured field is optional so existing `pets.List` callers are untouched

## Test plan

- [x] Existing tests pass — pets 198, gateway 1265, lib.pets 117, lib.api 92, lib.notifications 47
- [x] New behaviour covered — pets handler tests (featured filter applied/omitted) + gateway route tests (`featured=true` → `featuredFilter`)
- [x] No TypeScript errors; lint passes

## Related

Post-route-audit cleanup. Sibling PRs remove dead `lib.analytics` methods and add the chat analytics stat endpoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xjak7otuKv2PaPcqV1mcgk

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xjak7otuKv2PaPcqV1mcgk)_