### PR TITLE
ci: add PR-level commit message lint gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,6 +149,30 @@ jobs:
         run: pnpm check:renovate
 
   # ============================================================================
+  # COMMIT MESSAGE LINT — ADS-1103: CONTRIBUTING.md documented a CI commit-
+  # message check that didn't actually exist. Conventional Commits were only
+  # enforced by the local `.husky/commit-msg` hook, which `--no-verify`
+  # bypasses and which never runs for web-UI or agent commits. Lints every
+  # commit on the PR against the repo's existing commitlint.config.js
+  # (@commitlint/config-conventional). No path filter — commit messages
+  # aren't tied to which files changed — and already in ci-required's needs.
+  # ============================================================================
+  commit-lint:
+    name: Verify Commit Messages
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          fetch-depth: 0
+
+      - uses: ./.github/actions/setup-workspace
+
+      - name: Lint commit messages
+        run: pnpm exec commitlint --from ${{ github.event.pull_request.base.sha }} --to ${{ github.event.pull_request.head.sha }} --verbose
+
+  # ============================================================================
   # CHANGE DETECTION — gate all downstream jobs on relevant path changes
   # ============================================================================
   changes:
@@ -512,6 +536,7 @@ jobs:
     if: always()
     needs:
       - workspace-drift
+      - commit-lint
       - build-libs
       - test-frontend
       - test-libs


### PR DESCRIPTION
## Summary

- `CONTRIBUTING.md:59` claims "the CI commit-message check will still fail the PR" if the local hook is bypassed with `--no-verify`, but no such CI check existed — Conventional Commits were enforced only by the local `.husky/commit-msg` hook, which is bypassable and never runs for web-UI or agent commits.
- Adds a `commit-lint` job to `ci.yml` that lints every commit on a PR against the repo's existing `commitlint.config.js` (`@commitlint/config-conventional`), and wires it into the `ci-required` aggregator gate so a non-conforming commit message fails the PR.

## Changes

- `.github/workflows/ci.yml` — new `commit-lint` job (checks out full history via `fetch-depth: 0`, installs the workspace via the existing `setup-workspace` composite action, then runs `pnpm exec commitlint --from <base sha> --to <head sha>`); added to `ci-required`'s `needs` list.

## Before requesting review

- [ ] Ran `pnpm ci:local:quick` locally (or installed the pre-push hook — see CONTRIBUTING.md)
- [x] Tests for new behaviour added (N/A — this is a CI workflow change; verified locally, see Test plan)
- [ ] If touching `.env` requirements, updated `.env.example`'s REQUIRED block
- [ ] If touching a `lib.*`, considered consumer impact across `app.*` and `service.backend`

## Test plan

- [x] `node scripts/check-workflow-paths.mjs` — passes (no path-filter drift)
- [x] `node scripts/check-workspace-consistency.mjs` — passes
- [x] `pnpm test:scripts` — 190/190 passing
- [x] Verified `pnpm exec commitlint` against the repo's `commitlint.config.js` accepts a conforming message (`feat: add commit lint`) and rejects a non-conforming one (`this is a bad message` → `subject-empty`, `type-empty`)
- [ ] Tested manually — the job itself only runs on `pull_request` events reading `github.event.pull_request.base.sha`/`head.sha`, so it can't be exercised outside GitHub Actions; will confirm it fires green on this PR once CI runs
- [ ] No TypeScript errors (`pnpm type-check`) — N/A, no TS changed
- [ ] Lint passes (`pnpm lint`) — N/A, no lintable source changed (YAML workflow files are outside this repo's Prettier/ESLint scope)

## Related

Linear: [ADS-1103](https://linear.app/ideasquared/issue/ADS-1103/no-ci-commit-message-lint-gate-but-contributing-claims-one-exists)

---

This is the first concrete step on this ticket (adding the CI gate itself). Follow-up, if needed: reconciling `CONTRIBUTING.md`'s wording now that the claim is actually true (checked — the current text already matches this behavior, so no doc change was required).


---
_Generated by [Claude Code](https://claude.ai/code/session_01RYSeB3JLwABBySZVeebcQB)_