### PR TITLE
feat: full pets.List filtering + page pagination; repoint pets/rescue/my

### DIFF
--- a/packages/lib.pets/src/constants/endpoints.ts
+++ b/packages/lib.pets/src/constants/endpoints.ts
@@ -11,10 +11,6 @@ export const PETS_ENDPOINTS = {
   // Recent pets (featured pets are served by PETS with a ?featured=true query)
   RECENT_PETS: '/api/v1/pets/recent',
 
-  // Pets by rescue (rescue-scoped list is served by PETS with a ?rescueId=
-  // query — see getPetsByRescue; no dedicated /pets/rescue/:id route exists)
-  MY_RESCUE_PETS: '/api/v1/pets/rescue/my',
-
   // Breed and type information
   PET_BREEDS: '/api/v1/pets/breeds',
   PET_BREEDS_BY_TYPE: (type: string) => `/api/v1/pets/breeds/${type}`,
@@ -41,7 +37,6 @@ export const {
   PETS,
   PET_BY_ID,
   RECENT_PETS,
-  MY_RESCUE_PETS,
   PET_BREEDS,
   PET_BREEDS_BY_TYPE,
   PET_TYPES,

--- a/packages/lib.pets/src/services/__tests__/pets-management-service.test.ts
+++ b/packages/lib.pets/src/services/__tests__/pets-management-service.test.ts
@@ -224,7 +224,7 @@ describe('PetManagementService', () => {
         hasNext: true,
         hasPrev: true,
       });
-      expect(mockApiService.get).toHaveBeenCalledWith('/api/v1/pets/rescue/my', {
+      expect(mockApiService.get).toHaveBeenCalledWith('/api/v1/pets', {
         limit: 10,
         status: 'available',
       });

--- a/packages/lib.pets/src/services/pets-management-service.ts
+++ b/packages/lib.pets/src/services/pets-management-service.ts
@@ -212,7 +212,9 @@ export class PetManagementService {
     };
   }> {
     try {
-      // Use the new "my rescue pets" endpoint that automatically gets the user's rescue
+      // GET /api/v1/pets scopes rescue staff to their own rescue server-side
+      // from the authenticated principal (no rescueId needed). Page/search/
+      // breed/age/gender/sort filters are all honoured by the gateway.
       const params = {
         ...filters,
       };
@@ -227,7 +229,7 @@ export class PetManagementService {
           hasNext: boolean;
           hasPrev: boolean;
         };
-      }>(PETS_ENDPOINTS.MY_RESCUE_PETS, params);
+      }>(PETS_ENDPOINTS.PETS, params);
 
       if (response.success && response.data && response.meta) {
         return {

--- a/packages/proto/proto/adopt_dont_shop/pets/v1/pet.proto
+++ b/packages/proto/proto/adopt_dont_shop/pets/v1/pet.proto
@@ -285,11 +285,29 @@ message ListPetsRequest {
   // Restrict to featured pets only (the public "featured" homepage rail).
   // false / unset = no featured filter.
   optional bool featured_filter = 7;
+  // Page-based pagination (1-based). When set (> 0), the handler switches
+  // from keyset/cursor mode to offset pagination and returns `total` — the
+  // rescue Pet Management dashboard needs jump-to-page + total counts.
+  // Unset / 0 keeps the default cursor behaviour for every other caller.
+  optional uint32 page = 8;
+  // Free-text search over the pets.search_vector (name / breed / description).
+  optional string search = 9;
+  // Breed-name filter (case-insensitive substring against the breeds catalogue).
+  optional string breed = 10;
+  PetGender gender_filter = 11;
+  PetAgeGroup age_group_filter = 12;
+  // Sort column (allowlisted server-side) + direction ("ASC"/"DESC"). Only
+  // honoured in page mode; cursor mode keeps its fixed keyset order.
+  optional string sort_by = 13;
+  optional string sort_order = 14;
 }
 
 message ListPetsResponse {
   repeated Pet pets = 1;
   optional string next_cursor = 2;
+  // Total matching rows — populated only in page mode (offset pagination),
+  // so the dashboard can render page counts. Unset in cursor mode.
+  optional uint32 total = 3;
 }
 
 // --- ListBreeds -------------------------------------------------------

--- a/packages/proto/proto/adopt_dont_shop/pets/v1/pet.proto
+++ b/packages/proto/proto/adopt_dont_shop/pets/v1/pet.proto
@@ -294,8 +294,11 @@ message ListPetsRequest {
   optional string search = 9;
   // Breed-name filter (case-insensitive substring against the breeds catalogue).
   optional string breed = 10;
-  PetGender gender_filter = 11;
-  PetAgeGroup age_group_filter = 12;
+  // Enum filters. UNSPECIFIED / unset = "no filter". `optional` (explicit
+  // presence) so existing ListPetsRequest construction sites don't have to
+  // set them — every other caller stays a compile-clean no-op.
+  optional PetGender gender_filter = 11;
+  optional PetAgeGroup age_group_filter = 12;
   // Sort column (allowlisted server-side) + direction ("ASC"/"DESC"). Only
   // honoured in page mode; cursor mode keeps its fixed keyset order.
   optional string sort_by = 13;

--- a/packages/proto/src/generated/proto/adopt_dont_shop/pets/v1/pet.ts
+++ b/packages/proto/src/generated/proto/adopt_dont_shop/pets/v1/pet.ts
@@ -441,12 +441,44 @@ export interface ListPetsRequest {
    * Restrict to featured pets only (the public "featured" homepage rail).
    * false / unset = no featured filter.
    */
-  featuredFilter?: boolean | undefined;
+  featuredFilter?:
+    | boolean
+    | undefined;
+  /**
+   * Page-based pagination (1-based). When set (> 0), the handler switches
+   * from keyset/cursor mode to offset pagination and returns `total` — the
+   * rescue Pet Management dashboard needs jump-to-page + total counts.
+   * Unset / 0 keeps the default cursor behaviour for every other caller.
+   */
+  page?:
+    | number
+    | undefined;
+  /** Free-text search over the pets.search_vector (name / breed / description). */
+  search?:
+    | string
+    | undefined;
+  /** Breed-name filter (case-insensitive substring against the breeds catalogue). */
+  breed?: string | undefined;
+  genderFilter: PetGender;
+  ageGroupFilter: PetAgeGroup;
+  /**
+   * Sort column (allowlisted server-side) + direction ("ASC"/"DESC"). Only
+   * honoured in page mode; cursor mode keeps its fixed keyset order.
+   */
+  sortBy?: string | undefined;
+  sortOrder?: string | undefined;
 }
 
 export interface ListPetsResponse {
   pets: Pet[];
-  nextCursor?: string | undefined;
+  nextCursor?:
+    | string
+    | undefined;
+  /**
+   * Total matching rows — populated only in page mode (offset pagination),
+   * so the dashboard can render page counts. Unset in cursor mode.
+   */
+  total?: number | undefined;
 }
 
 export interface ListBreedsRequest {
@@ -2228,6 +2260,13 @@ function createBaseListPetsRequest(): ListPetsRequest {
     sizeFilter: 0,
     rescueIdFilter: undefined,
     featuredFilter: undefined,
+    page: undefined,
+    search: undefined,
+    breed: undefined,
+    genderFilter: 0,
+    ageGroupFilter: 0,
+    sortBy: undefined,
+    sortOrder: undefined,
   };
 }
 
@@ -2253,6 +2292,27 @@ export const ListPetsRequest: MessageFns<ListPetsRequest> = {
     }
     if (message.featuredFilter !== undefined) {
       writer.uint32(56).bool(message.featuredFilter);
+    }
+    if (message.page !== undefined) {
+      writer.uint32(64).uint32(message.page);
+    }
+    if (message.search !== undefined) {
+      writer.uint32(74).string(message.search);
+    }
+    if (message.breed !== undefined) {
+      writer.uint32(82).string(message.breed);
+    }
+    if (message.genderFilter !== 0) {
+      writer.uint32(88).int32(message.genderFilter);
+    }
+    if (message.ageGroupFilter !== 0) {
+      writer.uint32(96).int32(message.ageGroupFilter);
+    }
+    if (message.sortBy !== undefined) {
+      writer.uint32(106).string(message.sortBy);
+    }
+    if (message.sortOrder !== undefined) {
+      writer.uint32(114).string(message.sortOrder);
     }
     return writer;
   },
@@ -2320,6 +2380,62 @@ export const ListPetsRequest: MessageFns<ListPetsRequest> = {
           message.featuredFilter = reader.bool();
           continue;
         }
+        case 8: {
+          if (tag !== 64) {
+            break;
+          }
+
+          message.page = reader.uint32();
+          continue;
+        }
+        case 9: {
+          if (tag !== 74) {
+            break;
+          }
+
+          message.search = reader.string();
+          continue;
+        }
+        case 10: {
+          if (tag !== 82) {
+            break;
+          }
+
+          message.breed = reader.string();
+          continue;
+        }
+        case 11: {
+          if (tag !== 88) {
+            break;
+          }
+
+          message.genderFilter = reader.int32() as any;
+          continue;
+        }
+        case 12: {
+          if (tag !== 96) {
+            break;
+          }
+
+          message.ageGroupFilter = reader.int32() as any;
+          continue;
+        }
+        case 13: {
+          if (tag !== 106) {
+            break;
+          }
+
+          message.sortBy = reader.string();
+          continue;
+        }
+        case 14: {
+          if (tag !== 114) {
+            break;
+          }
+
+          message.sortOrder = reader.string();
+          continue;
+        }
       }
       if ((tag & 7) === 4 || tag === 0) {
         break;
@@ -2358,6 +2474,29 @@ export const ListPetsRequest: MessageFns<ListPetsRequest> = {
         : isSet(object.featured_filter)
         ? globalThis.Boolean(object.featured_filter)
         : undefined,
+      page: isSet(object.page) ? globalThis.Number(object.page) : undefined,
+      search: isSet(object.search) ? globalThis.String(object.search) : undefined,
+      breed: isSet(object.breed) ? globalThis.String(object.breed) : undefined,
+      genderFilter: isSet(object.genderFilter)
+        ? petGenderFromJSON(object.genderFilter)
+        : isSet(object.gender_filter)
+        ? petGenderFromJSON(object.gender_filter)
+        : 0,
+      ageGroupFilter: isSet(object.ageGroupFilter)
+        ? petAgeGroupFromJSON(object.ageGroupFilter)
+        : isSet(object.age_group_filter)
+        ? petAgeGroupFromJSON(object.age_group_filter)
+        : 0,
+      sortBy: isSet(object.sortBy)
+        ? globalThis.String(object.sortBy)
+        : isSet(object.sort_by)
+        ? globalThis.String(object.sort_by)
+        : undefined,
+      sortOrder: isSet(object.sortOrder)
+        ? globalThis.String(object.sortOrder)
+        : isSet(object.sort_order)
+        ? globalThis.String(object.sort_order)
+        : undefined,
     };
   },
 
@@ -2384,6 +2523,27 @@ export const ListPetsRequest: MessageFns<ListPetsRequest> = {
     if (message.featuredFilter !== undefined) {
       obj.featuredFilter = message.featuredFilter;
     }
+    if (message.page !== undefined) {
+      obj.page = Math.round(message.page);
+    }
+    if (message.search !== undefined) {
+      obj.search = message.search;
+    }
+    if (message.breed !== undefined) {
+      obj.breed = message.breed;
+    }
+    if (message.genderFilter !== 0) {
+      obj.genderFilter = petGenderToJSON(message.genderFilter);
+    }
+    if (message.ageGroupFilter !== 0) {
+      obj.ageGroupFilter = petAgeGroupToJSON(message.ageGroupFilter);
+    }
+    if (message.sortBy !== undefined) {
+      obj.sortBy = message.sortBy;
+    }
+    if (message.sortOrder !== undefined) {
+      obj.sortOrder = message.sortOrder;
+    }
     return obj;
   },
 
@@ -2399,12 +2559,19 @@ export const ListPetsRequest: MessageFns<ListPetsRequest> = {
     message.sizeFilter = object.sizeFilter ?? 0;
     message.rescueIdFilter = object.rescueIdFilter ?? undefined;
     message.featuredFilter = object.featuredFilter ?? undefined;
+    message.page = object.page ?? undefined;
+    message.search = object.search ?? undefined;
+    message.breed = object.breed ?? undefined;
+    message.genderFilter = object.genderFilter ?? 0;
+    message.ageGroupFilter = object.ageGroupFilter ?? 0;
+    message.sortBy = object.sortBy ?? undefined;
+    message.sortOrder = object.sortOrder ?? undefined;
     return message;
   },
 };
 
 function createBaseListPetsResponse(): ListPetsResponse {
-  return { pets: [], nextCursor: undefined };
+  return { pets: [], nextCursor: undefined, total: undefined };
 }
 
 export const ListPetsResponse: MessageFns<ListPetsResponse> = {
@@ -2414,6 +2581,9 @@ export const ListPetsResponse: MessageFns<ListPetsResponse> = {
     }
     if (message.nextCursor !== undefined) {
       writer.uint32(18).string(message.nextCursor);
+    }
+    if (message.total !== undefined) {
+      writer.uint32(24).uint32(message.total);
     }
     return writer;
   },
@@ -2441,6 +2611,14 @@ export const ListPetsResponse: MessageFns<ListPetsResponse> = {
           message.nextCursor = reader.string();
           continue;
         }
+        case 3: {
+          if (tag !== 24) {
+            break;
+          }
+
+          message.total = reader.uint32();
+          continue;
+        }
       }
       if ((tag & 7) === 4 || tag === 0) {
         break;
@@ -2458,6 +2636,7 @@ export const ListPetsResponse: MessageFns<ListPetsResponse> = {
         : isSet(object.next_cursor)
         ? globalThis.String(object.next_cursor)
         : undefined,
+      total: isSet(object.total) ? globalThis.Number(object.total) : undefined,
     };
   },
 
@@ -2469,6 +2648,9 @@ export const ListPetsResponse: MessageFns<ListPetsResponse> = {
     if (message.nextCursor !== undefined) {
       obj.nextCursor = message.nextCursor;
     }
+    if (message.total !== undefined) {
+      obj.total = Math.round(message.total);
+    }
     return obj;
   },
 
@@ -2479,6 +2661,7 @@ export const ListPetsResponse: MessageFns<ListPetsResponse> = {
     const message = createBaseListPetsResponse();
     message.pets = object.pets?.map((e) => Pet.fromPartial(e)) || [];
     message.nextCursor = object.nextCursor ?? undefined;
+    message.total = object.total ?? undefined;
     return message;
   },
 };

--- a/packages/proto/src/generated/proto/adopt_dont_shop/pets/v1/pet.ts
+++ b/packages/proto/src/generated/proto/adopt_dont_shop/pets/v1/pet.ts
@@ -458,9 +458,18 @@ export interface ListPetsRequest {
     | string
     | undefined;
   /** Breed-name filter (case-insensitive substring against the breeds catalogue). */
-  breed?: string | undefined;
-  genderFilter: PetGender;
-  ageGroupFilter: PetAgeGroup;
+  breed?:
+    | string
+    | undefined;
+  /**
+   * Enum filters. UNSPECIFIED / unset = "no filter". `optional` (explicit
+   * presence) so existing ListPetsRequest construction sites don't have to
+   * set them — every other caller stays a compile-clean no-op.
+   */
+  genderFilter?: PetGender | undefined;
+  ageGroupFilter?:
+    | PetAgeGroup
+    | undefined;
   /**
    * Sort column (allowlisted server-side) + direction ("ASC"/"DESC"). Only
    * honoured in page mode; cursor mode keeps its fixed keyset order.
@@ -2263,8 +2272,8 @@ function createBaseListPetsRequest(): ListPetsRequest {
     page: undefined,
     search: undefined,
     breed: undefined,
-    genderFilter: 0,
-    ageGroupFilter: 0,
+    genderFilter: undefined,
+    ageGroupFilter: undefined,
     sortBy: undefined,
     sortOrder: undefined,
   };
@@ -2302,10 +2311,10 @@ export const ListPetsRequest: MessageFns<ListPetsRequest> = {
     if (message.breed !== undefined) {
       writer.uint32(82).string(message.breed);
     }
-    if (message.genderFilter !== 0) {
+    if (message.genderFilter !== undefined) {
       writer.uint32(88).int32(message.genderFilter);
     }
-    if (message.ageGroupFilter !== 0) {
+    if (message.ageGroupFilter !== undefined) {
       writer.uint32(96).int32(message.ageGroupFilter);
     }
     if (message.sortBy !== undefined) {
@@ -2481,12 +2490,12 @@ export const ListPetsRequest: MessageFns<ListPetsRequest> = {
         ? petGenderFromJSON(object.genderFilter)
         : isSet(object.gender_filter)
         ? petGenderFromJSON(object.gender_filter)
-        : 0,
+        : undefined,
       ageGroupFilter: isSet(object.ageGroupFilter)
         ? petAgeGroupFromJSON(object.ageGroupFilter)
         : isSet(object.age_group_filter)
         ? petAgeGroupFromJSON(object.age_group_filter)
-        : 0,
+        : undefined,
       sortBy: isSet(object.sortBy)
         ? globalThis.String(object.sortBy)
         : isSet(object.sort_by)
@@ -2532,10 +2541,10 @@ export const ListPetsRequest: MessageFns<ListPetsRequest> = {
     if (message.breed !== undefined) {
       obj.breed = message.breed;
     }
-    if (message.genderFilter !== 0) {
+    if (message.genderFilter !== undefined) {
       obj.genderFilter = petGenderToJSON(message.genderFilter);
     }
-    if (message.ageGroupFilter !== 0) {
+    if (message.ageGroupFilter !== undefined) {
       obj.ageGroupFilter = petAgeGroupToJSON(message.ageGroupFilter);
     }
     if (message.sortBy !== undefined) {
@@ -2562,8 +2571,8 @@ export const ListPetsRequest: MessageFns<ListPetsRequest> = {
     message.page = object.page ?? undefined;
     message.search = object.search ?? undefined;
     message.breed = object.breed ?? undefined;
-    message.genderFilter = object.genderFilter ?? 0;
-    message.ageGroupFilter = object.ageGroupFilter ?? 0;
+    message.genderFilter = object.genderFilter ?? undefined;
+    message.ageGroupFilter = object.ageGroupFilter ?? undefined;
     message.sortBy = object.sortBy ?? undefined;
     message.sortOrder = object.sortOrder ?? undefined;
     return message;

--- a/services/gateway/src/routes/dashboard.ts
+++ b/services/gateway/src/routes/dashboard.ts
@@ -185,8 +185,6 @@ export const registerDashboardRoutes = async (
           statusFilter: PetsV1.PetStatus.PET_STATUS_UNSPECIFIED,
           typeFilter: PetsV1.PetType.PET_TYPE_UNSPECIFIED,
           sizeFilter: PetsV1.PetSize.PET_SIZE_UNSPECIFIED,
-          genderFilter: PetsV1.PetGender.PET_GENDER_UNSPECIFIED,
-          ageGroupFilter: PetsV1.PetAgeGroup.PET_AGE_GROUP_UNSPECIFIED,
         };
         const appListReq: ListApplicationsRequest = {
           rescueIdFilter: rescueId,
@@ -275,8 +273,6 @@ export const registerDashboardRoutes = async (
           statusFilter: PetsV1.PetStatus.PET_STATUS_UNSPECIFIED,
           typeFilter: PetsV1.PetType.PET_TYPE_UNSPECIFIED,
           sizeFilter: PetsV1.PetSize.PET_SIZE_UNSPECIFIED,
-          genderFilter: PetsV1.PetGender.PET_GENDER_UNSPECIFIED,
-          ageGroupFilter: PetsV1.PetAgeGroup.PET_AGE_GROUP_UNSPECIFIED,
         };
         const appListReq: ListApplicationsRequest = {
           rescueIdFilter: rescueId,

--- a/services/gateway/src/routes/dashboard.ts
+++ b/services/gateway/src/routes/dashboard.ts
@@ -185,6 +185,8 @@ export const registerDashboardRoutes = async (
           statusFilter: PetsV1.PetStatus.PET_STATUS_UNSPECIFIED,
           typeFilter: PetsV1.PetType.PET_TYPE_UNSPECIFIED,
           sizeFilter: PetsV1.PetSize.PET_SIZE_UNSPECIFIED,
+          genderFilter: PetsV1.PetGender.PET_GENDER_UNSPECIFIED,
+          ageGroupFilter: PetsV1.PetAgeGroup.PET_AGE_GROUP_UNSPECIFIED,
         };
         const appListReq: ListApplicationsRequest = {
           rescueIdFilter: rescueId,
@@ -273,6 +275,8 @@ export const registerDashboardRoutes = async (
           statusFilter: PetsV1.PetStatus.PET_STATUS_UNSPECIFIED,
           typeFilter: PetsV1.PetType.PET_TYPE_UNSPECIFIED,
           sizeFilter: PetsV1.PetSize.PET_SIZE_UNSPECIFIED,
+          genderFilter: PetsV1.PetGender.PET_GENDER_UNSPECIFIED,
+          ageGroupFilter: PetsV1.PetAgeGroup.PET_AGE_GROUP_UNSPECIFIED,
         };
         const appListReq: ListApplicationsRequest = {
           rescueIdFilter: rescueId,

--- a/services/gateway/src/routes/pets-view.ts
+++ b/services/gateway/src/routes/pets-view.ts
@@ -122,15 +122,29 @@ export type PetsListMeta = {
   hasPrev: boolean;
 };
 
-// Best-effort page meta from a keyset page. `total`/`totalPages` reflect
-// the current page only (the proto List is keyset; no global count) —
-// `hasNext` is driven by the cursor so the SPA can page forward.
-export function listToEnvelope(res: ListPetsResponse): {
+// In page mode the handler returns a global `total`, so we can build real
+// page meta (page/totalPages/hasNext/hasPrev) from the caller's page+limit.
+// In cursor mode there's no global count, so meta stays best-effort (the
+// current page only) with `hasNext` driven by the cursor.
+export function listToEnvelope(
+  res: ListPetsResponse,
+  pageContext?: { page: number; limit: number }
+): {
   success: true;
   data: Record<string, unknown>[];
   meta: PetsListMeta;
 } {
   const data = res.pets.map(petToView);
+  if (res.total !== undefined && pageContext) {
+    const { page, limit } = pageContext;
+    const total = res.total;
+    const totalPages = limit > 0 ? Math.ceil(total / limit) : 0;
+    return {
+      success: true,
+      data,
+      meta: { page, total, totalPages, hasNext: page < totalPages, hasPrev: page > 1 },
+    };
+  }
   const hasNext = res.nextCursor !== undefined && res.nextCursor !== '';
   return {
     success: true,

--- a/services/gateway/src/routes/pets.test.ts
+++ b/services/gateway/src/routes/pets.test.ts
@@ -180,6 +180,41 @@ describe('GET /api/v1/pets', () => {
     expect(req.featuredFilter).toBe(false);
   });
 
+  it('page mode: forwards page/search/breed/gender/ageGroup/sort and builds real meta', async () => {
+    listMock.mockResolvedValueOnce({ pets: [PET_FIXTURE], nextCursor: undefined, total: 42 });
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/v1/pets?page=3&limit=12&search=rex&breed=labr&gender=male&ageGroup=adult&sortBy=name&sortOrder=ASC',
+      headers: { 'x-user-id': 'usr-1', 'x-user-roles': 'rescue_staff', 'x-rescue-id': 'rsc-1' },
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json() as { meta: Record<string, unknown> };
+    // total 42 / limit 12 → 4 pages; page 3 has both prev and next.
+    expect(body.meta).toEqual({ page: 3, total: 42, totalPages: 4, hasNext: true, hasPrev: true });
+
+    const [gr] = listMock.mock.calls[0];
+    expect(gr.page).toBe(3);
+    expect(gr.search).toBe('rex');
+    expect(gr.breed).toBe('labr');
+    expect(gr.genderFilter).toBe(PetsV1.PetGender.PET_GENDER_MALE);
+    expect(gr.ageGroupFilter).toBe(PetsV1.PetAgeGroup.PET_AGE_GROUP_ADULT);
+    expect(gr.sortBy).toBe('name');
+    expect(gr.sortOrder).toBe('ASC');
+  });
+
+  it('stays in cursor mode (no page) when page is not requested', async () => {
+    listMock.mockResolvedValueOnce({ pets: [PET_FIXTURE], nextCursor: undefined });
+    await app.inject({
+      method: 'GET',
+      url: '/api/v1/pets?limit=12',
+      headers: { 'x-user-id': 'usr-1', 'x-user-roles': 'adopter' },
+    });
+    const [gr] = listMock.mock.calls[0];
+    expect(gr.page).toBeUndefined();
+  });
+
   it('coerces an unknown status to UNSPECIFIED (service returns 400)', async () => {
     listMock.mockResolvedValueOnce({ pets: [] });
     await app.inject({ method: 'GET', url: '/api/v1/pets?status=not_a_status' });

--- a/services/gateway/src/routes/pets.ts
+++ b/services/gateway/src/routes/pets.ts
@@ -154,6 +154,13 @@ export const registerPetsRoutes = async (
             size: { type: 'string' },
             rescueId: { type: 'string' },
             featured: { type: 'string' },
+            page: { type: 'string' },
+            search: { type: 'string' },
+            breed: { type: 'string' },
+            gender: { type: 'string' },
+            ageGroup: { type: 'string' },
+            sortBy: { type: 'string' },
+            sortOrder: { type: 'string' },
           },
         },
         response: {
@@ -190,6 +197,10 @@ export const registerPetsRoutes = async (
       if (!pagination.ok) {
         return reply.code(400).send({ error: pagination.error });
       }
+      // parsePagination already validated + defaulted page (non-integer → 400
+      // above). Only switch the handler into page mode when the caller
+      // explicitly asked for a page; other list callers stay cursor-based.
+      const page = query.page !== undefined && query.page !== '' ? pagination.page : undefined;
       const grpcReq: ListPetsRequest = {
         cursor: query.cursor,
         limit: pagination.limit,
@@ -198,11 +209,21 @@ export const registerPetsRoutes = async (
         sizeFilter: parseSize(query.size),
         rescueIdFilter: query.rescueId,
         featuredFilter: query.featured === 'true',
+        page,
+        search: query.search,
+        breed: query.breed,
+        genderFilter: parseGender(query.gender),
+        ageGroupFilter: parseAgeGroup(query.ageGroup),
+        sortBy: query.sortBy,
+        sortOrder: query.sortOrder,
       };
       try {
         const res = await client.list(grpcReq, buildMetadata(req));
-        // Stage B: frontend lib.pets shape ({ success, data, meta }).
-        return reply.send(listToEnvelope(res));
+        // Stage B: frontend lib.pets shape ({ success, data, meta }). In page
+        // mode the handler returns a total → real page meta.
+        return reply.send(
+          listToEnvelope(res, page !== undefined ? { page, limit: pagination.limit } : undefined)
+        );
       } catch (err) {
         return handleGrpcError(err, reply);
       }
@@ -1242,4 +1263,26 @@ function parseSize(raw: string | undefined): PetsV1.PetSize {
   const candidate = Object.values(PetsV1.PetSize).includes(upper as never) ? upper : raw;
   const out = PetsV1.petSizeFromJSON(candidate);
   return out === PetsV1.PetSize.UNRECOGNIZED ? PetsV1.PetSize.PET_SIZE_UNSPECIFIED : out;
+}
+
+function parseGender(raw: string | undefined): PetsV1.PetGender {
+  if (!raw) {
+    return PetsV1.PetGender.PET_GENDER_UNSPECIFIED;
+  }
+  const upper = `PET_GENDER_${raw.toUpperCase()}`;
+  const candidate = Object.values(PetsV1.PetGender).includes(upper as never) ? upper : raw;
+  const out = PetsV1.petGenderFromJSON(candidate);
+  return out === PetsV1.PetGender.UNRECOGNIZED ? PetsV1.PetGender.PET_GENDER_UNSPECIFIED : out;
+}
+
+function parseAgeGroup(raw: string | undefined): PetsV1.PetAgeGroup {
+  if (!raw) {
+    return PetsV1.PetAgeGroup.PET_AGE_GROUP_UNSPECIFIED;
+  }
+  const upper = `PET_AGE_GROUP_${raw.toUpperCase()}`;
+  const candidate = Object.values(PetsV1.PetAgeGroup).includes(upper as never) ? upper : raw;
+  const out = PetsV1.petAgeGroupFromJSON(candidate);
+  return out === PetsV1.PetAgeGroup.UNRECOGNIZED
+    ? PetsV1.PetAgeGroup.PET_AGE_GROUP_UNSPECIFIED
+    : out;
 }

--- a/services/pets/src/grpc/handlers.test.ts
+++ b/services/pets/src/grpc/handlers.test.ts
@@ -354,6 +354,73 @@ describe('listPets', () => {
     expect(params).not.toContain(true);
   });
 
+  it('page mode: runs a COUNT, offsets, honours sort, and returns the total', async () => {
+    mocks.poolMock.query
+      .mockResolvedValueOnce({ rows: [{ count: '42' }] }) // COUNT
+      .mockResolvedValueOnce({ rows: [] }); // page SELECT
+    const res = await listPets(mocks.deps, ADOPTER, {
+      limit: 12,
+      page: 3,
+      sortBy: 'name',
+      sortOrder: 'ASC',
+    } as never);
+
+    const countSql = mocks.poolMock.query.mock.calls[0][0] as string;
+    expect(countSql).toMatch(/SELECT COUNT\(\*\)/);
+
+    const selectSql = mocks.poolMock.query.mock.calls[1][0] as string;
+    const selectParams = mocks.poolMock.query.mock.calls[1][1] as unknown[];
+    expect(selectSql).toMatch(/ORDER BY name ASC/);
+    expect(selectSql).toMatch(/LIMIT \$\d+ OFFSET \$\d+/);
+    expect(selectParams).toContain(24); // offset = (3 - 1) * 12
+    expect(res.total).toBe(42);
+    expect(res.nextCursor).toBeUndefined();
+  });
+
+  it('page mode: applies search / breed / gender / age-group filters', async () => {
+    mocks.poolMock.query
+      .mockResolvedValueOnce({ rows: [{ count: '0' }] })
+      .mockResolvedValueOnce({ rows: [] });
+    await listPets(mocks.deps, ADOPTER, {
+      limit: 12,
+      page: 1,
+      search: 'rex',
+      breed: 'labr',
+      genderFilter: PetsV1.PetGender.PET_GENDER_MALE,
+      ageGroupFilter: PetsV1.PetAgeGroup.PET_AGE_GROUP_ADULT,
+    } as never);
+
+    const countSql = mocks.poolMock.query.mock.calls[0][0] as string;
+    const countParams = mocks.poolMock.query.mock.calls[0][1] as unknown[];
+    expect(countSql).toMatch(/search_vector @@ websearch_to_tsquery/);
+    expect(countSql).toMatch(/breed_id IN \(SELECT breed_id FROM pets\.breeds/);
+    expect(countSql).toMatch(/gender = \$/);
+    expect(countSql).toMatch(/age_group = \$/);
+    expect(countParams).toContain('rex');
+    expect(countParams).toContain('%labr%');
+  });
+
+  it('rejects an unknown sort column (falls back to created_at, no injection)', async () => {
+    mocks.poolMock.query
+      .mockResolvedValueOnce({ rows: [{ count: '0' }] })
+      .mockResolvedValueOnce({ rows: [] });
+    await listPets(mocks.deps, ADOPTER, {
+      limit: 12,
+      page: 1,
+      sortBy: 'name; DROP TABLE pets;--',
+    } as never);
+    const selectSql = mocks.poolMock.query.mock.calls[1][0] as string;
+    expect(selectSql).toMatch(/ORDER BY created_at DESC/);
+    expect(selectSql).not.toMatch(/DROP TABLE/);
+  });
+
+  it('stays in cursor mode (single query, no total) when page is unset', async () => {
+    mocks.poolMock.query.mockResolvedValueOnce({ rows: [] });
+    const res = await listPets(mocks.deps, ADOPTER, { limit: 12 } as never);
+    expect(res.total).toBeUndefined();
+    expect(mocks.poolMock.query).toHaveBeenCalledTimes(1);
+  });
+
   it('pins rescue staff to their own rescue, ignoring a foreign rescueIdFilter', async () => {
     mocks.poolMock.query.mockResolvedValueOnce({ rows: [] });
     // STAFF is scoped to rsc-1 but asks for rsc-2's pets.

--- a/services/pets/src/grpc/handlers.ts
+++ b/services/pets/src/grpc/handlers.ts
@@ -350,6 +350,21 @@ type ListCursor = { createdAt: string; petId: string };
 const DEFAULT_LIST_LIMIT = 20;
 const MAX_LIST_LIMIT = 100;
 
+// Allowlisted sort columns — never interpolate a caller-supplied column
+// name into SQL. Anything unknown falls back to created_at. pet_id is
+// always appended as a deterministic tie-breaker.
+const SORT_COLUMNS: Record<string, string> = {
+  created_at: 'created_at',
+  updated_at: 'updated_at',
+  name: 'name',
+};
+
+function buildOrderBy(sortBy: string | undefined, sortOrder: string | undefined): string {
+  const column = (sortBy && SORT_COLUMNS[sortBy]) ?? 'created_at';
+  const direction = sortOrder && sortOrder.toUpperCase() === 'ASC' ? 'ASC' : 'DESC';
+  return `ORDER BY ${column} ${direction}, pet_id DESC`;
+}
+
 export async function listPets(
   deps: HandlerDeps,
   principal: Principal,
@@ -377,7 +392,11 @@ export async function listPets(
   const privileged = hasPermission(principal, PETS_READ_ANY) || principal.rescueId !== undefined;
 
   const limit = clampLimit(req.limit);
-  const cursor = req.cursor ? parseCursor(req.cursor) : undefined;
+  // Page mode (offset + total count) when the caller asks for a 1-based
+  // page; otherwise the default keyset/cursor mode. The two never mix.
+  const pageNum = req.page ?? 0;
+  const usePageMode = pageNum > 0;
+  const cursor = !usePageMode && req.cursor ? parseCursor(req.cursor) : undefined;
 
   const where: string[] = ['deleted_at IS NULL'];
   const params: unknown[] = [];
@@ -411,12 +430,68 @@ export async function listPets(
     params.push(true);
     n++;
   }
+  if (req.search) {
+    // Full-text over the trigger-maintained, GIN-indexed search_vector.
+    where.push(`search_vector @@ websearch_to_tsquery('english', $${n})`);
+    params.push(req.search);
+    n++;
+  }
+  if (req.breed) {
+    // Breed is a free-text field; match the breeds catalogue by name.
+    where.push(`breed_id IN (SELECT breed_id FROM pets.breeds WHERE name ILIKE $${n})`);
+    params.push(`%${req.breed}%`);
+    n++;
+  }
+  if (
+    req.genderFilter !== undefined &&
+    req.genderFilter !== PetsV1.PetGender.PET_GENDER_UNSPECIFIED
+  ) {
+    where.push(`gender = $${n}`);
+    params.push(genderToDb(req.genderFilter));
+    n++;
+  }
+  if (
+    req.ageGroupFilter !== undefined &&
+    req.ageGroupFilter !== PetsV1.PetAgeGroup.PET_AGE_GROUP_UNSPECIFIED
+  ) {
+    where.push(`age_group = $${n}`);
+    params.push(ageGroupToDb(req.ageGroupFilter));
+    n++;
+  }
   if (!privileged) {
     const placeholders = PUBLIC_HIDDEN_STATUSES.map(() => `$${n++}`).join(', ');
     where.push(`status NOT IN (${placeholders})`);
     params.push(...PUBLIC_HIDDEN_STATUSES);
     where.push('archived = false');
   }
+  // Page mode: offset pagination + a COUNT so the dashboard can render page
+  // numbers. sortBy/sortOrder are honoured (allowlisted). The filters above
+  // are shared with cursor mode, so `where`/`params` already hold them.
+  if (usePageMode) {
+    const whereSql = where.join(' AND ');
+    const countResult = await deps.pool.query<{ count: string }>(
+      `SELECT COUNT(*) FROM pets.pets WHERE ${whereSql}`,
+      params
+    );
+    const total = Number(countResult.rows[0].count);
+    const offset = (pageNum - 1) * limit;
+    const result = await deps.pool.query<PetRow>(
+      `
+      SELECT ${PETS_SELECT} FROM pets.pets
+      WHERE ${whereSql}
+      ${buildOrderBy(req.sortBy, req.sortOrder)}
+      LIMIT $${n} OFFSET $${n + 1}
+      `,
+      [...params, limit, offset]
+    );
+    return {
+      pets: result.rows.map(row => rowToProto(row, privileged)),
+      nextCursor: undefined,
+      total,
+    };
+  }
+
+  // Cursor mode (default): keyset pagination, fixed order, no total.
   if (cursor) {
     where.push(`(created_at, pet_id) < ($${n}, $${n + 1})`);
     params.push(new Date(cursor.createdAt));
@@ -435,14 +510,14 @@ export async function listPets(
   );
 
   const hasMore = result.rows.length > limit;
-  const page = hasMore ? result.rows.slice(0, limit) : result.rows;
-  const last = page[page.length - 1];
+  const pageRows = hasMore ? result.rows.slice(0, limit) : result.rows;
+  const last = pageRows[pageRows.length - 1];
   const nextCursor =
     hasMore && last
       ? encodeCursor({ createdAt: last.created_at.toISOString(), petId: last.pet_id })
       : undefined;
 
-  return { pets: page.map(row => rowToProto(row, privileged)), nextCursor };
+  return { pets: pageRows.map(row => rowToProto(row, privileged)), nextCursor };
 }
 
 // --- ListBreeds ------------------------------------------------------


### PR DESCRIPTION
## Summary

Closes the last legacy pets path — the rescue Pet Management page's `getMyRescuePets` was calling the unbacked `/api/v1/pets/rescue/my` because `pets.List` couldn't match its needs (page-based pagination + total count, free-text search, breed/age-group/gender filters, sort). This brings `pets.List` to parity and repoints the page onto `GET /api/v1/pets`.

## Changes

**`pets.List` — proto + handler** (`pet.proto`, `services/pets/.../handlers.ts`)
- **`page`** (1-based, optional): when set, the handler switches from keyset/cursor mode to **offset pagination + a `total` COUNT** so the dashboard can render page numbers. **Unset keeps the existing cursor behaviour** — every other caller (`getPets`, `getPetsByRescue`, dashboard) is unaffected.
- **`search`** over the trigger-maintained, GIN-indexed `pets.search_vector`.
- **`breed`** (free-text, matched against the breeds catalogue by name) + **`gender`** and **`age_group`** enum filters — all real columns, nothing fabricated.
- **`sort_by`/`sort_order`**, allowlisted server-side (`created_at`/`updated_at`/`name`) with a `pet_id` tie-breaker — a caller can never inject a column.

**Gateway** (`routes/pets.ts`, `pets-view.ts`, `dashboard.ts`)
- Parse the new query params (reusing `parsePagination`'s validated `page`), forward them, and build **real page meta** (`total`/`totalPages`/`hasNext`/`hasPrev`) from the handler's `total` in page mode. Added `parseGender`/`parseAgeGroup`. `dashboard.ts`'s two `ListPetsRequest` constructions get the new required enum fields (UNSPECIFIED).

**Frontend** (`lib.pets`)
- `getMyRescuePets` now GETs `/api/v1/pets`; the gateway scopes rescue staff to their own rescue **from the principal**, so no `rescueId` is needed. Removed the dead `MY_RESCUE_PETS` constant.

## Before requesting review

- [x] Ran quick checks locally (type-check + lint + affected tests)
- [x] Tests for new behaviour added (TDD)
- [x] Considered consumer impact — the new `page`/filter fields are opt-in; cursor-mode callers are byte-for-byte unaffected (verified by the unchanged cursor tests)

## Test plan

- [x] Existing + new tests pass — pets **202**, gateway **1269**, lib.pets **117**
- [x] New behaviour covered — pets handler (page-mode COUNT/offset/sort, search/breed/gender/age filters, sort allowlist rejects injection, cursor mode unchanged), gateway route (param forwarding + real page meta), updated lib.pets service test
- [x] No TypeScript errors; lint passes

## Screenshots / recordings

n/a — backend RPC/route enhancement + a frontend service repoint; the rescue Pet Management page keeps its existing UI and now drives it against the gateway.

## Related

Final item of the post-route-audit endpoint sweep — the one endpoint I'd previously left as tech-debt because it needed this `pets.List` enhancement rather than a one-line repoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xjak7otuKv2PaPcqV1mcgk

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xjak7otuKv2PaPcqV1mcgk)_