### PR TITLE
Pagination envelope standardization: all datatables on one canonical envelope (fixes admin rescues crash)

### DIFF
--- a/apps/admin/src/__tests__/audit.behavior.test.tsx
+++ b/apps/admin/src/__tests__/audit.behavior.test.tsx
@@ -48,7 +48,7 @@ const makeLog = (overrides: Partial<AuditLog> = {}): AuditLog => ({
 const paginated = (logs: AuditLog[]) => ({
   success: true,
   data: logs,
-  pagination: { page: 1, limit: 50, total: logs.length, pages: 1 },
+  pagination: { page: 1, limit: 50, total: logs.length, totalPages: 1 },
 });
 
 beforeEach(() => {

--- a/apps/admin/src/components/modals/ChatDetailModal/MessagesTab.test.tsx
+++ b/apps/admin/src/components/modals/ChatDetailModal/MessagesTab.test.tsx
@@ -43,7 +43,12 @@ describe('MessagesTab', () => {
 
   it('renders empty state when there are no messages', () => {
     mockUseAdminChatMessages.mockReturnValue({
-      data: { data: { messages: [], pagination: { page: 1, pages: 1, total: 0 } } },
+      data: {
+        data: {
+          messages: [],
+          pagination: { page: 1, limit: 50, hasNext: false, hasPrev: false, nextCursor: null },
+        },
+      },
       isLoading: false,
       refetch: mockRefetch,
     } as ReturnType<typeof useAdminChatMessages>);
@@ -65,7 +70,7 @@ describe('MessagesTab', () => {
             },
             { id: 'msg-2', content: 'Hi!', senderName: 'Bob', timestamp: new Date().toISOString() },
           ],
-          pagination: { page: 1, pages: 1, total: 2 },
+          pagination: { page: 1, limit: 50, hasNext: false, hasPrev: false, nextCursor: null },
         },
       },
       isLoading: false,
@@ -91,7 +96,7 @@ describe('MessagesTab', () => {
               timestamp: new Date().toISOString(),
             },
           ],
-          pagination: { page: 1, pages: 1, total: 1 },
+          pagination: { page: 1, limit: 50, hasNext: false, hasPrev: false, nextCursor: null },
         },
       },
       isLoading: false,
@@ -115,7 +120,7 @@ describe('MessagesTab', () => {
               timestamp: new Date().toISOString(),
             },
           ],
-          pagination: { page: 1, pages: 1, total: 1 },
+          pagination: { page: 1, limit: 50, hasNext: false, hasPrev: false, nextCursor: null },
         },
       },
       isLoading: false,
@@ -148,7 +153,7 @@ describe('MessagesTab', () => {
               timestamp: new Date().toISOString(),
             },
           ],
-          pagination: { page: 1, pages: 1, total: 1 },
+          pagination: { page: 1, limit: 50, hasNext: false, hasPrev: false, nextCursor: null },
         },
       },
       isLoading: false,

--- a/apps/admin/src/components/modals/ChatDetailModal/MessagesTab.tsx
+++ b/apps/admin/src/components/modals/ChatDetailModal/MessagesTab.tsx
@@ -104,9 +104,7 @@ export const MessagesTab: React.FC<MessagesTabProps> = ({ chatId, onMessageDelet
     );
   }
 
-  const hasMorePages =
-    messagesData?.data?.pagination &&
-    messagesData.data.pagination.page < messagesData.data.pagination.pages;
+  const hasMorePages = messagesData?.data?.pagination?.hasNext ?? false;
 
   return (
     <>

--- a/apps/admin/src/pages/Applications.test.tsx
+++ b/apps/admin/src/pages/Applications.test.tsx
@@ -92,7 +92,14 @@ const setApplicationsResult = (
   mockUseApplications.mockReturnValue({
     data: {
       data,
-      pagination: { pages: 1, total: data.length, page: 1, limit: 20 },
+      pagination: {
+        page: 1,
+        limit: 20,
+        total: data.length,
+        totalPages: 1,
+        hasNext: false,
+        hasPrev: false,
+      },
     },
     isLoading: overrides.isLoading ?? false,
     error: overrides.error ?? null,

--- a/apps/admin/src/services/applicationService.test.ts
+++ b/apps/admin/src/services/applicationService.test.ts
@@ -40,7 +40,7 @@ describe('applicationService', () => {
             updatedAt: '2024-01-02',
           },
         ],
-        pagination: { page: 2, limit: 30, total: 1, pages: 1 },
+        pagination: { page: 2, limit: 30, total: 1, totalPages: 1, hasNext: false, hasPrev: true },
       });
 
       const result = await applicationService.getAll({
@@ -75,7 +75,14 @@ describe('applicationService', () => {
           updatedAt: '2024-01-02',
         },
       ]);
-      expect(result.pagination).toEqual({ page: 2, limit: 30, total: 1, pages: 1 });
+      expect(result.pagination).toEqual({
+        page: 2,
+        limit: 30,
+        total: 1,
+        totalPages: 1,
+        hasNext: false,
+        hasPrev: true,
+      });
     });
 
     it('defaults missing applicant/pet/rescue fields to empty strings', async () => {
@@ -91,7 +98,7 @@ describe('applicationService', () => {
             updatedAt: '2024-01-02',
           },
         ],
-        pagination: { page: 1, limit: 20, total: 1, pages: 1 },
+        pagination: { page: 1, limit: 20, total: 1, totalPages: 1, hasNext: false, hasPrev: false },
       });
 
       const result = await applicationService.getAll();

--- a/apps/admin/src/services/applicationService.ts
+++ b/apps/admin/src/services/applicationService.ts
@@ -46,7 +46,14 @@ type BackendApplication = {
 type ApplicationsPaginatedResponse = {
   success: boolean;
   data: BackendApplication[];
-  pagination: { page: number; limit: number; total: number; pages: number };
+  pagination: {
+    page: number;
+    limit: number;
+    total: number;
+    totalPages: number;
+    hasNext: boolean;
+    hasPrev: boolean;
+  };
 };
 
 const toAdminApplication = (a: BackendApplication): AdminApplication => ({
@@ -68,7 +75,14 @@ class ApplicationServiceClient {
 
   async getAll(filters: ApplicationFilters = {}): Promise<{
     data: AdminApplication[];
-    pagination: { page: number; limit: number; total: number; pages: number };
+    pagination: {
+      page: number;
+      limit: number;
+      total: number;
+      totalPages: number;
+      hasNext: boolean;
+      hasPrev: boolean;
+    };
   }> {
     const params: Record<string, string> = {};
     if (filters.search) {

--- a/apps/admin/src/services/rescueService.test.ts
+++ b/apps/admin/src/services/rescueService.test.ts
@@ -55,7 +55,7 @@ describe('AdminRescueService', () => {
         dateTo: '2024-02-01',
       });
 
-      expect(mockGet).toHaveBeenCalledWith('/api/v1/rescues', {
+      expect(mockGet).toHaveBeenCalledWith('/api/v1/admin/rescues', {
         page: '2',
         limit: '10',
         search: 'paws',
@@ -86,7 +86,7 @@ describe('AdminRescueService', () => {
 
       const result = await rescueService.getAll();
 
-      expect(mockGet).toHaveBeenCalledWith('/api/v1/rescues', {});
+      expect(mockGet).toHaveBeenCalledWith('/api/v1/admin/rescues', {});
       expect(result.pagination.totalPages).toBe(5);
       expect(result.pagination.hasNext).toBe(true);
       expect(result.pagination.hasPrev).toBe(false);

--- a/apps/admin/src/services/rescueService.ts
+++ b/apps/admin/src/services/rescueService.ts
@@ -74,6 +74,9 @@ const buildQueryParams = (filters: AdminRescueFilters): Record<string, string> =
  */
 class AdminRescueService {
   private baseUrl = '/api/v1/rescues';
+  // The admin dashboard list has its own offset-paginated, all-statuses
+  // endpoint (the public /api/v1/rescues is keyset + verified-only).
+  private listUrl = '/api/v1/admin/rescues';
 
   /**
    * Fetch all rescues with pagination and filtering
@@ -91,7 +94,7 @@ class AdminRescueService {
         pages?: number;
         totalPages?: number;
       };
-    }>(this.baseUrl, params);
+    }>(this.listUrl, params);
 
     if (!response.success) {
       throw new Error('Failed to fetch rescues');

--- a/apps/client/src/__tests__/distance-sorting.behavior.test.tsx
+++ b/apps/client/src/__tests__/distance-sorting.behavior.test.tsx
@@ -168,8 +168,9 @@ const handlers = [
     return HttpResponse.json({
       success: true,
       data: mockPetsWithDistance,
-      meta: {
+      pagination: {
         page: 1,
+        limit: 20,
         total: 2,
         totalPages: 1,
         hasNext: false,

--- a/apps/client/src/__tests__/search-page-error-state.behavior.test.tsx
+++ b/apps/client/src/__tests__/search-page-error-state.behavior.test.tsx
@@ -78,7 +78,7 @@ const server = setupServer(
     return HttpResponse.json({
       success: true,
       data: [],
-      meta: { page: 1, total: 0, totalPages: 0, hasNext: false, hasPrev: false },
+      pagination: { page: 1, limit: 20, total: 0, totalPages: 0, hasNext: false, hasPrev: false },
     });
   })
 );
@@ -95,7 +95,7 @@ afterEach(() => {
       return HttpResponse.json({
         success: true,
         data: [],
-        meta: { page: 1, total: 0, totalPages: 0, hasNext: false, hasPrev: false },
+        pagination: { page: 1, limit: 20, total: 0, totalPages: 0, hasNext: false, hasPrev: false },
       });
     })
   );

--- a/packages/lib.chat/src/services/__tests__/admin-chat-hooks.test.tsx
+++ b/packages/lib.chat/src/services/__tests__/admin-chat-hooks.test.tsx
@@ -97,16 +97,23 @@ describe('useAdminChatById', () => {
 });
 
 describe('useAdminChatMessages', () => {
-  it('requests messages with pagination params', async () => {
-    const response = {
-      success: true,
-      data: { messages: [], pagination: { page: 1, limit: 50, total: 0, pages: 0 } },
+  it('wraps the top-level keyset messages feed in the data envelope', async () => {
+    // The route returns messages top-level alongside the keyset pagination;
+    // the hook wraps them in { data } for its consumers.
+    const routeBody = {
+      messages: [],
+      pagination: { page: 1, limit: 50, hasNext: false, hasPrev: false },
     };
-    get.mockResolvedValue(response);
+    get.mockResolvedValue(routeBody);
 
     const { result } = renderHook(() => useAdminChatMessages('chat-1', 2, 25));
 
-    await waitFor(() => expect(result.current.data).toEqual(response));
+    await waitFor(() =>
+      expect(result.current.data).toEqual({
+        success: true,
+        data: { messages: [], pagination: { page: 1, limit: 50, hasNext: false, hasPrev: false } },
+      })
+    );
     expect(get).toHaveBeenCalledWith('/api/v1/chats/chat-1/messages', { page: 2, limit: 25 });
   });
 

--- a/packages/lib.chat/src/services/admin-chat-hooks.ts
+++ b/packages/lib.chat/src/services/admin-chat-hooks.ts
@@ -39,11 +39,14 @@ interface MessagesResponse {
   success: boolean;
   data: {
     messages: Message[];
+    // Chat history is a keyset (reverse-scroll) feed, so the envelope carries
+    // hasNext + nextCursor rather than a page count.
     pagination: {
       page: number;
       limit: number;
-      total: number;
-      pages: number;
+      hasNext: boolean;
+      hasPrev: boolean;
+      nextCursor?: string;
     };
   };
 }
@@ -141,11 +144,18 @@ export const useAdminChatMessages = (
     try {
       setIsLoading(true);
       setError(null);
-      const response = await apiService.get<MessagesResponse>(`/api/v1/chats/${chatId}/messages`, {
-        page,
-        limit,
+      // The messages route is a keyset feed: `messages` (+ `nextCursor`) are
+      // top-level alongside the canonical keyset `pagination`. Wrap them in the
+      // `{ data }` shape this hook's consumers read.
+      const response = await apiService.get<{
+        messages: Message[];
+        nextCursor?: string;
+        pagination: MessagesResponse['data']['pagination'];
+      }>(`/api/v1/chats/${chatId}/messages`, { page, limit });
+      setData({
+        success: true,
+        data: { messages: response.messages, pagination: response.pagination },
       });
-      setData(response);
     } catch (err) {
       setError(err as Error);
     } finally {

--- a/packages/lib.pets/src/services/__tests__/pets-management-service.test.ts
+++ b/packages/lib.pets/src/services/__tests__/pets-management-service.test.ts
@@ -208,10 +208,10 @@ describe('PetManagementService', () => {
   });
 
   describe('getMyRescuePets', () => {
-    const meta = { page: 2, total: 30, totalPages: 3, hasNext: true, hasPrev: true };
+    const pagination = { page: 2, total: 30, totalPages: 3, hasNext: true, hasPrev: true };
 
     it('returns pets and normalised pagination from the my-rescue endpoint', async () => {
-      mockApiService.get.mockResolvedValueOnce({ success: true, data: [samplePet], meta });
+      mockApiService.get.mockResolvedValueOnce({ success: true, data: [samplePet], pagination });
 
       const result = await service.getMyRescuePets({ limit: 10, status: 'available' as PetStatus });
 
@@ -230,11 +230,11 @@ describe('PetManagementService', () => {
       });
     });
 
-    it('falls back to default pagination values when meta fields are missing', async () => {
+    it('falls back to default pagination values when pagination fields are missing', async () => {
       mockApiService.get.mockResolvedValueOnce({
         success: true,
         data: [],
-        meta: { page: 0, total: 0, totalPages: 0, hasNext: false, hasPrev: false },
+        pagination: { page: 0, total: 0, totalPages: 0, hasNext: false, hasPrev: false },
       });
 
       const result = await service.getMyRescuePets();
@@ -249,7 +249,7 @@ describe('PetManagementService', () => {
       });
     });
 
-    it('throws when the response is missing meta', async () => {
+    it('throws when the response is missing pagination', async () => {
       mockApiService.get.mockResolvedValueOnce({ success: true, data: [samplePet] });
 
       await expect(service.getMyRescuePets()).rejects.toThrow('Invalid API response structure');
@@ -263,10 +263,10 @@ describe('PetManagementService', () => {
   });
 
   describe('getRescuePets', () => {
-    const meta = { page: 1, total: 5, totalPages: 1, hasNext: false, hasPrev: false };
+    const pagination = { page: 1, total: 5, totalPages: 1, hasNext: false, hasPrev: false };
 
     it('sends the rescueId alongside filters to the pets endpoint', async () => {
-      mockApiService.get.mockResolvedValueOnce({ success: true, data: [samplePet], meta });
+      mockApiService.get.mockResolvedValueOnce({ success: true, data: [samplePet], pagination });
 
       const result = await service.getRescuePets('rescue-9', { page: 1, search: 'lab' });
 

--- a/packages/lib.pets/src/services/__tests__/pets-service.test.ts
+++ b/packages/lib.pets/src/services/__tests__/pets-service.test.ts
@@ -59,7 +59,7 @@ describe('PetsService', () => {
             updatedAt: '2023-01-01',
           },
         ],
-        meta: {
+        pagination: {
           page: 1,
           total: 1,
           totalPages: 1,
@@ -107,7 +107,7 @@ describe('PetsService', () => {
             updated_at: '2023-01-01',
           },
         ],
-        meta: { page: 1, total: 1, totalPages: 1, hasNext: false, hasPrev: false },
+        pagination: { page: 1, total: 1, totalPages: 1, hasNext: false, hasPrev: false },
       };
 
       it('sends user coordinates to the API when latitude and longitude are provided', async () => {
@@ -282,7 +282,7 @@ describe('PetsService', () => {
     const emptyResponse = {
       success: true,
       data: [],
-      meta: { page: 1, total: 0, totalPages: 1, hasNext: false, hasPrev: false },
+      pagination: { page: 1, total: 0, totalPages: 1, hasNext: false, hasPrev: false },
     };
 
     it('maps an age range to ageMin/ageMax and drops the age object', async () => {
@@ -410,7 +410,7 @@ describe('PetsService', () => {
       mockApiService.get.mockResolvedValueOnce({
         success: true,
         data: [{ petId: 'p1', name: 'A' }],
-        meta: { page: 3, total: 50, totalPages: 3, hasNext: false, hasPrev: true },
+        pagination: { page: 3, total: 50, totalPages: 3, hasNext: false, hasPrev: true },
       });
 
       const result = await service.getPetsByRescue('rescue-1', 3);
@@ -425,7 +425,7 @@ describe('PetsService', () => {
       });
     });
 
-    it('falls back to the requested page when meta is absent', async () => {
+    it('falls back to the requested page when pagination is absent', async () => {
       mockApiService.get.mockResolvedValueOnce({ success: true, data: [] });
 
       const result = await service.getPetsByRescue('rescue-1', 2);
@@ -668,7 +668,7 @@ describe('PetsService', () => {
             updatedAt: '2026-01-01',
           },
         ],
-        meta: { page: 1, total: 1, totalPages: 1, hasNext: false, hasPrev: false },
+        pagination: { page: 1, total: 1, totalPages: 1, hasNext: false, hasPrev: false },
       });
 
       const result = await service.searchPets();
@@ -708,7 +708,7 @@ describe('PetsService', () => {
             status: 'deceased',
           },
         ],
-        meta: { page: 1, total: 2, totalPages: 1, hasNext: false, hasPrev: false },
+        pagination: { page: 1, total: 2, totalPages: 1, hasNext: false, hasPrev: false },
       });
 
       const result = await service.searchPets();

--- a/packages/lib.pets/src/services/pets-management-service.ts
+++ b/packages/lib.pets/src/services/pets-management-service.ts
@@ -222,7 +222,7 @@ export class PetManagementService {
       const response = await this.apiService.get<{
         success: boolean;
         data: Pet[];
-        meta: {
+        pagination: {
           page: number;
           total: number;
           totalPages: number;
@@ -231,16 +231,16 @@ export class PetManagementService {
         };
       }>(PETS_ENDPOINTS.PETS, params);
 
-      if (response.success && response.data && response.meta) {
+      if (response.success && response.data && response.pagination) {
         return {
           pets: response.data,
           pagination: {
-            page: response.meta.page || 1,
+            page: response.pagination.page || 1,
             limit: filters.limit || 12,
-            total: response.meta.total || 0,
-            totalPages: response.meta.totalPages || 1,
-            hasNext: response.meta.hasNext || false,
-            hasPrev: response.meta.hasPrev || false,
+            total: response.pagination.total || 0,
+            totalPages: response.pagination.totalPages || 1,
+            hasNext: response.pagination.hasNext || false,
+            hasPrev: response.pagination.hasPrev || false,
           },
         };
       } else {
@@ -287,7 +287,7 @@ export class PetManagementService {
       const response = await this.apiService.get<{
         success: boolean;
         data: Pet[];
-        meta: {
+        pagination: {
           page: number;
           total: number;
           totalPages: number;
@@ -296,16 +296,16 @@ export class PetManagementService {
         };
       }>(PETS_ENDPOINTS.PETS, params);
 
-      if (response.success && response.data && response.meta) {
+      if (response.success && response.data && response.pagination) {
         return {
           pets: response.data,
           pagination: {
-            page: response.meta.page || 1,
+            page: response.pagination.page || 1,
             limit: filters.limit || 12,
-            total: response.meta.total || 0,
-            totalPages: response.meta.totalPages || 1,
-            hasNext: response.meta.hasNext || false,
-            hasPrev: response.meta.hasPrev || false,
+            total: response.pagination.total || 0,
+            totalPages: response.pagination.totalPages || 1,
+            hasNext: response.pagination.hasNext || false,
+            hasPrev: response.pagination.hasPrev || false,
           },
         };
       } else {

--- a/packages/lib.pets/src/services/pets-service.ts
+++ b/packages/lib.pets/src/services/pets-service.ts
@@ -140,7 +140,7 @@ export class PetsService {
       const response = await this.apiService.get<{
         success: boolean;
         data: unknown[];
-        meta: {
+        pagination: {
           page: number;
           total: number;
           totalPages: number;
@@ -150,16 +150,16 @@ export class PetsService {
       }>(PETS_ENDPOINTS.PETS, apiFilters);
 
       // Transform according to the actual API response structure
-      if (response.success && response.data && response.meta) {
+      if (response.success && response.data && response.pagination) {
         return {
           data: response.data.map((p) => normalisePet(p)),
           pagination: {
-            page: response.meta.page || 1,
+            page: response.pagination.page || 1,
             limit: typeof apiFilters.limit === 'number' ? apiFilters.limit : 12,
-            total: response.meta.total || 0,
-            totalPages: response.meta.totalPages || 1,
-            hasNext: response.meta.hasNext || false,
-            hasPrev: response.meta.hasPrev || false,
+            total: response.pagination.total || 0,
+            totalPages: response.pagination.totalPages || 1,
+            hasNext: response.pagination.hasNext || false,
+            hasPrev: response.pagination.hasPrev || false,
           },
         };
       } else {
@@ -252,7 +252,7 @@ export class PetsService {
       const response = await this.apiService.get<{
         success: boolean;
         data: unknown[];
-        meta: {
+        pagination: {
           page: number;
           total: number;
           totalPages: number;
@@ -268,12 +268,12 @@ export class PetsService {
       return {
         data: (response.data || []).map((p) => normalisePet(p)),
         pagination: {
-          page: response.meta?.page || page,
+          page: response.pagination?.page || page,
           limit: 20,
-          total: response.meta?.total || 0,
-          totalPages: response.meta?.totalPages || 1,
-          hasNext: response.meta?.hasNext || false,
-          hasPrev: response.meta?.hasPrev || false,
+          total: response.pagination?.total || 0,
+          totalPages: response.pagination?.totalPages || 1,
+          hasNext: response.pagination?.hasNext || false,
+          hasPrev: response.pagination?.hasPrev || false,
         },
       };
     } catch (error) {

--- a/packages/lib.support-tickets/src/hooks.test.tsx
+++ b/packages/lib.support-tickets/src/hooks.test.tsx
@@ -30,7 +30,7 @@ const baseTicket = {
   updatedAt: '2026-01-01T00:00:00Z',
 };
 
-const pagination = { currentPage: 1, totalPages: 1, totalItems: 1, itemsPerPage: 20 };
+const pagination = { page: 1, limit: 20, total: 1, totalPages: 1, hasNext: false, hasPrev: false };
 
 beforeEach(() => {
   vi.clearAllMocks();

--- a/packages/lib.support-tickets/src/schemas.ts
+++ b/packages/lib.support-tickets/src/schemas.ts
@@ -149,10 +149,12 @@ export const TicketFiltersSchema = z.object({
 
 // Response schemas
 export const PaginationSchema = z.object({
-  currentPage: z.number().int(),
+  page: z.number().int(),
+  limit: z.number().int(),
+  total: z.number().int(),
   totalPages: z.number().int(),
-  totalItems: z.number().int(),
-  itemsPerPage: z.number().int(),
+  hasNext: z.boolean(),
+  hasPrev: z.boolean(),
 });
 
 export const TicketsResponseSchema = z.object({

--- a/packages/lib.support-tickets/src/support-ticket-service.test.ts
+++ b/packages/lib.support-tickets/src/support-ticket-service.test.ts
@@ -41,7 +41,14 @@ describe('SupportTicketService', () => {
   });
 
   describe('getTickets', () => {
-    const pagination = { currentPage: 1, totalPages: 1, totalItems: 1, itemsPerPage: 20 };
+    const pagination = {
+      page: 1,
+      limit: 20,
+      total: 1,
+      totalPages: 1,
+      hasNext: false,
+      hasPrev: false,
+    };
 
     it('requests the tickets endpoint and parses the response into data + pagination', async () => {
       mockApi.get.mockResolvedValue({ success: true, data: [baseTicket], pagination });

--- a/packages/proto/proto/adopt_dont_shop/applications/v1/application.proto
+++ b/packages/proto/proto/adopt_dont_shop/applications/v1/application.proto
@@ -421,11 +421,20 @@ message ListApplicationsRequest {
   // from principal.userId); admins + super_admin can pass any
   // adopter_id_filter explicitly.
   optional string adopter_id_filter = 5;
+  // Offset pagination for the staff / admin applications datatable. When
+  // set (>0) the handler returns an OFFSET page plus a real `total`
+  // (COUNT) instead of a keyset cursor, so the shared DataTable can render
+  // "Page X of Y". The principal scope (adopter-owns / rescue-staff /
+  // admin) still applies — offset mode never widens what a caller sees.
+  optional uint32 page = 6;
 }
 
 message ListApplicationsResponse {
   repeated Application applications = 1;
   optional string next_cursor = 2;
+  // Total row count for the current filter — present only in offset mode
+  // (page set). Keyset responses omit it.
+  optional uint32 total = 3;
 }
 
 // --- GetStats --------------------------------------------------------

--- a/packages/proto/proto/adopt_dont_shop/chat/v1/chat.proto
+++ b/packages/proto/proto/adopt_dont_shop/chat/v1/chat.proto
@@ -222,11 +222,18 @@ message ListChatsRequest {
   uint32 limit = 2;
   // Optional unread-only filter.
   bool unread_only = 3;
+  // Offset pagination for the admin chats datatable. When set (>0) the
+  // handler returns an OFFSET page plus a real `total` (COUNT) instead of a
+  // keyset cursor, so the shared DataTable can render "Page X of Y".
+  optional uint32 page = 4;
 }
 
 message ListChatsResponse {
   repeated Chat chats = 1;
   optional string next_cursor = 2;
+  // Total row count for the current filter — present only in offset mode
+  // (page set). Keyset responses omit it.
+  optional uint32 total = 3;
 }
 
 // --- MarkRead --------------------------------------------------------

--- a/packages/proto/proto/adopt_dont_shop/moderation/v1/moderation.proto
+++ b/packages/proto/proto/adopt_dont_shop/moderation/v1/moderation.proto
@@ -451,11 +451,18 @@ message ListReportsRequest {
   // Filter to reports assigned to a specific moderator (or
   // unassigned via the empty string).
   optional string assigned_moderator = 6;
+  // Offset pagination for admin datatables. When set (>0) the handler
+  // returns an OFFSET page plus a real `total` (COUNT) instead of a keyset
+  // cursor, so the shared DataTable can render "Page X of Y".
+  optional uint32 page = 7;
 }
 
 message ListReportsResponse {
   repeated Report reports = 1;
   optional string next_cursor = 2;
+  // Total row count for the current filter — present only in offset mode
+  // (page set). Keyset responses omit it.
+  optional uint32 total = 3;
 }
 
 // --- AssignReport ----------------------------------------------------
@@ -532,11 +539,18 @@ message ListModeratorActionsRequest {
   // When true, return only currently-active actions (is_active AND not
   // expired) — powers the "active sanctions/actions" view.
   optional bool active_only = 6;
+  // Offset pagination for admin datatables. When set (>0) the handler
+  // returns an OFFSET page plus a real `total` (COUNT) instead of a keyset
+  // cursor, so the shared DataTable can render "Page X of Y".
+  optional uint32 page = 7;
 }
 
 message ListModeratorActionsResponse {
   repeated ModeratorAction actions = 1;
   optional string next_cursor = 2;
+  // Total row count for the current filter — present only in offset mode
+  // (page set). Keyset responses omit it.
+  optional uint32 total = 3;
 }
 
 // --- GetModerationMetrics --------------------------------------------
@@ -691,11 +705,18 @@ message ListSupportTicketsRequest {
   optional string assigned_to = 6;
   // Filter to tickets opened by a specific user.
   optional string user_id = 7;
+  // Offset pagination for admin datatables. When set (>0) the handler
+  // returns an OFFSET page plus a real `total` (COUNT) instead of a keyset
+  // cursor, so the shared DataTable can render "Page X of Y".
+  optional uint32 page = 8;
 }
 
 message ListSupportTicketsResponse {
   repeated SupportTicket tickets = 1;
   optional string next_cursor = 2;
+  // Total row count for the current filter — present only in offset mode
+  // (page set). Keyset responses omit it.
+  optional uint32 total = 3;
 }
 
 // --- RespondToTicket -------------------------------------------------

--- a/packages/proto/proto/adopt_dont_shop/rescue/v1/rescue.proto
+++ b/packages/proto/proto/adopt_dont_shop/rescue/v1/rescue.proto
@@ -384,11 +384,22 @@ message ListRescuesRequest {
   optional double latitude = 6;
   optional double longitude = 7;
   optional double radius_km = 8;
+  // Offset pagination for admin datatables. When set (>0) the handler
+  // returns an OFFSET page plus a real `total` (COUNT) instead of a keyset
+  // cursor, so the shared DataTable can render "Page X of Y".
+  optional uint32 page = 9;
+  // Admin "show every lifecycle status" scope for the rescues datatable.
+  // Drops the status predicate entirely; gated on the platform-admin
+  // permission in the handler.
+  optional bool all_statuses = 10;
 }
 
 message ListRescuesResponse {
   repeated Rescue rescues = 1;
   optional string next_cursor = 2;
+  // Total row count for the current filter — present only in offset mode
+  // (page set). Keyset responses omit it.
+  optional uint32 total = 3;
 }
 
 // --- Update -----------------------------------------------------------

--- a/packages/proto/src/generated/proto/adopt_dont_shop/applications/v1/application.ts
+++ b/packages/proto/src/generated/proto/adopt_dont_shop/applications/v1/application.ts
@@ -334,12 +334,29 @@ export interface ListApplicationsRequest {
    * from principal.userId); admins + super_admin can pass any
    * adopter_id_filter explicitly.
    */
-  adopterIdFilter?: string | undefined;
+  adopterIdFilter?:
+    | string
+    | undefined;
+  /**
+   * Offset pagination for the staff / admin applications datatable. When
+   * set (>0) the handler returns an OFFSET page plus a real `total`
+   * (COUNT) instead of a keyset cursor, so the shared DataTable can render
+   * "Page X of Y". The principal scope (adopter-owns / rescue-staff /
+   * admin) still applies — offset mode never widens what a caller sees.
+   */
+  page?: number | undefined;
 }
 
 export interface ListApplicationsResponse {
   applications: Application[];
-  nextCursor?: string | undefined;
+  nextCursor?:
+    | string
+    | undefined;
+  /**
+   * Total row count for the current filter — present only in offset mode
+   * (page set). Keyset responses omit it.
+   */
+  total?: number | undefined;
 }
 
 export interface GetStatsRequest {
@@ -2979,7 +2996,14 @@ export const GetApplicationResponse: MessageFns<GetApplicationResponse> = {
 };
 
 function createBaseListApplicationsRequest(): ListApplicationsRequest {
-  return { cursor: undefined, limit: 0, statusFilter: 0, rescueIdFilter: undefined, adopterIdFilter: undefined };
+  return {
+    cursor: undefined,
+    limit: 0,
+    statusFilter: 0,
+    rescueIdFilter: undefined,
+    adopterIdFilter: undefined,
+    page: undefined,
+  };
 }
 
 export const ListApplicationsRequest: MessageFns<ListApplicationsRequest> = {
@@ -2998,6 +3022,9 @@ export const ListApplicationsRequest: MessageFns<ListApplicationsRequest> = {
     }
     if (message.adopterIdFilter !== undefined) {
       writer.uint32(42).string(message.adopterIdFilter);
+    }
+    if (message.page !== undefined) {
+      writer.uint32(48).uint32(message.page);
     }
     return writer;
   },
@@ -3049,6 +3076,14 @@ export const ListApplicationsRequest: MessageFns<ListApplicationsRequest> = {
           message.adopterIdFilter = reader.string();
           continue;
         }
+        case 6: {
+          if (tag !== 48) {
+            break;
+          }
+
+          message.page = reader.uint32();
+          continue;
+        }
       }
       if ((tag & 7) === 4 || tag === 0) {
         break;
@@ -3077,6 +3112,7 @@ export const ListApplicationsRequest: MessageFns<ListApplicationsRequest> = {
         : isSet(object.adopter_id_filter)
         ? globalThis.String(object.adopter_id_filter)
         : undefined,
+      page: isSet(object.page) ? globalThis.Number(object.page) : undefined,
     };
   },
 
@@ -3097,6 +3133,9 @@ export const ListApplicationsRequest: MessageFns<ListApplicationsRequest> = {
     if (message.adopterIdFilter !== undefined) {
       obj.adopterIdFilter = message.adopterIdFilter;
     }
+    if (message.page !== undefined) {
+      obj.page = Math.round(message.page);
+    }
     return obj;
   },
 
@@ -3110,12 +3149,13 @@ export const ListApplicationsRequest: MessageFns<ListApplicationsRequest> = {
     message.statusFilter = object.statusFilter ?? 0;
     message.rescueIdFilter = object.rescueIdFilter ?? undefined;
     message.adopterIdFilter = object.adopterIdFilter ?? undefined;
+    message.page = object.page ?? undefined;
     return message;
   },
 };
 
 function createBaseListApplicationsResponse(): ListApplicationsResponse {
-  return { applications: [], nextCursor: undefined };
+  return { applications: [], nextCursor: undefined, total: undefined };
 }
 
 export const ListApplicationsResponse: MessageFns<ListApplicationsResponse> = {
@@ -3125,6 +3165,9 @@ export const ListApplicationsResponse: MessageFns<ListApplicationsResponse> = {
     }
     if (message.nextCursor !== undefined) {
       writer.uint32(18).string(message.nextCursor);
+    }
+    if (message.total !== undefined) {
+      writer.uint32(24).uint32(message.total);
     }
     return writer;
   },
@@ -3152,6 +3195,14 @@ export const ListApplicationsResponse: MessageFns<ListApplicationsResponse> = {
           message.nextCursor = reader.string();
           continue;
         }
+        case 3: {
+          if (tag !== 24) {
+            break;
+          }
+
+          message.total = reader.uint32();
+          continue;
+        }
       }
       if ((tag & 7) === 4 || tag === 0) {
         break;
@@ -3171,6 +3222,7 @@ export const ListApplicationsResponse: MessageFns<ListApplicationsResponse> = {
         : isSet(object.next_cursor)
         ? globalThis.String(object.next_cursor)
         : undefined,
+      total: isSet(object.total) ? globalThis.Number(object.total) : undefined,
     };
   },
 
@@ -3182,6 +3234,9 @@ export const ListApplicationsResponse: MessageFns<ListApplicationsResponse> = {
     if (message.nextCursor !== undefined) {
       obj.nextCursor = message.nextCursor;
     }
+    if (message.total !== undefined) {
+      obj.total = Math.round(message.total);
+    }
     return obj;
   },
 
@@ -3192,6 +3247,7 @@ export const ListApplicationsResponse: MessageFns<ListApplicationsResponse> = {
     const message = createBaseListApplicationsResponse();
     message.applications = object.applications?.map((e) => Application.fromPartial(e)) || [];
     message.nextCursor = object.nextCursor ?? undefined;
+    message.total = object.total ?? undefined;
     return message;
   },
 };

--- a/packages/proto/src/generated/proto/adopt_dont_shop/chat/v1/chat.ts
+++ b/packages/proto/src/generated/proto/adopt_dont_shop/chat/v1/chat.ts
@@ -194,11 +194,24 @@ export interface ListChatsRequest {
   limit: number;
   /** Optional unread-only filter. */
   unreadOnly: boolean;
+  /**
+   * Offset pagination for the admin chats datatable. When set (>0) the
+   * handler returns an OFFSET page plus a real `total` (COUNT) instead of a
+   * keyset cursor, so the shared DataTable can render "Page X of Y".
+   */
+  page?: number | undefined;
 }
 
 export interface ListChatsResponse {
   chats: Chat[];
-  nextCursor?: string | undefined;
+  nextCursor?:
+    | string
+    | undefined;
+  /**
+   * Total row count for the current filter — present only in offset mode
+   * (page set). Keyset responses omit it.
+   */
+  total?: number | undefined;
 }
 
 export interface MarkReadRequest {
@@ -1542,7 +1555,7 @@ export const ListMessagesResponse: MessageFns<ListMessagesResponse> = {
 };
 
 function createBaseListChatsRequest(): ListChatsRequest {
-  return { cursor: undefined, limit: 0, unreadOnly: false };
+  return { cursor: undefined, limit: 0, unreadOnly: false, page: undefined };
 }
 
 export const ListChatsRequest: MessageFns<ListChatsRequest> = {
@@ -1555,6 +1568,9 @@ export const ListChatsRequest: MessageFns<ListChatsRequest> = {
     }
     if (message.unreadOnly !== false) {
       writer.uint32(24).bool(message.unreadOnly);
+    }
+    if (message.page !== undefined) {
+      writer.uint32(32).uint32(message.page);
     }
     return writer;
   },
@@ -1590,6 +1606,14 @@ export const ListChatsRequest: MessageFns<ListChatsRequest> = {
           message.unreadOnly = reader.bool();
           continue;
         }
+        case 4: {
+          if (tag !== 32) {
+            break;
+          }
+
+          message.page = reader.uint32();
+          continue;
+        }
       }
       if ((tag & 7) === 4 || tag === 0) {
         break;
@@ -1608,6 +1632,7 @@ export const ListChatsRequest: MessageFns<ListChatsRequest> = {
         : isSet(object.unread_only)
         ? globalThis.Boolean(object.unread_only)
         : false,
+      page: isSet(object.page) ? globalThis.Number(object.page) : undefined,
     };
   },
 
@@ -1622,6 +1647,9 @@ export const ListChatsRequest: MessageFns<ListChatsRequest> = {
     if (message.unreadOnly !== false) {
       obj.unreadOnly = message.unreadOnly;
     }
+    if (message.page !== undefined) {
+      obj.page = Math.round(message.page);
+    }
     return obj;
   },
 
@@ -1633,12 +1661,13 @@ export const ListChatsRequest: MessageFns<ListChatsRequest> = {
     message.cursor = object.cursor ?? undefined;
     message.limit = object.limit ?? 0;
     message.unreadOnly = object.unreadOnly ?? false;
+    message.page = object.page ?? undefined;
     return message;
   },
 };
 
 function createBaseListChatsResponse(): ListChatsResponse {
-  return { chats: [], nextCursor: undefined };
+  return { chats: [], nextCursor: undefined, total: undefined };
 }
 
 export const ListChatsResponse: MessageFns<ListChatsResponse> = {
@@ -1648,6 +1677,9 @@ export const ListChatsResponse: MessageFns<ListChatsResponse> = {
     }
     if (message.nextCursor !== undefined) {
       writer.uint32(18).string(message.nextCursor);
+    }
+    if (message.total !== undefined) {
+      writer.uint32(24).uint32(message.total);
     }
     return writer;
   },
@@ -1675,6 +1707,14 @@ export const ListChatsResponse: MessageFns<ListChatsResponse> = {
           message.nextCursor = reader.string();
           continue;
         }
+        case 3: {
+          if (tag !== 24) {
+            break;
+          }
+
+          message.total = reader.uint32();
+          continue;
+        }
       }
       if ((tag & 7) === 4 || tag === 0) {
         break;
@@ -1692,6 +1732,7 @@ export const ListChatsResponse: MessageFns<ListChatsResponse> = {
         : isSet(object.next_cursor)
         ? globalThis.String(object.next_cursor)
         : undefined,
+      total: isSet(object.total) ? globalThis.Number(object.total) : undefined,
     };
   },
 
@@ -1703,6 +1744,9 @@ export const ListChatsResponse: MessageFns<ListChatsResponse> = {
     if (message.nextCursor !== undefined) {
       obj.nextCursor = message.nextCursor;
     }
+    if (message.total !== undefined) {
+      obj.total = Math.round(message.total);
+    }
     return obj;
   },
 
@@ -1713,6 +1757,7 @@ export const ListChatsResponse: MessageFns<ListChatsResponse> = {
     const message = createBaseListChatsResponse();
     message.chats = object.chats?.map((e) => Chat.fromPartial(e)) || [];
     message.nextCursor = object.nextCursor ?? undefined;
+    message.total = object.total ?? undefined;
     return message;
   },
 };

--- a/packages/proto/src/generated/proto/adopt_dont_shop/moderation/v1/moderation.ts
+++ b/packages/proto/src/generated/proto/adopt_dont_shop/moderation/v1/moderation.ts
@@ -1021,12 +1021,27 @@ export interface ListReportsRequest {
    * Filter to reports assigned to a specific moderator (or
    * unassigned via the empty string).
    */
-  assignedModerator?: string | undefined;
+  assignedModerator?:
+    | string
+    | undefined;
+  /**
+   * Offset pagination for admin datatables. When set (>0) the handler
+   * returns an OFFSET page plus a real `total` (COUNT) instead of a keyset
+   * cursor, so the shared DataTable can render "Page X of Y".
+   */
+  page?: number | undefined;
 }
 
 export interface ListReportsResponse {
   reports: Report[];
-  nextCursor?: string | undefined;
+  nextCursor?:
+    | string
+    | undefined;
+  /**
+   * Total row count for the current filter — present only in offset mode
+   * (page set). Keyset responses omit it.
+   */
+  total?: number | undefined;
 }
 
 export interface AssignReportRequest {
@@ -1108,12 +1123,27 @@ export interface ListModeratorActionsRequest {
    * When true, return only currently-active actions (is_active AND not
    * expired) — powers the "active sanctions/actions" view.
    */
-  activeOnly?: boolean | undefined;
+  activeOnly?:
+    | boolean
+    | undefined;
+  /**
+   * Offset pagination for admin datatables. When set (>0) the handler
+   * returns an OFFSET page plus a real `total` (COUNT) instead of a keyset
+   * cursor, so the shared DataTable can render "Page X of Y".
+   */
+  page?: number | undefined;
 }
 
 export interface ListModeratorActionsResponse {
   actions: ModeratorAction[];
-  nextCursor?: string | undefined;
+  nextCursor?:
+    | string
+    | undefined;
+  /**
+   * Total row count for the current filter — present only in offset mode
+   * (page set). Keyset responses omit it.
+   */
+  total?: number | undefined;
 }
 
 export interface GetModerationMetricsRequest {
@@ -1270,12 +1300,27 @@ export interface ListSupportTicketsRequest {
     | string
     | undefined;
   /** Filter to tickets opened by a specific user. */
-  userId?: string | undefined;
+  userId?:
+    | string
+    | undefined;
+  /**
+   * Offset pagination for admin datatables. When set (>0) the handler
+   * returns an OFFSET page plus a real `total` (COUNT) instead of a keyset
+   * cursor, so the shared DataTable can render "Page X of Y".
+   */
+  page?: number | undefined;
 }
 
 export interface ListSupportTicketsResponse {
   tickets: SupportTicket[];
-  nextCursor?: string | undefined;
+  nextCursor?:
+    | string
+    | undefined;
+  /**
+   * Total row count for the current filter — present only in offset mode
+   * (page set). Keyset responses omit it.
+   */
+  total?: number | undefined;
 }
 
 export interface RespondToTicketRequest {
@@ -4036,6 +4081,7 @@ function createBaseListReportsRequest(): ListReportsRequest {
     severity: undefined,
     category: undefined,
     assignedModerator: undefined,
+    page: undefined,
   };
 }
 
@@ -4058,6 +4104,9 @@ export const ListReportsRequest: MessageFns<ListReportsRequest> = {
     }
     if (message.assignedModerator !== undefined) {
       writer.uint32(50).string(message.assignedModerator);
+    }
+    if (message.page !== undefined) {
+      writer.uint32(56).uint32(message.page);
     }
     return writer;
   },
@@ -4117,6 +4166,14 @@ export const ListReportsRequest: MessageFns<ListReportsRequest> = {
           message.assignedModerator = reader.string();
           continue;
         }
+        case 7: {
+          if (tag !== 56) {
+            break;
+          }
+
+          message.page = reader.uint32();
+          continue;
+        }
       }
       if ((tag & 7) === 4 || tag === 0) {
         break;
@@ -4138,6 +4195,7 @@ export const ListReportsRequest: MessageFns<ListReportsRequest> = {
         : isSet(object.assigned_moderator)
         ? globalThis.String(object.assigned_moderator)
         : undefined,
+      page: isSet(object.page) ? globalThis.Number(object.page) : undefined,
     };
   },
 
@@ -4161,6 +4219,9 @@ export const ListReportsRequest: MessageFns<ListReportsRequest> = {
     if (message.assignedModerator !== undefined) {
       obj.assignedModerator = message.assignedModerator;
     }
+    if (message.page !== undefined) {
+      obj.page = Math.round(message.page);
+    }
     return obj;
   },
 
@@ -4175,12 +4236,13 @@ export const ListReportsRequest: MessageFns<ListReportsRequest> = {
     message.severity = object.severity ?? undefined;
     message.category = object.category ?? undefined;
     message.assignedModerator = object.assignedModerator ?? undefined;
+    message.page = object.page ?? undefined;
     return message;
   },
 };
 
 function createBaseListReportsResponse(): ListReportsResponse {
-  return { reports: [], nextCursor: undefined };
+  return { reports: [], nextCursor: undefined, total: undefined };
 }
 
 export const ListReportsResponse: MessageFns<ListReportsResponse> = {
@@ -4190,6 +4252,9 @@ export const ListReportsResponse: MessageFns<ListReportsResponse> = {
     }
     if (message.nextCursor !== undefined) {
       writer.uint32(18).string(message.nextCursor);
+    }
+    if (message.total !== undefined) {
+      writer.uint32(24).uint32(message.total);
     }
     return writer;
   },
@@ -4217,6 +4282,14 @@ export const ListReportsResponse: MessageFns<ListReportsResponse> = {
           message.nextCursor = reader.string();
           continue;
         }
+        case 3: {
+          if (tag !== 24) {
+            break;
+          }
+
+          message.total = reader.uint32();
+          continue;
+        }
       }
       if ((tag & 7) === 4 || tag === 0) {
         break;
@@ -4234,6 +4307,7 @@ export const ListReportsResponse: MessageFns<ListReportsResponse> = {
         : isSet(object.next_cursor)
         ? globalThis.String(object.next_cursor)
         : undefined,
+      total: isSet(object.total) ? globalThis.Number(object.total) : undefined,
     };
   },
 
@@ -4245,6 +4319,9 @@ export const ListReportsResponse: MessageFns<ListReportsResponse> = {
     if (message.nextCursor !== undefined) {
       obj.nextCursor = message.nextCursor;
     }
+    if (message.total !== undefined) {
+      obj.total = Math.round(message.total);
+    }
     return obj;
   },
 
@@ -4255,6 +4332,7 @@ export const ListReportsResponse: MessageFns<ListReportsResponse> = {
     const message = createBaseListReportsResponse();
     message.reports = object.reports?.map((e) => Report.fromPartial(e)) || [];
     message.nextCursor = object.nextCursor ?? undefined;
+    message.total = object.total ?? undefined;
     return message;
   },
 };
@@ -5046,6 +5124,7 @@ function createBaseListModeratorActionsRequest(): ListModeratorActionsRequest {
     reportId: undefined,
     actionType: undefined,
     activeOnly: undefined,
+    page: undefined,
   };
 }
 
@@ -5068,6 +5147,9 @@ export const ListModeratorActionsRequest: MessageFns<ListModeratorActionsRequest
     }
     if (message.activeOnly !== undefined) {
       writer.uint32(48).bool(message.activeOnly);
+    }
+    if (message.page !== undefined) {
+      writer.uint32(56).uint32(message.page);
     }
     return writer;
   },
@@ -5127,6 +5209,14 @@ export const ListModeratorActionsRequest: MessageFns<ListModeratorActionsRequest
           message.activeOnly = reader.bool();
           continue;
         }
+        case 7: {
+          if (tag !== 56) {
+            break;
+          }
+
+          message.page = reader.uint32();
+          continue;
+        }
       }
       if ((tag & 7) === 4 || tag === 0) {
         break;
@@ -5160,6 +5250,7 @@ export const ListModeratorActionsRequest: MessageFns<ListModeratorActionsRequest
         : isSet(object.active_only)
         ? globalThis.Boolean(object.active_only)
         : undefined,
+      page: isSet(object.page) ? globalThis.Number(object.page) : undefined,
     };
   },
 
@@ -5183,6 +5274,9 @@ export const ListModeratorActionsRequest: MessageFns<ListModeratorActionsRequest
     if (message.activeOnly !== undefined) {
       obj.activeOnly = message.activeOnly;
     }
+    if (message.page !== undefined) {
+      obj.page = Math.round(message.page);
+    }
     return obj;
   },
 
@@ -5197,12 +5291,13 @@ export const ListModeratorActionsRequest: MessageFns<ListModeratorActionsRequest
     message.reportId = object.reportId ?? undefined;
     message.actionType = object.actionType ?? undefined;
     message.activeOnly = object.activeOnly ?? undefined;
+    message.page = object.page ?? undefined;
     return message;
   },
 };
 
 function createBaseListModeratorActionsResponse(): ListModeratorActionsResponse {
-  return { actions: [], nextCursor: undefined };
+  return { actions: [], nextCursor: undefined, total: undefined };
 }
 
 export const ListModeratorActionsResponse: MessageFns<ListModeratorActionsResponse> = {
@@ -5212,6 +5307,9 @@ export const ListModeratorActionsResponse: MessageFns<ListModeratorActionsRespon
     }
     if (message.nextCursor !== undefined) {
       writer.uint32(18).string(message.nextCursor);
+    }
+    if (message.total !== undefined) {
+      writer.uint32(24).uint32(message.total);
     }
     return writer;
   },
@@ -5239,6 +5337,14 @@ export const ListModeratorActionsResponse: MessageFns<ListModeratorActionsRespon
           message.nextCursor = reader.string();
           continue;
         }
+        case 3: {
+          if (tag !== 24) {
+            break;
+          }
+
+          message.total = reader.uint32();
+          continue;
+        }
       }
       if ((tag & 7) === 4 || tag === 0) {
         break;
@@ -5258,6 +5364,7 @@ export const ListModeratorActionsResponse: MessageFns<ListModeratorActionsRespon
         : isSet(object.next_cursor)
         ? globalThis.String(object.next_cursor)
         : undefined,
+      total: isSet(object.total) ? globalThis.Number(object.total) : undefined,
     };
   },
 
@@ -5269,6 +5376,9 @@ export const ListModeratorActionsResponse: MessageFns<ListModeratorActionsRespon
     if (message.nextCursor !== undefined) {
       obj.nextCursor = message.nextCursor;
     }
+    if (message.total !== undefined) {
+      obj.total = Math.round(message.total);
+    }
     return obj;
   },
 
@@ -5279,6 +5389,7 @@ export const ListModeratorActionsResponse: MessageFns<ListModeratorActionsRespon
     const message = createBaseListModeratorActionsResponse();
     message.actions = object.actions?.map((e) => ModeratorAction.fromPartial(e)) || [];
     message.nextCursor = object.nextCursor ?? undefined;
+    message.total = object.total ?? undefined;
     return message;
   },
 };
@@ -7116,6 +7227,7 @@ function createBaseListSupportTicketsRequest(): ListSupportTicketsRequest {
     category: undefined,
     assignedTo: undefined,
     userId: undefined,
+    page: undefined,
   };
 }
 
@@ -7141,6 +7253,9 @@ export const ListSupportTicketsRequest: MessageFns<ListSupportTicketsRequest> = 
     }
     if (message.userId !== undefined) {
       writer.uint32(58).string(message.userId);
+    }
+    if (message.page !== undefined) {
+      writer.uint32(64).uint32(message.page);
     }
     return writer;
   },
@@ -7208,6 +7323,14 @@ export const ListSupportTicketsRequest: MessageFns<ListSupportTicketsRequest> = 
           message.userId = reader.string();
           continue;
         }
+        case 8: {
+          if (tag !== 64) {
+            break;
+          }
+
+          message.page = reader.uint32();
+          continue;
+        }
       }
       if ((tag & 7) === 4 || tag === 0) {
         break;
@@ -7234,6 +7357,7 @@ export const ListSupportTicketsRequest: MessageFns<ListSupportTicketsRequest> = 
         : isSet(object.user_id)
         ? globalThis.String(object.user_id)
         : undefined,
+      page: isSet(object.page) ? globalThis.Number(object.page) : undefined,
     };
   },
 
@@ -7260,6 +7384,9 @@ export const ListSupportTicketsRequest: MessageFns<ListSupportTicketsRequest> = 
     if (message.userId !== undefined) {
       obj.userId = message.userId;
     }
+    if (message.page !== undefined) {
+      obj.page = Math.round(message.page);
+    }
     return obj;
   },
 
@@ -7275,12 +7402,13 @@ export const ListSupportTicketsRequest: MessageFns<ListSupportTicketsRequest> = 
     message.category = object.category ?? undefined;
     message.assignedTo = object.assignedTo ?? undefined;
     message.userId = object.userId ?? undefined;
+    message.page = object.page ?? undefined;
     return message;
   },
 };
 
 function createBaseListSupportTicketsResponse(): ListSupportTicketsResponse {
-  return { tickets: [], nextCursor: undefined };
+  return { tickets: [], nextCursor: undefined, total: undefined };
 }
 
 export const ListSupportTicketsResponse: MessageFns<ListSupportTicketsResponse> = {
@@ -7290,6 +7418,9 @@ export const ListSupportTicketsResponse: MessageFns<ListSupportTicketsResponse> 
     }
     if (message.nextCursor !== undefined) {
       writer.uint32(18).string(message.nextCursor);
+    }
+    if (message.total !== undefined) {
+      writer.uint32(24).uint32(message.total);
     }
     return writer;
   },
@@ -7317,6 +7448,14 @@ export const ListSupportTicketsResponse: MessageFns<ListSupportTicketsResponse> 
           message.nextCursor = reader.string();
           continue;
         }
+        case 3: {
+          if (tag !== 24) {
+            break;
+          }
+
+          message.total = reader.uint32();
+          continue;
+        }
       }
       if ((tag & 7) === 4 || tag === 0) {
         break;
@@ -7336,6 +7475,7 @@ export const ListSupportTicketsResponse: MessageFns<ListSupportTicketsResponse> 
         : isSet(object.next_cursor)
         ? globalThis.String(object.next_cursor)
         : undefined,
+      total: isSet(object.total) ? globalThis.Number(object.total) : undefined,
     };
   },
 
@@ -7347,6 +7487,9 @@ export const ListSupportTicketsResponse: MessageFns<ListSupportTicketsResponse> 
     if (message.nextCursor !== undefined) {
       obj.nextCursor = message.nextCursor;
     }
+    if (message.total !== undefined) {
+      obj.total = Math.round(message.total);
+    }
     return obj;
   },
 
@@ -7357,6 +7500,7 @@ export const ListSupportTicketsResponse: MessageFns<ListSupportTicketsResponse> 
     const message = createBaseListSupportTicketsResponse();
     message.tickets = object.tickets?.map((e) => SupportTicket.fromPartial(e)) || [];
     message.nextCursor = object.nextCursor ?? undefined;
+    message.total = object.total ?? undefined;
     return message;
   },
 };

--- a/packages/proto/src/generated/proto/adopt_dont_shop/rescue/v1/rescue.ts
+++ b/packages/proto/src/generated/proto/adopt_dont_shop/rescue/v1/rescue.ts
@@ -507,12 +507,35 @@ export interface ListRescuesRequest {
    */
   latitude?: number | undefined;
   longitude?: number | undefined;
-  radiusKm?: number | undefined;
+  radiusKm?:
+    | number
+    | undefined;
+  /**
+   * Offset pagination for admin datatables. When set (>0) the handler
+   * returns an OFFSET page plus a real `total` (COUNT) instead of a keyset
+   * cursor, so the shared DataTable can render "Page X of Y".
+   */
+  page?:
+    | number
+    | undefined;
+  /**
+   * Admin "show every lifecycle status" scope for the rescues datatable.
+   * Drops the status predicate entirely; gated on the platform-admin
+   * permission in the handler.
+   */
+  allStatuses?: boolean | undefined;
 }
 
 export interface ListRescuesResponse {
   rescues: Rescue[];
-  nextCursor?: string | undefined;
+  nextCursor?:
+    | string
+    | undefined;
+  /**
+   * Total row count for the current filter — present only in offset mode
+   * (page set). Keyset responses omit it.
+   */
+  total?: number | undefined;
 }
 
 export interface UpdateRescueRequest {
@@ -2459,6 +2482,8 @@ function createBaseListRescuesRequest(): ListRescuesRequest {
     latitude: undefined,
     longitude: undefined,
     radiusKm: undefined,
+    page: undefined,
+    allStatuses: undefined,
   };
 }
 
@@ -2487,6 +2512,12 @@ export const ListRescuesRequest: MessageFns<ListRescuesRequest> = {
     }
     if (message.radiusKm !== undefined) {
       writer.uint32(65).double(message.radiusKm);
+    }
+    if (message.page !== undefined) {
+      writer.uint32(72).uint32(message.page);
+    }
+    if (message.allStatuses !== undefined) {
+      writer.uint32(80).bool(message.allStatuses);
     }
     return writer;
   },
@@ -2562,6 +2593,22 @@ export const ListRescuesRequest: MessageFns<ListRescuesRequest> = {
           message.radiusKm = reader.double();
           continue;
         }
+        case 9: {
+          if (tag !== 72) {
+            break;
+          }
+
+          message.page = reader.uint32();
+          continue;
+        }
+        case 10: {
+          if (tag !== 80) {
+            break;
+          }
+
+          message.allStatuses = reader.bool();
+          continue;
+        }
       }
       if ((tag & 7) === 4 || tag === 0) {
         break;
@@ -2593,6 +2640,12 @@ export const ListRescuesRequest: MessageFns<ListRescuesRequest> = {
         : isSet(object.radius_km)
         ? globalThis.Number(object.radius_km)
         : undefined,
+      page: isSet(object.page) ? globalThis.Number(object.page) : undefined,
+      allStatuses: isSet(object.allStatuses)
+        ? globalThis.Boolean(object.allStatuses)
+        : isSet(object.all_statuses)
+        ? globalThis.Boolean(object.all_statuses)
+        : undefined,
     };
   },
 
@@ -2622,6 +2675,12 @@ export const ListRescuesRequest: MessageFns<ListRescuesRequest> = {
     if (message.radiusKm !== undefined) {
       obj.radiusKm = message.radiusKm;
     }
+    if (message.page !== undefined) {
+      obj.page = Math.round(message.page);
+    }
+    if (message.allStatuses !== undefined) {
+      obj.allStatuses = message.allStatuses;
+    }
     return obj;
   },
 
@@ -2638,12 +2697,14 @@ export const ListRescuesRequest: MessageFns<ListRescuesRequest> = {
     message.latitude = object.latitude ?? undefined;
     message.longitude = object.longitude ?? undefined;
     message.radiusKm = object.radiusKm ?? undefined;
+    message.page = object.page ?? undefined;
+    message.allStatuses = object.allStatuses ?? undefined;
     return message;
   },
 };
 
 function createBaseListRescuesResponse(): ListRescuesResponse {
-  return { rescues: [], nextCursor: undefined };
+  return { rescues: [], nextCursor: undefined, total: undefined };
 }
 
 export const ListRescuesResponse: MessageFns<ListRescuesResponse> = {
@@ -2653,6 +2714,9 @@ export const ListRescuesResponse: MessageFns<ListRescuesResponse> = {
     }
     if (message.nextCursor !== undefined) {
       writer.uint32(18).string(message.nextCursor);
+    }
+    if (message.total !== undefined) {
+      writer.uint32(24).uint32(message.total);
     }
     return writer;
   },
@@ -2680,6 +2744,14 @@ export const ListRescuesResponse: MessageFns<ListRescuesResponse> = {
           message.nextCursor = reader.string();
           continue;
         }
+        case 3: {
+          if (tag !== 24) {
+            break;
+          }
+
+          message.total = reader.uint32();
+          continue;
+        }
       }
       if ((tag & 7) === 4 || tag === 0) {
         break;
@@ -2697,6 +2769,7 @@ export const ListRescuesResponse: MessageFns<ListRescuesResponse> = {
         : isSet(object.next_cursor)
         ? globalThis.String(object.next_cursor)
         : undefined,
+      total: isSet(object.total) ? globalThis.Number(object.total) : undefined,
     };
   },
 
@@ -2708,6 +2781,9 @@ export const ListRescuesResponse: MessageFns<ListRescuesResponse> = {
     if (message.nextCursor !== undefined) {
       obj.nextCursor = message.nextCursor;
     }
+    if (message.total !== undefined) {
+      obj.total = Math.round(message.total);
+    }
     return obj;
   },
 
@@ -2718,6 +2794,7 @@ export const ListRescuesResponse: MessageFns<ListRescuesResponse> = {
     const message = createBaseListRescuesResponse();
     message.rescues = object.rescues?.map((e) => Rescue.fromPartial(e)) || [];
     message.nextCursor = object.nextCursor ?? undefined;
+    message.total = object.total ?? undefined;
     return message;
   },
 };

--- a/services/applications/src/grpc/read-handlers.test.ts
+++ b/services/applications/src/grpc/read-handlers.test.ts
@@ -238,4 +238,56 @@ describe('listApplications', () => {
     expect(res.applications).toHaveLength(1);
     expect(res.nextCursor).toBeDefined();
   });
+
+  it('offset mode returns a page plus a real total via COUNT(*) when page is set', async () => {
+    const { deps, query } = makeDeps();
+    query
+      .mockResolvedValueOnce({
+        rows: [{ application_id: 'app-1', created_at: new Date('2026-06-02T12:00:00.000Z') }],
+      }) // the OFFSET page of index rows
+      .mockResolvedValueOnce({ rows: [{ total: '42' }] }) // the COUNT(*)
+      .mockResolvedValue({ rows: aggregateRows() }); // per-aggregate fold
+
+    // page not in the pre-regen ListApplicationsRequest type yet — cast as
+    // the existing tests cast the untyped shapes they build.
+    const res = await listApplications(deps, makePrincipal({ userId: 'usr-1' }), {
+      page: 2,
+      limit: 20,
+      statusFilter: S.APPLICATION_STATUS_UNSPECIFIED,
+    } as never);
+
+    expect(res.applications).toHaveLength(1);
+    expect(res.applications[0].status).toBe(S.APPLICATION_STATUS_SUBMITTED);
+    // Real total from the COUNT, and no keyset cursor in offset mode.
+    expect(res.total).toBe(42);
+    expect(res.nextCursor).toBeUndefined();
+
+    // The page query uses OFFSET; a separate COUNT(*) produces the total.
+    const pageSql = query.mock.calls[0][0] as string;
+    expect(pageSql).toContain('OFFSET');
+    expect(pageSql).not.toContain('application_id <'); // no cursor predicate
+    const countSql = query.mock.calls[1][0] as string;
+    expect(countSql).toContain('COUNT(*)');
+    // Scope ($1 = own user id), then LIMIT + OFFSET = (page-1)*limit = 20.
+    expect(query.mock.calls[0][1]).toEqual(['usr-1', 20, 20]);
+    expect(query.mock.calls[1][1]).toEqual(['usr-1']);
+  });
+
+  it('offset mode scopes the COUNT to the caller, never widening visibility', async () => {
+    const { deps, query } = makeDeps();
+    query
+      .mockResolvedValueOnce({ rows: [] }) // empty page
+      .mockResolvedValueOnce({ rows: [{ total: '0' }] }); // COUNT(*)
+
+    const res = await listApplications(
+      deps,
+      makePrincipal({ userId: 'staff-1', roles: ['rescue_staff'], rescueId: 'rsc-9' }),
+      { page: 1, limit: 20, statusFilter: S.APPLICATION_STATUS_UNSPECIFIED } as never
+    );
+
+    expect(res.applications).toEqual([]);
+    expect(res.total).toBe(0);
+    // The COUNT is pinned to the staff member's own rescue.
+    expect(query.mock.calls[1][1]).toContain('rsc-9');
+  });
 });

--- a/services/applications/src/grpc/read-handlers.ts
+++ b/services/applications/src/grpc/read-handlers.ts
@@ -144,6 +144,37 @@ export async function listApplications(
     params.push(statusToDb(req.statusFilter));
   }
 
+  // Offset mode: staff / admin datatables pass `page` and need a real total
+  // so the shared DataTable can render "Page X of Y" and gate Next. Keyset
+  // cursors can't cheaply produce a count, so this path issues a COUNT(*)
+  // over the same principal-scoped filter. Offset callers never send a
+  // cursor, so no cursor predicate is present in `where` — the scope + status
+  // predicates above are the whole filter, and the COUNT reuses them so it
+  // can never widen what the caller sees.
+  if (req.page !== undefined && req.page > 0) {
+    const offset = (req.page - 1) * limit;
+    const pageResult = await deps.pool.query<IndexRow>(
+      `
+      SELECT application_id, created_at
+      FROM applications
+      WHERE ${where.join(' AND ')}
+      ORDER BY created_at DESC, application_id DESC
+      LIMIT $${p} OFFSET $${p + 1}
+      `,
+      [...params, limit, offset]
+    );
+    const countResult = await deps.pool.query<{ total: string }>(
+      `SELECT COUNT(*)::text AS total FROM applications WHERE ${where.join(' AND ')}`,
+      params
+    );
+    const applications = await Promise.all(
+      pageResult.rows.map(async row =>
+        stateToProto(await loadAggregate(deps.pool, row.application_id))
+      )
+    );
+    return { applications, total: Number(countResult.rows[0]?.total ?? 0) };
+  }
+
   if (req.cursor !== undefined && req.cursor !== '') {
     let cursor;
     try {

--- a/services/chat/src/grpc/handlers.test.ts
+++ b/services/chat/src/grpc/handlers.test.ts
@@ -678,6 +678,50 @@ describe('listChats', () => {
     expect(res.chats).toHaveLength(1);
     expect(res.chats?.[0].chatId).toBe('chat-1');
   });
+
+  it('offset mode (page set) returns a real total and a LIMIT/OFFSET page, not a cursor', async () => {
+    // page SELECT
+    mocks.poolScript.push({ rows: [chatRowFixture()] });
+    // COUNT(DISTINCT c.chat_id)
+    mocks.poolScript.push({ rows: [{ total: '7' }] });
+    // chatRowToProto → loadChatParticipants + loadLastMessagePreview
+    mocks.poolScript.push({
+      rows: [{ participant_id: 'usr-adopter' }, { participant_id: 'usr-rescue' }],
+    });
+    mocks.poolScript.push({ rows: [] });
+
+    // `page`/`total` are new proto fields; buf generate is not run here, so the
+    // request is cast (as the rescue offset tests do) and total read via a cast.
+    const res = await listChats(mocks.deps, ADOPTER_PRINCIPAL, { ...BASE, page: 2 } as never);
+    expect(res.chats).toHaveLength(1);
+    expect((res as { total?: number }).total).toBe(7);
+    expect(res.nextCursor).toBeUndefined();
+
+    const pageSql = mocks.poolMock.query.mock.calls[0][0] as string;
+    const pageParams = mocks.poolMock.query.mock.calls[0][1] as unknown[];
+    expect(pageSql).toContain('OFFSET');
+    // limit defaults to DEFAULT_CHAT_LIMIT (20); offset = (2 - 1) * 20 = 20.
+    expect(pageParams).toEqual(expect.arrayContaining([20, 20]));
+    const countSql = mocks.poolMock.query.mock.calls[1][0] as string;
+    expect(countSql).toContain('COUNT(DISTINCT c.chat_id)');
+  });
+
+  it('offset mode stays self-scoped by participant_id (no widening)', async () => {
+    mocks.poolScript.push({ rows: [chatRowFixture()] });
+    mocks.poolScript.push({ rows: [{ total: '1' }] });
+    mocks.poolScript.push({
+      rows: [{ participant_id: 'usr-adopter' }, { participant_id: 'usr-rescue' }],
+    });
+    mocks.poolScript.push({ rows: [] });
+
+    await listChats(mocks.deps, ADOPTER_PRINCIPAL, { ...BASE, page: 1 } as never);
+
+    // Both the page SELECT and the COUNT filter on the caller's participant id.
+    const pageParams = mocks.poolMock.query.mock.calls[0][1] as unknown[];
+    const countParams = mocks.poolMock.query.mock.calls[1][1] as unknown[];
+    expect(pageParams).toContain('usr-adopter');
+    expect(countParams).toEqual(['usr-adopter']);
+  });
 });
 
 // --- MarkRead -------------------------------------------------------

--- a/services/chat/src/grpc/handlers.ts
+++ b/services/chat/src/grpc/handlers.ts
@@ -701,6 +701,38 @@ export async function listChats(
   const limit = clampLimit(req.limit, DEFAULT_CHAT_LIMIT, MAX_CHAT_LIMIT);
   const cursor = req.cursor ? decodeCursor<ChatCursor>(req.cursor) : null;
 
+  // Offset mode: the admin chats datatable passes `page` and needs a real
+  // total so the shared DataTable can render "Page X of Y". Keyset cursors
+  // can't cheaply produce a count, so this path issues a COUNT over the same
+  // participant-scoped filter. Offset callers never send a cursor. The filter
+  // is identical to the keyset path below — always self-scoped by
+  // participant_id, so this never widens who can see which chats.
+  if (req.page !== undefined && req.page > 0) {
+    const offset = (req.page - 1) * limit;
+    const pageResult = await deps.pool.query<ChatRow>(
+      `
+      SELECT DISTINCT c.*
+      FROM chats c
+      JOIN chat_participants p ON p.chat_id = c.chat_id
+      WHERE p.participant_id = $1 AND p.deleted_at IS NULL AND c.deleted_at IS NULL
+      ORDER BY c.updated_at DESC, c.chat_id DESC
+      LIMIT $2 OFFSET $3
+      `,
+      [principal.userId, limit, offset]
+    );
+    const countResult = await deps.pool.query<{ total: string }>(
+      `
+      SELECT COUNT(DISTINCT c.chat_id)::text AS total
+      FROM chats c
+      JOIN chat_participants p ON p.chat_id = c.chat_id
+      WHERE p.participant_id = $1 AND p.deleted_at IS NULL AND c.deleted_at IS NULL
+      `,
+      [principal.userId]
+    );
+    const chats = await Promise.all(pageResult.rows.map(row => chatRowToProto(deps, row)));
+    return { chats, total: Number.parseInt(countResult.rows[0]?.total ?? '0', 10) };
+  }
+
   // Always self-scoped by participant_id. super_admin still goes
   // through the participant filter — staff-tooling that needs to see
   // all chats should call a different RPC (not exposed today).

--- a/services/gateway/src/middleware/pagination.test.ts
+++ b/services/gateway/src/middleware/pagination.test.ts
@@ -4,7 +4,7 @@
 
 import { describe, expect, it } from 'vitest';
 
-import { MAX_PAGE_LIMIT, parsePagination } from './pagination.js';
+import { buildPaginationEnvelope, MAX_PAGE_LIMIT, parsePagination } from './pagination.js';
 
 describe('parsePagination', () => {
   it('returns page 1 / limit 20 when both params are missing', () => {
@@ -69,6 +69,82 @@ describe('parsePagination', () => {
       ok: true,
       page: 1,
       limit: 0,
+    });
+  });
+});
+
+describe('buildPaginationEnvelope', () => {
+  describe('offset mode (datatable surfaces with a real count)', () => {
+    it('derives totalPages and next/prev from a real backend total', () => {
+      expect(buildPaginationEnvelope({ mode: 'offset', page: 1, limit: 25, total: 100 })).toEqual({
+        page: 1,
+        limit: 25,
+        total: 100,
+        totalPages: 4,
+        hasNext: true,
+        hasPrev: false,
+      });
+    });
+
+    it('reports hasPrev and no hasNext on the last page', () => {
+      expect(buildPaginationEnvelope({ mode: 'offset', page: 4, limit: 25, total: 100 })).toEqual({
+        page: 4,
+        limit: 25,
+        total: 100,
+        totalPages: 4,
+        hasNext: false,
+        hasPrev: true,
+      });
+    });
+
+    it('rounds a partial final page up', () => {
+      const meta = buildPaginationEnvelope({ mode: 'offset', page: 1, limit: 25, total: 26 });
+      expect(meta.totalPages).toBe(2);
+      expect(meta.hasNext).toBe(true);
+    });
+
+    it('returns a single empty page for a zero total', () => {
+      expect(buildPaginationEnvelope({ mode: 'offset', page: 1, limit: 25, total: 0 })).toEqual({
+        page: 1,
+        limit: 25,
+        total: 0,
+        totalPages: 1,
+        hasNext: false,
+        hasPrev: false,
+      });
+    });
+
+    it('treats a zero limit (fetch-all) as a single page', () => {
+      expect(buildPaginationEnvelope({ mode: 'offset', page: 1, limit: 0, total: 40 })).toEqual({
+        page: 1,
+        limit: 0,
+        total: 40,
+        totalPages: 1,
+        hasNext: false,
+        hasPrev: false,
+      });
+    });
+  });
+
+  describe('keyset mode (feeds with no cheap count)', () => {
+    it('carries the cursor and omits the count it cannot produce', () => {
+      expect(
+        buildPaginationEnvelope({ mode: 'keyset', limit: 20, hasNext: true, nextCursor: 'c1' })
+      ).toEqual({
+        page: 1,
+        limit: 20,
+        hasNext: true,
+        hasPrev: false,
+        nextCursor: 'c1',
+      });
+    });
+
+    it('omits nextCursor and any count on the final page', () => {
+      const meta = buildPaginationEnvelope({ mode: 'keyset', limit: 20, hasNext: false });
+      expect(meta).toEqual({ page: 1, limit: 20, hasNext: false, hasPrev: false });
+      expect(meta).not.toHaveProperty('nextCursor');
+      expect(meta).not.toHaveProperty('total');
+      expect(meta).not.toHaveProperty('totalPages');
     });
   });
 });

--- a/services/gateway/src/middleware/pagination.ts
+++ b/services/gateway/src/middleware/pagination.ts
@@ -55,3 +55,61 @@ export const parsePagination = (
   }
   return { ok: true, page, limit };
 };
+
+// Canonical pagination envelope. Every list route embeds the same
+// `pagination` block so all datatables read one vocabulary regardless of
+// whether the backend paginates by offset or keyset:
+//
+//   { page, limit, hasNext, hasPrev, total?, totalPages?, nextCursor? }
+//
+// Offset/datatable surfaces carry a real `total` (+ derived `totalPages`)
+// so the shared DataTable can render "Page X of Y" and gate Next. Keyset
+// feeds carry `nextCursor` and omit the count they can't cheaply produce.
+export type PaginationMeta = {
+  page: number;
+  limit: number;
+  hasNext: boolean;
+  hasPrev: boolean;
+  total?: number;
+  totalPages?: number;
+  nextCursor?: string;
+};
+
+type OffsetPaginationInput = {
+  mode: 'offset';
+  page: number;
+  limit: number;
+  total: number;
+};
+
+type KeysetPaginationInput = {
+  mode: 'keyset';
+  limit: number;
+  hasNext: boolean;
+  nextCursor?: string;
+};
+
+export type PaginationInput = OffsetPaginationInput | KeysetPaginationInput;
+
+export const buildPaginationEnvelope = (input: PaginationInput): PaginationMeta => {
+  if (input.mode === 'offset') {
+    const { page, limit, total } = input;
+    const totalPages = limit > 0 ? Math.max(1, Math.ceil(total / limit)) : 1;
+    return {
+      page,
+      limit,
+      total,
+      totalPages,
+      hasNext: page < totalPages,
+      hasPrev: page > 1,
+    };
+  }
+  const { limit, hasNext, nextCursor } = input;
+  return {
+    page: 1,
+    limit,
+    hasNext,
+    hasPrev: false,
+    ...(nextCursor !== undefined ? { nextCursor } : {}),
+  };
+};

--- a/services/gateway/src/routes/applications.test.ts
+++ b/services/gateway/src/routes/applications.test.ts
@@ -239,6 +239,38 @@ describe('applications routes', () => {
     });
   });
 
+  it('offset-paginates List with a real total in the canonical envelope', async () => {
+    mocks.list.mockResolvedValue({ applications: [SUBMITTED], total: 42 });
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/v1/applications?page=2&limit=20&status=submitted',
+      headers: STAFF,
+    });
+    expect(res.statusCode).toBe(200);
+    // The route calls List in offset mode (page forwarded, no cursor).
+    expect(mocks.list.mock.calls[0][0]).toMatchObject({
+      page: 2,
+      limit: 20,
+      statusFilter: ApplicationsV1.ApplicationStatus.APPLICATION_STATUS_SUBMITTED,
+    });
+    expect(mocks.list.mock.calls[0][0]).not.toHaveProperty('cursor');
+    expect(res.json()).toMatchObject({
+      success: true,
+      data: [{ id: 'app-1', status: 'submitted' }],
+      pagination: { page: 2, limit: 20, total: 42, totalPages: 3, hasNext: true, hasPrev: true },
+    });
+  });
+
+  it('rejects a non-integer page with 400 (no gRPC call)', async () => {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/v1/applications?page=abc',
+      headers: STAFF,
+    });
+    expect(res.statusCode).toBe(400);
+    expect(mocks.list).not.toHaveBeenCalled();
+  });
+
   it('Get returns the frontend view in { data } for a visible application', async () => {
     mocks.get.mockResolvedValue({ application: SUBMITTED, timeline: [] });
     const res = await app.inject({

--- a/services/gateway/src/routes/applications.ts
+++ b/services/gateway/src/routes/applications.ts
@@ -66,7 +66,7 @@ import {
 } from './profile-view.js';
 import { buildMetadata } from '../middleware/metadata.js';
 import { GRPC_TO_HTTP, handleGrpcError } from '../middleware/grpc-error.js';
-import { parsePagination } from '../middleware/pagination.js';
+import { buildPaginationEnvelope, parsePagination } from '../middleware/pagination.js';
 
 export type ApplicationsRoutesOptions = {
   client: ApplicationsClient;
@@ -976,7 +976,7 @@ export const registerApplicationsRoutes = async (
         querystring: {
           type: 'object',
           properties: {
-            cursor: { type: 'string' },
+            page: { type: 'string' },
             limit: { type: 'string' },
             status: { type: 'string' },
             rescue: { type: 'string' },
@@ -987,9 +987,21 @@ export const registerApplicationsRoutes = async (
           200: {
             type: 'object',
             properties: {
+              success: { type: 'boolean' },
               data: {
                 type: 'array',
                 items: APPLICATION_VIEW_SCHEMA,
+              },
+              pagination: {
+                type: 'object',
+                properties: {
+                  page: { type: 'number' },
+                  limit: { type: 'number' },
+                  total: { type: 'number' },
+                  totalPages: { type: 'number' },
+                  hasNext: { type: 'boolean' },
+                  hasPrev: { type: 'boolean' },
+                },
               },
             },
           },
@@ -1005,12 +1017,12 @@ export const registerApplicationsRoutes = async (
     },
     async (req, reply) => {
       const q = req.query as Record<string, string | undefined>;
-      const pagination = parsePagination(q, { limit: 0 });
+      const pagination = parsePagination(q, { page: 1, limit: 20 });
       if (!pagination.ok) {
         return reply.code(400).send({ error: pagination.error });
       }
       const grpcReq: ListApplicationsRequest = {
-        cursor: q.cursor,
+        page: pagination.page,
         limit: pagination.limit,
         statusFilter: parseStatus(q.status),
         rescueIdFilter: q.rescue,
@@ -1019,11 +1031,21 @@ export const registerApplicationsRoutes = async (
       try {
         const res = await client.list(grpcReq, buildMetadata(req));
         // Stage B: map to the frontend view + drop draft/unspecified rows,
-        // and wrap in the `{ data }` envelope the SPA expects.
+        // then wrap in the canonical { success, data, pagination } envelope
+        // so the shared DataTable can render "Page X of Y" and gate Next.
         const data = res.applications
           .map(applicationToView)
           .filter((v): v is ApplicationView => v !== null);
-        return reply.send({ data });
+        return reply.send({
+          success: true,
+          data,
+          pagination: buildPaginationEnvelope({
+            mode: 'offset',
+            page: pagination.page,
+            limit: pagination.limit,
+            total: res.total ?? 0,
+          }),
+        });
       } catch (err) {
         return handleGrpcError(err, reply);
       }

--- a/services/gateway/src/routes/audit.test.ts
+++ b/services/gateway/src/routes/audit.test.ts
@@ -246,10 +246,24 @@ describe('GET /api/v1/admin/audit-logs', () => {
     const body = httpRes.json() as {
       success: boolean;
       data: Array<Record<string, unknown>>;
-      pagination: { page: number; limit: number; total: number; pages: number };
+      pagination: {
+        page: number;
+        limit: number;
+        total: number;
+        totalPages: number;
+        hasNext: boolean;
+        hasPrev: boolean;
+      };
     };
     expect(body.success).toBe(true);
-    expect(body.pagination).toEqual({ page: 3, limit: 50, total: 137, pages: 3 });
+    expect(body.pagination).toEqual({
+      page: 3,
+      limit: 50,
+      total: 137,
+      totalPages: 3,
+      hasNext: false,
+      hasPrev: true,
+    });
     const log = body.data[0];
     expect(log.id).toBe('evt-1');
     expect(log.action).toBe('login');
@@ -295,16 +309,20 @@ describe('GET /api/v1/admin/audit-logs', () => {
     expect((body.data[1].metadata as Record<string, unknown>).details).toBeUndefined();
   });
 
-  it('defaults total/pages to 0 when the service omits total', async () => {
+  it('defaults total to 0 (and totalPages to 1) when the service omits total', async () => {
     queryMock.mockResolvedValue({ events: [] });
     const httpRes = await app.inject({
       method: 'GET',
       url: '/api/v1/admin/audit-logs',
       headers: ADMIN_HEADERS,
     });
-    const body = httpRes.json() as { pagination: { total: number; pages: number } };
+    const body = httpRes.json() as {
+      pagination: { total: number; totalPages: number; hasNext: boolean; hasPrev: boolean };
+    };
     expect(body.pagination.total).toBe(0);
-    expect(body.pagination.pages).toBe(0);
+    expect(body.pagination.totalPages).toBe(1);
+    expect(body.pagination.hasNext).toBe(false);
+    expect(body.pagination.hasPrev).toBe(false);
   });
 
   it('rejects a non-integer page with 400', async () => {

--- a/services/gateway/src/routes/audit.ts
+++ b/services/gateway/src/routes/audit.ts
@@ -39,7 +39,7 @@ import {
 import type { AuditClient } from '../grpc-clients/audit-client.js';
 import { buildMetadata } from '../middleware/metadata.js';
 import { handleGrpcError } from '../middleware/grpc-error.js';
-import { parsePagination } from '../middleware/pagination.js';
+import { buildPaginationEnvelope, parsePagination } from '../middleware/pagination.js';
 
 export type AuditRoutesOptions = {
   client: AuditClient;
@@ -177,7 +177,24 @@ export const registerAuditRoutes = async (
           },
         },
         response: {
-          200: { type: 'object', additionalProperties: true },
+          200: {
+            type: 'object',
+            properties: {
+              success: { type: 'boolean' },
+              data: { type: 'array', items: { type: 'object', additionalProperties: true } },
+              pagination: {
+                type: 'object',
+                properties: {
+                  page: { type: 'number' },
+                  limit: { type: 'number' },
+                  total: { type: 'number' },
+                  totalPages: { type: 'number' },
+                  hasNext: { type: 'boolean' },
+                  hasPrev: { type: 'boolean' },
+                },
+              },
+            },
+          },
           400: { type: 'object', properties: { error: { type: 'string' } } },
         },
       },
@@ -204,12 +221,15 @@ export const registerAuditRoutes = async (
       };
       try {
         const res = await client.query(grpcReq, buildMetadata(req));
-        const total = res.total ?? 0;
-        const pages = pagination.limit > 0 ? Math.ceil(total / pagination.limit) : 0;
         return reply.send({
           success: true,
           data: res.events.map(eventToAuditLog),
-          pagination: { page: pagination.page, limit: pagination.limit, total, pages },
+          pagination: buildPaginationEnvelope({
+            mode: 'offset',
+            page: pagination.page,
+            limit: pagination.limit,
+            total: res.total ?? 0,
+          }),
         });
       } catch (err) {
         return handleGrpcError(err, reply);

--- a/services/gateway/src/routes/chat.test.ts
+++ b/services/gateway/src/routes/chat.test.ts
@@ -146,6 +146,55 @@ describe('GET /api/v1/chats — list', () => {
     const [req] = client.listChatsMock.mock.calls[0] as [ListChatsRequest, Metadata];
     expect(req.unreadOnly).toBe(true);
   });
+
+  it('replies with the canonical offset pagination envelope and forwards page', async () => {
+    client.listChatsMock.mockResolvedValueOnce({ chats: [CHAT_FIXTURE], total: 42 });
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/v1/chats?page=2&limit=20',
+      headers: { 'x-user-id': 'usr-1', 'x-user-roles': 'adopter' },
+    });
+
+    expect(res.statusCode).toBe(200);
+    const json = res.json() as {
+      success: boolean;
+      data: unknown[];
+      pagination: {
+        page: number;
+        limit: number;
+        total: number;
+        totalPages: number;
+        hasNext: boolean;
+        hasPrev: boolean;
+      };
+    };
+    expect(json.success).toBe(true);
+    expect(json.data).toHaveLength(1);
+    expect(json.pagination).toEqual({
+      page: 2,
+      limit: 20,
+      total: 42,
+      totalPages: 3,
+      hasNext: true,
+      hasPrev: true,
+    });
+    // page is forwarded so the handler takes its offset + COUNT branch.
+    const [req] = client.listChatsMock.mock.calls[0] as [ListChatsRequest, Metadata];
+    expect((req as { page?: number }).page).toBe(2);
+  });
+
+  it('defaults total to 0 when the handler omits it', async () => {
+    client.listChatsMock.mockResolvedValueOnce({ chats: [] });
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/v1/chats',
+      headers: { 'x-user-id': 'usr-1', 'x-user-roles': 'adopter' },
+    });
+    const json = res.json() as { pagination: { total: number; totalPages: number } };
+    expect(json.pagination.total).toBe(0);
+    expect(json.pagination.totalPages).toBe(1);
+  });
 });
 
 // --- POST /api/v1/chats ---------------------------------------------
@@ -339,6 +388,50 @@ describe('GET /api/v1/chats/:chatId/messages — listMessages', () => {
     // Both surfaced: `body` for back-compat, `content` for the SPA / e2e.
     expect(json.messages[0].body).toBe('Hello');
     expect(json.messages[0].content).toBe('Hello');
+  });
+
+  it('emits a keyset pagination envelope carrying the next cursor', async () => {
+    client.listMessagesMock.mockResolvedValueOnce({
+      messages: [MESSAGE_FIXTURE],
+      nextCursor: 'next-abc',
+    });
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/v1/chats/chat-1/messages?limit=25',
+      headers: { 'x-user-id': 'usr-1', 'x-user-roles': 'adopter' },
+    });
+    expect(res.statusCode).toBe(200);
+    const json = res.json() as {
+      messages: unknown[];
+      pagination: {
+        page: number;
+        limit: number;
+        hasNext: boolean;
+        hasPrev: boolean;
+        nextCursor?: string;
+      };
+    };
+    // messages stay top-level (the SPA chat window + e2e read them there).
+    expect(json.messages).toHaveLength(1);
+    expect(json.pagination).toEqual({
+      page: 1,
+      limit: 25,
+      hasNext: true,
+      hasPrev: false,
+      nextCursor: 'next-abc',
+    });
+  });
+
+  it('keyset envelope reports hasNext false + omits the cursor on the last page', async () => {
+    client.listMessagesMock.mockResolvedValueOnce({ messages: [MESSAGE_FIXTURE] });
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/v1/chats/chat-1/messages?limit=25',
+      headers: { 'x-user-id': 'usr-1', 'x-user-roles': 'adopter' },
+    });
+    const json = res.json() as { pagination: { hasNext: boolean; nextCursor?: string } };
+    expect(json.pagination.hasNext).toBe(false);
+    expect(json.pagination.nextCursor).toBeUndefined();
   });
 });
 

--- a/services/gateway/src/routes/chat.ts
+++ b/services/gateway/src/routes/chat.ts
@@ -27,7 +27,7 @@ import {
 import type { ChatClient } from '../grpc-clients/chat-client.js';
 import { buildMetadata } from '../middleware/metadata.js';
 import { handleGrpcError } from '../middleware/grpc-error.js';
-import { parsePagination } from '../middleware/pagination.js';
+import { buildPaginationEnvelope, parsePagination } from '../middleware/pagination.js';
 
 export type ChatRoutesOptions = {
   client: ChatClient;
@@ -156,12 +156,30 @@ const registerChatRoutesForPrefix = (
           type: 'object',
           properties: {
             cursor: { type: 'string' },
+            page: { type: 'string' },
             limit: { type: 'string' },
             unreadOnly: { type: 'string' },
           },
         },
         response: {
-          200: { type: 'object', additionalProperties: true },
+          200: {
+            type: 'object',
+            properties: {
+              success: { type: 'boolean' },
+              data: { type: 'array', items: { type: 'object', additionalProperties: true } },
+              pagination: {
+                type: 'object',
+                properties: {
+                  page: { type: 'number' },
+                  limit: { type: 'number' },
+                  total: { type: 'number' },
+                  totalPages: { type: 'number' },
+                  hasNext: { type: 'boolean' },
+                  hasPrev: { type: 'boolean' },
+                },
+              },
+            },
+          },
           400: { type: 'object', properties: { error: { type: 'string' } } },
         },
       },
@@ -173,15 +191,28 @@ const registerChatRoutesForPrefix = (
       if (!pagination.ok) {
         return reply.code(400).send({ error: pagination.error });
       }
+      // The admin chats datatable is offset-paginated: pass `page` so the
+      // handler runs its COUNT branch and returns a real total, and reply with
+      // the canonical { success, data, pagination } envelope.
       const grpcReq: ListChatsRequest = {
         cursor: query.cursor,
+        page: pagination.page,
         limit: pagination.limit,
         unreadOnly: query.unreadOnly === 'true' || query.unread_only === 'true',
       };
 
       try {
         const res = await client.listChats(grpcReq, metadata);
-        return reply.send(ChatV1.ListChatsResponse.toJSON(res));
+        return reply.send({
+          success: true,
+          data: res.chats.map(c => ChatV1.Chat.toJSON(c)),
+          pagination: buildPaginationEnvelope({
+            mode: 'offset',
+            page: pagination.page,
+            limit: pagination.limit,
+            total: res.total ?? 0,
+          }),
+        });
       } catch (err) {
         return handleGrpcError(err, reply);
       }
@@ -569,7 +600,24 @@ const registerChatRoutesForPrefix = (
           properties: { cursor: { type: 'string' }, limit: { type: 'string' } },
         },
         response: {
-          200: { type: 'object', additionalProperties: true },
+          // Keyset feed: `messages` (+ `nextCursor`) stay top-level for the SPA
+          // chat window; `pagination` carries the canonical keyset envelope.
+          200: {
+            type: 'object',
+            additionalProperties: true,
+            properties: {
+              pagination: {
+                type: 'object',
+                properties: {
+                  page: { type: 'number' },
+                  limit: { type: 'number' },
+                  hasNext: { type: 'boolean' },
+                  hasPrev: { type: 'boolean' },
+                  nextCursor: { type: 'string' },
+                },
+              },
+            },
+          },
           400: { type: 'object', properties: { error: { type: 'string' } } },
         },
       },
@@ -589,7 +637,21 @@ const registerChatRoutesForPrefix = (
 
       try {
         const res = await client.listMessages(grpcReq, metadata);
-        return reply.send(normalizeMessages(ChatV1.ListMessagesResponse.toJSON(res)));
+        // Chat history is a naturally infinite-scroll (reverse-scroll) feed, so
+        // it stays keyset — emit the keyset envelope rather than a page count.
+        const body = normalizeMessages(ChatV1.ListMessagesResponse.toJSON(res)) as Record<
+          string,
+          unknown
+        >;
+        return reply.send({
+          ...body,
+          pagination: buildPaginationEnvelope({
+            mode: 'keyset',
+            limit: pagination.limit,
+            hasNext: res.nextCursor !== undefined,
+            nextCursor: res.nextCursor,
+          }),
+        });
       } catch (err) {
         return handleGrpcError(err, reply);
       }

--- a/services/gateway/src/routes/moderation-admin.test.ts
+++ b/services/gateway/src/routes/moderation-admin.test.ts
@@ -96,26 +96,65 @@ describe('moderation admin reports', () => {
     await app.close();
   });
 
-  it('GET /admin/moderation/reports → list envelope with hasNext', async () => {
-    mocks.listReports.mockResolvedValueOnce({ reports: [REPORT], nextCursor: 'cur-2' });
+  it('GET /admin/moderation/reports → offset envelope with real total; page forwarded to gRPC', async () => {
+    mocks.listReports.mockResolvedValueOnce({ reports: [REPORT], total: 42 });
     const res = await app.inject({
       method: 'GET',
-      url: '/api/v1/admin/moderation/reports?status=pending&limit=10',
+      url: '/api/v1/admin/moderation/reports?status=pending&page=2&limit=10',
       headers: ADMIN,
     });
     expect(res.statusCode).toBe(200);
     const body = res.json() as {
+      success: boolean;
       data: Array<{ status: string }>;
-      pagination: { hasNext: boolean; nextCursor?: string };
+      pagination: {
+        page: number;
+        limit: number;
+        total: number;
+        totalPages: number;
+        hasNext: boolean;
+        hasPrev: boolean;
+        nextCursor?: string;
+      };
     };
+    expect(body.success).toBe(true);
     expect(body.data).toHaveLength(1);
     expect(body.data[0].status).toBe('pending');
-    expect(body.pagination.hasNext).toBe(true);
-    expect(body.pagination.nextCursor).toBe('cur-2');
+    expect(body.pagination).toMatchObject({
+      page: 2,
+      limit: 10,
+      total: 42,
+      totalPages: 5,
+      hasNext: true,
+      hasPrev: true,
+    });
+    // Offset mode: page forwarded to the gRPC request, no cursor.
     expect(mocks.listReports.mock.calls[0][0]).toMatchObject({
       status: ModerationV1.ReportStatus.REPORT_STATUS_PENDING,
+      page: 2,
       limit: 10,
     });
+    expect(mocks.listReports.mock.calls[0][0].cursor).toBeUndefined();
+  });
+
+  it('GET /admin/moderation/reports defaults to page 1 when no page is supplied', async () => {
+    mocks.listReports.mockResolvedValueOnce({ reports: [REPORT], total: 1 });
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/v1/admin/moderation/reports',
+      headers: ADMIN,
+    });
+    expect(res.statusCode).toBe(200);
+    const body = res.json() as {
+      pagination: { page: number; totalPages: number; hasNext: boolean; hasPrev: boolean };
+    };
+    expect(body.pagination).toMatchObject({
+      page: 1,
+      totalPages: 1,
+      hasNext: false,
+      hasPrev: false,
+    });
+    expect(mocks.listReports.mock.calls[0][0].page).toBe(1);
   });
 
   it('GET /admin/moderation/reports/:id → { data } with lowercase enums', async () => {
@@ -294,13 +333,20 @@ describe('moderation admin actions + tickets', () => {
     });
     const res = await app.inject({
       method: 'GET',
-      url: '/api/v1/admin/moderation/actions',
+      url: '/api/v1/admin/moderation/actions?page=3&limit=5',
       headers: ADMIN,
     });
     expect(res.statusCode).toBe(200);
-    expect((res.json() as { data: Array<{ actionType: string }> }).data[0].actionType).toBe(
-      'warning_issued'
-    );
+    const body = res.json() as {
+      success: boolean;
+      data: Array<{ actionType: string }>;
+      pagination: { page: number; limit: number; total: number; totalPages: number };
+    };
+    expect(body.success).toBe(true);
+    expect(body.data[0].actionType).toBe('warning_issued');
+    // No total from the mock → total defaults to 0, totalPages 1.
+    expect(body.pagination).toMatchObject({ page: 3, limit: 5, total: 0, totalPages: 1 });
+    expect(mocks.listModeratorActions.mock.calls[0][0]).toMatchObject({ page: 3, limit: 5 });
   });
 
   it('GET /admin/moderation/metrics → { success, data } with lowercased category tokens', async () => {
@@ -357,22 +403,37 @@ describe('moderation admin actions + tickets', () => {
     expect(res.statusCode).toBe(403);
   });
 
-  it('GET /admin/support/tickets → list envelope', async () => {
-    mocks.listSupportTickets.mockResolvedValueOnce({ tickets: [TICKET] });
+  it('GET /admin/support/tickets → offset envelope with real total', async () => {
+    mocks.listSupportTickets.mockResolvedValueOnce({ tickets: [TICKET], total: 3 });
     const res = await app.inject({
       method: 'GET',
-      url: '/api/v1/admin/support/tickets?status=open',
+      url: '/api/v1/admin/support/tickets?status=open&page=1&limit=20',
       headers: ADMIN,
     });
     expect(res.statusCode).toBe(200);
     const body = res.json() as {
+      success: boolean;
       data: Array<{ status: string }>;
-      pagination: { hasNext: boolean };
+      pagination: {
+        page: number;
+        limit: number;
+        total: number;
+        totalPages: number;
+        hasNext: boolean;
+      };
     };
+    expect(body.success).toBe(true);
     expect(body.data[0].status).toBe('open');
-    expect(body.pagination.hasNext).toBe(false);
+    expect(body.pagination).toMatchObject({
+      page: 1,
+      limit: 20,
+      total: 3,
+      totalPages: 1,
+      hasNext: false,
+    });
     expect(mocks.listSupportTickets.mock.calls[0][0]).toMatchObject({
       status: ModerationV1.SupportTicketStatus.SUPPORT_TICKET_STATUS_OPEN,
+      page: 1,
     });
   });
 

--- a/services/gateway/src/routes/moderation-admin.ts
+++ b/services/gateway/src/routes/moderation-admin.ts
@@ -33,7 +33,6 @@ import type { ModerationClient } from '../grpc-clients/moderation-client.js';
 
 import {
   dataEnvelope,
-  listEnvelope,
   metricsToView,
   moderatorActionToView,
   reportToView,
@@ -44,7 +43,7 @@ import {
 } from './moderation-view.js';
 import { buildMetadata } from '../middleware/metadata.js';
 import { handleGrpcError } from '../middleware/grpc-error.js';
-import { parsePagination } from '../middleware/pagination.js';
+import { buildPaginationEnvelope, parsePagination } from '../middleware/pagination.js';
 
 export type ModerationAdminRoutesOptions = {
   client: ModerationClient;
@@ -52,6 +51,28 @@ export type ModerationAdminRoutesOptions = {
 
 const RL_WRITE = { max: 30, timeWindow: '1 minute' } as const;
 const RL_READ = { max: 120, timeWindow: '1 minute' } as const;
+
+// Canonical list response schema: { success, data[], pagination }. The
+// pagination block carries the offset fields (page/limit/total/totalPages)
+// plus hasNext/hasPrev so the shared DataTable can render "Page X of Y".
+const LIST_RESPONSE_200 = {
+  type: 'object',
+  properties: {
+    success: { type: 'boolean' },
+    data: { type: 'array', items: { type: 'object', additionalProperties: true } },
+    pagination: {
+      type: 'object',
+      properties: {
+        page: { type: 'number' },
+        limit: { type: 'number' },
+        total: { type: 'number' },
+        totalPages: { type: 'number' },
+        hasNext: { type: 'boolean' },
+        hasPrev: { type: 'boolean' },
+      },
+    },
+  },
+} as const;
 
 // Upper bound on a single bulk-update batch — each id is one sequential gRPC
 // call, so the array can't be unbounded.
@@ -77,7 +98,7 @@ export const registerModerationAdminRoutes = async (
         querystring: {
           type: 'object',
           properties: {
-            cursor: { type: 'string' },
+            page: { type: 'string' },
             limit: { type: 'string' },
             status: { type: 'string' },
             severity: { type: 'string' },
@@ -86,19 +107,19 @@ export const registerModerationAdminRoutes = async (
           },
         },
         response: {
-          200: { type: 'object', additionalProperties: true },
+          200: LIST_RESPONSE_200,
           400: { type: 'object', properties: { error: { type: 'string' } } },
         },
       },
     },
     async (req, reply) => {
       const q = req.query as Record<string, string | undefined>;
-      const pagination = parsePagination(q, { limit: 0 });
+      const pagination = parsePagination(q, { page: 1, limit: 20 });
       if (!pagination.ok) {
         return reply.code(400).send({ error: pagination.error });
       }
       const grpcReq: ListReportsRequest = {
-        cursor: q.cursor,
+        page: pagination.page,
         limit: pagination.limit,
         status: parseEnum(
           ModerationV1.ReportStatus,
@@ -128,9 +149,16 @@ export const registerModerationAdminRoutes = async (
       };
       try {
         const res = await client.listReports(grpcReq, buildMetadata(req));
-        return reply.send(
-          listEnvelope(res.reports.map(reportToView), { nextCursor: res.nextCursor })
-        );
+        return reply.send({
+          success: true,
+          data: res.reports.map(reportToView),
+          pagination: buildPaginationEnvelope({
+            mode: 'offset',
+            page: pagination.page,
+            limit: pagination.limit,
+            total: res.total ?? 0,
+          }),
+        });
       } catch (err) {
         return handleGrpcError(err, reply);
       }
@@ -443,7 +471,7 @@ export const registerModerationAdminRoutes = async (
         querystring: {
           type: 'object',
           properties: {
-            cursor: { type: 'string' },
+            page: { type: 'string' },
             limit: { type: 'string' },
             user: { type: 'string' },
             report: { type: 'string' },
@@ -451,19 +479,19 @@ export const registerModerationAdminRoutes = async (
           },
         },
         response: {
-          200: { type: 'object', additionalProperties: true },
+          200: LIST_RESPONSE_200,
           400: { type: 'object', properties: { error: { type: 'string' } } },
         },
       },
     },
     async (req, reply) => {
       const q = req.query as Record<string, string | undefined>;
-      const pagination = parsePagination(q, { limit: 0 });
+      const pagination = parsePagination(q, { page: 1, limit: 20 });
       if (!pagination.ok) {
         return reply.code(400).send({ error: pagination.error });
       }
       const grpcReq: ListModeratorActionsRequest = {
-        cursor: q.cursor,
+        page: pagination.page,
         limit: pagination.limit,
         targetUserId: q.user,
         reportId: q.report,
@@ -478,9 +506,16 @@ export const registerModerationAdminRoutes = async (
       };
       try {
         const res = await client.listModeratorActions(grpcReq, buildMetadata(req));
-        return reply.send(
-          listEnvelope(res.actions.map(moderatorActionToView), { nextCursor: res.nextCursor })
-        );
+        return reply.send({
+          success: true,
+          data: res.actions.map(moderatorActionToView),
+          pagination: buildPaginationEnvelope({
+            mode: 'offset',
+            page: pagination.page,
+            limit: pagination.limit,
+            total: res.total ?? 0,
+          }),
+        });
       } catch (err) {
         return handleGrpcError(err, reply);
       }
@@ -626,7 +661,7 @@ export const registerModerationAdminRoutes = async (
         querystring: {
           type: 'object',
           properties: {
-            cursor: { type: 'string' },
+            page: { type: 'string' },
             limit: { type: 'string' },
             status: { type: 'string' },
             priority: { type: 'string' },
@@ -636,19 +671,19 @@ export const registerModerationAdminRoutes = async (
           },
         },
         response: {
-          200: { type: 'object', additionalProperties: true },
+          200: LIST_RESPONSE_200,
           400: { type: 'object', properties: { error: { type: 'string' } } },
         },
       },
     },
     async (req, reply) => {
       const q = req.query as Record<string, string | undefined>;
-      const pagination = parsePagination(q, { limit: 0 });
+      const pagination = parsePagination(q, { page: 1, limit: 20 });
       if (!pagination.ok) {
         return reply.code(400).send({ error: pagination.error });
       }
       const grpcReq: ListSupportTicketsRequest = {
-        cursor: q.cursor,
+        page: pagination.page,
         limit: pagination.limit,
         status: parseEnum(
           ModerationV1.SupportTicketStatus,
@@ -679,9 +714,16 @@ export const registerModerationAdminRoutes = async (
       };
       try {
         const res = await client.listSupportTickets(grpcReq, buildMetadata(req));
-        return reply.send(
-          listEnvelope(res.tickets.map(supportTicketToView), { nextCursor: res.nextCursor })
-        );
+        return reply.send({
+          success: true,
+          data: res.tickets.map(supportTicketToView),
+          pagination: buildPaginationEnvelope({
+            mode: 'offset',
+            page: pagination.page,
+            limit: pagination.limit,
+            total: res.total ?? 0,
+          }),
+        });
       } catch (err) {
         return handleGrpcError(err, reply);
       }

--- a/services/gateway/src/routes/moderation.test.ts
+++ b/services/gateway/src/routes/moderation.test.ts
@@ -125,18 +125,93 @@ describe('moderation report routes', () => {
     });
   });
 
-  it('GET /api/v1/moderation/reports → ListReports with filters', async () => {
-    mocks.listReports.mockResolvedValue({ reports: [] });
-    await app.inject({
+  it('GET /api/v1/moderation/reports (keyset) → canonical envelope + filters', async () => {
+    mocks.listReports.mockResolvedValue({ reports: [{ reportId: 'rpt-1' }], nextCursor: 'cur-2' });
+    const res = await app.inject({
       method: 'GET',
       url: '/api/v1/moderation/reports?status=pending&severity=high&limit=10',
       headers: HEADERS,
     });
-    expect(mocks.listReports.mock.calls[0][0]).toMatchObject({
+    expect(res.statusCode).toBe(200);
+    const body = res.json() as {
+      success: boolean;
+      data: Array<{ reportId: string }>;
+      pagination: {
+        page: number;
+        limit: number;
+        hasNext: boolean;
+        hasPrev: boolean;
+        nextCursor?: string;
+      };
+    };
+    expect(body.success).toBe(true);
+    expect(body.data[0].reportId).toBe('rpt-1');
+    expect(body.pagination).toMatchObject({
+      page: 1,
+      limit: 10,
+      hasNext: true,
+      hasPrev: false,
+      nextCursor: 'cur-2',
+    });
+    const grpcReq = mocks.listReports.mock.calls[0][0];
+    expect(grpcReq).toMatchObject({
       status: ModerationV1.ReportStatus.REPORT_STATUS_PENDING,
       severity: ModerationV1.Severity.SEVERITY_HIGH,
       limit: 10,
     });
+    // Keyset mode: no page forwarded (cursor path).
+    expect(grpcReq.page).toBeUndefined();
+  });
+
+  it('GET /api/v1/moderation/reports?page= → offset envelope with real total', async () => {
+    mocks.listReports.mockResolvedValue({ reports: [{ reportId: 'rpt-1' }], total: 42 });
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/v1/moderation/reports?page=2&limit=10',
+      headers: HEADERS,
+    });
+    expect(res.statusCode).toBe(200);
+    const body = res.json() as {
+      data: Array<{ reportId: string }>;
+      pagination: {
+        page: number;
+        total: number;
+        totalPages: number;
+        hasNext: boolean;
+        hasPrev: boolean;
+      };
+    };
+    expect(body.data[0].reportId).toBe('rpt-1');
+    expect(body.pagination).toMatchObject({
+      page: 2,
+      total: 42,
+      totalPages: 5,
+      hasNext: true,
+      hasPrev: true,
+    });
+    // Offset mode: page forwarded, no cursor.
+    const grpcReq = mocks.listReports.mock.calls[0][0];
+    expect(grpcReq.page).toBe(2);
+    expect(grpcReq.cursor).toBeUndefined();
+  });
+
+  it('GET /api/v1/moderation/actions?page= → offset envelope with page forwarded', async () => {
+    mocks.listModeratorActions.mockResolvedValue({ actions: [{ actionId: 'act-1' }], total: 7 });
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/v1/moderation/actions?page=1&limit=20',
+      headers: HEADERS,
+    });
+    expect(res.statusCode).toBe(200);
+    const body = res.json() as {
+      success: boolean;
+      data: Array<{ actionId: string }>;
+      pagination: { page: number; total: number; totalPages: number };
+    };
+    expect(body.success).toBe(true);
+    expect(body.data[0].actionId).toBe('act-1');
+    expect(body.pagination).toMatchObject({ page: 1, total: 7, totalPages: 1 });
+    expect(mocks.listModeratorActions.mock.calls[0][0].page).toBe(1);
   });
 
   it('GET /api/v1/moderation/reports/:id passes includeTransitions', async () => {
@@ -275,6 +350,33 @@ describe('moderation sanction + ticket routes', () => {
     });
     expect(res.statusCode).toBe(204);
     expect(mocks.acknowledgeSanction.mock.calls[0][0]).toEqual({ sanctionId: 'sanc-1' });
+  });
+
+  it('GET /api/v1/moderation/tickets (keyset) → canonical envelope with nextCursor', async () => {
+    mocks.listSupportTickets.mockResolvedValue({
+      tickets: [{ ticketId: 'tkt-1' }],
+      nextCursor: 'cur-9',
+    });
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/v1/moderation/tickets?status=open&limit=5',
+      headers: HEADERS,
+    });
+    expect(res.statusCode).toBe(200);
+    const body = res.json() as {
+      success: boolean;
+      data: Array<{ ticketId: string }>;
+      pagination: { page: number; limit: number; hasNext: boolean; nextCursor?: string };
+    };
+    expect(body.success).toBe(true);
+    expect(body.data[0].ticketId).toBe('tkt-1');
+    expect(body.pagination).toMatchObject({
+      page: 1,
+      limit: 5,
+      hasNext: true,
+      nextCursor: 'cur-9',
+    });
+    expect(mocks.listSupportTickets.mock.calls[0][0].page).toBeUndefined();
   });
 
   it('POST /api/v1/moderation/tickets → OpenSupportTicket, 201', async () => {

--- a/services/gateway/src/routes/moderation.ts
+++ b/services/gateway/src/routes/moderation.ts
@@ -55,11 +55,35 @@ import {
 import type { ModerationClient } from '../grpc-clients/moderation-client.js';
 import { buildMetadata } from '../middleware/metadata.js';
 import { handleGrpcError } from '../middleware/grpc-error.js';
-import { parsePagination } from '../middleware/pagination.js';
+import { buildPaginationEnvelope, parsePagination } from '../middleware/pagination.js';
 
 export type ModerationRoutesOptions = {
   client: ModerationClient;
 };
+
+// Canonical list response schema: { success, data[], pagination }. This raw
+// surface is dual-mode — offset (page/limit/total/totalPages) for admin
+// datatables, keyset (nextCursor) for the pre-existing cursor callers — so the
+// pagination block declares both vocabularies (unset keys are dropped).
+const LIST_RESPONSE_200 = {
+  type: 'object',
+  properties: {
+    success: { type: 'boolean' },
+    data: { type: 'array', items: { type: 'object', additionalProperties: true } },
+    pagination: {
+      type: 'object',
+      properties: {
+        page: { type: 'number' },
+        limit: { type: 'number' },
+        total: { type: 'number' },
+        totalPages: { type: 'number' },
+        hasNext: { type: 'boolean' },
+        hasPrev: { type: 'boolean' },
+        nextCursor: { type: 'string' },
+      },
+    },
+  },
+} as const;
 
 // Writes 30/min, reads 120/min — moderation is admin-driven so these
 // are sized for human use.
@@ -133,6 +157,7 @@ export const registerModerationRoutes = async (
         querystring: {
           type: 'object',
           properties: {
+            page: { type: 'string' },
             cursor: { type: 'string' },
             limit: { type: 'string' },
             status: { type: 'string' },
@@ -142,28 +167,47 @@ export const registerModerationRoutes = async (
           },
         },
         response: {
-          200: { type: 'object', additionalProperties: true },
+          200: LIST_RESPONSE_200,
           400: { type: 'object', properties: { error: { type: 'string' } } },
         },
       },
     },
     async (req, reply) => {
       const q = req.query as Record<string, string | undefined>;
-      const pagination = parsePagination(q, { limit: 0 });
+      // Offset mode when a `page` is supplied (admin datatable); otherwise the
+      // pre-existing keyset/cursor path. Both emit the canonical envelope.
+      const offsetMode = q.page !== undefined && q.page !== '';
+      const pagination = parsePagination(q, offsetMode ? { page: 1, limit: 20 } : { limit: 0 });
       if (!pagination.ok) {
         return reply.code(400).send({ error: pagination.error });
       }
       const grpcReq: ListReportsRequest = {
-        cursor: q.cursor,
         limit: pagination.limit,
         status: parseReportStatus(q.status),
         severity: parseSeverity(q.severity),
         category: parseCategory(q.category),
         assignedModerator: q.assigned,
+        ...(offsetMode ? { page: pagination.page } : { cursor: q.cursor }),
       };
       try {
         const res = await client.listReports(grpcReq, buildMetadata(req));
-        return reply.send(ModerationV1.ListReportsResponse.toJSON(res));
+        return reply.send({
+          success: true,
+          data: res.reports.map(r => ModerationV1.Report.toJSON(r)),
+          pagination: offsetMode
+            ? buildPaginationEnvelope({
+                mode: 'offset',
+                page: pagination.page,
+                limit: pagination.limit,
+                total: res.total ?? 0,
+              })
+            : buildPaginationEnvelope({
+                mode: 'keyset',
+                limit: pagination.limit,
+                hasNext: res.nextCursor !== undefined && res.nextCursor !== '',
+                nextCursor: res.nextCursor,
+              }),
+        });
       } catch (err) {
         return handleGrpcError(err, reply);
       }
@@ -312,6 +356,7 @@ export const registerModerationRoutes = async (
         querystring: {
           type: 'object',
           properties: {
+            page: { type: 'string' },
             cursor: { type: 'string' },
             limit: { type: 'string' },
             user: { type: 'string' },
@@ -320,27 +365,46 @@ export const registerModerationRoutes = async (
           },
         },
         response: {
-          200: { type: 'object', additionalProperties: true },
+          200: LIST_RESPONSE_200,
           400: { type: 'object', properties: { error: { type: 'string' } } },
         },
       },
     },
     async (req, reply) => {
       const q = req.query as Record<string, string | undefined>;
-      const pagination = parsePagination(q, { limit: 0 });
+      // Offset mode when a `page` is supplied (admin datatable); otherwise the
+      // pre-existing keyset/cursor path. Both emit the canonical envelope.
+      const offsetMode = q.page !== undefined && q.page !== '';
+      const pagination = parsePagination(q, offsetMode ? { page: 1, limit: 20 } : { limit: 0 });
       if (!pagination.ok) {
         return reply.code(400).send({ error: pagination.error });
       }
       const grpcReq: ListModeratorActionsRequest = {
-        cursor: q.cursor,
         limit: pagination.limit,
         targetUserId: q.user,
         reportId: q.report,
         actionType: parseActionType(q.action),
+        ...(offsetMode ? { page: pagination.page } : { cursor: q.cursor }),
       };
       try {
         const res = await client.listModeratorActions(grpcReq, buildMetadata(req));
-        return reply.send(ModerationV1.ListModeratorActionsResponse.toJSON(res));
+        return reply.send({
+          success: true,
+          data: res.actions.map(a => ModerationV1.ModeratorAction.toJSON(a)),
+          pagination: offsetMode
+            ? buildPaginationEnvelope({
+                mode: 'offset',
+                page: pagination.page,
+                limit: pagination.limit,
+                total: res.total ?? 0,
+              })
+            : buildPaginationEnvelope({
+                mode: 'keyset',
+                limit: pagination.limit,
+                hasNext: res.nextCursor !== undefined && res.nextCursor !== '',
+                nextCursor: res.nextCursor,
+              }),
+        });
       } catch (err) {
         return handleGrpcError(err, reply);
       }
@@ -592,6 +656,7 @@ export const registerModerationRoutes = async (
         querystring: {
           type: 'object',
           properties: {
+            page: { type: 'string' },
             cursor: { type: 'string' },
             limit: { type: 'string' },
             status: { type: 'string' },
@@ -602,29 +667,48 @@ export const registerModerationRoutes = async (
           },
         },
         response: {
-          200: { type: 'object', additionalProperties: true },
+          200: LIST_RESPONSE_200,
           400: { type: 'object', properties: { error: { type: 'string' } } },
         },
       },
     },
     async (req, reply) => {
       const q = req.query as Record<string, string | undefined>;
-      const pagination = parsePagination(q, { limit: 0 });
+      // Offset mode when a `page` is supplied (admin datatable); otherwise the
+      // pre-existing keyset/cursor path. Both emit the canonical envelope.
+      const offsetMode = q.page !== undefined && q.page !== '';
+      const pagination = parsePagination(q, offsetMode ? { page: 1, limit: 20 } : { limit: 0 });
       if (!pagination.ok) {
         return reply.code(400).send({ error: pagination.error });
       }
       const grpcReq: ListSupportTicketsRequest = {
-        cursor: q.cursor,
         limit: pagination.limit,
         status: parseTicketStatus(q.status),
         priority: parseTicketPriority(q.priority),
         category: parseTicketCategory(q.category),
         assignedTo: q.assigned,
         userId: q.user,
+        ...(offsetMode ? { page: pagination.page } : { cursor: q.cursor }),
       };
       try {
         const res = await client.listSupportTickets(grpcReq, buildMetadata(req));
-        return reply.send(ModerationV1.ListSupportTicketsResponse.toJSON(res));
+        return reply.send({
+          success: true,
+          data: res.tickets.map(t => ModerationV1.SupportTicket.toJSON(t)),
+          pagination: offsetMode
+            ? buildPaginationEnvelope({
+                mode: 'offset',
+                page: pagination.page,
+                limit: pagination.limit,
+                total: res.total ?? 0,
+              })
+            : buildPaginationEnvelope({
+                mode: 'keyset',
+                limit: pagination.limit,
+                hasNext: res.nextCursor !== undefined && res.nextCursor !== '',
+                nextCursor: res.nextCursor,
+              }),
+        });
       } catch (err) {
         return handleGrpcError(err, reply);
       }

--- a/services/gateway/src/routes/pets.test.ts
+++ b/services/gateway/src/routes/pets.test.ts
@@ -133,7 +133,7 @@ describe('GET /api/v1/pets', () => {
   });
 
   it('lists pets and forwards filters', async () => {
-    const listRes: ListPetsResponse = { pets: [PET_FIXTURE], nextCursor: 'abc' };
+    const listRes: ListPetsResponse = { pets: [PET_FIXTURE], total: 1 };
     listMock.mockResolvedValueOnce(listRes);
 
     const res = await app.inject({
@@ -143,14 +143,33 @@ describe('GET /api/v1/pets', () => {
     });
 
     expect(res.statusCode).toBe(200);
-    // Stage B envelope: { success, data, meta }.
-    const body = res.json() as { success: boolean; data: unknown[]; meta: { hasNext: boolean } };
+    // Canonical pagination envelope: { success, data, pagination }.
+    const body = res.json() as {
+      success: boolean;
+      data: unknown[];
+      pagination: {
+        page: number;
+        limit: number;
+        total: number;
+        totalPages: number;
+        hasNext: boolean;
+        hasPrev: boolean;
+      };
+    };
     expect(body.success).toBe(true);
     expect(body.data).toHaveLength(1);
-    expect(body.meta.hasNext).toBe(true);
+    expect(body.pagination).toEqual({
+      page: 1,
+      limit: 10,
+      total: 1,
+      totalPages: 1,
+      hasNext: false,
+      hasPrev: false,
+    });
 
     const [req, metadata] = listMock.mock.calls[0];
     expect(req.limit).toBe(10);
+    expect(req.page).toBe(1);
     expect(req.statusFilter).toBe(PetsV1.PetStatus.PET_STATUS_AVAILABLE);
     expect(req.typeFilter).toBe(PetsV1.PetType.PET_TYPE_DOG);
     expect(req.sizeFilter).toBe(PetsV1.PetSize.PET_SIZE_LARGE);
@@ -180,7 +199,7 @@ describe('GET /api/v1/pets', () => {
     expect(req.featuredFilter).toBe(false);
   });
 
-  it('page mode: forwards page/search/breed/gender/ageGroup/sort and builds real meta', async () => {
+  it('page mode: forwards page/search/breed/gender/ageGroup/sort and builds the canonical envelope', async () => {
     listMock.mockResolvedValueOnce({ pets: [PET_FIXTURE], nextCursor: undefined, total: 42 });
 
     const res = await app.inject({
@@ -190,9 +209,16 @@ describe('GET /api/v1/pets', () => {
     });
 
     expect(res.statusCode).toBe(200);
-    const body = res.json() as { meta: Record<string, unknown> };
+    const body = res.json() as { pagination: Record<string, unknown> };
     // total 42 / limit 12 → 4 pages; page 3 has both prev and next.
-    expect(body.meta).toEqual({ page: 3, total: 42, totalPages: 4, hasNext: true, hasPrev: true });
+    expect(body.pagination).toEqual({
+      page: 3,
+      limit: 12,
+      total: 42,
+      totalPages: 4,
+      hasNext: true,
+      hasPrev: true,
+    });
 
     const [gr] = listMock.mock.calls[0];
     expect(gr.page).toBe(3);
@@ -204,15 +230,15 @@ describe('GET /api/v1/pets', () => {
     expect(gr.sortOrder).toBe('ASC');
   });
 
-  it('stays in cursor mode (no page) when page is not requested', async () => {
-    listMock.mockResolvedValueOnce({ pets: [PET_FIXTURE], nextCursor: undefined });
+  it('defaults to page 1 when no page param is requested', async () => {
+    listMock.mockResolvedValueOnce({ pets: [PET_FIXTURE], total: 5 });
     await app.inject({
       method: 'GET',
       url: '/api/v1/pets?limit=12',
       headers: { 'x-user-id': 'usr-1', 'x-user-roles': 'adopter' },
     });
     const [gr] = listMock.mock.calls[0];
-    expect(gr.page).toBeUndefined();
+    expect(gr.page).toBe(1);
   });
 
   it('coerces an unknown status to UNSPECIFIED (service returns 400)', async () => {

--- a/services/gateway/src/routes/pets.ts
+++ b/services/gateway/src/routes/pets.ts
@@ -31,15 +31,10 @@ import {
 
 import type { PetsClient } from '../grpc-clients/pets-client.js';
 
-import {
-  listToEnvelope,
-  petToView,
-  viewToCreateRequest,
-  viewToUpdateRequest,
-} from './pets-view.js';
+import { petToView, viewToCreateRequest, viewToUpdateRequest } from './pets-view.js';
 import { buildMetadata } from '../middleware/metadata.js';
 import { handleGrpcError } from '../middleware/grpc-error.js';
-import { parsePagination } from '../middleware/pagination.js';
+import { buildPaginationEnvelope, parsePagination } from '../middleware/pagination.js';
 
 export type PetsRoutesOptions = {
   client: PetsClient;
@@ -139,7 +134,7 @@ export const registerPetsRoutes = async (
       config: { rateLimit: PETS_RATE_LIMITS.list },
       schema: {
         tags: ['pets'],
-        summary: 'List pets with cursor pagination and optional filters',
+        summary: 'List pets with pagination and optional filters',
         // Querystring is documented only — no `required`, no integer
         // coercion (the existing handler does its own parseInt). Keeps
         // OpenAPI useful for SDK generation without changing runtime
@@ -169,10 +164,11 @@ export const registerPetsRoutes = async (
             properties: {
               success: { type: 'boolean' },
               data: { type: 'array', items: PET_VIEW_SCHEMA },
-              meta: {
+              pagination: {
                 type: 'object',
                 properties: {
                   page: { type: 'number' },
+                  limit: { type: 'number' },
                   total: { type: 'number' },
                   totalPages: { type: 'number' },
                   hasNext: { type: 'boolean' },
@@ -193,14 +189,13 @@ export const registerPetsRoutes = async (
     },
     async (req, reply) => {
       const query = req.query as Record<string, string | undefined>;
-      const pagination = parsePagination(query, { limit: 0 });
+      const pagination = parsePagination(query, { page: 1, limit: 20 });
       if (!pagination.ok) {
         return reply.code(400).send({ error: pagination.error });
       }
-      // parsePagination already validated + defaulted page (non-integer → 400
-      // above). Only switch the handler into page mode when the caller
-      // explicitly asked for a page; other list callers stay cursor-based.
-      const page = query.page !== undefined && query.page !== '' ? pagination.page : undefined;
+      // Offset/page mode: always pass `page` so the handler runs its COUNT(*)
+      // and returns a real `total`, which drives the canonical pagination
+      // envelope every datatable reads.
       const grpcReq: ListPetsRequest = {
         cursor: query.cursor,
         limit: pagination.limit,
@@ -209,7 +204,7 @@ export const registerPetsRoutes = async (
         sizeFilter: parseSize(query.size),
         rescueIdFilter: query.rescueId,
         featuredFilter: query.featured === 'true',
-        page,
+        page: pagination.page,
         search: query.search,
         breed: query.breed,
         genderFilter: parseGender(query.gender),
@@ -219,11 +214,16 @@ export const registerPetsRoutes = async (
       };
       try {
         const res = await client.list(grpcReq, buildMetadata(req));
-        // Stage B: frontend lib.pets shape ({ success, data, meta }). In page
-        // mode the handler returns a total → real page meta.
-        return reply.send(
-          listToEnvelope(res, page !== undefined ? { page, limit: pagination.limit } : undefined)
-        );
+        return reply.send({
+          success: true,
+          data: res.pets.map(petToView),
+          pagination: buildPaginationEnvelope({
+            mode: 'offset',
+            page: pagination.page,
+            limit: pagination.limit,
+            total: res.total ?? 0,
+          }),
+        });
       } catch (err) {
         return handleGrpcError(err, reply);
       }

--- a/services/gateway/src/routes/rescue-admin.test.ts
+++ b/services/gateway/src/routes/rescue-admin.test.ts
@@ -129,6 +129,55 @@ const STATS = {
   averageTimeToAdoption: 0,
 };
 
+describe('GET /api/v1/admin/rescues', () => {
+  let app: FastifyInstance;
+  let m: Mocks;
+
+  beforeEach(async () => {
+    m = makeClient();
+    app = await makeApp(m.client);
+  });
+  afterEach(async () => {
+    await app.close();
+  });
+
+  it('offset-paginates with a real total in the canonical envelope, defaulting to all statuses', async () => {
+    const listMock = m.client.list as ReturnType<typeof vi.fn>;
+    listMock.mockResolvedValue({ rescues: [makeRescue()], total: 42 });
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/v1/admin/rescues?page=2&limit=20',
+      headers: ADMIN_HEADERS,
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(listMock.mock.calls[0][0]).toMatchObject({ page: 2, limit: 20, allStatuses: true });
+    expect(res.json()).toMatchObject({
+      success: true,
+      data: [{ rescue_id: 'rsc-1' }],
+      pagination: { page: 2, limit: 20, total: 42, totalPages: 3, hasNext: true, hasPrev: true },
+    });
+  });
+
+  it('narrows to a concrete status without the all-statuses scope', async () => {
+    const listMock = m.client.list as ReturnType<typeof vi.fn>;
+    listMock.mockResolvedValue({ rescues: [], total: 0 });
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/v1/admin/rescues?status=pending',
+      headers: ADMIN_HEADERS,
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(listMock.mock.calls[0][0]).toMatchObject({
+      allStatuses: false,
+      statusFilter: RescueV1.RescueStatus.RESCUE_STATUS_PENDING,
+    });
+  });
+});
+
 describe('PATCH /api/v1/admin/rescues/:rescueId/plan', () => {
   let app: FastifyInstance;
   let m: Mocks;

--- a/services/gateway/src/routes/rescue-admin.ts
+++ b/services/gateway/src/routes/rescue-admin.ts
@@ -41,6 +41,7 @@ import {
   type GetRescueStatisticsRequest,
   type InviteStaffRequest,
   type ListRescueInvitationsRequest,
+  type ListRescuesRequest,
   type ListStaffMembersRequest,
   type SendRescueEmailRequest,
   type UpdateRescuePlanRequest,
@@ -52,6 +53,7 @@ import type { AuthClient } from '../grpc-clients/auth-client.js';
 import type { RescueClient } from '../grpc-clients/rescue-client.js';
 import { buildMetadata } from '../middleware/metadata.js';
 import { handleGrpcError } from '../middleware/grpc-error.js';
+import { buildPaginationEnvelope, parsePagination } from '../middleware/pagination.js';
 import { rescueToView } from './rescue-view.js';
 
 export type RescueAdminRoutesOptions = {
@@ -70,6 +72,16 @@ const BULK_ACTION_STATUS: Record<string, RescueV1.RescueStatus> = {
   approve: RescueV1.RescueStatus.RESCUE_STATUS_VERIFIED,
   verify: RescueV1.RescueStatus.RESCUE_STATUS_VERIFIED,
   suspend: RescueV1.RescueStatus.RESCUE_STATUS_SUSPENDED,
+};
+
+// Admin datatable status filter → proto enum. 'all' (or unset) uses the
+// all_statuses scope instead of a concrete filter.
+const ADMIN_STATUS_FILTER: Record<string, RescueV1.RescueStatus> = {
+  pending: RescueV1.RescueStatus.RESCUE_STATUS_PENDING,
+  verified: RescueV1.RescueStatus.RESCUE_STATUS_VERIFIED,
+  suspended: RescueV1.RescueStatus.RESCUE_STATUS_SUSPENDED,
+  inactive: RescueV1.RescueStatus.RESCUE_STATUS_INACTIVE,
+  rejected: RescueV1.RescueStatus.RESCUE_STATUS_REJECTED,
 };
 
 // proto StaffMember + (optional) auth user → the SPA's StaffMember shape.
@@ -132,6 +144,90 @@ export const registerRescueAdminRoutes = async (
   const { client, authClient } = opts;
 
   await app.register(rateLimit, { global: false });
+
+  // GET /api/v1/admin/rescues — the admin dashboard datatable. Offset
+  // paginated with a real total (so the shared DataTable renders "Page X of
+  // Y" and gates Next), and defaults to the all-statuses scope so pending /
+  // suspended rescues are visible for moderation. `status=<concrete>`
+  // narrows to a single status.
+  app.get(
+    '/api/v1/admin/rescues',
+    {
+      config: { rateLimit: RL_READ },
+      schema: {
+        tags: ['rescues'],
+        summary: 'List rescues for the admin dashboard',
+        querystring: {
+          type: 'object',
+          properties: {
+            page: { type: 'string' },
+            limit: { type: 'string' },
+            status: { type: 'string' },
+            search: { type: 'string' },
+          },
+        },
+        response: {
+          200: {
+            type: 'object',
+            properties: {
+              success: { type: 'boolean' },
+              data: { type: 'array', items: { type: 'object', additionalProperties: true } },
+              pagination: {
+                type: 'object',
+                properties: {
+                  page: { type: 'number' },
+                  limit: { type: 'number' },
+                  total: { type: 'number' },
+                  totalPages: { type: 'number' },
+                  hasNext: { type: 'boolean' },
+                  hasPrev: { type: 'boolean' },
+                },
+              },
+            },
+          },
+          400: {
+            type: 'object',
+            properties: { success: { type: 'boolean' }, error: { type: 'string' } },
+          },
+        },
+      },
+    },
+    async (req, reply) => {
+      const q = req.query as Record<string, string | undefined>;
+      const pagination = parsePagination(q, { page: 1, limit: 20 });
+      if (!pagination.ok) {
+        return reply.code(400).send({ success: false, error: pagination.error });
+      }
+      const status = q.status;
+      const allStatuses = status === undefined || status === '' || status === 'all';
+      const statusFilter =
+        !allStatuses && status
+          ? (ADMIN_STATUS_FILTER[status] ?? RescueV1.RescueStatus.RESCUE_STATUS_UNSPECIFIED)
+          : RescueV1.RescueStatus.RESCUE_STATUS_UNSPECIFIED;
+      const grpcReq: ListRescuesRequest = {
+        page: pagination.page,
+        limit: pagination.limit,
+        allStatuses,
+        statusFilter,
+        ...(q.search !== undefined && q.search !== '' ? { nameSearch: q.search } : {}),
+      };
+      try {
+        const res = await client.list(grpcReq, buildMetadata(req));
+        return reply.send({
+          success: true,
+          data: res.rescues.map(rescueToView),
+          pagination: buildPaginationEnvelope({
+            mode: 'offset',
+            page: pagination.page,
+            limit: pagination.limit,
+            total: res.total ?? 0,
+          }),
+        });
+      } catch (err) {
+        return handleGrpcError(err, reply);
+      }
+    }
+  );
 
   // PATCH /api/v1/admin/rescues/:rescueId/plan
   app.patch<{

--- a/services/gateway/src/routes/users.test.ts
+++ b/services/gateway/src/routes/users.test.ts
@@ -490,11 +490,26 @@ describe('GET /api/v1/users/search', () => {
     const body = res.json() as {
       success: boolean;
       data: Array<{ userId: string }>;
-      pagination: { total: number; totalPages: number };
+      pagination: {
+        page: number;
+        limit: number;
+        total: number;
+        totalPages: number;
+        hasNext: boolean;
+        hasPrev: boolean;
+      };
     };
     expect(body.success).toBe(true);
     expect(body.data).toHaveLength(1);
-    expect(body.pagination.total).toBe(1);
+    // Canonical pagination envelope (hasNext/hasPrev derived from the count).
+    expect(body.pagination).toEqual({
+      page: 1,
+      limit: 20,
+      total: 1,
+      totalPages: 1,
+      hasNext: false,
+      hasPrev: false,
+    });
 
     const [grpcReq] = auth.searchUsersMock.mock.calls[0] as [SearchUsersReqShape, Metadata];
     expect(grpcReq.search).toBe('jane');
@@ -559,9 +574,28 @@ describe('/api/v1/admin/users surface', () => {
       headers: { 'x-user-id': 'svc-admin', 'x-user-roles': 'admin' },
     });
     expect(res.statusCode).toBe(200);
-    const body = res.json() as { data: Array<{ userType: string; status: string }> };
+    const body = res.json() as {
+      data: Array<{ userType: string; status: string }>;
+      pagination: {
+        page: number;
+        limit: number;
+        total: number;
+        totalPages: number;
+        hasNext: boolean;
+        hasPrev: boolean;
+      };
+    };
     expect(body.data[0].userType).toBe('adopter');
     expect(body.data[0].status).toBe('active');
+    // Canonical pagination envelope, identical in shape to every datatable.
+    expect(body.pagination).toEqual({
+      page: 1,
+      limit: 50,
+      total: 1,
+      totalPages: 1,
+      hasNext: false,
+      hasPrev: false,
+    });
   });
 
   it('GET :userId returns the user with a canonical status string', async () => {

--- a/services/gateway/src/routes/users.ts
+++ b/services/gateway/src/routes/users.ts
@@ -35,7 +35,7 @@ import type { AuthClient } from '../grpc-clients/auth-client.js';
 import type { NotificationsClient } from '../grpc-clients/notifications-client.js';
 import { buildMetadata } from '../middleware/metadata.js';
 import { handleGrpcError } from '../middleware/grpc-error.js';
-import { parsePagination } from '../middleware/pagination.js';
+import { buildPaginationEnvelope, parsePagination } from '../middleware/pagination.js';
 import { userToApiJson } from './auth-user-json.js';
 
 export type UsersRoutesOptions = {
@@ -470,6 +470,8 @@ export const registerUsersRoutes = async (
                   limit: { type: 'number' },
                   total: { type: 'number' },
                   totalPages: { type: 'number' },
+                  hasNext: { type: 'boolean' },
+                  hasPrev: { type: 'boolean' },
                 },
               },
             },
@@ -508,12 +510,12 @@ export const registerUsersRoutes = async (
         return reply.send({
           success: true,
           data: res.users.map(u => AuthV1.User.toJSON(u)),
-          pagination: {
+          pagination: buildPaginationEnvelope({
+            mode: 'offset',
             page: res.page,
             limit: grpcReq.limit || 20,
             total: res.total,
-            totalPages: res.totalPages,
-          },
+          }),
         });
       } catch (err) {
         return handleGrpcError(err, reply);
@@ -825,6 +827,8 @@ export const registerUsersRoutes = async (
                   limit: { type: 'number' },
                   total: { type: 'number' },
                   totalPages: { type: 'number' },
+                  hasNext: { type: 'boolean' },
+                  hasPrev: { type: 'boolean' },
                 },
               },
             },
@@ -863,12 +867,12 @@ export const registerUsersRoutes = async (
         return reply.send({
           success: true,
           data: res.users.map(userToApiJson),
-          pagination: {
+          pagination: buildPaginationEnvelope({
+            mode: 'offset',
             page: res.page,
             limit: grpcReq.limit || 20,
             total: res.total,
-            totalPages: res.totalPages,
-          },
+          }),
         });
       } catch (err) {
         return handleGrpcError(err, reply);

--- a/services/gateway/src/server.test.ts
+++ b/services/gateway/src/server.test.ts
@@ -621,8 +621,12 @@ describe('createServer — domain route registration', () => {
     });
     const res = await server.inject({ method: 'GET', url: '/api/v1/applications' });
     // The gateway route served it — the view adapter wraps the (empty)
-    // result in the frontend's `{ data }` envelope.
-    expect(res.json()).toEqual({ data: [] });
+    // result in the canonical { success, data, pagination } envelope.
+    expect(res.json()).toEqual({
+      success: true,
+      data: [],
+      pagination: { page: 1, limit: 20, total: 0, totalPages: 1, hasNext: false, hasPrev: false },
+    });
   });
 
   it('404s /api/v1/applications when no applications client is wired', async () => {

--- a/services/moderation/src/grpc/action-handlers.test.ts
+++ b/services/moderation/src/grpc/action-handlers.test.ts
@@ -209,6 +209,39 @@ describe('listModeratorActions', () => {
     const sql = query.mock.calls[0][0] as string;
     expect(sql).not.toContain('is_active = true');
   });
+
+  it('offset mode (page set) returns an OFFSET page + real total via COUNT(*)', async () => {
+    const { deps, query } = makeDeps([
+      { rows: [actionRow()] }, // page query
+      { rows: [{ total: '7' }] }, // count query
+    ]);
+    const res = await listModeratorActions(deps, makePrincipal(), {
+      page: 2,
+      limit: 10,
+    } as ListModeratorActionsRequest);
+    const pageSql = query.mock.calls[0][0] as string;
+    expect(pageSql).toContain('LIMIT $1 OFFSET $2');
+    expect(query.mock.calls[0][1]).toEqual([10, 10]);
+    expect(query.mock.calls[1][0] as string).toContain('COUNT(*)');
+    expect((res as { total?: number }).total).toBe(7);
+    expect(res.nextCursor).toBeUndefined();
+    expect(res.actions).toHaveLength(1);
+  });
+
+  it('offset mode applies filters to BOTH the page and count queries', async () => {
+    const { deps, query } = makeDeps([
+      { rows: [] }, // page query
+      { rows: [{ total: '0' }] }, // count query
+    ]);
+    await listModeratorActions(deps, makePrincipal(), {
+      targetUserId: 'usr-2',
+      page: 1,
+      limit: 10,
+    } as ListModeratorActionsRequest);
+    expect(query.mock.calls[0][0] as string).toContain('target_user_id = $1');
+    expect(query.mock.calls[1][0] as string).toContain('target_user_id = $1');
+    expect((query.mock.calls[1][1] as unknown[])[0]).toBe('usr-2');
+  });
 });
 
 describe('addEvidence', () => {

--- a/services/moderation/src/grpc/action-handlers.ts
+++ b/services/moderation/src/grpc/action-handlers.ts
@@ -196,7 +196,14 @@ export async function listModeratorActions(
     where.push(`is_active = true AND (expires_at IS NULL OR expires_at > now())`);
   }
 
-  if (req.cursor !== undefined && req.cursor !== '') {
+  // Offset mode: admin datatables pass `page` and need a real total so the
+  // shared DataTable can render "Page X of Y" and gate Next. Keyset cursors
+  // can't cheaply produce a count, so this path issues a COUNT(*) over the
+  // same filter. Offset callers never send a cursor, so the cursor predicate
+  // is skipped.
+  const offsetMode = req.page !== undefined && req.page > 0;
+
+  if (!offsetMode && req.cursor !== undefined && req.cursor !== '') {
     let cursor;
     try {
       cursor = decodeCursor(req.cursor);
@@ -212,6 +219,32 @@ export async function listModeratorActions(
   }
 
   const whereSql = where.length === 0 ? '' : `WHERE ${where.join(' AND ')}`;
+
+  if (offsetMode) {
+    const offset = ((req.page ?? 1) - 1) * limit;
+    const pageResult = await deps.pool.query<ModeratorActionRow>(
+      `
+      SELECT action_id, moderator_id, report_id, target_entity_type,
+             target_entity_id, target_user_id, action_type, severity, reason,
+             description, metadata, duration, expires_at, is_active,
+             acknowledged_at, created_at, updated_at
+      FROM moderator_actions
+      ${whereSql}
+      ORDER BY created_at DESC, action_id DESC
+      LIMIT $${p} OFFSET $${p + 1}
+      `,
+      [...params, limit, offset]
+    );
+    const countResult = await deps.pool.query<{ total: string }>(
+      `SELECT COUNT(*)::text AS total FROM moderator_actions ${whereSql}`,
+      params
+    );
+    return {
+      actions: pageResult.rows.map(actionRowToProto),
+      total: Number(countResult.rows[0]?.total ?? 0),
+    };
+  }
+
   params.push(limit + 1);
   const sql = `
     SELECT action_id, moderator_id, report_id, target_entity_type,

--- a/services/moderation/src/grpc/handlers.test.ts
+++ b/services/moderation/src/grpc/handlers.test.ts
@@ -501,6 +501,41 @@ describe('listReports', () => {
     expect(sql).toContain('created_at <');
     expect(sql).toContain('report_id <');
   });
+
+  it('offset mode (page set) returns an OFFSET page + real total via COUNT(*)', async () => {
+    const { deps, query } = makeDeps([
+      { rows: [reportRow()] }, // page query
+      { rows: [{ total: '42' }] }, // count query
+    ]);
+    const res = await listReports(deps, makePrincipal(), {
+      page: 2,
+      limit: 10,
+    } as ListReportsRequest);
+    const pageSql = query.mock.calls[0][0] as string;
+    expect(pageSql).toContain('LIMIT $1 OFFSET $2');
+    // params: [limit, (page - 1) * limit]
+    expect(query.mock.calls[0][1]).toEqual([10, 10]);
+    const countSql = query.mock.calls[1][0] as string;
+    expect(countSql).toContain('COUNT(*)');
+    expect((res as { total?: number }).total).toBe(42);
+    expect(res.nextCursor).toBeUndefined();
+    expect(res.reports).toHaveLength(1);
+  });
+
+  it('offset mode keeps the reporter self-scope in BOTH the page and count queries', async () => {
+    const { deps, query } = makeDeps([
+      { rows: [] }, // page query
+      { rows: [{ total: '0' }] }, // count query
+    ]);
+    await listReports(deps, makePrincipal({ userId: 'usr-1', permissions: [] }), {
+      page: 1,
+      limit: 10,
+    } as ListReportsRequest);
+    expect(query.mock.calls[0][0] as string).toContain('reporter_id = $1');
+    expect(query.mock.calls[1][0] as string).toContain('reporter_id = $1');
+    expect((query.mock.calls[0][1] as unknown[])[0]).toBe('usr-1');
+    expect((query.mock.calls[1][1] as unknown[])[0]).toBe('usr-1');
+  });
 });
 
 describe('assignReport', () => {

--- a/services/moderation/src/grpc/handlers.ts
+++ b/services/moderation/src/grpc/handlers.ts
@@ -290,7 +290,15 @@ export async function listReports(
     }
   }
 
-  if (req.cursor !== undefined && req.cursor !== '') {
+  // Offset mode: admin datatables pass `page` and need a real total so the
+  // shared DataTable can render "Page X of Y" and gate Next. Keyset cursors
+  // can't cheaply produce a count, so this path issues a COUNT(*) over the
+  // same filter (the reporter self-scope predicate included, so the total
+  // respects visibility). Offset callers never send a cursor, so the cursor
+  // predicate is skipped.
+  const offsetMode = req.page !== undefined && req.page > 0;
+
+  if (!offsetMode && req.cursor !== undefined && req.cursor !== '') {
     let cursor;
     try {
       cursor = decodeCursor(req.cursor);
@@ -306,6 +314,33 @@ export async function listReports(
   }
 
   const whereSql = where.length === 0 ? '' : `WHERE ${where.join(' AND ')}`;
+
+  if (offsetMode) {
+    const offset = ((req.page ?? 1) - 1) * limit;
+    const pageResult = await deps.pool.query<ReportRow>(
+      `
+      SELECT report_id, reporter_id, reported_entity_type, reported_entity_id,
+             reported_user_id, category, severity, status, title, description,
+             metadata, assigned_moderator, assigned_at, resolved_by, resolved_at,
+             resolution, resolution_notes, escalated_to, escalated_at,
+             escalation_reason, created_at, updated_at
+      FROM reports
+      ${whereSql}
+      ORDER BY created_at DESC, report_id DESC
+      LIMIT $${p} OFFSET $${p + 1}
+      `,
+      [...params, limit, offset]
+    );
+    const countResult = await deps.pool.query<{ total: string }>(
+      `SELECT COUNT(*)::text AS total FROM reports ${whereSql}`,
+      params
+    );
+    return {
+      reports: pageResult.rows.map(row => reportRowToProto(row, !canViewInternal)),
+      total: Number(countResult.rows[0]?.total ?? 0),
+    };
+  }
+
   params.push(limit + 1);
   const sql = `
     SELECT report_id, reporter_id, reported_entity_type, reported_entity_id,

--- a/services/moderation/src/grpc/ticket-handlers.test.ts
+++ b/services/moderation/src/grpc/ticket-handlers.test.ts
@@ -370,6 +370,39 @@ describe('listSupportTickets', () => {
     expect(res.tickets).toHaveLength(10);
     expect(res.nextCursor).toBeDefined();
   });
+
+  it('offset mode (page set) returns an OFFSET page + real total via COUNT(*)', async () => {
+    const { deps, query } = makeDeps([
+      { rows: [ticketRow()] }, // page query
+      { rows: [{ total: '20' }] }, // count query
+    ]);
+    const res = await listSupportTickets(deps, makePrincipal(), {
+      page: 2,
+      limit: 10,
+    } as ListSupportTicketsRequest);
+    const pageSql = query.mock.calls[0][0] as string;
+    expect(pageSql).toContain('LIMIT $1 OFFSET $2');
+    expect(query.mock.calls[0][1]).toEqual([10, 10]);
+    expect(query.mock.calls[1][0] as string).toContain('COUNT(*)');
+    expect((res as { total?: number }).total).toBe(20);
+    expect(res.nextCursor).toBeUndefined();
+    expect(res.tickets).toHaveLength(1);
+  });
+
+  it('offset mode keeps the non-admin self-scope in BOTH the page and count queries', async () => {
+    const { deps, query } = makeDeps([
+      { rows: [] }, // page query
+      { rows: [{ total: '0' }] }, // count query
+    ]);
+    await listSupportTickets(deps, makePrincipal({ userId: 'usr-1', permissions: [] }), {
+      page: 1,
+      limit: 10,
+    } as ListSupportTicketsRequest);
+    expect(query.mock.calls[0][0] as string).toContain('user_id = $1');
+    expect(query.mock.calls[1][0] as string).toContain('user_id = $1');
+    expect((query.mock.calls[0][1] as unknown[])[0]).toBe('usr-1');
+    expect((query.mock.calls[1][1] as unknown[])[0]).toBe('usr-1');
+  });
 });
 
 describe('respondToTicket', () => {

--- a/services/moderation/src/grpc/ticket-handlers.ts
+++ b/services/moderation/src/grpc/ticket-handlers.ts
@@ -318,7 +318,15 @@ export async function listSupportTickets(
     params.push(req.userId);
   }
 
-  if (req.cursor !== undefined && req.cursor !== '') {
+  // Offset mode: admin datatables pass `page` and need a real total so the
+  // shared DataTable can render "Page X of Y" and gate Next. Keyset cursors
+  // can't cheaply produce a count, so this path issues a COUNT(*) over the
+  // same filter (the non-admin self-scope predicate included, so the total
+  // respects visibility). Offset callers never send a cursor, so the cursor
+  // predicate is skipped.
+  const offsetMode = req.page !== undefined && req.page > 0;
+
+  if (!offsetMode && req.cursor !== undefined && req.cursor !== '') {
     let cursor;
     try {
       cursor = decodeCursor(req.cursor);
@@ -334,6 +342,29 @@ export async function listSupportTickets(
   }
 
   const whereSql = where.length === 0 ? '' : `WHERE ${where.join(' AND ')}`;
+
+  if (offsetMode) {
+    const offset = ((req.page ?? 1) - 1) * limit;
+    const pageResult = await deps.pool.query<SupportTicketRow>(
+      `
+      SELECT ${TICKET_SELECT}
+      FROM support_tickets
+      ${whereSql}
+      ORDER BY created_at DESC, ticket_id DESC
+      LIMIT $${p} OFFSET $${p + 1}
+      `,
+      [...params, limit, offset]
+    );
+    const countResult = await deps.pool.query<{ total: string }>(
+      `SELECT COUNT(*)::text AS total FROM support_tickets ${whereSql}`,
+      params
+    );
+    return {
+      tickets: pageResult.rows.map(ticketRowToProto),
+      total: Number(countResult.rows[0]?.total ?? 0),
+    };
+  }
+
   params.push(limit + 1);
   const sql = `
     SELECT ${TICKET_SELECT}

--- a/services/rescue/src/grpc/handlers.test.ts
+++ b/services/rescue/src/grpc/handlers.test.ts
@@ -368,6 +368,54 @@ describe('listRescues', () => {
     expect(res.rescues).toHaveLength(2);
     expect(res.nextCursor).toBeDefined();
   });
+
+  it('offset mode (page set) returns a real total and a LIMIT/OFFSET page, not a cursor', async () => {
+    const rows = [rescueRow({ rescue_id: 'rsc-0' }), rescueRow({ rescue_id: 'rsc-1' })];
+    mocks.poolMock.query
+      .mockResolvedValueOnce({ rows }) // page SELECT
+      .mockResolvedValueOnce({ rows: [{ total: '42' }] }); // COUNT(*)
+    const res = await listRescues(mocks.deps, ADMIN, {
+      page: 3,
+      limit: 10,
+      statusFilter: RescueV1.RescueStatus.RESCUE_STATUS_UNSPECIFIED,
+    } as never);
+    expect(res.total).toBe(42);
+    expect(res.nextCursor).toBeUndefined();
+    const pageSql = mocks.poolMock.query.mock.calls[0][0] as string;
+    const pageParams = mocks.poolMock.query.mock.calls[0][1] as unknown[];
+    expect(pageSql).toContain('OFFSET');
+    // limit 10, offset (3 - 1) * 10 = 20
+    expect(pageParams).toEqual(expect.arrayContaining([10, 20]));
+    const countSql = mocks.poolMock.query.mock.calls[1][0] as string;
+    expect(countSql).toContain('COUNT(*)');
+  });
+
+  it('all-statuses scope requires the platform-admin permission', async () => {
+    await expect(
+      listRescues(mocks.deps, ADOPTER, {
+        page: 1,
+        limit: 20,
+        allStatuses: true,
+        statusFilter: RescueV1.RescueStatus.RESCUE_STATUS_UNSPECIFIED,
+      } as never)
+    ).rejects.toMatchObject({ code: 'PERMISSION_DENIED' });
+  });
+
+  it('all-statuses (admin) drops the status filter so pending/suspended are visible', async () => {
+    mocks.poolMock.query
+      .mockResolvedValueOnce({ rows: [rescueRow()] })
+      .mockResolvedValueOnce({ rows: [{ total: '5' }] });
+    const res = await listRescues(mocks.deps, ADMIN, {
+      page: 1,
+      limit: 20,
+      allStatuses: true,
+      statusFilter: RescueV1.RescueStatus.RESCUE_STATUS_UNSPECIFIED,
+    } as never);
+    expect(res.total).toBe(5);
+    // no verified-only default was applied
+    const pageParams = mocks.poolMock.query.mock.calls[0][1] as unknown[];
+    expect(pageParams).not.toContain('verified');
+  });
 });
 
 // --- updateRescue ----------------------------------------------------

--- a/services/rescue/src/grpc/handlers.ts
+++ b/services/rescue/src/grpc/handlers.ts
@@ -372,11 +372,16 @@ export async function listRescues(
   const params: unknown[] = [];
   let n = 1;
 
-  // UNSPECIFIED in the filter slot = the public default ("verified
-  // only"). super_admin bypasses the default by passing a concrete
-  // status; everyone else can still filter on PENDING / SUSPENDED /
-  // etc. but won't see them in the default list.
-  if (req.statusFilter === RescueV1.RescueStatus.RESCUE_STATUS_UNSPECIFIED) {
+  // Status visibility. UNSPECIFIED in the filter slot = the public default
+  // ("verified only"). A caller can filter to a concrete status. all_statuses
+  // is the admin datatable's "show everything" scope — it drops the status
+  // predicate entirely and so is gated on the platform-admin permission
+  // (defence-in-depth; the gateway also gates the /admin route).
+  if (req.allStatuses) {
+    if (!hasPermission(principal, ADMIN_SECURITY_MANAGE)) {
+      throw new HandlerError('PERMISSION_DENIED', `'${ADMIN_SECURITY_MANAGE}' required`);
+    }
+  } else if (req.statusFilter === RescueV1.RescueStatus.RESCUE_STATUS_UNSPECIFIED) {
     where.push(`status = $${n}`);
     params.push('verified');
     n++;
@@ -419,6 +424,33 @@ export async function listRescues(
   }
 
   const orderBy = useRandom ? 'random()' : 'created_at DESC, rescue_id DESC';
+
+  // Offset mode: admin datatables pass `page` and need a real total so the
+  // shared DataTable can render "Page X of Y" and gate Next. Keyset cursors
+  // can't cheaply produce a count, so this path issues a COUNT(*) over the
+  // same filter. Offset callers never send a cursor, so no cursor predicate
+  // is present in `where`.
+  if (req.page !== undefined && req.page > 0) {
+    const offset = (req.page - 1) * limit;
+    const pageResult = await deps.pool.query<RescueRow>(
+      `
+      SELECT ${RESCUES_SELECT} FROM rescue.rescues
+      WHERE ${where.join(' AND ')}
+      ORDER BY ${orderBy}
+      LIMIT $${n} OFFSET $${n + 1}
+      `,
+      [...params, limit, offset]
+    );
+    const countResult = await deps.pool.query<{ total: string }>(
+      `SELECT COUNT(*)::text AS total FROM rescue.rescues WHERE ${where.join(' AND ')}`,
+      params
+    );
+    const accessMap = resolveFieldAccessMap('rescues', principal.roles);
+    return {
+      rescues: pageResult.rows.map(row => maskRescueWithAccessMap(rowToProto(row), accessMap)),
+      total: Number(countResult.rows[0]?.total ?? 0),
+    };
+  }
 
   const result = await deps.pool.query<RescueRow>(
     `


### PR DESCRIPTION
## Summary

- Introduces **one canonical pagination envelope** — `{ page, limit, hasNext, hasPrev, total?, totalPages?, nextCursor? }` — via a shared `buildPaginationEnvelope()` helper, and converges **every datatable** (backend routes + frontend consumers) onto it, replacing 6+ competing gateway shapes and 4 competing frontend key vocabularies.
- **Fixes the crashing admin Rescues datatable**: it was hitting the public keyset `/api/v1/rescues` (no `success`/`pagination`) so `rescueService.getAll` threw `"Failed to fetch rescues"`. Now served by a dedicated offset+count `/api/v1/admin/rescues`.
- Datatable-backing endpoints now return a **real `COUNT(*)` total** (so the shared DataTable can render "Page X of Y" and gate Next); genuine infinite-scroll feeds (end-user chat message stream) stay keyset under the same envelope.

## Changes

**Contract** — `services/gateway/src/middleware/pagination.ts`: `buildPaginationEnvelope()` + `PaginationMeta` (offset vs keyset discriminated input).

**Backend (offset + `COUNT(*)`, canonical envelope; visibility predicates reused in every count so totals never widen access):**
- **rescue** — new `GET /api/v1/admin/rescues`; permission-gated all-statuses scope (`admin.security.manage`) so pending/suspended are visible.
- **applications** — restores the dropped pagination on `GET /api/v1/applications` (principal-scoped count).
- **moderation ×3** — reports / actions / tickets (admin routes always-offset; raw routes dual-mode).
- **chat** — `ListChats` → offset+count (admin datatable); `ListMessages` → keyset (end-user reverse-scroll stream).
- **conform** — pets / users / audit already had real totals but emitted three different shapes; re-wrapped through the helper.
- protos regenerated (`page`/`total` fields added where needed).

**Frontend (read the canonical `pagination`):**
- **lib.pets** `meta.*` → `pagination.*`; **lib.support-tickets** strict Zod rewritten off `currentPage/totalItems/itemsPerPage` (it was throwing and hard-failing the admin Support screen); **lib.chat** admin messages hook wrapped + retyped keyset; **app.admin** applications/chat/audit consumers.

## Before requesting review

- [x] Tests for new behaviour added (TDD throughout)
- [x] Considered consumer impact across `app.*` and shared `lib.*`
- [ ] Ran `pnpm ci:local:quick` — ran the touched packages' full suites + type-check + lint instead (below); full CI runs on this PR

## Test plan

- [x] Backend suites green — gateway **1288**, rescue **276**, applications **357**, moderation **363**, chat **181**
- [x] Frontend suites green — app.admin **687**, lib.pets **117**, lib.support-tickets **72**, lib.chat **176**
- [x] `type-check` clean for every touched package (incl. app.admin after lib rebuild); lint clean (0 errors)
- [ ] Manual full-stack run — not from this environment (no live DB); covered by unit + route (`fastify.inject`) tests

## Known follow-ups (deliberately out of scope; none are regressions)

- **lib.applications** (rescue-app ApplicationList) still sends `offset` + reads `meta`; it never paginated before (the route returned no pagination — that was the bug), so it's an unconverged secondary consumer, not a regression. The **admin** applications datatable uses its own `applicationService` and is fixed here.
- **Admin chat message load-more** advances by `page`, but the messages route is keyset; the first page renders correctly (previously it rendered nothing), full advance needs a `page`→`cursor` refactor.
- **lib.api / lib.types** still carry the old `meta?`/`pagination?` + `currentPage` type-drift — type-hygiene cleanup with broad blast radius, best as its own change.

## Related

Follows the standardization discussion with the maintainer. No Linear ticket linked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CpgB3heYWQKvBnnCR2W1ES